### PR TITLE
fix: reduce logging in unit test

### DIFF
--- a/packages/@o3r/localization/src/tools/localization.service.ts
+++ b/packages/@o3r/localization/src/tools/localization.service.ts
@@ -63,7 +63,9 @@ export class LocalizationService {
         closestSupportedLanguageCode && ' closest supported language ' ||
         this.configuration.fallbackLanguage && ' configured default language ';
       const fallbackLang = fallbackForLanguage || closestSupportedLanguageCode || this.configuration.fallbackLanguage || language;
-      this.logger.debug(`Non supported languages ${language} will fallback to ${fallbackStrategyDebug} ${fallbackLang}`);
+      if (language !== fallbackLang) {
+        this.logger.debug(`Non supported languages ${language} will fallback to ${fallbackStrategyDebug} ${fallbackLang}`);
+      }
       return fallbackLang;
     } else if (!language) {
       this.logger.debug('Language is not defined');

--- a/packages/@o3r/testing/src/localization/localization-mock.ts
+++ b/packages/@o3r/testing/src/localization/localization-mock.ts
@@ -4,7 +4,7 @@ import { LocalizationConfiguration, LocalizationModule, LocalizationTranslatePip
 import { of } from 'rxjs';
 
 const defaultLocalizationConfiguration: Partial<LocalizationConfiguration> = {
-  supportedLocales: [],
+  supportedLocales: ['en'],
   language: 'en',
   endPointUrl: '',
   fallbackLanguage: 'en'


### PR DESCRIPTION
When using our default localization configuration, the supported language list is empty with english as a fallback language

We should not log messages in the case the requested language match the fallback

We should also count english as a supported language not to systematically compute the fallback language when requesting it