### PR TITLE
fix: sdk generators packaging

### DIFF
--- a/packages/@ama-sdk/generator-sdk/project.json
+++ b/packages/@ama-sdk/generator-sdk/project.json
@@ -40,7 +40,9 @@
           "packages/@ama-sdk/generator-sdk/src/**/swagger-codegen-cli.jar",
           "packages/@ama-sdk/generator-sdk/src/**/config/*.json",
           "packages/@ama-sdk/generator-sdk/src/generators/**/target/*.jar",
-          "packages/@ama-sdk/generator-sdk/src/generators/*/templates/**/*",
+          "packages/@ama-sdk/generator-sdk/src/generators/shell/templates/**/*",
+          "packages/@ama-sdk/generator-sdk/src/generators/api-extension/templates/**/*",
+          "packages/@ama-sdk/generator-sdk/src/generators/core/templates/src/spec/**/*",
           "packages/@ama-sdk/generator-sdk/src/schematics/*/schema.json",
           "packages/@ama-sdk/generator-sdk/collection.json"
         ],


### PR DESCRIPTION
Prevent adding other files than **.jar** to /templates/target folders for java generators