### PR TITLE
fix: mock helper getPath - adding an HTTP method constraint when several matches

### DIFF
--- a/packages/@ama-sdk/core/src/fwk/mocks/alf-mock-adapter.ts
+++ b/packages/@ama-sdk/core/src/fwk/mocks/alf-mock-adapter.ts
@@ -65,7 +65,7 @@ function getRequest(log: string, corrId: string, operationAdapter: PathObject[])
     // so we remove the SAP information at the beginning and URL parameters at the end if any
     const requestUrl = match[2].substring(match[2].indexOf('/'), match[2].indexOf('?') > -1 ? match[2].indexOf('?') : match[2].length);
     const method = match[1];
-    const pathObject = getPath(requestUrl, operationAdapter);
+    const pathObject = getPath(requestUrl, operationAdapter, method);
     if (pathObject) {
       const operationId = getOperationId(pathObject, method);
       return {

--- a/packages/@ama-sdk/core/src/fwk/mocks/base-mock-adapter.ts
+++ b/packages/@ama-sdk/core/src/fwk/mocks/base-mock-adapter.ts
@@ -34,7 +34,7 @@ export abstract class BaseMockAdapter implements MockAdapter {
    * @inheritDoc
    */
   public getOperationId(request: EncodedApiRequest): string {
-    const object = getPath(request.basePath, this.pathObjects);
+    const object = getPath(request.basePath, this.pathObjects, request.method);
     if (!object) {
       throw new Error(`No operation has been found for ${request.basePath}`);
     }


### PR DESCRIPTION
## Proposed change

Adding a last way to filter out several matches in the `packages/@ama-sdk/core/src/fwk/mocks/helper.ts` > `getPath` method, based on the HTTP method of the matching results.

## Related issues

- :bug: Fixes #296
