### PR TITLE
fix: remove deprecated jfrog url

### DIFF
--- a/packages/@ama-sdk/generator-sdk/src/generators/java-client-core/templates/swagger-codegen-java-client/src/main/resources/javaClient/README.mustache
+++ b/packages/@ama-sdk/generator-sdk/src/generators/java-client-core/templates/swagger-codegen-java-client/src/main/resources/javaClient/README.mustache
@@ -60,7 +60,7 @@ Modify your settings.xml:
     <mirrors>
         ...
         <mirror>
-            <url>https://digitalforairlines.jfrog.io/digitalforairlines/mvn-otter</url>
+            <url>https://pkgs.dev.azure.com/AmadeusDigitalAirline/DES-SDKs/_packaging/des-sdks/maven/v1</url>
             <id>public-artifactory</id>
             <name>External Repository of artifacts</name>
             <mirrorOf>public-artifactory</mirrorOf>
@@ -83,7 +83,7 @@ Modify your settings.xml:
                 <repository>
                     <id>public-artifactory</id>
                     <name>public-artifactory</name>
-                    <url>https://digitalforairlines.jfrog.io/digitalforairlines/mvn-otter</url>
+                    <url>https://pkgs.dev.azure.com/AmadeusDigitalAirline/DES-SDKs/_packaging/des-sdks/maven/v1</url>
                 </repository>
             </repositories>
         </profile>

--- a/packages/@ama-sdk/generator-sdk/src/generators/java-client-core/templates/swagger-codegen-java-client/src/main/resources/javaClient/pom.mustache
+++ b/packages/@ama-sdk/generator-sdk/src/generators/java-client-core/templates/swagger-codegen-java-client/src/main/resources/javaClient/pom.mustache
@@ -136,7 +136,7 @@
   <repositories>
     <repository>
       <id>public-artifactory</id>
-      <url>https://digitalforairlines.jfrog.io/digitalforairlines/mvn-otter</url>
+      <url>https://pkgs.dev.azure.com/AmadeusDigitalAirline/DES-SDKs/_packaging/des-sdks/maven/v1</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -148,7 +148,7 @@
   <distributionManagement>
     <repository>
       <id>public-artifactory</id>
-      <url>https://digitalforairlines.jfrog.io/digitalforairlines/mvn-otter</url>
+      <url>https://pkgs.dev.azure.com/AmadeusDigitalAirline/DES-SDKs/_packaging/des-sdks/maven/v1</url>
     </repository>
   </distributionManagement>
 

--- a/packages/@ama-sdk/generator-sdk/src/generators/java-client-core/templates/swagger-codegen-java-client/src/main/resources/javaClient/settings.mustache
+++ b/packages/@ama-sdk/generator-sdk/src/generators/java-client-core/templates/swagger-codegen-java-client/src/main/resources/javaClient/settings.mustache
@@ -4,7 +4,7 @@
   <mirrors>
     <mirror>
       <id>public-artifactory</id>
-      <url>https://digitalforairlines.jfrog.io/digitalforairlines/mvn-otter</url>
+      <url>https://pkgs.dev.azure.com/AmadeusDigitalAirline/DES-SDKs/_packaging/des-sdks/maven/v1</url>
       <name>External Repository</name>
       <mirrorOf>public-artifactory</mirrorOf>
     </mirror>

--- a/packages/@ama-sdk/generator-sdk/src/generators/java-resteasy-client-core/templates/swagger-codegen-java-resteasy-client/src/main/resources/javaRestEasyClient/README.mustache
+++ b/packages/@ama-sdk/generator-sdk/src/generators/java-resteasy-client-core/templates/swagger-codegen-java-resteasy-client/src/main/resources/javaRestEasyClient/README.mustache
@@ -60,7 +60,7 @@ Modify your settings.xml:
     <mirrors>
         ...
         <mirror>
-            <url>https://digitalforairlines.jfrog.io/digitalforairlines/mvn-otter</url>
+            <url>https://pkgs.dev.azure.com/AmadeusDigitalAirline/DES-SDKs/_packaging/des-sdks/maven/v1</url>
             <id>public-artifactory</id>
             <name>External Repository of artifacts</name>
             <mirrorOf>public-artifactory</mirrorOf>
@@ -83,7 +83,7 @@ Modify your settings.xml:
                 <repository>
                     <id>public-artifactory</id>
                     <name>public-artifactory</name>
-                    <url>https://digitalforairlines.jfrog.io/digitalforairlines/mvn-otter</url>
+                    <url>https://pkgs.dev.azure.com/AmadeusDigitalAirline/DES-SDKs/_packaging/des-sdks/maven/v1</url>
                 </repository>
             </repositories>
         </profile>

--- a/packages/@ama-sdk/generator-sdk/src/generators/java-resteasy-client-core/templates/swagger-codegen-java-resteasy-client/src/main/resources/javaRestEasyClient/settings.mustache
+++ b/packages/@ama-sdk/generator-sdk/src/generators/java-resteasy-client-core/templates/swagger-codegen-java-resteasy-client/src/main/resources/javaRestEasyClient/settings.mustache
@@ -5,7 +5,7 @@
     http://maven.apache.org/xsd/settings-1.0.0.xsd">
   <mirrors>
     <mirror>
-      <url>https://digitalforairlines.jfrog.io/digitalforairlines/mvn-otter</url>
+      <url>https://pkgs.dev.azure.com/AmadeusDigitalAirline/DES-SDKs/_packaging/des-sdks/maven/v1</url>
       <id>external.repository</id>
       <name>External Repository</name>
       <mirrorOf>external.repo</mirrorOf>


### PR DESCRIPTION
JFrog artifacts are no longer supported, use the new Azure repository