### PR TITLE
ci: publish verdaccio state in the PR in case of failure

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -41,18 +41,33 @@ jobs:
             !.cache/test-sdk/@o3r*
           key: ${{ runner.os }}-test-sdk-yarn3-${{ env.currentMonth }}
       - name: Setup verdaccio once for all tests
-        run: yarn verdaccio:start && yarn verdaccio:publish
+        id: setup-verdaccio
+        run: |
+          mkdir ./.verdaccio/storage
+          chmod a+rwx -R ./.verdaccio/storage
+          yarn verdaccio:start-persistent
+          yarn verdaccio:publish
       - name: Test
-        run: yarn test-int
-      - name: Stop verdaccio
-        if: always()
-        run: yarn verdaccio:stop
-      - name: Prepare for publish generated app
-        if: failure()
+        id: it-tests
+        run: yarn test-int --output-style=stream
+      - name: Zip verdaccio storage on failure
+        if: failure() && (steps.setup-verdaccio.conclusion == 'failure' || steps.it-tests.conclusion == 'failure')
+        run: zip -r verdaccio.zip ./.verdaccio
+      - name: Zip generated app on failure
+        if: failure() && steps.it-tests.conclusion == 'failure'
         run: zip -r it-tests.zip ../it-tests -x "../it-tests/*/.cache"
-      - name: Publish generated tests environment
-        if: failure()
+      - name: Publish verdaccio storage on failure
+        if: failure() && (steps.setup-verdaccio.conclusion == 'failure' || steps.it-tests.conclusion == 'failure')
+        uses: actions/upload-artifact@v3
+        with:
+          name: verdaccio
+          path: verdaccio.zip
+      - name: Publish generated tests environment on failure
+        if: failure() && steps.it-tests.conclusion == 'failure'
         uses: actions/upload-artifact@v3
         with:
           name: it-tests
           path: it-tests.zip
+      - name: Stop verdaccio
+        if: always()
+        run: yarn verdaccio:stop

--- a/.verdaccio/.gitignore
+++ b/.verdaccio/.gitignore
@@ -1,2 +1,2 @@
-conf/.npmrc
+conf/.npmrc-logged
 storage

--- a/.verdaccio/README.md
+++ b/.verdaccio/README.md
@@ -1,0 +1,27 @@
+# Verdaccio
+
+Verdaccio is a tool used to publish npm packages in a local registry (https://verdaccio.org/)
+
+You can run the following commands inside this folder
+
+## How to start
+
+Unix:
+```bash
+docker run -d -it --rm --name verdaccio -p 4873:4873 -v "$(pwd)/conf":/verdaccio/conf -v "$(pwd)/storage":/verdaccio/storage:z verdaccio/verdaccio
+```
+
+Windows:
+```bash
+docker run -d -it --rm --name verdaccio -p 4873:4873 -v "%cd%/conf":/verdaccio/conf -v "%cd%/storage":/verdaccio/storage verdaccio/verdaccio
+```
+
+## How to stop
+
+```bash
+docker ps -a -q --filter="name=verdaccio" | xargs docker container stop
+```
+
+## How to use
+
+Add `registry=http://localhost:4873` in your `.npmrc` / `yarnrc.yml` files or as a parameter of the install command

--- a/.verdaccio/conf/config.yaml
+++ b/.verdaccio/conf/config.yaml
@@ -12,7 +12,7 @@
 # Read about the best practices
 # https://verdaccio.org/docs/best
 
-storage: /verdaccio/storage/data
+storage: /verdaccio/storage
 
 plugins: /verdaccio/plugins
 
@@ -22,6 +22,7 @@ web:
 auth:
   htpasswd:
     file: /verdaccio/storage/htpasswd
+    algorithm: bcrypt
 
 uplinks:
   npmjs:
@@ -43,4 +44,4 @@ middlewares:
   audit:
     enabled: true
 
-log: { type: stdout, format: pretty, level: http }
+logs: { type: file, format: pretty, level: http, colors: false, path: /verdaccio/storage/verdaccio.log }

--- a/README.md
+++ b/README.md
@@ -146,7 +146,15 @@ Check Unit Tests:
 yarn run test
 ```
 
-Each module can be test independently thanks to [Nx](https://nx.dev/packages/nx/documents/run) commands:
+Check Integration Tests:
+
+```shell
+yarn run test-int
+```
+
+[Verdaccio](./.verdaccio/README.md) is used to run the integration tests as close as possible to a real npm publication.
+
+Each module can be tested independently thanks to [Nx](https://nx.dev/packages/nx/documents/run) commands:
 
 ```shell
 # ex: Test Core package only

--- a/package.json
+++ b/package.json
@@ -33,8 +33,11 @@
     "doc:generate:json": "yarn update-doc-summary ./docs && yarn compodoc -e json -d .",
     "start:modules": "yarn run build:dev:modules && yarn run watch:modules",
     "storybook": "yarn doc:generate:json && yarn ng run storybook:extract-style && start-storybook -p 6006",
-    "verdaccio:start": "docker run -d -it --rm --name verdaccio -p 4873:4873 -v $(shx pwd)/.verdaccio/conf:/verdaccio/conf verdaccio/verdaccio",
-    "verdaccio:publish": "yarn set:version 999.0.0 --include \"!**/!(dist)/package.json\" --include !package.json && npx --yes npm-cli-login -u verdaccio -p verdaccio -e test@test.com -r http://localhost:4873 --config-path \".verdaccio/conf/.npmrc\" && yarn run publish --userconfig \".verdaccio/conf/.npmrc\" --tag=latest --@o3r:registry=http://localhost:4873 --@ama-sdk:registry=http://localhost:4873",
+    "verdaccio:start": "docker run -d -it --rm --name verdaccio -p 4873:4873 -v \"$(shx pwd)/.verdaccio/conf\":/verdaccio/conf verdaccio/verdaccio",
+    "verdaccio:start-persistent": "docker run -d -it --rm --name verdaccio -p 4873:4873 -v \"$(shx pwd)/.verdaccio/conf\":/verdaccio/conf -v \"$(shx pwd)/.verdaccio/storage\":/verdaccio/storage:z verdaccio/verdaccio",
+    "verdaccio:clean": "rimraf ./.verdaccio/storage",
+    "verdaccio:login": "yarn cpy --cwd=./.verdaccio/conf .npmrc . --rename=.npmrc-logged && npx --yes npm-cli-login -u verdaccio -p verdaccio -e test@test.com -r http://localhost:4873 --config-path \".verdaccio/conf/.npmrc-logged\"",
+    "verdaccio:publish": "yarn set:version 999.0.0 --include \"!**/!(dist)/package.json\" --include !package.json && yarn verdaccio:login && yarn run publish --userconfig \".verdaccio/conf/.npmrc-logged\" --tag=latest --@o3r:registry=http://localhost:4873 --@ama-sdk:registry=http://localhost:4873",
     "verdaccio:stop": "docker container stop $(docker ps -a -q --filter=\"name=verdaccio\")",
     "watch:vscode-extension": "yarn nx run vscode-extension:compile:watch",
     "workspaces:list": "yarn workspaces list --no-private --json | shx sed \"s/.*\\\"location\\\":\\\"(.*?)\\\".*/\\$1/\""


### PR DESCRIPTION
In case of failure on the it-tests, we'll now publish an artifact containing the storage of verdaccio, so we can download it and run the docker image locally with the same state as the CI