### PR TITLE
feat: support external nested config

### DIFF
--- a/packages/@o3r/components/builders/component-extractor/helpers/component/component.parser.ts
+++ b/packages/@o3r/components/builders/component-extractor/helpers/component/component.parser.ts
@@ -61,8 +61,9 @@ export class ComponentParser {
    * @param tsconfigPath Path to the tsconfig defining the list of path to parse
    * @param logger Logger
    * @param strictMode
+   * @param libraries
    */
-  constructor(private libraryName: string, private tsconfigPath: string, private logger: logging.LoggerApi, private strictMode: boolean = false) {
+  constructor(private libraryName: string, private tsconfigPath: string, private logger: logging.LoggerApi, private strictMode: boolean = false, private libraries: string[] = []) {
 
   }
 
@@ -106,7 +107,7 @@ export class ComponentParser {
    * @param checker Typescript TypeChecker of the program
    */
   private getConfiguration(file: string, source: ts.SourceFile, checker: ts.TypeChecker) {
-    const configurationFileExtractor = new ComponentConfigExtractor(this.libraryName, this.strictMode, source, this.logger, file, checker);
+    const configurationFileExtractor = new ComponentConfigExtractor(this.libraryName, this.strictMode, source, this.logger, file, checker, this.libraries);
     const configuration = configurationFileExtractor.extract();
     if (configuration.configurationInformation && this.strictMode) {
       configuration.configurationInformation.properties = configuration.configurationInformation.properties
@@ -153,7 +154,7 @@ export class ComponentParser {
       const source = program.getSourceFile(filePath);
       if (source) {
         const configurationFromSource = this.getConfiguration(filePath, source, checker);
-        if (configurationFromSource.configurationInformation) {
+        if (configurationFromSource.configurationInformation || configurationFromSource.nestedConfiguration) {
           configurations[filePath] = {configuration: configurationFromSource, file: filePath};
         }
         const componentFromSource = this.getComponent(filePath, source);

--- a/packages/@o3r/components/builders/component-extractor/index.ts
+++ b/packages/@o3r/components/builders/component-extractor/index.ts
@@ -66,7 +66,7 @@ export default createBuilder<ComponentExtractorBuilderSchema>(async (options, co
 
     context.reportProgress(1, STEP_NUMBER, 'Generating component parser');
     const libraryName = options.name || defaultLibraryName(context.currentDirectory);
-    const parser = new ComponentParser(libraryName, tsConfig, context.logger, options.strictMode);
+    const parser = new ComponentParser(libraryName, tsConfig, context.logger, options.strictMode, options.libraries);
 
     context.reportProgress(2, STEP_NUMBER, 'Gathering project data');
     const parserOutput = await parser.parse();


### PR DESCRIPTION
## Proposed change

Support nested configuration defined outside the configuration file.
Limitations : 
- import from the file where we have the definition
- import from one of the libraries specified in the builder configuration

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
