### PR TITLE
feat: enhance the BaseMockAdapter class to accept a function that returns a promise that resolves to PathObject[]

### DIFF
--- a/packages/@ama-sdk/core/src/fwk/mocks/alf-mock-adapter.ts
+++ b/packages/@ama-sdk/core/src/fwk/mocks/alf-mock-adapter.ts
@@ -176,16 +176,17 @@ function buildMockMap(log: string, operationAdapter: PathObject[]): MockMap {
  * Get the mock adapter corresponding to the logs retrieved from ALF
  *
  * @param binFilePath the path to the file containing the logs downloaded from Alf in .bin format
- * @param operationAdapter an array of PathObject to map request with their operationId
+ * @param operationAdapter an array of PathObject or a function that returns an array of PathObject or a Promise that resolves to an array of PathObject, to map request with their operationId
  * @returns a sequential mock adapter containing each response found in Alf
  */
-export function getAlfMockAdapter(binFilePath: string, operationAdapter: PathObject[]): SequentialMockAdapter {
+export function getAlfMockAdapter(binFilePath: string, operationAdapter: PathObject[] | (() => PathObject[] | Promise<PathObject[]>)): SequentialMockAdapter {
   return new SequentialMockAdapter(operationAdapter, async () => {
     const response = await fetch(binFilePath);
     if (response.ok) {
       const content = await response.text();
 
-      return buildMockMap(content, operationAdapter);
+      const adapter = typeof operationAdapter === 'function' ? await operationAdapter() : operationAdapter;
+      return buildMockMap(content, adapter);
     }
     return {};
   });

--- a/packages/@ama-sdk/core/src/fwk/mocks/mock-adapter.ts
+++ b/packages/@ama-sdk/core/src/fwk/mocks/mock-adapter.ts
@@ -21,8 +21,17 @@ export interface MockAdapter {
    * Retrieves an operation ID from an API request
    *
    * @param request the api request
+   * @deprecated Please use retrieveOperationId instead
    */
   getOperationId(request: EncodedApiRequest): string;
+
+  /**
+   * Retrieves an operation ID from an API request
+   *
+   * @param request the api request
+   */
+  retrieveOperationId(request: EncodedApiRequest): Promise<string>;
+
   /**
    * Initializes the adapter
    */

--- a/packages/@ama-sdk/core/src/plugins/mock-intercept/mock-intercept.request.ts
+++ b/packages/@ama-sdk/core/src/plugins/mock-intercept/mock-intercept.request.ts
@@ -37,7 +37,7 @@ export class MockInterceptRequest implements RequestPlugin {
           ...data,
           method: data.method || 'GET'
         };
-        const operationId = this.options.adapter.getOperationId(requestOption);
+        const operationId = await this.options.adapter.retrieveOperationId(requestOption);
         const mock = this.options.adapter.getMock(operationId);
         const text = JSON.stringify(mock.mockData);
         const blob = new Blob([text], { type: 'application/json' });

--- a/packages/@ama-sdk/core/src/plugins/mock-intercept/mock-intercept.spec.ts
+++ b/packages/@ama-sdk/core/src/plugins/mock-intercept/mock-intercept.spec.ts
@@ -10,12 +10,14 @@ const testMock: Mock<any> = {
 const getMockSpy = jest.fn().mockReturnValue(testMock);
 const getLatestMockSpy = jest.fn().mockReturnValue(testMock);
 const getOperationIdSpy = jest.fn().mockReturnValue('testOperation');
+const retrieveOperationIdSpy = jest.fn().mockReturnValue(Promise.resolve('testOperation'));
 const initializeSpy = jest.fn().mockReturnValue(Promise.resolve());
 const testMockAdapter: MockAdapter = {
   getMock: getMockSpy,
   getLatestMock: getLatestMockSpy,
   getOperationId: getOperationIdSpy,
-  initialize: initializeSpy
+  initialize: initializeSpy,
+  retrieveOperationId: retrieveOperationIdSpy
 };
 
 const requestPlugins: RequestPlugin[] = [new MockInterceptRequest({adapter: new SequentialMockAdapter([], {})})];
@@ -69,7 +71,8 @@ describe('Mock intercept', () => {
           initialize: initializeSpy,
           getMock: getMockSpy,
           getLatestMock: getLatestMockSpy,
-          getOperationId: getOperationIdSpy
+          getOperationId: getOperationIdSpy,
+          retrieveOperationId: retrieveOperationIdSpy
         };
         plugin = new MockInterceptFetch({adapter: asyncMockAdapter});
       });


### PR DESCRIPTION


## Proposed change
This PR adds the capability for the `BaseMockAdaper`  to accept a Promise that resolves to an array of `PathObject` in addition to accepting a simple array. This would enable the tree-shaking of the relatively big list of `PathObject` for production environments whilst still allowing for the mock adapter to take effect when enabled.

## Related issues

- :rocket: Feature [#(498)](https://github.com/AmadeusITGroup/otter/issues/498)
