### PR TITLE
feat: support jsonPath in placeholders

### DIFF
--- a/packages/@o3r/components/src/stores/placeholder-template/placeholder-template.state.ts
+++ b/packages/@o3r/components/src/stores/placeholder-template/placeholder-template.state.ts
@@ -8,6 +8,7 @@ export interface PlaceholderVariable {
   type: 'fact' | 'fullUrl' | 'relativeUrl' | 'localisation';
   value: string;
   vars?: string[];
+  path?: string;
 }
 
 /**

--- a/packages/@o3r/rules-engine/src/services/rules-engine.effect.spec.ts
+++ b/packages/@o3r/rules-engine/src/services/rules-engine.effect.spec.ts
@@ -88,7 +88,8 @@ describe('Rules Engine Effects', () => {
         },
         factInTemplate: {
           type: 'fact',
-          value: 'factInTemplate'
+          value: 'factInTemplate',
+          path: '$.myKey'
         }
       },
       template: '<img src=\'<%= myRelPath %>\'> <div><%= test %></div><span><%= factInTemplate %></span>'
@@ -101,7 +102,7 @@ describe('Rules Engine Effects', () => {
     }));
     factsStream.myFact.next('ignored');
     factsStream.parameter.next('success');
-    factsStream.factInTemplate.next('Outstanding fact');
+    factsStream.factInTemplate.next({'myKey': 'Outstanding fact'});
 
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const result = (await firstValueFrom(setPlaceholderEffect$)) as SetAsyncStoreItemEntityActionPayload<PlaceholderTemplateModel>

--- a/packages/@o3r/rules-engine/src/services/rules-engine.effect.ts
+++ b/packages/@o3r/rules-engine/src/services/rules-engine.effect.ts
@@ -14,6 +14,7 @@ import {LocalizationService} from '@o3r/localization';
 import {combineLatest, EMPTY, firstValueFrom, Observable, of} from 'rxjs';
 import {map, switchMap, take} from 'rxjs/operators';
 import {RulesEngineService} from './rules-engine.service';
+import {JSONPath} from 'jsonpath-plus';
 
 /**
  * Service to handle async PlaceholderTemplate actions
@@ -102,7 +103,10 @@ export class PlaceholderTemplateResponseEffect {
               break;
             }
             case 'fact': {
-              template = template.replace(ejsVar, factset[vars[varName].value] || '');
+              const factValue = factset[vars[varName].value] || '';
+              // eslint-disable-next-line new-cap
+              const resolvedFactValue = vars[varName].path ? factValue && JSONPath({wrap: false, json: factValue, path: vars[varName].path!}) : factValue;
+              template = template.replace(ejsVar, resolvedFactValue);
               break;
             }
             case 'localisation': {


### PR DESCRIPTION
Today the placeholder supports facts variables : 
```
{
  "template": "<p>My fact : <%= myFact %>",
  "vars": {
    "myFact ": {
      "value": "myFact ",
      "type": "fact"
    }
  }
}
```
The goal is to add support to an optional field, path, that will be used as a json path to extract a slice of a complex object:
```
{
  "template": "<p>My cart data : <%= cart %>",
  "vars": {
    "cart": {
      "value": "cart",
      "type": "fact",
      "path": "$.airOffers[*].offerItems[*].air.bounds[*].destinationLocation.countryCode"
    }
  }
}
```
