### PR TITLE
fix: generators templates

### DIFF
--- a/packages/@o3r/core/schematics/module/templates/base/ng-package.json.template
+++ b/packages/@o3r/core/schematics/module/templates/base/ng-package.json.template
@@ -1,10 +1,10 @@
 
 {
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
-  "dest": "../dist",
+  "dest": "./dist",
   "deleteDestPath": false,
 
   "lib": {
-    "entryFile": "public_api.ts"
+    "entryFile": "src/public_api.ts"
   }
 }


### PR DESCRIPTION
## Proposed change

Apply subentries fix on generated module. 
Move ng-package into the source folder to take the src folder as the root of the subentries instead of the package folder.
Include the scripts to target the src ng-package.json

- :bug: Fixes #(issue)
## Type of change

- [x] :bug: Bug fix (non-breaking change which fixes an issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
