### PR TITLE
fix: export assets-path-override store module

### DIFF
--- a/packages/@o3r/dynamic-content/src/stores/index.ts
+++ b/packages/@o3r/dynamic-content/src/stores/index.ts
@@ -1,4 +1,5 @@
 export * from './asset-path-override/asset-path-override.actions';
+export * from './asset-path-override/asset-path-override.module';
 export * from './asset-path-override/asset-path-override.reducer';
 export * from './asset-path-override/asset-path-override.selectors';
 export * from './asset-path-override/asset-path-override.state';


### PR DESCRIPTION
## Proposed change

export assets-path-override store module from dynamic-content package

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
