### PR TITLE
fix: jasmine fixtures wrong import type

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -152,8 +152,8 @@
         "jest-fixtures"
       ],
       "outputs": [
-        "{projectRoot}/dist/**/fixtures/jasmine",
-        "{projectRoot}/dist/**/fixtures/jest"
+        "{projectRoot}/dist/fixtures/jasmine",
+        "{projectRoot}/dist/fixtures/jest"
       ],
       "dependsOn": [
         "build-fixtures-jasmine",
@@ -165,7 +165,7 @@
         "jasmine-fixtures"
       ],
       "outputs": [
-        "{projectRoot}/dist/**/fixtures/jasmine"
+        "{projectRoot}/dist/fixtures/jasmine"
       ],
       "dependsOn": [
         "compile"
@@ -176,7 +176,7 @@
         "jest-fixtures"
       ],
       "outputs": [
-        "{projectRoot}/dist/**/fixtures/jest"
+        "{projectRoot}/dist/fixtures/jest"
       ],
       "dependsOn": [
         "compile"


### PR DESCRIPTION
**Description**:
Since build-fixtures-jasmine output parameter was wrongly set, nx was only considering the output of compile task (which contain the issue with double import type jasmine and jest) and not the jasmine fixture task which is meant to replace the files generated by the compile task with jasmine specific tsconfig to have only the right import type.