### PR TITLE
feat: add otter schematics collection to ngCli at ngAdd time

### DIFF
--- a/packages/@o3r/schematics/src/utility/collection.ts
+++ b/packages/@o3r/schematics/src/utility/collection.ts
@@ -1,0 +1,17 @@
+import type { WorkspaceSchema } from '../interfaces';
+
+/**
+ * Register the collection schematic to the workspace
+ *
+ * @param workspace Workspace to add the collection to
+ * @param collection Collection to add to the workspace schematic collection
+ * @returns the updated workspace
+ */
+export function registerCollectionSchematics(workspace: WorkspaceSchema, collection: string): WorkspaceSchema {
+  workspace.cli ||= {};
+  workspace.cli.schematicCollections ||= [];
+  if (!workspace.cli.schematicCollections.includes(collection)) {
+    workspace.cli.schematicCollections.push(collection);
+  }
+  return workspace;
+}

--- a/packages/@o3r/schematics/src/utility/index.ts
+++ b/packages/@o3r/schematics/src/utility/index.ts
@@ -13,3 +13,4 @@ export * from './package-manager-runner';
 export * from './package-version';
 export * from './monorepo';
 export * from './update-imports';
+export * from './collection';

--- a/packages/@o3r/schematics/src/utility/loaders.ts
+++ b/packages/@o3r/schematics/src/utility/loaders.ts
@@ -28,9 +28,10 @@ export function readAngularJson(tree: Tree, angularJsonFile = '/angular.json'): 
  *
  * @param tree File tree
  * @param workspace Angular workspace
+ * @param angularJsonFile Angular.json file path
  */
-export function writeAngularJson(tree: Tree, workspace: WorkspaceSchema) {
-  tree.overwrite('/angular.json', commentJson.stringify(workspace, null, 2));
+export function writeAngularJson(tree: Tree, workspace: WorkspaceSchema, angularJsonFile = '/angular.json') {
+  tree.overwrite(angularJsonFile, commentJson.stringify(workspace, null, 2));
   return tree;
 }
 

--- a/packages/@o3r/testing/schematics/ng-add/index.ts
+++ b/packages/@o3r/testing/schematics/ng-add/index.ts
@@ -1,6 +1,7 @@
 import { chain, Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { NgAddSchematicsSchema } from '../../schematics/ng-add/schema';
 import * as path from 'node:path';
+import * as fs from 'node:fs';
 
 /**
  * Add Otter testing to an Angular Project
@@ -10,8 +11,17 @@ import * as path from 'node:path';
 export function ngAdd(options: NgAddSchematicsSchema): Rule {
   return async (tree: Tree, context: SchematicContext) => {
     try {
-      const {addVsCodeRecommendations, getProjectDepType, getO3rPeerDeps, ngAddPackages, ngAddPeerDependencyPackages, removePackages} = await import('@o3r/schematics');
+      const {
+        addVsCodeRecommendations,
+        getProjectDepType,
+        getO3rPeerDeps,
+        ngAddPackages,
+        ngAddPeerDependencyPackages,
+        removePackages,
+        registerPackageCollectionSchematics
+      } = await import('@o3r/schematics');
       const testPackageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
+      const packageJson = JSON.parse(fs.readFileSync(testPackageJsonPath, { encoding: 'utf-8' }));
       const depsInfo = getO3rPeerDeps(testPackageJsonPath);
       const dependencyType = getProjectDepType(tree);
 
@@ -24,7 +34,8 @@ export function ngAdd(options: NgAddSchematicsSchema): Rule {
           parentPackageInfo: depsInfo.packageName,
           dependencyType: dependencyType
         }),
-        ngAddPeerDependencyPackages(['pixelmatch', 'pngjs'], testPackageJsonPath, dependencyType, options)
+        ngAddPeerDependencyPackages(['pixelmatch', 'pngjs'], testPackageJsonPath, dependencyType, options),
+        registerPackageCollectionSchematics(packageJson)
       ])(tree, context);
 
     } catch (e) {


### PR DESCRIPTION
## Proposed change

Add Otter Schematics collections in the `ng g --help` output