### PR TITLE
fix: publish only latest cascading version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,6 +76,11 @@ jobs:
       - uses: ./tools/github-actions/download-build-output
       - uses: ./tools/github-actions/setup
       - run: yarn set:version ${{ inputs.version }}
+      - name: Get tag name
+        id: get-npm-tag
+        uses: ./tools/github-actions/get-npm-tag
+        with:
+          is-prerelease: ${{ inputs.prerelease }}
       - name: 'NPM install locally'
         run: |
           pushd './${{env.APP_PATH}}'
@@ -84,7 +89,7 @@ jobs:
       - name: 'Publish Cascading Azure Functions'
         env:
           PUBLISH_PROFILE: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_8996AC226FB9456EA73A6B8439B12946 || secrets.CASCADING_AZURE_APP_PUBLISH_PROFILE }}
-        if: env.PUBLISH_PROFILE != null
+        if: env.PUBLISH_PROFILE != null && steps.get-npm-tag.outputs.tag == 'latest'
         uses: Azure/functions-action@v1
         with:
           app-name: 'github-cascading'


### PR DESCRIPTION
## Proposed change

Fix the deployment of the cascading github app to deploy only the latest version of the app