### PR TITLE
fix: playwright integration

### DIFF
--- a/packages/@o3r/core/schematics/module/templates/base/package.json.template
+++ b/packages/@o3r/core/schematics/module/templates/base/package.json.template
@@ -48,7 +48,7 @@
     "@nrwl/jest": "<%= versions['nrwl'] %>",
     "@nrwl/js": "<%= versions['nrwl'] %>",
     "@nrwl/linter": "<%= versions['nrwl'] %>",
-<% } %>    "@o3r/build-helpers": "<%= otterVersion %>",
+<% } %>
     "@o3r/dev-tools": "<%= otterVersion %>",
     "@o3r/eslint-plugin": "<%= otterVersion %>",
     "@schematics/angular": "<%= versions['angular-devkit'] %>",

--- a/packages/@o3r/core/schematics/rule-factories/playwright/index.ts
+++ b/packages/@o3r/core/schematics/rule-factories/playwright/index.ts
@@ -37,7 +37,7 @@ export function updatePlaywright(rootPath: string, options: NgAddPackageOptions 
       tree.overwrite('/package.json', JSON.stringify(packageJson, null, 2));
     }
     const corePackageJsonPath = path.resolve(__dirname, '..', '..', '..', 'package.json');
-    const ngAddRules = ngAddPeerDependencyPackages(['playwright', '@playwright/test', 'rimraf'], corePackageJsonPath, NodeDependencyType.Dev, options);
+    const ngAddRules = ngAddPeerDependencyPackages(['@playwright/test', 'rimraf'], corePackageJsonPath, NodeDependencyType.Dev, options);
 
     // generate files
     if (!tree.exists('/e2e-playwright/playwright-config.ts')) {

--- a/packages/@o3r/testing/package.json
+++ b/packages/@o3r/testing/package.json
@@ -105,7 +105,6 @@
     "@o3r/schematics": "workspace:^",
     "comment-json": "^4.1.0",
     "pixelmatch": "^5.2.1",
-    "playwright": "^1.16.3",
     "pngjs": "^4.0.1",
     "protractor": "^7.0.0",
     "rxjs": "^7.4.0",

--- a/packages/@o3r/testing/src/core/playwright/element.ts
+++ b/packages/@o3r/testing/src/core/playwright/element.ts
@@ -1,4 +1,4 @@
-import {Locator, Page} from 'playwright';
+import type {Locator, Page} from 'playwright';
 import {ElementProfile} from '../element';
 
 export {ElementProfile} from '../element';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7483,7 +7483,6 @@ __metadata:
     "@o3r/schematics": "workspace:^"
     comment-json: ^4.1.0
     pixelmatch: ^5.2.1
-    playwright: ^1.16.3
     pngjs: ^4.0.1
     protractor: ^7.0.0
     rxjs: ^7.4.0


### PR DESCRIPTION
## Proposed change

`playwright` is only a devDep for `@o3r/testing`
When install after `@playwright/test` it cause the following issue when running `playwright` command.

```shell
Please install @playwright/test package to use Playwright Test.
  npm install -D @playwright/test
```

## Related issues

- :bug: Fixes

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
