### PR TITLE
feat: add outputObject on fc metadata json schema to be compatible wi…

### DIFF
--- a/packages/@o3r/application/schemas/functional-content.metadata.schema.json
+++ b/packages/@o3r/application/schemas/functional-content.metadata.schema.json
@@ -66,6 +66,10 @@
             "type": "string",
             "description": "Name of the object definition to use as the root of the model described by this section"
           },
+          "outputObject": {
+            "type": "string",
+            "description": "Name of the parent object which contains this section on exported file"
+          },
           "definitions": {
             "type": "array",
             "description": "Object definitions for this section",


### PR DESCRIPTION
Update JSON schema for functional-content metadata in order to take into account a new possibility.
New property added at section level: "outputObject"

> The outputObject specifies the parent object that includes the contents of the section in the exported file. It is optional, by default, the export is done on the root object of the file.
> 
> This property impacts the import of content into the CMS. Importing previous content will fail after the application is updated.
> 
> It is possible to write multiple sections in the same output object, on the same file. In this case you have to make sure that there are no common properties at the root of the section, otherwise one will overwrite the properties of the other.

## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

- :rocket: Feature #(issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] :rocket: New feature (non-breaking change which adds functionality)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
