### PR TITLE
fix: correctly cache o3r/schematics schematics

### DIFF
--- a/packages/@o3r/schematics/project.json
+++ b/packages/@o3r/schematics/project.json
@@ -29,17 +29,7 @@
       "executor": "nx:run-script",
       "options": {
         "script": "build:builders"
-      },
-      "outputs": [
-        "{projectRoot}/dist/package.json",
-        "{projectRoot}/dist/builders.json",
-        "{projectRoot}/dist/migration.json",
-        "{projectRoot}/dist/collection.json",
-        "{projectRoot}/dist/builders/**/*.json",
-        "{projectRoot}/dist/schemas/**/*.json",
-        "{projectRoot}/dist/schematics/**/*.json",
-        "{projectRoot}/dist/schematics/**/templates/**"
-      ]
+      }
     },
     "compile": {
       "executor": "@nrwl/js:tsc",


### PR DESCRIPTION
## Proposed change
Remove incorrect cache output.

Task build-builders is in charge of compiling the typescripts and should only cache javascript files
Task prepare-build-builders does not impact the package.json file

Thus both task can rely on nx.json output

## Related issues

- :bug: Missing files in published @o3r/schematics

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
