### PR TITLE
fix: throwOnUndefined to work with playwrigh

### DIFF
--- a/packages/@ama-sdk/core/schematics/ng-add/mocks/angular.mocks.json
+++ b/packages/@ama-sdk/core/schematics/ng-add/mocks/angular.mocks.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/14.0.x/packages/angular/cli/lib/config/workspace-schema.json",
+  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular/cli/lib/config/workspace-schema.json",
   "version": 1,
   "newProjectRoot": ".",
   "projects": {

--- a/packages/@ama-sdk/generator-sdk/collection.json
+++ b/packages/@ama-sdk/generator-sdk/collection.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/14.0.x/packages/angular_devkit/schematics/collection-schema.json",
+  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular_devkit/schematics/collection-schema.json",
   "schematics": {
     "mock": {
       "description": "Generate an api mock into the project.",

--- a/packages/@o3r/components/builders.json
+++ b/packages/@o3r/components/builders.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/14.0.x/packages/angular_devkit/architect/src/builders-schema.json",
+  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular_devkit/architect/src/builders-schema.json",
   "builders": {
     "extractor": {
       "implementation": "./builders/component-extractor/",

--- a/packages/@o3r/components/testing/mocks/angular.mocks.json
+++ b/packages/@o3r/components/testing/mocks/angular.mocks.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/14.0.x/packages/angular/cli/lib/config/workspace-schema.json",
+  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular/cli/lib/config/workspace-schema.json",
   "version": 1,
   "newProjectRoot": ".",
   "projects": {

--- a/packages/@o3r/core/builders.json
+++ b/packages/@o3r/core/builders.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/14.0.x/packages/angular_devkit/architect/src/builders-schema.json",
+  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular_devkit/architect/src/builders-schema.json",
   "builders": {
     "app-version": {
       "implementation": "./builders/app-version/",

--- a/packages/@o3r/core/collection.json
+++ b/packages/@o3r/core/collection.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/14.0.x/packages/angular_devkit/schematics/collection-schema.json",
+  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular_devkit/schematics/collection-schema.json",
   "schematics": {
     "ng-add": {
       "description": "Add Otter Library to the project.",

--- a/packages/@o3r/core/migration.json
+++ b/packages/@o3r/core/migration.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/14.0.x/packages/angular_devkit/schematics/collection-schema.json",
+  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular_devkit/schematics/collection-schema.json",
   "schematics": {
     "migration-v3": {
       "version": "3.1.0-alpha.0",

--- a/packages/@o3r/core/package.json
+++ b/packages/@o3r/core/package.json
@@ -152,6 +152,41 @@
   "builders": "./dist/builders.json",
   "ng-update": {
     "migrations": "./dist/migration.json",
-    "packageGroup": []
+    "packageGroup": [
+      "@ama-sdk/core",
+      "@ama-sdk/generator-sdk",
+      "@ama-sdk/swagger-builder",
+      "@ama-terasu/cli",
+      "@ama-terasu/core",
+      "@ama-terasu/schematics",
+      "@o3r/amaterasu-api-spec",
+      "@o3r/amaterasu-dodo",
+      "@o3r/amaterasu-otter",
+      "@o3r/amaterasu-sdk",
+      "@o3r/analytics",
+      "@o3r/apis-manager",
+      "@o3r/application",
+      "@o3r/build-helpers",
+      "@o3r/chrome-devtools",
+      "@o3r/components",
+      "@o3r/configuration",
+      "@o3r/dev-tools",
+      "@o3r/dynamic-content",
+      "@o3r/eslint-config-otter",
+      "@o3r/eslint-plugin",
+      "@o3r/extractors",
+      "@o3r/forms",
+      "@o3r/localization",
+      "@o3r/logger",
+      "@o3r/mobile",
+      "@o3r/routing",
+      "@o3r/rules-engine",
+      "@o3r/schematics",
+      "@o3r/storybook",
+      "@o3r/stylelint-plugin",
+      "@o3r/styling",
+      "@o3r/testing",
+      "@o3r/third-party"
+    ]
   }
 }

--- a/packages/@o3r/core/schematics/fixture/helpers.ts
+++ b/packages/@o3r/core/schematics/fixture/helpers.ts
@@ -93,38 +93,40 @@ export const getImplementation = (
   switch (methodType) {
     case 'clickOnButton': {
       return `{
-    const elt = await this.query(this.${classPropSelector});
-    return this.throwOnUndefined(elt).click();
+    const elt = await this.throwOnUndefined(this.query(this.${classPropSelector}));
+    return elt.click();
   }`;
     }
     case 'getText': {
       return `{
-    const elt = await this.query(this.${classPropSelector});
-    return this.throwOnUndefined(elt).getText();
+    const elt = await this.throwOnUndefined(this.query(this.${classPropSelector}));
+    return elt.getText();
   }`;
     }
     case 'getInputValue': {
       return `{
-    const elt = await this.query(this.${classPropSelector});
-    return this.throwOnUndefined(elt).getValue();
+    const elt = await this.throwOnUndefined(this.query(this.${classPropSelector}));
+    return elt.getValue();
   }`;
     }
     case 'setInputValue': {
       return `{
-    const elt = await this.query(this.${classPropSelector});
-    return this.throwOnUndefined(elt).setValue(value);
+    const elt = await this.throwOnUndefined(this.query(this.${classPropSelector}));
+    return elt.setValue(value);
   }`;
     }
     case 'getTextInList': {
       return `{
-    const elements = await this.queryAll(this.${classPropSelector});
-    return this.throwOnUndefined(elements[index]).getText();
+    const elements = this.queryAll(this.${classPropSelector});
+    const elt = await this.throwOnUndefinedElement(items[index]);
+    return elf.getText();
   }`;
     }
     case 'clickButtonInList': {
       return `{
-    const elements = await this.queryAll(this.${classPropSelector});
-    return this.throwOnUndefined(elements[index]).click();
+    const elements = this.queryAll(this.${classPropSelector});
+    const elt = await this.throwOnUndefinedElement(items[index]);
+    return elt.click();
   }`;
     }
     case 'getNumberOfItems': {

--- a/packages/@o3r/core/testing/mocks/angular.mocks.json
+++ b/packages/@o3r/core/testing/mocks/angular.mocks.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/14.0.x/packages/angular/cli/lib/config/workspace-schema.json",
+  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular/cli/lib/config/workspace-schema.json",
   "version": 1,
   "newProjectRoot": ".",
   "projects": {

--- a/packages/@o3r/localization/builders.json
+++ b/packages/@o3r/localization/builders.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/14.0.x/packages/angular_devkit/architect/src/builders-schema.json",
+  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular_devkit/architect/src/builders-schema.json",
   "builders": {
     "i18n": {
       "implementation": "./builders/i18n/",

--- a/packages/@o3r/rules-engine/builders.json
+++ b/packages/@o3r/rules-engine/builders.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/14.0.x/packages/angular_devkit/architect/src/builders-schema.json",
+  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular_devkit/architect/src/builders-schema.json",
   "builders": {
     "extractor": {
       "implementation": "./builders/rules-engine-extractor/",

--- a/packages/@o3r/schematics/src/utility/loaders.ts
+++ b/packages/@o3r/schematics/src/utility/loaders.ts
@@ -104,7 +104,7 @@ export function getAllFilesInTree(tree: Tree, basePath = '/', excludes: string[]
 /**
  * Get all files with specific extension from the specified folder for all the projects described in the workspace
  *
- * @deprecated please use `getFilesInFolderFromWorkspaceProjectsInTree`, will be removed in v9
+ * @deprecated please use {@link getFilesInFolderFromWorkspaceProjectsInTree}, will be removed in v9
  * @param tree
  * @param extension
  * @param folderInProject
@@ -129,7 +129,7 @@ export function getFilesInFolderFromWorkspaceProjects(tree: Tree, folderInProjec
  */
 export function getFilesInFolderFromWorkspaceProjectsInTree(tree: Tree, folderInProject: string, extension: string) {
   const workspace = readAngularJson(tree);
-  const extensionMatcher = new RegExp(`\\.${extension}$`);
+  const extensionMatcher = new RegExp(`\\.${extension.replace(/^\./, '')}$`);
   const excludes = ['**/node_modules/**', '**/.cache/**'];
   return Object.values(workspace.projects)
     .flatMap((project) => getAllFilesInTree(tree, path.posix.join(project.root, folderInProject), excludes))

--- a/packages/@o3r/styling/builders.json
+++ b/packages/@o3r/styling/builders.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/14.0.x/packages/angular_devkit/architect/src/builders-schema.json",
+  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular_devkit/architect/src/builders-schema.json",
   "builders": {
     "extractor": {
       "implementation": "./builders/style-extractor/",

--- a/packages/@o3r/styling/collection.json
+++ b/packages/@o3r/styling/collection.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/14.0.x/packages/angular_devkit/schematics/collection-schema.json",
+  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular_devkit/schematics/collection-schema.json",
   "schematics": {
     "ng-add": {
       "description": "Add Otter styling to the project.",

--- a/packages/@o3r/testing/migration.json
+++ b/packages/@o3r/testing/migration.json
@@ -1,4 +1,10 @@
 {
-  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/14.0.x/packages/angular_devkit/schematics/collection-schema.json",
-  "schematics": {}
+  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular_devkit/schematics/collection-schema.json",
+  "schematics": {
+    "migration-v9_0": {
+      "version": "9.0.0-alpha.0",
+      "description": "Updates of the Otter Testing module to v9.0.x",
+      "factory": "./schematics/ng-update/v9-0/index#update"
+    }
+  }
 }

--- a/packages/@o3r/testing/schematics/ng-update/v9-0/index.ts
+++ b/packages/@o3r/testing/schematics/ng-update/v9-0/index.ts
@@ -1,0 +1,16 @@
+import { chain, Rule } from '@angular-devkit/schematics';
+import { updateThrowOnUndefinedCalls } from './throw-on-undefined/throw-on-undefined';
+
+/**
+ * Default 9.0.0 update function
+ */
+export function update(): Rule {
+  return (tree, context) => {
+
+    const updateRules: Rule[] = [
+      updateThrowOnUndefinedCalls()
+    ];
+
+    return chain(updateRules)(tree, context);
+  };
+}

--- a/packages/@o3r/testing/schematics/ng-update/v9-0/throw-on-undefined/mocks/angular.mocks.json.template
+++ b/packages/@o3r/testing/schematics/ng-update/v9-0/throw-on-undefined/mocks/angular.mocks.json.template
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "newProjectRoot": ".",
+  "projects": {
+    "test-project": {
+      "projectType": "application",
+      "root": ".",
+      "sourceRoot": "./src",
+      "prefix": "tst",
+      "architect": {
+      }
+    }
+  }
+}

--- a/packages/@o3r/testing/schematics/ng-update/v9-0/throw-on-undefined/mocks/fixture.mocks.result.ts.template
+++ b/packages/@o3r/testing/schematics/ng-update/v9-0/throw-on-undefined/mocks/fixture.mocks.result.ts.template
@@ -1,0 +1,10 @@
+export class FareFamilyGroupSelectorPresFixtureComponent extends O3rComponentFixture implements FareFamilyGroupSelectorPresFixture {
+
+  /**
+   * @inheritDoc
+   */
+  public async getFareFamilyGroupPriceFixture(index: number): Promise<PriceContFixture | undefined> {
+    const elt = (await this.queryNth(this.FARE_FAMILY_GROUP_PRICES, index));
+    return new this.priceFixture(await this.throwOnUndefinedElement(elt));
+  }
+}

--- a/packages/@o3r/testing/schematics/ng-update/v9-0/throw-on-undefined/mocks/fixture.mocks.ts.template
+++ b/packages/@o3r/testing/schematics/ng-update/v9-0/throw-on-undefined/mocks/fixture.mocks.ts.template
@@ -1,0 +1,10 @@
+export class FareFamilyGroupSelectorPresFixtureComponent extends O3rComponentFixture implements FareFamilyGroupSelectorPresFixture {
+
+  /**
+   * @inheritDoc
+   */
+  public async getFareFamilyGroupPriceFixture(index: number): Promise<PriceContFixture | undefined> {
+    const elt = (await this.queryNth(this.FARE_FAMILY_GROUP_PRICES, index));
+    return new this.priceFixture(this.throwOnUndefined(elt));
+  }
+}

--- a/packages/@o3r/testing/schematics/ng-update/v9-0/throw-on-undefined/throw-on-undefined.spec.ts
+++ b/packages/@o3r/testing/schematics/ng-update/v9-0/throw-on-undefined/throw-on-undefined.spec.ts
@@ -1,0 +1,34 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { lastValueFrom } from 'rxjs';
+import { updateThrowOnUndefinedCalls } from './throw-on-undefined';
+
+const collectionPath = path.join(__dirname, '..', '..', '..', '..', 'migration.json');
+
+describe('Update ThrowOnUndefined helper', () => {
+
+  let initialTree: Tree;
+
+  beforeEach(() => {
+    initialTree = Tree.empty();
+    initialTree.create('angular.json', fs.readFileSync(path.resolve(__dirname, 'mocks', 'angular.mocks.json.template')));
+    initialTree.create('/src/mock.fixture.ts', fs.readFileSync(path.resolve(__dirname, 'mocks', 'fixture.mocks.ts.template')));
+    initialTree.create('/src/mock.component.ts', fs.readFileSync(path.resolve(__dirname, 'mocks', 'fixture.mocks.ts.template')));
+  });
+
+  it('should not update non-fixture files', async () => {
+    const runner = new SchematicTestRunner('migrations', collectionPath);
+    const tree = await lastValueFrom(runner.callRule(updateThrowOnUndefinedCalls(), initialTree));
+
+    expect(tree.readText('/src/mock.component.ts')).toBe(fs.readFileSync(path.resolve(__dirname, 'mocks', 'fixture.mocks.ts.template'), {encoding: 'utf-8'}));
+  });
+
+  it('should update fixture files', async () => {
+    const runner = new SchematicTestRunner('migrations', collectionPath);
+    const tree = await lastValueFrom(runner.callRule(updateThrowOnUndefinedCalls(), initialTree));
+
+    expect(tree.readText('/src/mock.fixture.ts')).toBe(fs.readFileSync(path.resolve(__dirname, 'mocks', 'fixture.mocks.result.ts.template'), { encoding: 'utf-8' }));
+  });
+});

--- a/packages/@o3r/testing/schematics/ng-update/v9-0/throw-on-undefined/throw-on-undefined.ts
+++ b/packages/@o3r/testing/schematics/ng-update/v9-0/throw-on-undefined/throw-on-undefined.ts
@@ -1,0 +1,24 @@
+import { chain, Rule } from '@angular-devkit/schematics';
+import { getFilesInFolderFromWorkspaceProjectsInTree } from '@o3r/schematics';
+
+/**
+ * Replace the call of {@link O3rComponentFixture.ThrowOnUndefined} to {@link O3rComponentFixture.ThrowOnUndefinedElement}
+ */
+export function updateThrowOnUndefinedCalls(): Rule {
+  const update: Rule = (tree) => {
+    const fixtureFiles = getFilesInFolderFromWorkspaceProjectsInTree(tree, '/', 'fixture.ts');
+    fixtureFiles
+      .forEach((fixtureFile) => {
+        const content = tree.readText(fixtureFile);
+        tree.overwrite(fixtureFile, content.replace(/\b(?<!await )this\.throwOnUndefined\b/g, 'await this.throwOnUndefinedElement'));
+      });
+    return tree;
+  };
+
+  const notice: Rule = (_, ctx) => {
+    ctx.logger.warn('Please notice that the "throwOnUndefined" update has change the `sync` function to `async` one.');
+    ctx.logger.warn('It may require to update manually some synchronous fixtures to asynchronous functions');
+  };
+
+  return chain([update, notice]);
+}

--- a/packages/@o3r/testing/src/core/angular/component-fixture.ts
+++ b/packages/@o3r/testing/src/core/angular/component-fixture.ts
@@ -1,12 +1,12 @@
 /* eslint-disable new-cap */
 import { By } from '@angular/platform-browser';
 import { FixtureUsageError } from '../../errors/index';
-import { ComponentFixtureProfile } from '../component-fixture';
+import type { ComponentFixtureProfile } from '../component-fixture';
+import { isPromise, withTimeout } from '../helpers';
 import { O3rElement, O3rElementConstructor } from './element';
 import { O3rGroup, O3rGroupConstructor } from './group';
 
-
-export { ComponentFixtureProfile, Constructable, FixtureWithCustom } from '../component-fixture';
+export type { ComponentFixtureProfile, Constructable, FixtureWithCustom } from '../component-fixture';
 
 /**
  * Implementation of the fixture dedicated to angular, hence using angular testing framework.
@@ -26,9 +26,56 @@ export class O3rComponentFixture<V extends O3rElement = O3rElement> implements C
     this.element = element;
   }
 
-  protected throwOnUndefined<T extends O3rElement>(element?: T) {
+  /**
+   * Throws an exception if the element is undefined.
+   * Otherwise returns the element.
+   *
+   * @param element ElementProfile to test
+   * @param _timeout specific timeout that will throw when reach
+   */
+  protected throwOnUndefinedElement<T extends O3rElement>(element?: T, _timeout?: number): Promise<T> {
     if (!element) {
       throw new Error('Element not found in ' + this.constructor.name);
+    }
+    return Promise.resolve(element);
+  }
+
+  /**
+   * Throws an exception if the element is undefined.
+   * Otherwise returns the element.
+   *
+   * @param element ElementProfile to test
+   * @deprecated use {@link Promise} only as {@link throwOnUndefined} parameter or use {@see throwOnUndefinedElement} instead. Will be removed in v10
+   */
+  protected throwOnUndefined<T extends O3rElement>(element?: T): T;
+  /**
+   * Throws an exception if the element is undefined.
+   * Otherwise returns the element.
+   *
+   * @param element ElementProfile to test
+   * @param timeout specific timeout that will throw when reach
+   */
+  protected async throwOnUndefined<T extends O3rElement>(element: Promise<T | undefined>, timeout?: number): Promise<T>;
+  /**
+   * Throws an exception if the element is undefined.
+   * Otherwise returns the element.
+   *
+   * @param element ElementProfile to test
+   * @param timeout specific timeout that will throw when reach
+   * @deprecated use {@link Promise} only as {@link throwOnUndefined} parameter or use {@link throwOnUndefinedElement} instead. Will be removed in v10
+   */
+  protected throwOnUndefined<T extends O3rElement>(element?: Promise<T | undefined> | T, timeout?: number): Promise<T> | T {
+    if (!element) {
+      throw new Error('Element not found in ' + this.constructor.name);
+    }
+    if (isPromise(element)) {
+      return withTimeout(element, timeout)
+        .then((el) => {
+          if (!el) {
+            throw new Error('Element not found in ' + this.constructor.name);
+          }
+          return el;
+        });
     }
     return element;
   }

--- a/packages/@o3r/testing/src/core/component-fixture.ts
+++ b/packages/@o3r/testing/src/core/component-fixture.ts
@@ -105,22 +105,47 @@ export class O3rComponentFixture<V extends O3rElement = O3rElement> implements C
    * Otherwise returns the element.
    *
    * @param _element ElementProfile to test
+   * @param _timeout specific timeout that will throw when reach
    */
-  protected throwOnUndefined<T extends O3rElement>(_element?: T): T {
+  protected throwOnUndefinedElement<T extends O3rElement>(_element: T | undefined, _timeout?: number): Promise<T> {
+    throw new TranspilationPurposeOnlyError('Should target a proper implementation');
+  }
+
+  /**
+   * Throws an exception if the element is undefined.
+   * Otherwise returns the element.
+   *
+   * @param _element ElementProfile to test
+   * @deprecated use {@link Promise} only as {@link throwOnUndefined} parameter or use {@see throwOnUndefinedElement} instead. Will be removed in v10
+   */
+  protected throwOnUndefined<T extends O3rElement>(_element?: T): T;
+  /**
+   * Throws an exception if the element is undefined.
+   * Otherwise returns the element.
+   *
+   * @param _element ElementProfile to test
+   * @param _timeout specific timeout that will throw when reach
+   */
+  protected throwOnUndefined<T extends O3rElement>(_element: Promise<T | undefined>, _timeout?: number): Promise<T | undefined> {
     throw new TranspilationPurposeOnlyError('Should target a proper implementation');
   }
 
   /** @inheritdoc */
   public query(_selector: string, _returnType?: undefined, timeout?: number): Promise<O3rElement | undefined>;
+  /** @inheritdoc */
   public query<T extends O3rElement>(_selector: string, _returnType: O3rElementConstructor<T>, timeout?: number): Promise<T | undefined>;
+  /** @inheritdoc */
   public query<T extends O3rElement>(_selector: string, _returnType: O3rElementConstructor<T> | undefined): Promise<T | O3rElement | undefined> {
     throw new TranspilationPurposeOnlyError('Should target a proper implementation');
   }
 
   /** @inheritdoc */
   public queryAll(_selector: string, _returnType?: undefined, _groupType?: undefined, timeout?: number): Promise<O3rElement[]>;
+  /** @inheritdoc */
   public queryAll<T extends O3rElement>(_selector: string, _returnType: O3rElementConstructor<T>, _groupType?: undefined, timeout?: number): Promise<T[]>;
+  /** @inheritdoc */
   public queryAll<T extends O3rElement, K extends GroupProfile<T>>(_selector: string, _returnType: O3rElementConstructor<T>, _groupType: O3rGroupConstructor<K, T>, timeout?: number): Promise<K>;
+  /** @inheritdoc */
   public queryAll<T extends O3rElement, K extends GroupProfile<T>>(
     _selector: string,
     _returnType: O3rElementConstructor<T> | undefined,

--- a/packages/@o3r/testing/src/core/helpers.ts
+++ b/packages/@o3r/testing/src/core/helpers.ts
@@ -1,0 +1,29 @@
+
+/**
+ * Determine if the given item is a promise
+ *
+ * @param item Item to check
+ */
+export const isPromise = <T>(item: T | Promise<T>): item is Promise<T> => !!item && typeof (item as Promise<T>).then === 'function';
+
+/**
+ * Error raised when promise timeout
+ */
+export class TimeoutError extends Error {
+  constructor(message?: string | undefined) {
+    super(message || 'Timeout of the promise');
+  }
+}
+
+/**
+ * Apply timeout to a given promise
+ *
+ * @param promise Promise to timeout
+ * @param timeout timeout of the given promise (in ms)
+ */
+export const withTimeout = async <T>(promise: Promise<T>, timeout?: number): Promise<T> => {
+  if (!timeout) {
+    return promise;
+  }
+  return Promise.race([promise, new Promise<T>((_, reject) => setTimeout(() => reject(new TimeoutError()), timeout))]);
+};

--- a/packages/@o3r/testing/testing/mocks/angular.mocks.json
+++ b/packages/@o3r/testing/testing/mocks/angular.mocks.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/14.0.x/packages/angular/cli/lib/config/workspace-schema.json",
+  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular/cli/lib/config/workspace-schema.json",
   "version": 1,
   "newProjectRoot": ".",
   "projects": {

--- a/packages/@o3r/testing/tsconfig.json
+++ b/packages/@o3r/testing/tsconfig.json
@@ -7,6 +7,9 @@
     },
     {
       "path": "./tsconfig.tools.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
     }
   ]
 }


### PR DESCRIPTION
fix: throwOnUndefined to work with playwrigh
feat: add promise support to throwOnUndefined

## Proposed change

Add support of Promise to `throwOnUndefined` to avoid breaking change of the fix

## Related issues

- :bug: Fixes 1441

## Remains To Do:

- [x] Ng Update for migration
