### PR TITLE
fix: logo URL in npmjs

### DIFF
--- a/packages/@o3r/analytics/README.md
+++ b/packages/@o3r/analytics/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter Analytics</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).

--- a/packages/@o3r/apis-manager/README.md
+++ b/packages/@o3r/apis-manager/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter APIs-manager</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).

--- a/packages/@o3r/application/README.md
+++ b/packages/@o3r/application/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter application</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).

--- a/packages/@o3r/components/README.md
+++ b/packages/@o3r/components/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter components</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).

--- a/packages/@o3r/configuration/README.md
+++ b/packages/@o3r/configuration/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter configuration</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).

--- a/packages/@o3r/core/README.md
+++ b/packages/@o3r/core/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter core</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 ## Description

--- a/packages/@o3r/dev-tools/README.md
+++ b/packages/@o3r/dev-tools/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter dev tools</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 ## Description

--- a/packages/@o3r/dynamic-content/README.md
+++ b/packages/@o3r/dynamic-content/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter dynamic content</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).

--- a/packages/@o3r/eslint-config-otter/README.md
+++ b/packages/@o3r/eslint-config-otter/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter eslint config</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).

--- a/packages/@o3r/eslint-plugin/README.md
+++ b/packages/@o3r/eslint-plugin/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter eslint plugin</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).

--- a/packages/@o3r/extractors/README.md
+++ b/packages/@o3r/extractors/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter extractor</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).

--- a/packages/@o3r/forms/README.md
+++ b/packages/@o3r/forms/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter forms</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).

--- a/packages/@o3r/localization/README.md
+++ b/packages/@o3r/localization/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter localization</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).

--- a/packages/@o3r/logger/README.md
+++ b/packages/@o3r/logger/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter logger</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).

--- a/packages/@o3r/mobile/README.md
+++ b/packages/@o3r/mobile/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter Mobile</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).

--- a/packages/@o3r/routing/README.md
+++ b/packages/@o3r/routing/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter routing</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).

--- a/packages/@o3r/rules-engine/README.md
+++ b/packages/@o3r/rules-engine/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter rules-engine</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).

--- a/packages/@o3r/schematics/README.md
+++ b/packages/@o3r/schematics/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter schematics</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).

--- a/packages/@o3r/storybook/README.md
+++ b/packages/@o3r/storybook/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter storybook</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).

--- a/packages/@o3r/stylelint-plugin/README.md
+++ b/packages/@o3r/stylelint-plugin/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter stylelint plugin</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).

--- a/packages/@o3r/styling/README.md
+++ b/packages/@o3r/styling/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter styling</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).

--- a/packages/@o3r/testing/README.md
+++ b/packages/@o3r/testing/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter testing</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).

--- a/packages/@o3r/third-party/README.md
+++ b/packages/@o3r/third-party/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Otter third-party</h1>
 <p align="center">
-  <img src="../../../.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/.attachments/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
 
 This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).


### PR DESCRIPTION
## Proposed change

Turn relative path to full path for the Otter Logo.
This fix the issue on [npmjs.org](https://www.npmjs.com/package/@o3r/core):

![image](https://github.com/AmadeusITGroup/otter/assets/2467012/4e051e48-6727-42c8-80b5-a19442ff7c56)
