### PR TITLE
feat: support multiple templates in placeholders

### DIFF
--- a/docs/rules-engine/how-to-use/integration.md
+++ b/docs/rules-engine/how-to-use/integration.md
@@ -50,7 +50,7 @@ The Actions available on the Rules Engine depend on the Otter modules imported b
 - __UPDATE_ASSET__: requires the import of `AssetPathOverrideStoreModule` from [@o3r/dynamic-content](https://github.com/AmadeusITGroup/otter/blob/main/packages/%40o3r/dynamic-content/)
 - __UPDATE_LOCALISATION__: requires the import of `LocalizationOverrideStoreModule` from [@o3r/localization](https://github.com/AmadeusITGroup/otter/blob/main/packages/%40o3r/localization/)
 - __UPDATE_CONFIG__: requires the import of `ConfigOverrideStoreModule` from [@o3r/configuration](https://github.com/AmadeusITGroup/otter/blob/main/packages/%40o3r/configuration/)
-- __UPDATE_PLACEHOLDER__: requires the import of `PlaceholderTemplateStoreModule` from [@o3r/components](https://github.com/AmadeusITGroup/otter/blob/main/packages/%40o3r/components/)
+- __UPDATE_PLACEHOLDER__: requires the import of `PlaceholderTemplateStoreModule` and `PlaceholderRequestStoreModule` from [@o3r/components](https://github.com/AmadeusITGroup/otter/blob/main/packages/%40o3r/components/)
 
 #### Facts modules integration  
 

--- a/docs/rules-engine/how-to-use/placeholders.md
+++ b/docs/rules-engine/how-to-use/placeholders.md
@@ -99,7 +99,23 @@ And then in the angular.json :
 * Html limited to angular sanitizer supported behavior
 * Urls (relative ones will be processed to add the dynamic-media-path)
 * Facts references
-* Localization : for each change a new url will be fetched
+
+### Static localization
+The first choice you have when you want to localize your template is the static localization.
+You need to create a localized template for each locale and provide the template URL with [LANGUAGE] (ex: assets/placeholders/[LANGUAGE]/myPlaceholder.json)
+The rules engine service will handle the replacement of [LANGUAGE] for you, and when you change language a new call will be performed to the new 'translated' URL.
+
+Note that the URL caching mechanism is based on the url NOT 'translated', meaning that if you change from en-GB to fr-FR then you decide to switch back and all the calls will be made again.
+This behavior is based on the fact that a real user rarely goes back and forth with the language update.
+
+### Dynamic localization
+
+### Multiple templates in same placeholder
+You can use placeholder actions to target the same placeholderId with different template URLs.
+It groups the rendered templates in the same placeholder, and you can choose the order by using the `priority` attribute in the action.
+If not specified, the priority defaults to 0. Then the higher the number, the higher the priority. The final results are displayed in descending order of priority.
+The placeholder component waits for all the calls to be resolved (not pending) to display the content.
+The placeholder component ignores a template if the application failed to retrieve it.
 
 ## Investigate issues
 If the placeholder is not rendered properly, you can perform several check to find out the root cause, simply looking at the store state.

--- a/packages/@o3r/components/src/stores/index.ts
+++ b/packages/@o3r/components/src/stores/index.ts
@@ -1,1 +1,2 @@
 export * from './placeholder-template/index';
+export * from './placeholder-request/index';

--- a/packages/@o3r/components/src/stores/placeholder-request/index.ts
+++ b/packages/@o3r/components/src/stores/placeholder-request/index.ts
@@ -1,0 +1,7 @@
+export * from './placeholder-request.actions';
+export * from './placeholder-request.module';
+export * from './placeholder-request.reducer';
+export * from './placeholder-request.selectors';
+export * from './placeholder-request.state';
+export * from './placeholder-request.sync';
+

--- a/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.actions.ts
+++ b/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.actions.ts
@@ -1,0 +1,32 @@
+import {createAction, props} from '@ngrx/store';
+import {
+  asyncProps,
+  AsyncRequest,
+  FailAsyncStoreItemEntitiesActionPayload,
+  FromApiActionPayload,
+  UpdateAsyncStoreItemEntityActionPayloadWithId,
+  UpdateEntityActionPayloadWithId
+} from '@o3r/core';
+import {PlaceholderRequestModel, PlaceholderRequestReply} from './placeholder-request.state';
+
+const ACTION_FAIL_ENTITIES = '[PlaceholderRequest] fail entities';
+const ACTION_SET_ENTITY_FROM_URL = '[PlaceholderRequest] set entity from url';
+const ACTION_CANCEL_REQUEST = '[PlaceholderRequest] cancel request';
+const ACTION_UPDATE_ENTITY = '[PlaceholderRequest] update entity';
+const ACTION_UPDATE_ENTITY_SYNC = '[PlaceholderRequest] update entity sync';
+
+/** Action to cancel a Request ID registered in the store. Can happen from effect based on a switchMap for instance */
+export const cancelPlaceholderRequest = createAction(ACTION_CANCEL_REQUEST, props<AsyncRequest & {id: string}>());
+
+/** Action to update failureStatus for PlaceholderRequestModels */
+export const failPlaceholderRequestEntity = createAction(ACTION_FAIL_ENTITIES, props<FailAsyncStoreItemEntitiesActionPayload<any>>());
+
+/** Action to update an entity */
+export const updatePlaceholderRequestEntity = createAction(ACTION_UPDATE_ENTITY, props<UpdateAsyncStoreItemEntityActionPayloadWithId<PlaceholderRequestModel>>());
+
+/** Action to update an entity without impact on request id */
+export const updatePlaceholderRequestEntitySync = createAction(ACTION_UPDATE_ENTITY_SYNC, props<UpdateEntityActionPayloadWithId<PlaceholderRequestModel>>());
+
+/** Action to update PlaceholderRequest with known IDs, will create the entity with only the url, the call will be created in the effect */
+export const setPlaceholderRequestEntityFromUrl =
+  createAction(ACTION_SET_ENTITY_FROM_URL, asyncProps<FromApiActionPayload<PlaceholderRequestReply> & {resolvedUrl: string; id: string}>());

--- a/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.module.ts
+++ b/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.module.ts
@@ -1,0 +1,32 @@
+import { InjectionToken, ModuleWithProviders, NgModule } from '@angular/core';
+import { Action, ActionReducer, StoreModule } from '@ngrx/store';
+
+import { placeholderRequestReducer } from './placeholder-request.reducer';
+import { PLACEHOLDER_REQUEST_STORE_NAME, PlaceholderRequestState } from './placeholder-request.state';
+
+/** Token of the PlaceholderRequest reducer */
+export const PLACEHOLDER_REQUEST_REDUCER_TOKEN = new InjectionToken<ActionReducer<PlaceholderRequestState, Action>>('Feature PlaceholderRequest Reducer');
+
+/** Provide default reducer for PlaceholderRequest store */
+export function getDefaultplaceholderRequestReducer() {
+  return placeholderRequestReducer;
+}
+
+@NgModule({
+  imports: [
+    StoreModule.forFeature(PLACEHOLDER_REQUEST_STORE_NAME, PLACEHOLDER_REQUEST_REDUCER_TOKEN)
+  ],
+  providers: [
+    { provide: PLACEHOLDER_REQUEST_REDUCER_TOKEN, useFactory: getDefaultplaceholderRequestReducer }
+  ]
+})
+export class PlaceholderRequestStoreModule {
+  public static forRoot<T extends PlaceholderRequestState>(reducerFactory: () => ActionReducer<T, Action>): ModuleWithProviders<PlaceholderRequestStoreModule> {
+    return {
+      ngModule: PlaceholderRequestStoreModule,
+      providers: [
+        { provide: PLACEHOLDER_REQUEST_REDUCER_TOKEN, useFactory: reducerFactory }
+      ]
+    };
+  }
+}

--- a/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.reducer.spec.ts
+++ b/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.reducer.spec.ts
@@ -1,0 +1,110 @@
+import * as actions from './placeholder-request.actions';
+import {placeholderRequestInitialState, placeholderRequestReducer} from './placeholder-request.reducer';
+
+describe('PlaceholderRequest Store reducer', () => {
+
+  it('should have the correct initial state', () => {
+    expect(placeholderRequestInitialState.ids.length).toBe(0);
+  });
+
+  it('should by default return the initial state', () => {
+    const state = placeholderRequestReducer(placeholderRequestInitialState, {type: 'fake'} as any);
+    expect(state).toEqual(placeholderRequestInitialState);
+  });
+
+  it('Cancel request should work properly', () => {
+    const initialState = placeholderRequestReducer(placeholderRequestInitialState, actions.setPlaceholderRequestEntityFromUrl({
+      call: Promise.resolve({'template': '<div>Template3</div>'}),
+      id: 'www.url3.com/[LANG]',
+      resolvedUrl: 'www.url3.com/en',
+      requestId: 'id1'
+    }));
+    expect(initialState.entities['www.url3.com/[LANG]'].isPending).toBe(true);
+    expect(initialState.entities['www.url3.com/[LANG]'].requestIds).toStrictEqual(['id1']);
+    const firstState = placeholderRequestReducer(initialState, actions.cancelPlaceholderRequest({
+      requestId: 'id1',
+      id: 'www.url3.com/[LANG]'
+    }));
+    expect(firstState.entities['www.url3.com/[LANG]'].isPending).toBe(false);
+    expect(firstState.entities['www.url3.com/[LANG]'].requestIds).toStrictEqual([]);
+  });
+
+  describe('Entity actions', () => {
+    it('ACTION_UPDATE_ENTITY_SYNC action should not touch existing properties not provided in the payload', () => {
+      const initialState = placeholderRequestReducer(placeholderRequestInitialState, actions.setPlaceholderRequestEntityFromUrl({
+        call: Promise.resolve({'template': '<div>Template3</div>'}),
+        id: 'www.url3.com/[LANG]',
+        resolvedUrl: 'www.url3.com/en',
+        requestId: 'id1'
+      }));
+      expect(initialState.entities['www.url3.com/[LANG]'].used).toBe(true);
+      expect(initialState.entities['www.url3.com/[LANG]'].isPending).toBe(true);
+      const firstState = placeholderRequestReducer(initialState, actions.updatePlaceholderRequestEntitySync({
+        entity: {
+          id: 'www.url3.com/[LANG]',
+          used: false
+        }
+      }));
+      expect(firstState.entities['www.url3.com/[LANG]'].used).toBe(false);
+      expect(firstState.entities['www.url3.com/[LANG]'].resolvedUrl).toBe('www.url3.com/en');
+      expect(firstState.entities['www.url3.com/[LANG]'].isPending).toBe(true);
+    });
+
+    it('ACTION_UPDATE_ENTITY action should not touch existing properties not provided in the payload and update the pending status', () => {
+      const initialState = placeholderRequestReducer(placeholderRequestInitialState, actions.setPlaceholderRequestEntityFromUrl({
+        call: Promise.resolve({'template': '<div>Template3</div>'}),
+        id: 'www.url3.com/[LANG]',
+        resolvedUrl: 'www.url3.com/en',
+        requestId: 'id1'
+      }));
+      expect(initialState.entities['www.url3.com/[LANG]'].isPending).toBe(true);
+      const firstState = placeholderRequestReducer(initialState, actions.updatePlaceholderRequestEntity({
+        entity: {
+          id: 'www.url3.com/[LANG]',
+          resolvedUrl: 'www.url3.com/en'
+        },
+        requestId: 'id1'
+      }));
+      expect(firstState.entities['www.url3.com/[LANG]'].used).toBe(true);
+      expect(firstState.entities['www.url3.com/[LANG]'].resolvedUrl).toBe('www.url3.com/en');
+      expect(firstState.entities['www.url3.com/[LANG]'].isPending).toBe(false);
+    });
+
+    it('FAIL_ENTITIES action should update the global isPending to false in case there are some newIds in the payload', () => {
+      const initialState = placeholderRequestReducer(placeholderRequestInitialState, actions.setPlaceholderRequestEntityFromUrl({
+        call: Promise.resolve({'template': '<div>Template3</div>'}),
+        id: 'www.url3.com/[LANG]',
+        resolvedUrl: 'www.url3.com/en',
+        requestId: 'id1'
+      }));
+
+      expect(initialState.isPending).toBe(true);
+      expect(initialState.isFailure).toBe(false);
+      const firstState = placeholderRequestReducer(initialState, actions.failPlaceholderRequestEntity({
+        error: 'dummy error',
+        ids: ['www.url3.com/[LANG]'],
+        requestId: 'id1'
+      }));
+
+      expect(firstState.isPending).toBe(false);
+      expect(firstState.isFailure).toBe(false);
+      expect(firstState.entities['www.url3.com/[LANG]'].isPending).toBe(false);
+      expect(firstState.entities['www.url3.com/[LANG]'].isFailure).toBe(true);
+    });
+  });
+
+  describe('API call actions', () => {
+    it('SET_ENTITY_FROM_URL action should clear current entities and set new ones', () => {
+      const firstState = placeholderRequestReducer(placeholderRequestInitialState, actions.setPlaceholderRequestEntityFromUrl({
+        call: Promise.resolve({'template': '<div>Template3</div>'}),
+        id: 'www.url3.com/[LANG]',
+        resolvedUrl: 'www.url3.com/en',
+        requestId: 'id1'
+      }));
+
+      expect(firstState.entities['www.url3.com/[LANG]'].isPending).toBe(true);
+      expect(firstState.entities['www.url3.com/[LANG]'].isFailure).toBe(false);
+      expect(firstState.entities['www.url3.com/[LANG]'].used).toBe(true);
+    });
+  });
+});

--- a/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.reducer.ts
+++ b/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.reducer.ts
@@ -1,0 +1,87 @@
+import {createEntityAdapter} from '@ngrx/entity';
+import {ActionCreator, createReducer, on, ReducerTypes} from '@ngrx/store';
+import {asyncStoreItemAdapter, createEntityAsyncRequestAdapter} from '@o3r/core';
+import * as actions from './placeholder-request.actions';
+import {
+  PlaceholderRequestModel,
+  PlaceholderRequestState,
+  PlaceholderRequestStateDetails
+} from './placeholder-request.state';
+
+/**
+ * PlaceholderRequest Store adapter
+ */
+export const placeholderRequestAdapter = createEntityAsyncRequestAdapter(createEntityAdapter<PlaceholderRequestModel>({
+  selectId: (model) => model.id
+}));
+
+/**
+ * PlaceholderRequest Store initial value
+ */
+export const placeholderRequestInitialState: PlaceholderRequestState = placeholderRequestAdapter.getInitialState<PlaceholderRequestStateDetails>({
+  requestIds: []
+});
+
+/**
+ * Reducers of Placeholder request store that handles the call to the placeholder template URL
+ */
+export const placeholderRequestReducerFeatures: ReducerTypes<PlaceholderRequestState, ActionCreator[]>[] = [
+  on(actions.cancelPlaceholderRequest, (state, action) => {
+    const id = action.id;
+    if (!id || !state.entities[id]) {
+      return state;
+    }
+    return placeholderRequestAdapter.updateOne({
+      id: action.id,
+      changes: asyncStoreItemAdapter.resolveRequest(state.entities[id]!, action.requestId)
+    }, asyncStoreItemAdapter.resolveRequest(state, action.requestId));
+  }),
+  on(actions.updatePlaceholderRequestEntity, (state, action) => {
+    const currentEntity = state.entities[action.entity.id]!;
+    const newEntity = asyncStoreItemAdapter.resolveRequest({...action.entity, ...asyncStoreItemAdapter.extractAsyncStoreItem(currentEntity)}, action.requestId);
+    return placeholderRequestAdapter.updateOne({
+      id: newEntity.id,
+      changes: newEntity
+    }, asyncStoreItemAdapter.resolveRequest(state, action.requestId));
+  }),
+  on(actions.updatePlaceholderRequestEntitySync, (state, action) => {
+    return placeholderRequestAdapter.updateOne({
+      id: action.entity.id,
+      changes: {
+        ...action.entity
+      }
+    }, state);
+  }),
+  on(actions.setPlaceholderRequestEntityFromUrl, (state, payload) => {
+    const currentEntity = state.entities[payload.id];
+    // Nothing to update if resolved URLs already match
+    if (currentEntity && currentEntity.resolvedUrl === payload.resolvedUrl) {
+      return state;
+    }
+    let newEntity = {
+      id: payload.id,
+      resolvedUrl: payload.resolvedUrl,
+      used: true
+    };
+    if (currentEntity) {
+      newEntity = {...asyncStoreItemAdapter.extractAsyncStoreItem(currentEntity), ...newEntity};
+    }
+    return placeholderRequestAdapter.addOne(
+      asyncStoreItemAdapter.addRequest(
+        asyncStoreItemAdapter.initialize(newEntity),
+        payload.requestId),
+      asyncStoreItemAdapter.addRequest(state, payload.requestId)
+    );
+  }),
+  on(actions.failPlaceholderRequestEntity, (state, payload) => {
+    return placeholderRequestAdapter.failRequestMany(asyncStoreItemAdapter.resolveRequest(state, payload.requestId), payload && payload.ids, payload.requestId);
+  })
+];
+
+/**
+ * PlaceholderRequest Store reducer
+ */
+export const placeholderRequestReducer = createReducer(
+  placeholderRequestInitialState,
+  ...placeholderRequestReducerFeatures
+);

--- a/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.selectors.spec.ts
+++ b/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.selectors.spec.ts
@@ -1,0 +1,17 @@
+import * as selectors from './placeholder-request.selectors';
+import { PlaceholderRequestState } from './placeholder-request.state';
+
+const entity = { id: 'www.google.com', resolvedUrl: 'www.google.com', template: '<span>ok</span>', requestIds: [] as any[], vars: {} };
+const entities = { tpl1: entity };
+const state: PlaceholderRequestState = { entities, ids: Object.keys(entities), requestIds: [] };
+
+describe('PlaceholderRequest Selectors tests', () => {
+
+  it('should return undefined if requested ID is not in the state', () => {
+    expect(selectors.selectPlaceholderRequestEntityUsage('random')(state)).toBeUndefined();
+  });
+
+  it('should return the correct entity if requested ID is in the state', () => {
+    expect(selectors.selectPlaceholderRequestEntityUsage('www.google.com')(state)).toBeUndefined();
+  });
+});

--- a/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.selectors.ts
+++ b/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.selectors.ts
@@ -1,0 +1,21 @@
+import {createFeatureSelector, createSelector} from '@ngrx/store';
+import {PLACEHOLDER_REQUEST_STORE_NAME, PlaceholderRequestState} from './placeholder-request.state';
+import {placeholderRequestAdapter} from './placeholder-request.reducer';
+
+export const selectPlaceholderRequestState = createFeatureSelector<PlaceholderRequestState>(PLACEHOLDER_REQUEST_STORE_NAME);
+
+const {selectEntities} = placeholderRequestAdapter.getSelectors();
+
+/** Select the dictionary of PlaceholderRequest entities */
+export const selectPlaceholderRequestEntities = createSelector(selectPlaceholderRequestState, (state) => state && selectEntities(state));
+
+/**
+ * Select a specific PlaceholderRequest entity using a raw url as id
+ *
+ * @param rawUrl
+ */
+export const selectPlaceholderRequestEntityUsage = (rawUrl: string) => createSelector(
+  selectPlaceholderRequestState,
+  (state) => {
+    return state?.entities[rawUrl] ? state?.entities[rawUrl]!.used : undefined;
+  });

--- a/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.state.ts
+++ b/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.state.ts
@@ -1,0 +1,61 @@
+import { EntityState } from '@ngrx/entity';
+import { AsyncStoreItem } from '@o3r/core';
+
+/**
+ * Variable model from the placeholder reply
+ */
+export interface PlaceholderVariable {
+  type: 'fact' | 'fullUrl' | 'relativeUrl' | 'localisation';
+  value: string;
+  vars?: string[];
+  path?: string;
+}
+
+/**
+ * Raw JSON template coming back from the CMS or any other source
+ */
+export interface PlaceholderRequestReply {
+  template?: string;
+  vars?: Record<string, PlaceholderVariable>;
+}
+
+/**
+ * PlaceholderRequest model
+ */
+export interface PlaceholderRequestModel extends AsyncStoreItem, PlaceholderRequestReply {
+  /** Raw URL that is not localized, ex: my_url/[LANGUAGE]/my_placeholder.json */
+  id: string;
+  /** Resolved URL that is localized, ex: my_url/en-GB/my_placeholder.json  */
+  resolvedUrl: string;
+  /** Rendered template associated to the resolved URL, can be dynamic */
+  renderedTemplate?: string;
+  /** Unknown type found in the reply */
+  unknownTypeFound?: boolean;
+
+  /** A mechanism to cache previous request results for a given language. This boolean disables the dynamic rendering when it is set to false */
+  used?: boolean;
+}
+
+/**
+ * PlaceholderRequest state details
+ */
+export interface PlaceholderRequestStateDetails extends AsyncStoreItem {}
+
+/**
+ * PlaceholderRequest store state
+ */
+export interface PlaceholderRequestState extends EntityState<PlaceholderRequestModel>, PlaceholderRequestStateDetails {
+}
+
+/**
+ * Name of the PlaceholderRequest Store
+ */
+export const PLACEHOLDER_REQUEST_STORE_NAME = 'placeholderRequest';
+
+/**
+ * PlaceholderRequest Store Interface
+ */
+export interface PlaceholderRequestStore {
+  /** PlaceholderRequest state */
+  [PLACEHOLDER_REQUEST_STORE_NAME]: PlaceholderRequestState;
+}

--- a/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.sync.ts
+++ b/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.sync.ts
@@ -1,0 +1,23 @@
+import { PlaceholderRequestModel } from './placeholder-request.state';
+import { asyncEntitySerializer, Serializer } from '@o3r/core';
+import { placeholderRequestAdapter, placeholderRequestInitialState } from './placeholder-request.reducer';
+import { PlaceholderRequestState } from './placeholder-request.state';
+
+export const placeholderRequestStorageSerializer = asyncEntitySerializer;
+
+export const placeholderRequestStorageDeserializer = (rawObject: any) => {
+  if (!rawObject || !rawObject.ids) {
+    return placeholderRequestInitialState;
+  }
+  const storeObject = placeholderRequestAdapter.getInitialState(rawObject);
+  for (const id of rawObject.ids) {
+    storeObject.entities[id] = rawObject.entities[id] as PlaceholderRequestModel;
+
+  }
+  return storeObject;
+};
+
+export const placeholderRequestStorageSync: Serializer<PlaceholderRequestState> = {
+  serialize: placeholderRequestStorageSerializer,
+  deserialize: placeholderRequestStorageDeserializer
+};

--- a/packages/@o3r/components/src/stores/placeholder-template/placeholder-template.actions.ts
+++ b/packages/@o3r/components/src/stores/placeholder-template/placeholder-template.actions.ts
@@ -1,25 +1,12 @@
-import { createAction, props } from '@ngrx/store';
-import { asyncProps, AsyncRequest, FailAsyncStoreItemEntitiesActionPayload, FromApiActionPayload, SetAsyncStoreItemEntityActionPayload } from '@o3r/core';
-import { PlaceholderTemplateModel, PlaceholderTemplateReply } from './placeholder-template.state';
+import {createAction, props} from '@ngrx/store';
+import { SetEntityActionPayload} from '@o3r/core';
+import {PlaceholderTemplateModel} from './placeholder-template.state';
 
-const ACTION_CANCEL_REQUEST = '[PlaceholderTemplate] cancel request';
 const ACTION_DELETE_ENTITY = '[PlaceholderTemplate] delete entity';
 const ACTION_SET_ENTITY = '[PlaceholderTemplate] set entity';
-const ACTION_FAIL_ENTITIES = '[PlaceholderTemplate] fail entities';
-const ACTION_UPSERT_ENTITY_FROM_URL = '[PlaceholderTemplate] upsert from url';
-
-/** Action to cancel a Request ID registered in the store. Can happen from effect based on a switchMap for instance */
-export const cancelPlaceholderTemplateRequest = createAction(ACTION_CANCEL_REQUEST, props<AsyncRequest & {id : string}>());
 
 /** Action to delete a specific entity */
-export const deletePlaceholderTemplateEntity = createAction(ACTION_DELETE_ENTITY, asyncProps<FromApiActionPayload<void> & {id : string}>());
+export const deletePlaceholderTemplateEntity = createAction(ACTION_DELETE_ENTITY, props<{ id: string }>());
 
 /** Action to clear all placeholderTemplate and fill the store with the payload */
-export const setPlaceholderTemplateEntity = createAction(ACTION_SET_ENTITY, props<SetAsyncStoreItemEntityActionPayload<PlaceholderTemplateModel>>());
-
-/** Action to update failureStatus for every PlaceholderTemplateModel */
-export const failPlaceholderTemplateEntity = createAction(ACTION_FAIL_ENTITIES, props<FailAsyncStoreItemEntitiesActionPayload<any>>());
-
-/** Action to update placeholderTemplate with known IDs, will create the entity with only the url, the call will be created in the effect */
-export const setPlaceholderTemplateEntityFromUrl =
-  createAction(ACTION_UPSERT_ENTITY_FROM_URL, asyncProps<FromApiActionPayload<PlaceholderTemplateReply> & { id: string; url: string; resolvedUrl: string }>());
+export const setPlaceholderTemplateEntity = createAction(ACTION_SET_ENTITY, props<SetEntityActionPayload<PlaceholderTemplateModel>>());

--- a/packages/@o3r/components/src/stores/placeholder-template/placeholder-template.module.ts
+++ b/packages/@o3r/components/src/stores/placeholder-template/placeholder-template.module.ts
@@ -1,8 +1,8 @@
-import { InjectionToken, ModuleWithProviders, NgModule } from '@angular/core';
-import { Action, ActionReducer, StoreModule } from '@ngrx/store';
+import {InjectionToken, ModuleWithProviders, NgModule} from '@angular/core';
+import {Action, ActionReducer, StoreModule} from '@ngrx/store';
 
-import { placeholderTemplateReducer } from './placeholder-template.reducer';
-import { PLACEHOLDER_TEMPLATE_STORE_NAME, PlaceholderTemplateState } from './placeholder-template.state';
+import {placeholderTemplateReducer} from './placeholder-template.reducer';
+import {PLACEHOLDER_TEMPLATE_STORE_NAME, PlaceholderTemplateState} from './placeholder-template.state';
 
 /** Token of the PlaceholderTemplate reducer */
 export const PLACEHOLDER_TEMPLATE_REDUCER_TOKEN = new InjectionToken<ActionReducer<PlaceholderTemplateState, Action>>('Feature PlaceholderTemplate Reducer');

--- a/packages/@o3r/components/src/stores/placeholder-template/placeholder-template.reducer.spec.ts
+++ b/packages/@o3r/components/src/stores/placeholder-template/placeholder-template.reducer.spec.ts
@@ -1,12 +1,7 @@
 import * as actions from './placeholder-template.actions';
 import {placeholderTemplateInitialState, placeholderTemplateReducer} from './placeholder-template.reducer';
-import {PlaceholderTemplateState} from './placeholder-template.state';
 
 describe('PlaceholderTemplate Store reducer', () => {
-
-  let entitiesState: PlaceholderTemplateState;
-  const firstPlaceholderTemplate: any = {id: 'placeholder1', genericItems: [], vars: {}, requestIds: []};
-  const secondPlaceholderTemplate: any = {id: 'placeholder2', genericItems: [], vars: {}, requestIds: []};
 
   it('should have the correct initial state', () => {
     expect(placeholderTemplateInitialState.ids.length).toBe(0);
@@ -14,93 +9,22 @@ describe('PlaceholderTemplate Store reducer', () => {
 
   it('should by default return the initial state', () => {
     const state = placeholderTemplateReducer(placeholderTemplateInitialState, {type: 'fake'} as any);
-
     expect(state).toEqual(placeholderTemplateInitialState);
   });
+  it('ACTION_DELETE_ENTITY and ACTION_SET_ENTITY actions should work properly', () => {
+    const initialState = placeholderTemplateReducer(placeholderTemplateInitialState, actions.setPlaceholderTemplateEntity({
+      entity: {
+        id: 'o3r-my-placeholder',
+        urlsWithPriority: [
+          {rawUrl: 'www.url1.com/[LANG]', priority: 0},
+          {rawUrl: 'www.url2.com/[LANG]', priority: 1}
+        ]
+      }
+    }));
+    expect(initialState.ids.length).toEqual(1);
+    expect(initialState.entities['o3r-my-placeholder']).toBeDefined();
 
-  describe('Actions on state details', () => {
-    beforeEach(() => {
-      entitiesState = placeholderTemplateReducer(placeholderTemplateInitialState, actions.setPlaceholderTemplateEntityFromUrl({
-        call: Promise.resolve({'template': '<div></div>'}),
-        id: 'placeholder1',
-        url: 'myPlaceholderUrl',
-        resolvedUrl: 'myPlaceholderResolvedUrl'
-      }));
-      entitiesState = placeholderTemplateReducer(entitiesState, actions.setPlaceholderTemplateEntity({entity: firstPlaceholderTemplate}));
-    });
-
-    it('FAIL action should update the isPending to false and the isFailure to true', () => {
-      const state = placeholderTemplateReducer({...placeholderTemplateInitialState, isPending: true}, actions.failPlaceholderTemplateEntity({}));
-
-      expect(state.ids.length).toBe(0);
-      expect(state.isPending).toBe(false);
-      expect(state.isFailure).toBe(true);
-    });
-  });
-
-  describe('Entity actions', () => {
-    it('SET_ENTITY action should not clear current entities', () => {
-      const initialState = placeholderTemplateReducer(placeholderTemplateInitialState, actions.setPlaceholderTemplateEntityFromUrl({
-        call: Promise.resolve({'template': '<div></div>'}),
-        id: 'placeholder1',
-        url: 'myPlaceholderUrl',
-        resolvedUrl: 'myPlaceholderResolvedUrl'
-      }));
-      const firstState = placeholderTemplateReducer(initialState, actions.setPlaceholderTemplateEntity({entity: firstPlaceholderTemplate}));
-      const intermediaryState = placeholderTemplateReducer(firstState, actions.setPlaceholderTemplateEntityFromUrl({
-        call: Promise.resolve({'template': '<div></div>'}),
-        id: 'placeholder2',
-        url: 'myPlaceholderUrl',
-        resolvedUrl: 'myPlaceholderResolvedUrl'
-      }));
-      const secondState = placeholderTemplateReducer(intermediaryState, actions.setPlaceholderTemplateEntity({entity: secondPlaceholderTemplate}));
-
-      expect(secondState.ids.length).toEqual(2);
-      expect((secondState.ids as string[]).find((id) => (id === firstPlaceholderTemplate.id))).toBeDefined();
-      expect((secondState.ids as string[]).find((id) => (id === secondPlaceholderTemplate.id))).toBeDefined();
-    });
-
-    it('FAIL_ENTITY action should update the isPending to false and the isFailure to true', () => {
-      const state = placeholderTemplateReducer({...placeholderTemplateInitialState, isPending: true}, actions.failPlaceholderTemplateEntity({}));
-
-      expect(state.ids.length).toBe(0);
-      expect(state.isPending).toBe(false);
-      expect(state.isFailure).toBe(true);
-    });
-
-    it('FAIL_ENTITIES action should update the global isPending to false in case there are some newIds in the payload', () => {
-      const initialState = placeholderTemplateReducer(placeholderTemplateInitialState, actions.setPlaceholderTemplateEntityFromUrl({
-        call: Promise.resolve({'template': '<div></div>'}),
-        id: 'placeholder1',
-        url: 'myPlaceholderUrl',
-        resolvedUrl: 'myPlaceholderResolvedUrl',
-        requestId: 'id1'
-      }));
-
-      expect(initialState.isPending).toBe(undefined);
-      expect(initialState.isFailure).toBe(undefined);
-      const firstState = placeholderTemplateReducer(initialState, actions.failPlaceholderTemplateEntity({error: 'dummy error', ids: ['placeholder1'], requestId: 'id1'}));
-
-      expect(firstState.isPending).toBe(false);
-      expect(firstState.isFailure).toBe(undefined);
-      expect(firstState.entities.placeholder1.isPending).toBe(false);
-      expect(firstState.entities.placeholder1.isFailure).toBe(true);
-    });
-  });
-
-  describe('API call actions', () => {
-    it('SET_ENTITY_FROM_URL action should clear current entities and set new ones', () => {
-      const firstState = placeholderTemplateReducer(placeholderTemplateInitialState, actions.setPlaceholderTemplateEntityFromUrl({
-        call: Promise.resolve({'template': '<div></div>'}),
-        id: 'placeholder1',
-        url: 'myPlaceholderUrl',
-        resolvedUrl: 'myPlaceholderResolvedUrl',
-        requestId: 'id1'
-      }));
-
-      expect(firstState.entities.placeholder1.isPending).toBe(true);
-      expect(firstState.entities.placeholder1.isFailure).toBe(false);
-    });
-
+    const firstState = placeholderTemplateReducer(placeholderTemplateInitialState, actions.deletePlaceholderTemplateEntity({id:'o3r-my-placeholder'}));
+    expect(firstState.ids.length).toEqual(0);
   });
 });

--- a/packages/@o3r/components/src/stores/placeholder-template/placeholder-template.reducer.ts
+++ b/packages/@o3r/components/src/stores/placeholder-template/placeholder-template.reducer.ts
@@ -1,56 +1,29 @@
-import { createEntityAdapter } from '@ngrx/entity';
-import { ActionCreator, createReducer, on, ReducerTypes } from '@ngrx/store';
-import { asyncStoreItemAdapter, createEntityAsyncRequestAdapter } from '@o3r/core';
+import {createEntityAdapter} from '@ngrx/entity';
+import {ActionCreator, createReducer, on, ReducerTypes} from '@ngrx/store';
 import * as actions from './placeholder-template.actions';
 import {
   PlaceholderTemplateModel,
-  PlaceholderTemplateState,
-  PlaceholderTemplateStateDetails
+  PlaceholderTemplateState
 } from './placeholder-template.state';
 
 /**
  * PlaceholderTemplate Store adapter
  */
-export const placeholderTemplateAdapter = createEntityAsyncRequestAdapter(createEntityAdapter<PlaceholderTemplateModel>({
+export const placeholderTemplateAdapter = createEntityAdapter<PlaceholderTemplateModel>({
   selectId: (model) => model.id
-}));
+});
 
 /**
  * PlaceholderTemplate Store initial value
  */
-export const placeholderTemplateInitialState: PlaceholderTemplateState = placeholderTemplateAdapter.getInitialState<PlaceholderTemplateStateDetails>({
-  requestIds: []
-});
+export const placeholderTemplateInitialState: PlaceholderTemplateState = placeholderTemplateAdapter.getInitialState();
 
 /**
  * List of basic actions for PlaceholderTemplate Store
  */
 export const placeholderTemplateReducerFeatures: ReducerTypes<PlaceholderTemplateState, ActionCreator[]>[] = [
-  on(actions.cancelPlaceholderTemplateRequest, (state, action) => {
-    const id = action.id;
-    if (!id || !state.entities[id]) {
-      return state;
-    }
-    return placeholderTemplateAdapter.updateOne({id: action.id, changes: asyncStoreItemAdapter.resolveRequest(state.entities[id]!, action.requestId)}, state);
-  }),
-  on(actions.setPlaceholderTemplateEntity, (state, payload) => {
-    const placeholderModel = state.entities[payload.entity.id];
-    return placeholderTemplateAdapter.resolveRequestOne(state, {
-      ...placeholderModel,
-      ...payload.entity
-    }, payload.requestId);
-  }),
-  on(actions.setPlaceholderTemplateEntityFromUrl, (state, payload) =>
-    placeholderTemplateAdapter.addRequestOne(placeholderTemplateAdapter.upsertOne(
-      asyncStoreItemAdapter.initialize({
-        id: payload.id,
-        url: payload.url,
-        resolvedUrl: payload.resolvedUrl
-      }), state), payload.id, payload.requestId)
-  ),
-  on(actions.failPlaceholderTemplateEntity, (state, payload) => {
-    return placeholderTemplateAdapter.failRequestMany(asyncStoreItemAdapter.resolveRequest(state, payload.requestId), payload && payload.ids, payload.requestId);
-  }),
+  on(actions.setPlaceholderTemplateEntity, (state, payload) =>
+    placeholderTemplateAdapter.addOne(payload.entity, placeholderTemplateAdapter.removeOne(payload.entity.id, state))),
   on(actions.deletePlaceholderTemplateEntity, (state, payload) => {
     const id = payload.id;
     if (!id || !state.entities[id]) {

--- a/packages/@o3r/components/src/stores/placeholder-template/placeholder-template.selectors.spec.ts
+++ b/packages/@o3r/components/src/stores/placeholder-template/placeholder-template.selectors.spec.ts
@@ -1,23 +1,131 @@
-import { placeholderTemplateInitialState } from './placeholder-template.reducer';
 import * as selectors from './placeholder-template.selectors';
-import { PlaceholderTemplateState } from './placeholder-template.state';
+import {PlaceholderTemplateState} from './placeholder-template.state';
+import {PlaceholderRequestState} from '@o3r/components';
 
-const entity = { id: 'tpl1', url: 'www.google.com', resolvedUrl: 'www.google.com', template: '<span>ok</span>', requestIds: [] as any[], vars: {} };
-const entities = { tpl1: entity };
-const state: PlaceholderTemplateState = { entities, ids: Object.keys(entities), requestIds: [] };
+let placeholderRequestState: PlaceholderRequestState;
+let placeholderTemplateState: PlaceholderTemplateState;
 
-describe('PlaceholderTemplate Selectors tests', () => {
-  it('should provide the pending status of the store', () => {
-    expect(selectors.selectPlaceholderTemplateStorePendingStatus.projector(placeholderTemplateInitialState)).toBeFalsy();
-    expect(selectors.selectPlaceholderTemplateStorePendingStatus.projector({...placeholderTemplateInitialState, isPending: false})).toBe(false);
-    expect(selectors.selectPlaceholderTemplateStorePendingStatus.projector({...placeholderTemplateInitialState, isPending: true})).toBe(true);
+describe('selectPlaceholderRenderedTemplates', () => {
+  beforeEach(()=>{
+    placeholderTemplateState = {
+      ids: [
+        'pl2358lv-2c63-42e1-b450-6aafd91fbae8'
+      ],
+      entities: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'pl2358lv-2c63-42e1-b450-6aafd91fbae8': {
+          id: 'pl2358lv-2c63-42e1-b450-6aafd91fbae8',
+          urlsWithPriority: [
+            {
+              rawUrl: 'assets/placeholders/[LANGUAGE]/searchSecondPlaceholder.json',
+              priority: 1
+            },
+            {
+              rawUrl: 'assets/placeholders/searchPlaceholder.json',
+              priority: 10
+            }
+          ]
+        }
+      }
+    };
+    placeholderRequestState = {
+      requestIds: [],
+      ids: ['assets/placeholders/[LANGUAGE]/searchSecondPlaceholder.json', 'assets/placeholders/searchPlaceholder.json'],
+      entities: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'assets/placeholders/[LANGUAGE]/searchSecondPlaceholder.json': {
+          id: 'assets/placeholders/[LANGUAGE]/searchSecondPlaceholder.json',
+          resolvedUrl: 'assets/placeholders/en-GB/searchSecondPlaceholder.json',
+          used: true,
+          requestIds: [],
+          isFailure: false,
+          isPending: false,
+          vars: {
+            myRelPath: {
+              type: 'relativeUrl',
+              value: 'assets-demo-app/img/logo/logo-positive.png'
+            },
+            pageUrl: {
+              type: 'fact',
+              value: 'pageUrl'
+            }
+          },
+          template: '<div>Placeholder from application pageUrl=<%= pageUrl %></div><img src="<%= myRelPath %>">',
+          renderedTemplate: '<div>Placeholder from application pageUrl=/search</div><img src="assets/assets-demo-app/img/logo/logo-positive.png">',
+          unknownTypeFound: false
+        },
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'assets/placeholders/searchPlaceholder.json': {
+          id: 'assets/placeholders/searchPlaceholder.json',
+          resolvedUrl: 'assets/placeholders/searchPlaceholder.json',
+          used: true,
+          requestIds: [],
+          isFailure: false,
+          isPending: false,
+          vars: {
+            myRelPath: {
+              type: 'relativeUrl',
+              value: 'assets-demo-app/img/logo/logo-positive.png'
+            },
+            pageUrl: {
+              type: 'fact',
+              value: 'pageUrl'
+            }
+          },
+          template: '<div>Placeholder from the library, only default language pageUrl=<%= pageUrl %></div><img src="<%= myRelPath %>">',
+          renderedTemplate: '<div>Placeholder from the library, only default language pageUrl=/search</div><img src="assets/assets-demo-app/img/logo/logo-positive.png">',
+          unknownTypeFound: false
+        }
+      }
+    };
+  });
+  it('should handle undefined state properly', () => {
+    expect(selectors.selectPlaceholderRenderedTemplates('fakeId')({
+      placeholderRequest: undefined,
+      placeholderTemplate: undefined
+    })).toBeUndefined();
+    expect(selectors.selectPlaceholderRenderedTemplates('fakeId')({
+      placeholderRequest: placeholderRequestState,
+      placeholderTemplate: undefined
+    })).toBeUndefined();
+    expect(selectors.selectPlaceholderRenderedTemplates('fakeId')({
+      placeholderRequest: undefined,
+      placeholderTemplate: placeholderTemplateState
+    })).toBeUndefined();
+    expect(selectors.selectPlaceholderRenderedTemplates('fakeId')({
+      placeholderRequest: placeholderRequestState,
+      placeholderTemplate: placeholderTemplateState
+    })).toBeUndefined();
   });
 
-  it('should return undefined if requested ID is not in the state', () => {
-    expect(selectors.selectPlaceholderTemplateEntity.projector(state, { id: 'random' })).toBeUndefined();
+  it('should handle pending status properly', () => {
+    placeholderRequestState.entities['assets/placeholders/[LANGUAGE]/searchSecondPlaceholder.json'].isPending = true;
+    expect(selectors.selectPlaceholderRenderedTemplates('pl2358lv-2c63-42e1-b450-6aafd91fbae8')({
+      placeholderRequest: placeholderRequestState,
+      placeholderTemplate: placeholderTemplateState
+    })).toStrictEqual({orderedRenderedTemplates: undefined, isPending: true});
   });
 
-  it('should return the correct entity if requested ID is in the state', () => {
-    expect(selectors.selectPlaceholderTemplateEntity.projector(state, { id: 'tpl1' })).toEqual(entity);
+  it('should filter items on failure out', () => {
+    placeholderRequestState.entities['assets/placeholders/[LANGUAGE]/searchSecondPlaceholder.json'].isFailure = true;
+    expect(selectors.selectPlaceholderRenderedTemplates('pl2358lv-2c63-42e1-b450-6aafd91fbae8')({
+      placeholderRequest: placeholderRequestState,
+      placeholderTemplate: placeholderTemplateState
+    })?.orderedRenderedTemplates?.length).toBe(1);
+    placeholderRequestState.entities['assets/placeholders/searchPlaceholder.json'].isFailure = true;
+    expect(selectors.selectPlaceholderRenderedTemplates('pl2358lv-2c63-42e1-b450-6aafd91fbae8')({
+      placeholderRequest: placeholderRequestState,
+      placeholderTemplate: placeholderTemplateState
+    })?.orderedRenderedTemplates?.length).toBe(0);
+  });
+
+  it('should return the list of sorted placeholders', () => {
+    const results = selectors.selectPlaceholderRenderedTemplates('pl2358lv-2c63-42e1-b450-6aafd91fbae8')({
+      placeholderRequest: placeholderRequestState,
+      placeholderTemplate: placeholderTemplateState
+    });
+    expect(results?.isPending).toBeFalsy();
+    expect(results?.orderedRenderedTemplates[0]).toContain('Placeholder from the library');
+    expect(results?.orderedRenderedTemplates[1]).toContain('Placeholder from application');
   });
 });

--- a/packages/@o3r/components/src/stores/placeholder-template/placeholder-template.state.ts
+++ b/packages/@o3r/components/src/stores/placeholder-template/placeholder-template.state.ts
@@ -1,45 +1,19 @@
-import { EntityState } from '@ngrx/entity';
-import { AsyncStoreItem } from '@o3r/core';
-
-/**
- * Variable model from the placeholder reply
- */
-export interface PlaceholderVariable {
-  type: 'fact' | 'fullUrl' | 'relativeUrl' | 'localisation';
-  value: string;
-  vars?: string[];
-  path?: string;
-}
-
-/**
- * Response of the call to the placeholder
- */
-export interface PlaceholderTemplateReply {
-  template?: string;
-  vars?: Record<string, PlaceholderVariable>;
-}
+import {EntityState} from '@ngrx/entity';
 
 /**
  * PlaceholderTemplate model
  */
-export interface PlaceholderTemplateModel extends AsyncStoreItem, PlaceholderTemplateReply {
+export interface PlaceholderTemplateModel {
+  /** Placeholder id that is unique*/
   id: string;
-  url: string;
-  resolvedUrl:string;
-  renderedTemplate?: string;
-  unknownTypeFound?: boolean;
-}
-
-/**
- * PlaceholderTemplate state details
- */
-export interface PlaceholderTemplateStateDetails extends AsyncStoreItem {
+  /** Urls to the templates to be fetched, and priority for rendering order */
+  urlsWithPriority: { rawUrl:string; priority: number }[];
 }
 
 /**
  * PlaceholderTemplate store state
  */
-export interface PlaceholderTemplateState extends EntityState<PlaceholderTemplateModel>, PlaceholderTemplateStateDetails {
+export interface PlaceholderTemplateState extends EntityState<PlaceholderTemplateModel> {
 }
 
 /**

--- a/packages/@o3r/components/src/stores/placeholder-template/placeholder-template.sync.ts
+++ b/packages/@o3r/components/src/stores/placeholder-template/placeholder-template.sync.ts
@@ -1,11 +1,6 @@
-import { PlaceholderTemplateModel } from './placeholder-template.state';
-
-
-import { asyncEntitySerializer, Serializer } from '@o3r/core';
-import { placeholderTemplateAdapter, placeholderTemplateInitialState } from './placeholder-template.reducer';
-import { PlaceholderTemplateState } from './placeholder-template.state';
-
-export const placeholderTemplateStorageSerializer = asyncEntitySerializer;
+import {PlaceholderTemplateModel, PlaceholderTemplateState} from './placeholder-template.state';
+import {Serializer} from '@o3r/core';
+import {placeholderTemplateAdapter, placeholderTemplateInitialState} from './placeholder-template.reducer';
 
 export const placeholderTemplateStorageDeserializer = (rawObject: any) => {
   if (!rawObject || !rawObject.ids) {
@@ -20,6 +15,5 @@ export const placeholderTemplateStorageDeserializer = (rawObject: any) => {
 };
 
 export const placeholderTemplateStorageSync: Serializer<PlaceholderTemplateState> = {
-  serialize: placeholderTemplateStorageSerializer,
   deserialize: placeholderTemplateStorageDeserializer
 };

--- a/packages/@o3r/components/src/tools/placeholder/placeholder.component.ts
+++ b/packages/@o3r/components/src/tools/placeholder/placeholder.component.ts
@@ -1,8 +1,16 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
-import { select, Store } from '@ngrx/store';
-import { ReplaySubject, Subscription } from 'rxjs';
-import { distinctUntilChanged, switchMap } from 'rxjs/operators';
-import { PlaceholderTemplateStore, selectPlaceholderTemplateEntity } from '../../stores/placeholder-template';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Input,
+  OnDestroy,
+  OnInit,
+  ViewEncapsulation
+} from '@angular/core';
+import {Store} from '@ngrx/store';
+import {ReplaySubject, Subscription} from 'rxjs';
+import {distinctUntilChanged, switchMap} from 'rxjs/operators';
+import {PlaceholderTemplateStore, selectPlaceholderRenderedTemplates} from '../../stores/placeholder-template';
 
 /**
  * Placeholder component that is bind to the PlaceholderTemplateStore to display a template based on its ID
@@ -44,11 +52,17 @@ export class PlaceholderComponent implements OnInit, OnDestroy {
     this.subscription.add(
       this.id$.pipe(
         distinctUntilChanged(),
-        switchMap((id) => this.store.pipe(select(selectPlaceholderTemplateEntity, {id})))
-      ).subscribe((entity) => {
-        if (entity) {
-          this.isPending = entity.isPending;
-          this.template = entity.renderedTemplate;
+        switchMap((id) => this.store.select(selectPlaceholderRenderedTemplates(id)))
+      ).subscribe((templates) => {
+        if (templates) {
+          this.isPending = templates.isPending;
+          const orderedRenderedTemplates = templates.orderedRenderedTemplates;
+          if (!orderedRenderedTemplates || !orderedRenderedTemplates.length) {
+            this.template = undefined;
+          } else {
+            // Concatenates the list of templates
+            this.template = orderedRenderedTemplates.join('');
+          }
         } else {
           this.isPending = false;
           this.template = undefined;

--- a/packages/@o3r/components/src/tools/placeholder/placeholder.module.ts
+++ b/packages/@o3r/components/src/tools/placeholder/placeholder.module.ts
@@ -3,12 +3,14 @@ import { NgModule } from '@angular/core';
 import { StoreModule } from '@ngrx/store';
 import { PlaceholderTemplateStoreModule } from '../../stores/placeholder-template/index';
 import { PlaceholderComponent } from './placeholder.component';
+import {PlaceholderRequestStoreModule} from '../../stores/placeholder-request/index';
 
 @NgModule({
   imports: [
     CommonModule,
     StoreModule,
-    PlaceholderTemplateStoreModule
+    PlaceholderTemplateStoreModule,
+    PlaceholderRequestStoreModule
   ],
   declarations: [PlaceholderComponent],
   exports: [PlaceholderComponent]

--- a/packages/@o3r/rules-engine/src/fixtures/jest/rules-engine.service.fixture.jest.ts
+++ b/packages/@o3r/rules-engine/src/fixtures/jest/rules-engine.service.fixture.jest.ts
@@ -1,5 +1,5 @@
-import type { PlaceholderTemplateReply } from '@o3r/components';
-import type { Fact, Operator, RulesEngineService, UnaryOperator } from '@o3r/rules-engine';
+import type {Fact, Operator, RulesEngineService, UnaryOperator} from '@o3r/rules-engine';
+import {PlaceholderRequestReply} from '@o3r/components';
 
 export class RulesEngineServiceFixture implements Readonly<Partial<RulesEngineService>> {
 
@@ -13,7 +13,7 @@ export class RulesEngineServiceFixture implements Readonly<Partial<RulesEngineSe
   public resolveUrlWithLang: jest.Mock<string, [string, string]> = jest.fn();
 
   /** @inheritDoc */
-  public retrieveTemplate: jest.Mock<Promise<PlaceholderTemplateReply>, [string]> = jest.fn();
+  public retrieveTemplate: jest.Mock<Promise<PlaceholderRequestReply>, [string]> = jest.fn();
 
   /** @inheritDoc */
   public enableRuleSetFor: jest.Mock<void, [string]> = jest.fn();

--- a/packages/@o3r/rules-engine/src/services/rules-engine.effect.spec.ts
+++ b/packages/@o3r/rules-engine/src/services/rules-engine.effect.spec.ts
@@ -1,14 +1,19 @@
 import {TestBed} from '@angular/core/testing';
 import {provideMockActions} from '@ngrx/effects/testing';
 import {TypedAction} from '@ngrx/store/src/models';
-import {SetAsyncStoreItemEntityActionPayload} from '@o3r/core';
+import {UpdateAsyncStoreItemEntityActionPayloadWithId} from '@o3r/core';
 import {firstValueFrom, of, ReplaySubject, Subject, Subscription} from 'rxjs';
-import {PlaceholderTemplateModel, PlaceholderTemplateReply, setPlaceholderTemplateEntityFromUrl} from '@o3r/components';
+import {
+  PlaceholderRequestModel,
+  PlaceholderRequestReply,
+  setPlaceholderRequestEntityFromUrl
+} from '@o3r/components';
 import {DynamicContentService} from '@o3r/dynamic-content';
 import {LocalizationService} from '@o3r/localization';
 import {shareReplay} from 'rxjs/operators';
 import {RulesEngineService} from './rules-engine.service';
 import {PlaceholderTemplateResponseEffect} from './rules-engine.effect';
+import {Store} from '@ngrx/store';
 
 describe('Rules Engine Effects', () => {
   let effect: PlaceholderTemplateResponseEffect;
@@ -16,6 +21,12 @@ describe('Rules Engine Effects', () => {
   let factsStream: { [key: string]: Subject<any> };
   const translations: { [key: string]: string } = {
     localisationkey: 'This is a test with a { parameter }'
+  };
+  const storeValue = new Subject<any>();
+  const mockStore = {
+    pipe: jest.fn().mockReturnValue(storeValue),
+    dispatch: jest.fn(),
+    select: jest.fn().mockReturnValue(of(true))
   };
 
 
@@ -58,7 +69,8 @@ describe('Rules Engine Effects', () => {
                 )
             )
           }
-        }
+        },
+        {provide: Store, useValue: mockStore}
       ]
     }).compileComponents();
 
@@ -70,8 +82,8 @@ describe('Rules Engine Effects', () => {
   });
 
   it('should resolve vars', async () => {
-    const setPlaceholderEffect$ = effect.setPlaceholderTemplateEntityFromCall$.pipe(shareReplay(1));
-    const response: PlaceholderTemplateReply = {
+    const setPlaceholderEffect$ = effect.setPlaceholderRequestEntityFromUrl$.pipe(shareReplay(1));
+    const response: PlaceholderRequestReply = {
       vars: {
         myRelPath: {
           type: 'relativeUrl',
@@ -94,10 +106,9 @@ describe('Rules Engine Effects', () => {
       },
       template: '<img src=\'<%= myRelPath %>\'> <div><%= test %></div><span><%= factInTemplate %></span>'
     };
-    actions.next(setPlaceholderTemplateEntityFromUrl({
+    actions.next(setPlaceholderRequestEntityFromUrl({
       call: Promise.resolve(response),
-      id: 'placeholder1',
-      url: 'myPlaceholderUrl',
+      id: 'myPlaceholderUrl',
       resolvedUrl: 'myPlaceholderResolvedUrl'
     }));
     factsStream.myFact.next('ignored');
@@ -105,15 +116,15 @@ describe('Rules Engine Effects', () => {
     factsStream.factInTemplate.next({'myKey': 'Outstanding fact'});
 
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    const result = (await firstValueFrom(setPlaceholderEffect$)) as SetAsyncStoreItemEntityActionPayload<PlaceholderTemplateModel>
-      & TypedAction<'[PlaceholderTemplate] set entity'>;
-    expect(result.type).toBe('[PlaceholderTemplate] set entity');
+    const result = (await firstValueFrom(setPlaceholderEffect$)) as UpdateAsyncStoreItemEntityActionPayloadWithId<PlaceholderRequestModel>
+      & TypedAction<'[PlaceholderRequest] update entity'>;
+    expect(result.type).toBe('[PlaceholderRequest] update entity');
     expect(result.entity.renderedTemplate).toBe('<img src=\'fakeUrl\'> <div>This is a test with a success</div><span>Outstanding fact</span>');
     expect(result.entity.unknownTypeFound).toBeFalsy();
   });
 
   it('should notify user some vars have an unknown type', async () => {
-    const setPlaceholderEffect$ = effect.setPlaceholderTemplateEntityFromCall$.pipe(shareReplay(1));
+    const setPlaceholderEffect$ = effect.setPlaceholderRequestEntityFromUrl$.pipe(shareReplay(1));
     const response: any = {
       vars: {
         test: {
@@ -123,16 +134,15 @@ describe('Rules Engine Effects', () => {
       },
       template: '<div><%= test %></div>'
     };
-    actions.next(setPlaceholderTemplateEntityFromUrl({
+    actions.next(setPlaceholderRequestEntityFromUrl({
       call: Promise.resolve(response),
-      id: 'placeholder2',
-      url: 'myPlaceholderUrl',
+      id: 'myPlaceholderUrl',
       resolvedUrl: 'myPlaceholderResolvedUrl2'
     }));
     factsStream.myFact.next('ignored');
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    const result = (await firstValueFrom(setPlaceholderEffect$)) as SetAsyncStoreItemEntityActionPayload<PlaceholderTemplateModel>
-      & TypedAction<'[PlaceholderTemplate] set entity'>;
+    const result = (await firstValueFrom(setPlaceholderEffect$)) as UpdateAsyncStoreItemEntityActionPayloadWithId<PlaceholderRequestModel>
+      & TypedAction<'[PlaceholderRequest] update entity'>;
     expect(result.entity.unknownTypeFound).toBeTruthy();
     expect(result.entity.renderedTemplate).toBe('<div><%= test %></div>');
   });

--- a/packages/@o3r/rules-engine/src/services/rules-engine.effect.ts
+++ b/packages/@o3r/rules-engine/src/services/rules-engine.effect.ts
@@ -1,19 +1,21 @@
 import {Injectable, Optional} from '@angular/core';
 import {Actions, createEffect, ofType} from '@ngrx/effects';
 import {
-  cancelPlaceholderTemplateRequest,
-  deletePlaceholderTemplateEntity,
-  failPlaceholderTemplateEntity, PlaceholderTemplateReply,
+  cancelPlaceholderRequest,
+  failPlaceholderRequestEntity,
+  PlaceholderRequestStore,
   PlaceholderVariable,
-  setPlaceholderTemplateEntity,
-  setPlaceholderTemplateEntityFromUrl
+  selectPlaceholderRequestEntityUsage,
+  setPlaceholderRequestEntityFromUrl,
+  updatePlaceholderRequestEntity
 } from '@o3r/components';
 import {fromApiEffectSwitchMapById} from '@o3r/core';
 import {DynamicContentService} from '@o3r/dynamic-content';
 import {LocalizationService} from '@o3r/localization';
 import {combineLatest, EMPTY, firstValueFrom, Observable, of} from 'rxjs';
-import {map, switchMap, take} from 'rxjs/operators';
+import {distinctUntilChanged, map, switchMap, take} from 'rxjs/operators';
 import {RulesEngineService} from './rules-engine.service';
+import {Store} from '@ngrx/store';
 import {JSONPath} from 'jsonpath-plus';
 
 /**
@@ -21,44 +23,46 @@ import {JSONPath} from 'jsonpath-plus';
  */
 @Injectable()
 export class PlaceholderTemplateResponseEffect {
-
-  public setPlaceholderTemplateEntityFromCall$ = createEffect(() =>
+  /**
+   * Set the PlaceholderRequest entity with the reply content, dispatch failPlaceholderRequestEntity if it catches a failure
+   * Handles the rendering of the HTML content from the template and creates the combine latest from facts list if needed
+   * Disables unused templates refresh if used is false in the store
+   */
+  public setPlaceholderRequestEntityFromUrl$ = createEffect(() =>
     this.actions$.pipe(
-      ofType(setPlaceholderTemplateEntityFromUrl, deletePlaceholderTemplateEntity),
+      ofType(setPlaceholderRequestEntityFromUrl),
       fromApiEffectSwitchMapById(
-        (templateResponse: PlaceholderTemplateReply, action) => {
-          if (action.type === '[PlaceholderTemplate] delete entity') {
-            return EMPTY;
-          }
+        (templateResponse, action) => {
           const facts = templateResponse.vars ? Object.values(templateResponse.vars).filter((variable: PlaceholderVariable) => variable.type === 'fact') : [];
           const factsStreamsList = facts.map((fact) =>
             this.rulesEngineService.engine.retrieveOrCreateFactStream(fact.value).pipe(map((factValue) => ({
               name: fact.value, factValue
             }))));
-          return (factsStreamsList.length ? combineLatest(factsStreamsList) : of([])).pipe(
-            switchMap((allFacts) => {
-              return this.getRenderedHTML$(templateResponse.template, templateResponse.vars, allFacts).pipe(
-                map(({renderedTemplate, unknownTypeFound}) => setPlaceholderTemplateEntity({
-                  entity: {
-                    ...templateResponse,
-                    resolvedUrl: action.resolvedUrl,
-                    id: action.id,
-                    url: action.url,
-                    requestIds: [action.requestId],
-                    renderedTemplate,
-                    unknownTypeFound
-                  },
-                  requestId: action.requestId
-                }))
+          const factsStreamsList$ = factsStreamsList.length ? combineLatest(factsStreamsList) : of([]);
+          return combineLatest([factsStreamsList$, this.store.select(selectPlaceholderRequestEntityUsage(action.id)).pipe(distinctUntilChanged())]).pipe(
+            switchMap(([factsUsedInTemplate, placeholderRequestUsage]) => {
+              if (!placeholderRequestUsage) {
+                return EMPTY;
+              }
+              return this.getRenderedHTML$(templateResponse.template, templateResponse.vars, factsUsedInTemplate).pipe(
+                map(({renderedTemplate, unknownTypeFound}) =>
+                  // Update instead of set because used already set by the update from url action
+                  updatePlaceholderRequestEntity({
+                    entity: {
+                      ...templateResponse,
+                      resolvedUrl: action.resolvedUrl,
+                      id: action.id,
+                      renderedTemplate,
+                      unknownTypeFound
+                    },
+                    requestId: action.requestId
+                  })
+                )
               );
             }));
         },
-        ((error, action) => of(failPlaceholderTemplateEntity({
-          ids: [action.id],
-          error: error,
-          requestId: action.requestId
-        }))),
-        (requestIdPayload, action) => cancelPlaceholderTemplateRequest({...requestIdPayload, id: action.id})
+        (error, action) => of(failPlaceholderRequestEntity({ids: [action.id], error, requestId: action.requestId})),
+        (requestIdPayload, action) => cancelPlaceholderRequest({...requestIdPayload, id: action.id})
       )
     )
   );
@@ -67,6 +71,7 @@ export class PlaceholderTemplateResponseEffect {
     private actions$: Actions,
     private rulesEngineService: RulesEngineService,
     private dynamicContentService: DynamicContentService,
+    private store: Store<PlaceholderRequestStore>,
     @Optional() private translationService?: LocalizationService) {
   }
 

--- a/packages/@o3r/rules-engine/src/services/rules-engine.service.ts
+++ b/packages/@o3r/rules-engine/src/services/rules-engine.service.ts
@@ -1,25 +1,28 @@
-import { Inject, Injectable, OnDestroy, Optional } from '@angular/core';
-import { select, Store } from '@ngrx/store';
-import { TranslateService } from '@ngx-translate/core';
-import type { PlaceholderTemplateStore } from '@o3r/components';
-import { deletePlaceholderTemplateEntity, PlaceholderTemplateReply, selectPlaceholderTemplateEntities, setPlaceholderTemplateEntityFromUrl } from '@o3r/components';
-import { computeConfigurationName, PropertyOverride, setConfigOverride } from '@o3r/configuration';
-import type { ConfigOverrideStore } from '@o3r/configuration';
-import { AssetPathOverrideStore, DynamicContentService, setAssetPathOverride } from '@o3r/dynamic-content';
-import type { LocalizationOverrideStore } from '@o3r/localization';
-import { setLocalizationOverride } from '@o3r/localization';
-import { BehaviorSubject, combineLatest, firstValueFrom, Observable, Subject, Subscription } from 'rxjs';
-import { distinctUntilChanged, filter, map, shareReplay, switchMap, withLatestFrom } from 'rxjs/operators';
-import type { ActionBlock, Fact, Operator, Ruleset, UnaryOperator } from '../engine/index';
-import { EngineDebugger, operatorList, RulesEngine } from '../engine/index';
-import { ActionOverrideBlock } from '../interfaces/index';
+import {Inject, Injectable, OnDestroy, Optional} from '@angular/core';
+import {select, Store} from '@ngrx/store';
+import {TranslateService} from '@ngx-translate/core';
+import type { PlaceholderRequestReply, PlaceholderTemplateStore } from '@o3r/components';
 import {
-  RulesetsStore,
-  selectActiveRuleSets,
-  selectAllRulesets,
-  selectRuleSetLinkComponents
-} from '../stores';
-import { RULES_ENGINE_OPTIONS, RulesEngineServiceOptions } from './rules-engine.token';
+  deletePlaceholderTemplateEntity,
+  selectPlaceholderRequestEntities,
+  selectPlaceholderTemplateEntities,
+  setPlaceholderRequestEntityFromUrl,
+  setPlaceholderTemplateEntity,
+  updatePlaceholderRequestEntity
+} from '@o3r/components';
+import {computeConfigurationName, setConfigOverride} from '@o3r/configuration';
+import type { ConfigOverrideStore, PropertyOverride } from '@o3r/configuration';
+import {AssetPathOverrideStore, DynamicContentService, setAssetPathOverride} from '@o3r/dynamic-content';
+import type { LocalizationOverrideStore } from '@o3r/localization';
+import {setLocalizationOverride} from '@o3r/localization';
+import {BehaviorSubject, combineLatest, firstValueFrom, Observable, Subject, Subscription} from 'rxjs';
+import {distinctUntilChanged, filter, map, shareReplay, switchMap, withLatestFrom} from 'rxjs/operators';
+import type {ActionBlock, Fact, Operator, Ruleset, UnaryOperator} from '../engine/index';
+import {EngineDebugger, operatorList, RulesEngine} from '../engine/index';
+import type {ActionOverrideBlock} from '../interfaces/index';
+import type {RulesetsStore} from '../stores';
+import {selectActiveRuleSets, selectAllRulesets, selectRuleSetLinkComponents} from '../stores';
+import {RULES_ENGINE_OPTIONS, RulesEngineServiceOptions} from './rules-engine.token';
 import {LoggerService} from '@o3r/logger';
 
 @Injectable()
@@ -43,7 +46,7 @@ export class RulesEngineService implements OnDestroy {
 
   protected linkedComponents$: BehaviorSubject<{ [key: string]: number }> = new BehaviorSubject({});
 
-  protected placeholdersActions$: Subject<{ placeholderId: string; templateUrl: string }[]> = new Subject();
+  protected placeholdersActions$: Subject<{ placeholderId: string; templateUrl: string; priority: number }[]> = new Subject();
 
   constructor(
     private store: Store<RulesetsStore & PlaceholderTemplateStore & AssetPathOverrideStore & LocalizationOverrideStore & ConfigOverrideStore>,
@@ -53,7 +56,10 @@ export class RulesEngineService implements OnDestroy {
     @Optional() @Inject(RULES_ENGINE_OPTIONS) engineConfig?: RulesEngineServiceOptions) {
 
     this.enabled = !engineConfig?.dryRun;
-    this.engine = new RulesEngine({debugger: engineConfig?.debug ? new EngineDebugger({eventsStackLimit: engineConfig?.debugEventsStackLimit}) : undefined, logger: this.logger});
+    this.engine = new RulesEngine({
+      debugger: engineConfig?.debug ? new EngineDebugger({eventsStackLimit: engineConfig?.debugEventsStackLimit}) : undefined,
+      logger: this.logger
+    });
     this.ruleSets$ = combineLatest([
       this.store.pipe(select(selectActiveRuleSets)),
       this.linkedComponents$.pipe(
@@ -92,44 +98,99 @@ export class RulesEngineService implements OnDestroy {
       map(({lang}) => lang),
       distinctUntilChanged()
     );
-    // Will prevent double instant emission
-    const filteredActions$ = combineLatest([lang$, this.placeholdersActions$]).pipe(
-      withLatestFrom(this.store.pipe(select(selectPlaceholderTemplateEntities))),
-      map(([langAndTemplatesUrls, storedPlaceholders]) => {
+    // TODO Check if distinctUntilChanged is a good idea
+    // DistinctUntilChanged will prevent double instant emission (second processed before first reach the store)
+    const filteredActions$ = combineLatest([lang$, this.placeholdersActions$.pipe(distinctUntilChanged((prev, next) => JSON.stringify(prev) === JSON.stringify(next)))]).pipe(
+      withLatestFrom(
+        combineLatest([this.store.pipe(select(selectPlaceholderTemplateEntities)), this.store.pipe(select(selectPlaceholderRequestEntities))])
+      ),
+      map(([langAndTemplatesUrls, storedPlaceholdersAndRequests]) => {
         const [lang, placeholderActions] = langAndTemplatesUrls;
-        const storedPlaceholdersDefined = storedPlaceholders || {};
+        const storedPlaceholders = storedPlaceholdersAndRequests[0] || {};
+        const storedPlaceholderRequests = storedPlaceholdersAndRequests[1] || {};
+        const placeholderNewRequests: { rawUrl: string; resolvedUrl: string }[] = [];
+        // Stores all raw Urls used from the current engine execution
+        const usedUrls = {};
+        // Get all Urls that needs to be resolved from current rules engine output
+        const placeholdersTemplates = placeholderActions.reduce((acc, placeholderAction) => {
+          const placeholdersTemplateUrl = {
+            rawUrl: placeholderAction.templateUrl,
+            priority: placeholderAction.priority
+          };
+          if (acc[placeholderAction.placeholderId]) {
+            acc[placeholderAction.placeholderId].push(placeholdersTemplateUrl);
+          } else {
+            acc[placeholderAction.placeholderId] = [placeholdersTemplateUrl];
+          }
+          const resolvedUrl = this.resolveUrlWithLang(placeholderAction.templateUrl, lang);
+          // Filters duplicates and resolved urls that are already in the store
+          if (!usedUrls[placeholderAction.templateUrl] && (!storedPlaceholderRequests[placeholderAction.templateUrl]
+            || storedPlaceholderRequests[placeholderAction.templateUrl]!.resolvedUrl !== resolvedUrl)) {
+            placeholderNewRequests.push({
+              rawUrl: placeholderAction.templateUrl,
+              resolvedUrl: this.resolveUrlWithLang(placeholderAction.templateUrl, lang)
+            });
+          }
+          usedUrls[placeholderAction.templateUrl] = true;
+          return acc;
+        }, {} as { [key: string]: { rawUrl: string; priority: number }[] });
+        // Urls not used anymore and not already disabled
+        const placeholderRequestsToDisable: string[] = [];
+        // Urls used that were disabled
+        const placeholderRequestsToEnable: string[] = [];
+        Object.keys(storedPlaceholderRequests).forEach((storedPlaceholderRequestRawUrl) => {
+          const usedFromEngineIteration = usedUrls[storedPlaceholderRequestRawUrl];
+          const usedFromStore = (storedPlaceholderRequests && storedPlaceholderRequests[storedPlaceholderRequestRawUrl]) ? storedPlaceholderRequests[storedPlaceholderRequestRawUrl]!.used : false;
+          if (!usedFromEngineIteration && usedFromStore) {
+            placeholderRequestsToDisable.push(storedPlaceholderRequestRawUrl);
+          } else if (usedFromEngineIteration && !usedFromStore) {
+            placeholderRequestsToEnable.push(storedPlaceholderRequestRawUrl);
+          }
+        });
         // Placeholder that are no longer filled by the current engine execution output will be cleared
-        const placeholdersIdsToBeCleanedUp = Object.keys(storedPlaceholdersDefined)
-          .filter(placeholderId => !placeholderActions.find(placeholderAction => placeholderAction.placeholderId === placeholderId));
-        // Filters out the placeholders that have the same Url in the store than the current execution
-        // Actions that need to be cleaned up will be added as well, with an empty string as Url
-        const placeholdersToBeSet = placeholderActions
-          .map((placeholderAction) => {
-            return {...placeholderAction, resolvedUrl: this.resolveUrlWithLang(placeholderAction.templateUrl, lang)};
-          })
-          .filter((placeholderAction) => {
-            if (!storedPlaceholdersDefined[placeholderAction.placeholderId]) {
-              return true;
-            }
-            return storedPlaceholdersDefined[placeholderAction.placeholderId]!.resolvedUrl !== placeholderAction.resolvedUrl;
-          });
-        // ex: { toSet: [{placeholderId: 'id1', templateUrl: '...'}], toClean: ['id2'] }
-        return {toSet: placeholdersToBeSet, toClean: placeholdersIdsToBeCleanedUp};
+        const placeholdersTemplatesToBeCleanedUp = Object.keys(storedPlaceholders)
+          .filter(placeholderId => !placeholdersTemplates[placeholderId]);
+
+        const placeholdersTemplatesToBeSet = Object.keys(placeholdersTemplates).reduce((changedPlaceholderTemplates, placeholderTemplateId) => {
+          // Caching if the placeholder template already exists with the same urls
+          if (!storedPlaceholders[placeholderTemplateId] ||
+            !(JSON.stringify(storedPlaceholders[placeholderTemplateId]!.urlsWithPriority) === JSON.stringify(placeholdersTemplates[placeholderTemplateId]))) {
+            changedPlaceholderTemplates.push({
+              id: placeholderTemplateId,
+              urlsWithPriority: placeholdersTemplates[placeholderTemplateId]
+            });
+          }
+          return changedPlaceholderTemplates;
+        }, [] as { id: string; urlsWithPriority: { rawUrl: string; priority: number }[] }[]);
+        return {
+          placeholdersTemplatesToBeCleanedUp,
+          placeholderRequestsToDisable,
+          placeholderRequestsToEnable,
+          placeholdersTemplatesToBeSet,
+          placeholderNewRequests
+        };
       })
     );
     this.subscription.add(filteredActions$.subscribe((placeholdersUpdates) => {
-      placeholdersUpdates.toClean.forEach(placeholderId =>
+      placeholdersUpdates.placeholdersTemplatesToBeCleanedUp.forEach(placeholderId =>
         this.store.dispatch(deletePlaceholderTemplateEntity({
-          call: Promise.resolve(),
           id: placeholderId
         }))
       );
-      placeholdersUpdates.toSet.forEach(placeholderUpdate => {
-        this.store.dispatch(setPlaceholderTemplateEntityFromUrl({
-          call: this.retrieveTemplate(placeholderUpdate.resolvedUrl),
-          id: placeholderUpdate.placeholderId,
-          resolvedUrl: placeholderUpdate.resolvedUrl,
-          url: placeholderUpdate.templateUrl
+      placeholdersUpdates.placeholdersTemplatesToBeSet.forEach(placeholdersTemplateToBeSet => {
+        this.store.dispatch(setPlaceholderTemplateEntity({entity: placeholdersTemplateToBeSet}));
+      });
+      placeholdersUpdates.placeholderRequestsToDisable.forEach(placeholderRequestToDisable => {
+        this.store.dispatch(updatePlaceholderRequestEntity({entity: {id: placeholderRequestToDisable, used: false}}));
+      });
+      placeholdersUpdates.placeholderRequestsToEnable.forEach(placeholderRequestToEnable => {
+        this.store.dispatch(updatePlaceholderRequestEntity({entity: {id: placeholderRequestToEnable, used: true}}));
+      });
+      placeholdersUpdates.placeholderNewRequests.forEach(placeholderNewRequest => {
+        this.store.dispatch(setPlaceholderRequestEntityFromUrl({
+          resolvedUrl: placeholderNewRequest.resolvedUrl,
+          id: placeholderNewRequest.rawUrl,
+          call: this.retrieveTemplate(placeholderNewRequest.resolvedUrl)
         }));
       });
     }));
@@ -145,7 +206,7 @@ export class RulesEngineService implements OnDestroy {
     const configOverrides: { library: string; component: string; property: string; value: any }[] = [];
     const assets: Record<string, string> = {};
     const locs: Record<string, string> = {};
-    const templates: { placeholderId: string; templateUrl: string }[] = [];
+    const templates: { placeholderId: string; templateUrl: string; priority: number }[] = [];
 
     // create a map of actions depending on actions type
     actions.forEach((action: (ActionBlock & Record<string, any>)) => {
@@ -170,7 +231,11 @@ export class RulesEngineService implements OnDestroy {
           break;
         }
         case 'UPDATE_PLACEHOLDER': {
-          templates.push({placeholderId: action.placeholderId, templateUrl: action.value});
+          templates.push({
+            placeholderId: action.placeholderId,
+            templateUrl: action.value,
+            priority: action.priority || 0
+          });
           break;
         }
         default: {
@@ -223,7 +288,7 @@ export class RulesEngineService implements OnDestroy {
   /**
    * Enable temporary a rule set
    *
-   * @param componentComputedName Name of the component to active the ruleset for
+   * @param componentComputedName Name of the component to enable the ruleset for
    */
   public enableRuleSetFor(componentComputedName: string) {
     const newMap = this.linkedComponents$.value;
@@ -234,7 +299,7 @@ export class RulesEngineService implements OnDestroy {
   /**
    * Disable temporary a rule set
    *
-   * @param componentComputedName Name of the component to inactive the ruleset for
+   * @param componentComputedName Name of the component to disable the ruleset for
    */
   public disableRuleSetFor(componentComputedName: string) {
     const newMap = this.linkedComponents$.value;
@@ -259,7 +324,7 @@ export class RulesEngineService implements OnDestroy {
    *
    * @param url
    */
-  public async retrieveTemplate(url: string): Promise<PlaceholderTemplateReply> {
+  public async retrieveTemplate(url: string): Promise<PlaceholderRequestReply> {
     const fullUrl = await firstValueFrom(this.dynamicContentService.getContentPathStream(url));
     return fetch(fullUrl).then((response) => response.json());
   }


### PR DESCRIPTION
__Previous Behavior__:
Today the current placeholder mechanism only allow to fetch a single URL to retrieve and display the template.
A common usage is to set an action as a result of a rule, and the RulesEngineService will trigger an action on the placeholder store.
The store contains a 1-1 mapping between placeholderId and url, and the fetch of the url + the rendering of the template is handled by the PlaceholderTemplateResponseEffect. The rendered template is set in the store, and is retrieved by the PlaceholderComponent that watch for a specific placeholderId.

__Issue__:
The issue with the current behavior is that as soon as we want to display a second message in the same placeholder, it forces to create a new template containing the 2 messages, and a a third one containing only the second messages, and have it driven by rules.
This doesn't scale much.

__Proposal__:
This pull request decorelates the mapping between placeholder and urls from the url resolve and render.
We have now the PlaceholderTemplate store that stores a mapping between placeholderId and associated Urls (as strings).
The new PlaceholderRequest store will handle the call to the Url, and with the effect the computation and rendering of the response template.
There is now a single selector from PlaceholderTemplate store that allow to get the list of rendered tempates for a given placeholderId : selectPlaceholderRenderedTemplates.
The result will be pending as long as one template is still pending (to prevent UI consecutive refresh adding a new part in the placeholder), but the ones in failure will just be filtered out of the result list.