### PR TITLE
feat: add release/*-next branches in the Renovate update rules

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -23,7 +23,8 @@
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
   "baseBranches": [
-    "main"
+    "main",
+    "/^release\\/.*-next$/"
   ],
   "enabledManagers": [
     "npm"


### PR DESCRIPTION
## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

Add `release/*-next` branches in the Renovate update rules

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
