### PR TITLE
fix: simple auth plugin - change office ID override parameter name

### DIFF
--- a/packages/@ama-sdk/core/src/plugins/simple-api-key-authentication/simple-api-key-authentication.request.ts
+++ b/packages/@ama-sdk/core/src/plugins/simple-api-key-authentication/simple-api-key-authentication.request.ts
@@ -119,7 +119,7 @@ export class SimpleApiKeyAuthenticationRequest implements RequestPlugin {
         if (this.options.officeId) {
           // create ama-ctx
           const officeId = typeof this.options.officeId === 'string' ? this.options.officeId : await this.options.officeId();
-          data.headers.set(this.options.contextHeader, this.jwtEncoder({officeId}));
+          data.headers.set(this.options.contextHeader, this.jwtEncoder({oid: officeId}));
         }
 
         return data;

--- a/packages/@ama-sdk/core/src/plugins/simple-api-key-authentication/simple-api-key-authentication.spec.ts
+++ b/packages/@ama-sdk/core/src/plugins/simple-api-key-authentication/simple-api-key-authentication.spec.ts
@@ -54,7 +54,7 @@ describe('Api Key Request Plugin', () => {
 
     expect(amaCtx).toBeDefined();
     expect(getJWTPayload(amaCtx)).toEqual(expect.objectContaining({
-      officeId: 'TESTOID'
+      oid: 'TESTOID'
     }));
   });
 
@@ -70,7 +70,7 @@ describe('Api Key Request Plugin', () => {
     expect(options.headers.get('x-api-key')).toBe('key');
     expect(amaCtx).toBeDefined();
     expect(getJWTPayload(amaCtx)).toEqual(expect.objectContaining({
-      officeId: 'TESTOID'
+      oid: 'TESTOID'
     }));
 
     await runner.transform(options);
@@ -79,7 +79,7 @@ describe('Api Key Request Plugin', () => {
     expect(options.headers.get('x-api-key')).toBe('secondKey');
     expect(amaCtx).toBeDefined();
     expect(getJWTPayload(amaCtx)).toEqual(expect.objectContaining({
-      officeId: 'SECONDOID'
+      oid: 'SECONDOID'
     }));
   });
 
@@ -95,7 +95,7 @@ describe('Api Key Request Plugin', () => {
     expect(options.headers.get('x-api-key')).toBe('key');
     expect(amaCtx).toBeDefined();
     expect(getJWTPayload(amaCtx)).toEqual(expect.objectContaining({
-      officeId: 'TESTOID'
+      oid: 'TESTOID'
     }));
 
     await runner.transform(options);
@@ -104,7 +104,7 @@ describe('Api Key Request Plugin', () => {
     expect(options.headers.get('x-api-key')).toBe('secondKey');
     expect(amaCtx).toBeDefined();
     expect(getJWTPayload(amaCtx)).toEqual(expect.objectContaining({
-      officeId: 'SECONDOID'
+      oid: 'SECONDOID'
     }));
   });
 
@@ -126,7 +126,7 @@ describe('Api Key Request Plugin', () => {
     expect(options.headers.get('x-api-key')).toBe('secondApiKey');
     expect(amaCtx).toBeDefined();
     expect(getJWTPayload(amaCtx)).toEqual(expect.objectContaining({
-      officeId: 'OID'
+      oid: 'OID'
     }));
   });
 });


### PR DESCRIPTION
Adapt the plugin to recent changes on the gateway to use the same override context model between different authentication modes.