### PR TITLE
fix: ng-add core add dev dependencies from the lib

### DIFF
--- a/packages/@o3r/schematics/schematics/ng-add/index.ts
+++ b/packages/@o3r/schematics/schematics/ng-add/index.ts
@@ -43,7 +43,7 @@ export function ngAdd(): Rule {
     for (const dependency of schematicsDependencies) {
       const version = getDependencyVersion(dependency);
       context.logger.info(`Installing ${dependency}${version || ''}`);
-      treePackageJson.devDependencies = {...packageJsonContent.devDependencies, [dependency]: version};
+      treePackageJson.devDependencies = {...treePackageJson.devDependencies, [dependency]: version};
       context.addTask(new DevInstall({
         hideOutput: false,
         packageName: `${dependency}${version ? '@' + version : ''}`,


### PR DESCRIPTION
When using `ng add @o3r/core` on an app, we are currently adding a devDependency to `@o3r/build-helpers` which is private and not published

Also fix yarn global caching issues when running in local
Also fix issue with `mkdir -p` not working as expected on Windows