### PR TITLE
feat: add cache for yarn for test-app on it tests

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -21,6 +21,18 @@ jobs:
       - uses: ./.github/actions/setup-java
         with:
           install-jdk: 'true'
+      - name: Get current month to build the cache key
+        run: echo "currentMonth=$(date +'%Y-%m')" >> $GITHUB_ENV
+        shell: bash
+      - name: Cache test-app yarn
+        uses: actions/cache@v3
+        with:
+          path: |
+            .cache/test-app
+            !.cache/test-app/v6/npm-@ama-sdk*
+            !.cache/test-app/v6/npm-@ama-terasu*
+            !.cache/test-app/v6/npm-@o3r*
+          key: ${{ runner.os }}-test-app-${{ env.currentMonth }}
       - name: Test
         run: yarn test-int
       - name: Prepare for publish generated app

--- a/packages/@o3r/core/schematics/index.it.spec.ts
+++ b/packages/@o3r/core/schematics/index.it.spec.ts
@@ -78,6 +78,7 @@ function setupNewApp() {
     execSync(`yarn config set npmScopes.o3r.npmRegistryServer ${registry}`, execAppOptions);
     execSync('yarn config set unsafeHttpWhitelist localhost', execAppOptions);
     execSync('yarn set version 1.22.19', execAppOptions);
+    execSync(`yarn config set cache-folder ${path.join(currentFolder, '.cache', 'test-app')}`, execAppOptions);
     execSync('yarn', execAppOptions);
 
     // Run ng add


### PR DESCRIPTION
Persist the cache generated by yarn on the install of the test-app generated by the it tests
The cache should be created once per month and the same instance should be reused by all the build