### PR TITLE
fix: resolve new package with fs instead of node resolver

### DIFF
--- a/packages/@ama-terasu/cli/src/helpers/version.helper.ts
+++ b/packages/@ama-terasu/cli/src/helpers/version.helper.ts
@@ -11,7 +11,7 @@ import { isInstalled, ModuleDiscovery } from './module.helper';
  * @returns the package version or undefined if not found
  */
 export const getPackageFormattedVersion = (pck: ModuleDiscovery): string => {
-  const officialMark = pck.isOfficialModule ? chalk.blue(String.fromCharCode(0x00AE)) : '';
+  const officialMark = pck.isOfficialModule ? `${chalk.blue(String.fromCharCode(0x00AE))} ` : '';
   if (isInstalled(pck)) {
     const isOutdated = pck.version && pck.version !== pck.package.version;
     return `${pck.name}${officialMark}: ${(isOutdated ? chalk.yellow : chalk.green).bold(pck.package.version)}${isOutdated ? chalk.grey.italic(` (${pck.version!} available)`) : ''}`;

--- a/packages/@ama-terasu/cli/src/modules/base-yargs.ts
+++ b/packages/@ama-terasu/cli/src/modules/base-yargs.ts
@@ -92,7 +92,7 @@ export const amaYargs = async (argv?: Record<string, any>) => {
         .command(mod.moduleName, getFormattedDescription(mod), async (yargsInstance) => {
           if (!isInstalled(mod)) {
             await baseContext.getSpinner(`Installing ${chalk.bold(mod.name)} module...`).fromPromise(installDependency(mod), `${mod.name} has been installed`, `Failed to install ${mod.name} module`);
-            const information = await getInstalledInformation(mod);
+            const information = await getInstalledInformation(mod, true);
             Object.assign(mod, information);
             if (!isInstalled(mod)) {
               throw new Error(`Something went wrong with the installation of ${mod.name}`);


### PR DESCRIPTION
## Proposed change

The issue was because node is keeping a cache of the `require.resolve` parsed folder.
Because of that, the dependency added at runtime are not returned by `require.resolve` and unfortunately Node does not give access to its cache.
The workaround is to use `fs` to resolve the package position main script position