### PR TITLE
fix: add missing package.json in schematics build builder's output

### DIFF
--- a/packages/@o3r/schematics/project.json
+++ b/packages/@o3r/schematics/project.json
@@ -29,7 +29,17 @@
       "executor": "nx:run-script",
       "options": {
         "script": "build:builders"
-      }
+      },
+      "outputs": [
+        "{projectRoot}/dist/package.json",
+        "{projectRoot}/dist/builders.json",
+        "{projectRoot}/dist/migration.json",
+        "{projectRoot}/dist/collection.json",
+        "{projectRoot}/dist/builders/**/*.json",
+        "{projectRoot}/dist/schemas/**/*.json",
+        "{projectRoot}/dist/schematics/**/*.json",
+        "{projectRoot}/dist/schematics/**/templates/**"
+      ]
     },
     "compile": {
       "executor": "@nrwl/js:tsc",


### PR DESCRIPTION
## Proposed change

Add missing package.json in schematics build builder's output
