### PR TITLE
fix(dev-tools): remove pcloudy bin from dev-tools package

### DIFF
--- a/packages/@o3r/dev-tools/package.json
+++ b/packages/@o3r/dev-tools/package.json
@@ -22,7 +22,6 @@
     "git-release-management": "./dist/src/cli/git-release-management.js",
     "in-source-dep-check": "./dist/src/cli/checks/in-source-dep-check.js",
     "package-export": "./dist/src/cli/package-export.js",
-    "pcloudy": "./dist/src/cli/pcloudy.connection.js",
     "peer-dependencies-updater": "./dist/src/cli/peer-dependencies-updater.js",
     "pr-artifact-cleaner": "./dist/src/cli/pr-artifact-cleaner.js",
     "set-version": "./dist/src/cli/set-version.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6265,7 +6265,6 @@ __metadata:
     git-release-management: ./dist/src/cli/git-release-management.js
     in-source-dep-check: ./dist/src/cli/checks/in-source-dep-check.js
     package-export: ./dist/src/cli/package-export.js
-    pcloudy: ./dist/src/cli/pcloudy.connection.js
     peer-dependencies-updater: ./dist/src/cli/peer-dependencies-updater.js
     pr-artifact-cleaner: ./dist/src/cli/pr-artifact-cleaner.js
     set-version: ./dist/src/cli/set-version.js


### PR DESCRIPTION
The `src/cli/pcloudy.connection.js` CLI does not exist on `@o3r/dev-tools` package, only on `@o3r/mobile` one. This bin has to be removed.