### PR TITLE
fix: remove the dependency of schematics to dev-tools

### DIFF
--- a/packages/@o3r/dev-tools/src/utils/check-peer-deps.ts
+++ b/packages/@o3r/dev-tools/src/utils/check-peer-deps.ts
@@ -67,6 +67,7 @@ export function getPackagesToInstallOrUpdate(packageName: string) {
 /**
  * Log an instruction with the packages to install or update to match a package peer dependencies
  *
+ * @deprecated use `checkPackagesRule` functions exposed by `@o3r/schematics` instead. Will be removed in Otter v10
  * @param packageName
  * @param angularJsonString
  */

--- a/packages/@o3r/schematics/package.json
+++ b/packages/@o3r/schematics/package.json
@@ -28,7 +28,6 @@
     }
   },
   "dependencies": {
-    "@o3r/dev-tools": "workspace:^",
     "comment-json": "^4.1.0",
     "globby": "^11.1.0",
     "minimatch": "^6.1.6",
@@ -55,6 +54,7 @@
     "@nrwl/js": "~15.9.0",
     "@nrwl/linter": "~15.9.0",
     "@o3r/build-helpers": "workspace:^",
+    "@o3r/dev-tools": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
     "@schematics/angular": "~15.2.0",
     "@types/jest": "~28.1.2",

--- a/packages/@o3r/schematics/src/rule-factories/check-packages-peers/index.ts
+++ b/packages/@o3r/schematics/src/rule-factories/check-packages-peers/index.ts
@@ -1,5 +1,114 @@
 import { SchematicContext, Tree } from '@angular-devkit/schematics';
-import { checkPackagesToInstallOrUpdate } from '@o3r/dev-tools';
+import type { PackageJson } from 'type-fest';
+import * as path from 'node:path';
+import * as commentJson from 'comment-json';
+import { satisfies } from 'semver';
+import type { LoggerApi } from '@angular-devkit/core/src/logger';
+
+/** Interface containing a npm package name, needed version and optionally found version */
+interface PackageVersion {
+  /** Npm package name */
+  packageName: string;
+  /** Npm package needed version */
+  version: string;
+  /** Npm package installed version found */
+  foundVersion?: string;
+}
+
+/**
+ * Get package manager used in runs
+ * Defaults to the package manager setup in process.env if no package manager set in angular.json
+ *
+ * @param angularJsonString Content of angular.json file
+ */
+function getPackageManager(angularJsonString?: string | null) {
+  let packageManager = process.env && process.env.npm_execpath && process.env.npm_execpath.indexOf('yarn') === -1 ? 'npm' : 'yarn';
+  if (angularJsonString) {
+    const angularJsonObj = commentJson.parse(angularJsonString) as any;
+    if (angularJsonObj?.cli?.packageManager) {
+      packageManager = angularJsonObj.cli.packageManager;
+    }
+  }
+  return packageManager;
+}
+
+
+/**
+ * Check if the first level of peer deps of a given package are installed.
+ * List all not installed packages or packages with version mismatch
+ *
+ * @param packageName
+ */
+function getPackagesToInstallOrUpdate(packageName: string) {
+  let installedPackage: PackageJson;
+  try {
+    installedPackage = require(`${packageName}${path.posix.sep}package.json`);
+  } catch (err) {
+    throw new Error(`The provided package is not installed: ${packageName}`);
+  }
+
+  const packagesToInstall: PackageVersion[] = [];
+  const packagesWrongVersion: PackageVersion[] = [];
+
+  const optionalPackages = Object.entries(installedPackage.peerDependenciesMeta || {})
+    .filter(([, dep]) => dep?.optional)
+    .map(([depName]) => depName);
+  const peerDependenciesMap = Object.entries(installedPackage.peerDependencies || {})
+    .reduce<Partial<Record<string, string>>>((acc, [name, val]) => {
+      if (!optionalPackages.includes(name)) {
+        acc[name] = val;
+      }
+      return acc;
+    }, {});
+  Object.entries(peerDependenciesMap).forEach(([pName, pVersion]) => {
+    let installedPackageVersion: string | undefined;
+    try {
+      installedPackageVersion = require(`${pName}${path.posix.sep}package.json`).version;
+    } catch (err) {
+      packagesToInstall.push({ packageName: pName, version: pVersion! });
+    }
+    if (installedPackageVersion && !satisfies(installedPackageVersion, pVersion!)) {
+      packagesWrongVersion.push({ packageName: pName, foundVersion: installedPackageVersion, version: pVersion! });
+    }
+  });
+  return { packagesToInstall, packagesWrongVersion };
+}
+
+/**
+ * Log an instruction with the packages to install or update to match a package peer dependencies
+ *
+ * @param packageName
+ * @param angularJsonString
+ * @param logger
+ */
+function checkPackagesToInstallOrUpdate(packageName: string, logger: LoggerApi, angularJsonString?: string | null) {
+
+  const packageManager = getPackageManager(angularJsonString);
+  const { packagesToInstall, packagesWrongVersion } = getPackagesToInstallOrUpdate(packageName);
+
+  if (packagesWrongVersion.length) {
+    logger.warn('');
+    logger.warn(`The following packages have a mismatch version installed to satisfy "${packageName}" needed versions:`);
+    packagesWrongVersion.forEach(dep => {
+      logger.warn(`${dep.packageName} found version is ${dep.foundVersion!}. "${packageName}" needs ${dep.version}`);
+    });
+    logger.warn('');
+    logger.warn('You might consider reinstalling the packages with the good versions:');
+    packagesWrongVersion.forEach((dep) => logger.warn(`${packageManager} run ng update ${dep.packageName}@${dep.version}`));
+  }
+
+  if (packagesToInstall.length) {
+    logger.error('');
+    logger.error(`The following packages need to be installed to have "${packageName}" working. Run the commands one by one:`);
+    packagesToInstall.forEach((dep) => logger.error(`${packageManager} run ng add ${dep.packageName}@${dep.version}`));
+    throw new Error('Missing peer dependencies');
+  }
+
+  if (!packagesToInstall.length && !packagesWrongVersion.length) {
+    logger.info(`The package ${packageName} has all peer deps installed.\n`);
+  }
+
+}
 
 /**
  * List peer deps packages of the given package, display a warning if version mismatch, error if peer dep is missing
@@ -7,9 +116,9 @@ import { checkPackagesToInstallOrUpdate } from '@o3r/dev-tools';
  * @param packageName The package to check peer deps for
  */
 export function checkPackagesRule(packageName: string) {
-  return (tree: Tree, _context: SchematicContext) => {
+  return (tree: Tree, context: SchematicContext) => {
     const angularJson = tree.read('/angular.json');
-    checkPackagesToInstallOrUpdate(packageName, angularJson?.toString());
+    checkPackagesToInstallOrUpdate(packageName, context.logger, angularJson?.toString());
     return tree;
   };
 }


### PR DESCRIPTION
## Proposed change

Removing dependency of schematics to the dev-tools to avoid ESM / CommonJs clash

## Related issues

- :bug: Fixes #332 

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
