### PR TITLE
fix: avoid error when not log history in -1

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           enable-build-cache: 'false'
       - run: |
-          LABELS=$(yarn pr-labels "$(git log -1 --pretty=%B)")
+          LABELS=$(yarn pr-labels "$(git log -1 --pretty=%B || echo '')")
           echo "LABELS=$LABELS" >> $GITHUB_ENV
       - uses: actions/github-script@v6
         if: env.LABELS != '[]'

--- a/tools/@o3r/build-helpers/scripts/pr-labels.mjs
+++ b/tools/@o3r/build-helpers/scripts/pr-labels.mjs
@@ -1,9 +1,14 @@
 import { EOL } from 'node:os';
 
+/**
+ * Get labels from the git log output command
+ *
+ * @param {string[] | undefined} commitMessage
+ */
 function getLabels(commitMessage) {
   const commitLabels = [];
 
-  const lines = commitMessage.split(EOL);
+  const lines = commitMessage?.split(EOL) || [];
 
   lines.forEach((line) => {
     if (line.match(/^feat(ures?)?\b/)) {


### PR DESCRIPTION
## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

Fix the error in cascading PR when there is no immediate git log

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
