### PR TITLE
chore: fix new logo ratio on published documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./.attachments/otter.png" alt="Super cute Otter!" width="30%" height="30%"/>
+  <img src="./.attachments/otter.png" alt="Super cute Otter!" width="30%"/>
 </p>
 
 # Otter Library - How to contribute

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter Framework</h1>
 <p align="center">
-  <img src="./.attachments/otter.png" alt="Super cute Otter!" width="40%" height="40%"/>
+  <img src="./.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 ## Description


### PR DESCRIPTION
## Proposed change

 :bug: Fixes 
![flat_otter](https://user-images.githubusercontent.com/122815763/232784667-06edbeb4-d833-4a38-80c8-15ec38f2f9f6.PNG)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] :file_cabinet: Documentation updates

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
