### PR TITLE
fix: sanitize component type

### DIFF
--- a/packages/@o3r/components/builders/component-extractor/helpers/component/component-class.extractor.ts
+++ b/packages/@o3r/components/builders/component-extractor/helpers/component/component-class.extractor.ts
@@ -100,8 +100,23 @@ export class ComponentClassExtractor {
     }
   }
 
+  /**
+   * Sanitize component type by removing extra quotes
+   * Example: "'Page'" becomes 'Page'
+   *
+   * @param type
+   * @private
+   */
+  private sanitizeComponentType(type: string | undefined) {
+    if (!type) {
+      return;
+    }
+    return type.replaceAll(/['"]/g, '');
+  }
+
   private getComponentStructure(type: string | undefined): ComponentStructure {
-    switch (type) {
+    const sanitizedType = this.sanitizeComponentType(type);
+    switch (sanitizedType) {
       case 'Block':
         return 'BLOCK';
       case 'Page':


### PR DESCRIPTION
Issue:
When migrating to O3rComponent, getComponentType function calls getComponentStructure with the type surrounded by extra quotes (ex: "'Page'"). That results in defaulting to COMPONENT type.

The goal of the fix is to sanitize the extracted type, to have getComponentStructure working as expected.