### PR TITLE
fix: enhance helpers for ng update schematics

### DIFF
--- a/packages/@o3r/schematics/src/rule-factories/update-imports/update-imports-with-scope.ts
+++ b/packages/@o3r/schematics/src/rule-factories/update-imports/update-imports-with-scope.ts
@@ -1,5 +1,5 @@
 import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
-import { getFilesFromRootOfWorkspaceProjects } from '../../utility';
+import { getFilesFromRootOfWorkspaceProjects, getFilesWithExtensionFromTree } from '../../utility';
 import { listOfExposedElements, SassImportExposedElement } from './list-of-vars';
 
 const imports = new RegExp(/^@import\s+['"]~?@(o3r|otter)\/styling.*\s*/, 'gm');
@@ -10,23 +10,24 @@ const imports = new RegExp(/^@import\s+['"]~?@(o3r|otter)\/styling.*\s*/, 'gm');
  * @param alias The name of the otter styling package
  * @param dependencyName The name of the dependency to update imports on
  * @param exposedElements The list of exposed elemeents
+ * @param fromRoot Perform on all files in project
  */
-export function updateSassImports(alias: string, dependencyName = '@o3r/styling', exposedElements: SassImportExposedElement[] = listOfExposedElements): Rule {
+export function updateSassImports(alias: string, dependencyName = '@o3r/styling', exposedElements: SassImportExposedElement[] = listOfExposedElements, fromRoot = false): Rule {
   return (tree: Tree, _context: SchematicContext) => {
-    const files = getFilesFromRootOfWorkspaceProjects(tree, 'scss');
-    files
-      .forEach((file) => {
-        let content = tree.read(file)!.toString();
-        if (content.match(imports)) {
-          const contentWithoutImports = content.replace(imports, '');
-          content = `@use '${dependencyName}' as ${alias};\n${contentWithoutImports}`;
-          exposedElements.forEach(elem => {
-            const elemRegex = new RegExp(`(?<![\\w\\d-])${elem.type === 'var' ? '\\' : ''}${elem.value}((?![\\w\\d-])(?!(\\s*\\:)))`, 'g');
-            content = content.replace(elemRegex, `${alias}.${(elem.replacement || elem.value)}`);
-          });
-          tree.overwrite(file, content);
-        }
-      });
+
+    const files = fromRoot ? getFilesWithExtensionFromTree(tree, 'scss') : getFilesFromRootOfWorkspaceProjects(tree, 'scss');
+    files.forEach((file) => {
+      let content = tree.read(file)!.toString();
+      if (content.match(imports)) {
+        const contentWithoutImports = content.replace(imports, '');
+        content = `@use '${dependencyName}' as ${alias};\n${contentWithoutImports}`;
+        exposedElements.forEach(elem => {
+          const elemRegex = new RegExp(`(?<![\\w\\d-]|o3r\\.)${elem.type === 'var' ? '\\' : ''}${elem.value}((?![\\w\\d-])(?!(\\s*\\:)))`, 'g');
+          content = content.replace(elemRegex, `${alias}.${(elem.replacement || elem.value)}`);
+        });
+        tree.overwrite(file, content);
+      }
+    });
 
     return tree;
   };

--- a/packages/@o3r/schematics/src/rule-factories/update-imports/update-ts-imports.ts
+++ b/packages/@o3r/schematics/src/rule-factories/update-imports/update-ts-imports.ts
@@ -1,17 +1,18 @@
 import { Rule } from '@angular-devkit/schematics';
 import * as ts from 'typescript';
-import { getSourceFilesFromWorkspaceProjects, ImportsMapping, updateImportsInFile } from '../../utility';
+import { getFilesWithExtensionFromTree, getSourceFilesFromWorkspaceProjects, ImportsMapping, updateImportsInFile } from '../../utility';
 
 /**
  * Update imports based on mapping
  *
  * @param mapImports Map of the import to replace
  * @param renamedPackages Map of the import package to replace
+ * @param fromRoot Perform on all files in project
  */
-export function updateImports(mapImports: ImportsMapping = {}, renamedPackages: Record<string, string> = {}): Rule {
+export function updateImports(mapImports: ImportsMapping = {}, renamedPackages: Record<string, string> = {}, fromRoot = false): Rule {
 
   return (tree, context) => {
-    const files = getSourceFilesFromWorkspaceProjects(tree);
+    const files = fromRoot ? getFilesWithExtensionFromTree(tree, 'ts') : getSourceFilesFromWorkspaceProjects(tree);
 
     // exact match on import path
     const importsRegexp = new RegExp(`^(${[...Object.keys(mapImports)].join('|')})$`);

--- a/packages/@o3r/schematics/src/utility/loaders.ts
+++ b/packages/@o3r/schematics/src/utility/loaders.ts
@@ -106,8 +106,8 @@ export function getAllFilesInTree(tree: Tree, basePath = '/', excludes: string[]
  *
  * @deprecated please use `getFilesInFolderFromWorkspaceProjectsInTree`, will be removed in v9
  * @param tree
- * @param extension
  * @param folderInProject
+ * @param extension
  */
 export function getFilesInFolderFromWorkspaceProjects(tree: Tree, folderInProject: string, extension: string) {
   const workspace = readAngularJson(tree);
@@ -124,8 +124,8 @@ export function getFilesInFolderFromWorkspaceProjects(tree: Tree, folderInProjec
  * Get all files with specific extension from the specified folder for all the projects described in the workspace
  *
  * @param tree
- * @param extension
  * @param folderInProject
+ * @param extension
  */
 export function getFilesInFolderFromWorkspaceProjectsInTree(tree: Tree, folderInProject: string, extension: string) {
   const workspace = readAngularJson(tree);
@@ -133,6 +133,20 @@ export function getFilesInFolderFromWorkspaceProjectsInTree(tree: Tree, folderIn
   const excludes = ['**/node_modules/**', '**/.cache/**'];
   return Object.values(workspace.projects)
     .flatMap((project) => getAllFilesInTree(tree, path.posix.join(project.root, folderInProject), excludes))
+    .filter((filePath) => extensionMatcher.test(filePath));
+}
+
+
+/**
+ * Get all files with specific extension from the tree
+ *
+ * @param tree
+ * @param extension
+ */
+export function getFilesWithExtensionFromTree(tree: Tree, extension: string) {
+  const excludes = ['**/node_modules/**', '**/.cache/**'];
+  const extensionMatcher = new RegExp(`\\.${extension}$`);
+  return getAllFilesInTree(tree, '/', excludes)
     .filter((filePath) => extensionMatcher.test(filePath));
 }
 

--- a/packages/@o3r/styling/schematics/ng-add/updates-of-old-otter-scope/imports/mocks/new.scss.result
+++ b/packages/@o3r/styling/schematics/ng-add/updates-of-old-otter-scope/imports/mocks/new.scss.result
@@ -12,3 +12,5 @@ $light-shadow: o3r.variable('light-shadow', o3r.color($palette-highlight, 100) )
 $background-color: o3r.variable('background-color', o3r.contrast($palette-highlight, 500) ) !default;
 $default-color: o3r.variable('default-color', o3r.color($palette-accent, 900) ) !default;
 $default-color-contrast: o3r.variable('default-color-contrast', o3r.contrast($palette-accent, 900) ) !default;
+$theme: o3r.meta-theme-to-otter($meta-theme);
+$mat-theme: o3r.meta-theme-to-material($meta-theme);

--- a/packages/@o3r/styling/schematics/ng-add/updates-of-old-otter-scope/imports/mocks/old.scss
+++ b/packages/@o3r/styling/schematics/ng-add/updates-of-old-otter-scope/imports/mocks/old.scss
@@ -14,3 +14,5 @@ $light-shadow: o3r-var('light-shadow', o3r-color($palette-highlight, 100) ) !def
 $background-color: o3r-var('background-color', o3r-contrast($palette-highlight, 500) ) !default;
 $default-color: o3r-var('default-color', o3r-color($palette-accent, 900) ) !default;
 $default-color-contrast: o3r-var('default-color-contrast', o3r-contrast($palette-accent, 900) ) !default;
+$theme: meta-theme-to-otter($meta-theme);
+$mat-theme: o3r.meta-theme-to-material($meta-theme);


### PR DESCRIPTION
## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

- ability to run scss update schematics on partially migrated code
- ng update helper functions can take into account all files in project

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
