### PR TITLE
fix: schematics cache

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          enable-build-cache: 'true'
+          enable-build-cache: ${{ github.event_name == 'pull_request' }}
           install-jdk: 'true'
       - name: Build Swagger CodeGen
         run: yarn build:swagger-gen

--- a/nx.json
+++ b/nx.json
@@ -134,10 +134,7 @@
         "^source"
       ],
       "outputs": [
-        "{projectRoot}/dist/",
-        "!{projectRoot}/dist/schematics",
-        "!{projectRoot}/dist/builders",
-        "!{projectRoot}/dist/middlewares"
+        "{projectRoot}/dist/"
       ]
     },
     "prepare-build-builders": {

--- a/packages/@o3r/configuration/project.json
+++ b/packages/@o3r/configuration/project.json
@@ -29,21 +29,7 @@
       "executor": "nx:run-script",
       "options": {
         "script": "build:builders"
-      },
-      "outputs": [
-        "{projectRoot}/dist/middlewares",
-        "{projectRoot}/dist/builders.json",
-        "{projectRoot}/dist/migration.json",
-        "{projectRoot}/dist/collection.json",
-        "{projectRoot}/dist/builders/**/*.json",
-        "{projectRoot}/dist/schematics/**/*.json",
-        "{projectRoot}/dist/schematics/**/templates"
-      ],
-      "dependsOn": [
-        "^build",
-        "compile",
-        "prepare-build-builders"
-      ]
+      }
     },
     "lint": {
       "executor": "@nrwl/linter:eslint",

--- a/packages/@o3r/mobile/project.json
+++ b/packages/@o3r/mobile/project.json
@@ -29,12 +29,10 @@
       ],
       "outputs": [
         "{projectRoot}/dist/pcloudy",
-        "{projectRoot}/dist/builders.json",
-        "{projectRoot}/dist/migration.json",
-        "{projectRoot}/dist/collection.json",
-        "{projectRoot}/dist/builders/**/*.json",
-        "{projectRoot}/dist/schematics/**/*.json",
-        "{projectRoot}/dist/schematics/**/templates"
+        "{projectRoot}/dist/schematics/**/*.js",
+        "{projectRoot}/dist/schematics/**/*.d.ts",
+        "{projectRoot}/dist/schematics/**/*.d.ts.map",
+        "{projectRoot}/build/.tsbuildinfo.builders"
       ],
       "options": {
         "script": "build:builders"

--- a/packages/@o3r/styling/project.json
+++ b/packages/@o3r/styling/project.json
@@ -18,28 +18,19 @@
       "options": {
         "project": "packages/@o3r/styling/ng-package.json",
         "tsConfig": "packages/@o3r/styling/tsconfig.build.json"
-      },
-      "dependsOn": [
-        "^build",
-        "build-builders"
-      ]
+      }
     },
     "prepare-build-builders": {
       "executor": "nx:run-script",
       "options": {
         "script": "prepare:build:builders"
-      },
-      "dependsOn": []
+      }
     },
     "build-builders": {
       "executor": "nx:run-script",
       "options": {
         "script": "build:builders"
-      },
-      "dependsOn": [
-        "^build",
-        "prepare-build-builders"
-      ]
+      }
     },
     "lint": {
       "executor": "@nrwl/linter:eslint",

--- a/packages/@o3r/styling/tsconfig.build.composite.json
+++ b/packages/@o3r/styling/tsconfig.build.composite.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.build",
-  "compilerOptions": {
-    "composite": true
-  }
-}

--- a/packages/@o3r/styling/tsconfig.builders.json
+++ b/packages/@o3r/styling/tsconfig.builders.json
@@ -16,10 +16,5 @@
     "**/*.spec.ts",
     "builders/**/templates/**",
     "schematics/**/templates/**"
-  ],
-  "references": [
-    {
-      "path": "./tsconfig.build.composite.json"
-    }
   ]
 }

--- a/packages/@o3r/testing/project.json
+++ b/packages/@o3r/testing/project.json
@@ -53,7 +53,7 @@
     "build-tools": {
       "executor": "nx:run-script",
       "outputs": [
-        "{projectRoot}/dist-tools/src/tools/protractor"
+        "{projectRoot}/dist/src/tools/protractor"
       ],
       "options": {
         "script": "build:tools"


### PR DESCRIPTION
Remove incorrect outputs and dependency on project.json

Only package with non standard structure should have custom outputs and dependsOn properties

Remove the reference in o3r/styling/tsconfig.builders.json to the src folder (composite build)

o3r/styling builders have a dependency over the compiled package and should not try to compile it themselves