### PR TITLE
fix: rules engine devtools service in root; logger service clients calls

### DIFF
--- a/packages/@o3r/logger/src/services/logger/logger.service.ts
+++ b/packages/@o3r/logger/src/services/logger/logger.service.ts
@@ -101,7 +101,7 @@ export class LoggerService implements Logger {
    * @param optionalParams
    */
   public info(message?: any, ...optionalParams: any[]): void {
-    this.clients.forEach((client) => (client.info ? client.info : client.log)(message, ...optionalParams));
+    this.clients.forEach((client) => (client.info ? client.info(message, ...optionalParams) : client.log(message, ...optionalParams)));
   }
 
   /**

--- a/packages/@o3r/rules-engine/src/devkit/rules-engine-devtools.module.ts
+++ b/packages/@o3r/rules-engine/src/devkit/rules-engine-devtools.module.ts
@@ -4,7 +4,6 @@ import { RulesetsStoreModule } from '../stores/index';
 import type { RulesEngineDevtoolsServiceOptions } from './rules-engine-devkit.interface';
 import { RulesEngineDevtoolsConsoleService } from './rules-engine-devtools.console.service';
 import { RulesEngineDevtoolsMessageService } from './rules-engine-devtools.message.service';
-import { OtterRulesEngineDevtools } from './rules-engine-devtools.service';
 import { OTTER_RULES_ENGINE_DEVTOOLS_DEFAULT_OPTIONS, OTTER_RULES_ENGINE_DEVTOOLS_OPTIONS } from './rules-engine-devtools.token';
 
 @NgModule({
@@ -15,8 +14,7 @@ import { OTTER_RULES_ENGINE_DEVTOOLS_DEFAULT_OPTIONS, OTTER_RULES_ENGINE_DEVTOOL
   providers: [
     { provide: OTTER_RULES_ENGINE_DEVTOOLS_OPTIONS, useValue: OTTER_RULES_ENGINE_DEVTOOLS_DEFAULT_OPTIONS },
     RulesEngineDevtoolsMessageService,
-    RulesEngineDevtoolsConsoleService,
-    OtterRulesEngineDevtools
+    RulesEngineDevtoolsConsoleService
   ]
 })
 export class RulesEngineDevtoolsModule {
@@ -32,8 +30,7 @@ export class RulesEngineDevtoolsModule {
       providers: [
         { provide: OTTER_RULES_ENGINE_DEVTOOLS_OPTIONS, useValue: {...OTTER_RULES_ENGINE_DEVTOOLS_DEFAULT_OPTIONS, ...options}, multi: false },
         RulesEngineDevtoolsMessageService,
-        RulesEngineDevtoolsConsoleService,
-        OtterRulesEngineDevtools
+        RulesEngineDevtoolsConsoleService
       ]
     };
   }

--- a/packages/@o3r/rules-engine/src/devkit/rules-engine-devtools.service.ts
+++ b/packages/@o3r/rules-engine/src/devkit/rules-engine-devtools.service.ts
@@ -8,7 +8,9 @@ import { RulesetsStore, selectRulesetsEntities } from '../stores';
 import { RulesEngineDevtoolsServiceOptions } from './rules-engine-devkit.interface';
 import { OTTER_RULES_ENGINE_DEVTOOLS_DEFAULT_OPTIONS, OTTER_RULES_ENGINE_DEVTOOLS_OPTIONS } from './rules-engine-devtools.token';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class OtterRulesEngineDevtools {
 
   /** Stream of rules engine report */


### PR DESCRIPTION
provide rules engine devtools service in root to have one instance in app root and lazy loaded features
