### PR TITLE
feat: add specificationLink in fc metadata schema

### DIFF
--- a/packages/@o3r/application/schemas/functional-content.metadata.schema.json
+++ b/packages/@o3r/application/schemas/functional-content.metadata.schema.json
@@ -70,6 +70,10 @@
             "type": "string",
             "description": "Name of the parent object which contains this section on exported file"
           },
+          "specificationLink": {
+            "type": "string",
+            "description": "URL of the specification corresponding to the current section"
+          },
           "definitions": {
             "type": "array",
             "description": "Object definitions for this section",


### PR DESCRIPTION
Update JSON schema for functional-content metadata in order to take into account a new possibility.
New property added at section level: "specificationLink"

> The specificationLink specifies a URL that the end user can open to learn more about the current functional content section. It is optional.
> 
> The link is available through a clickable help icon at the top of the page, next to the Functional content title.


## Proposed change

- :rocket: Feature #(issue)

## Type of change
 🚀 New feature 

- [ ] (non-breaking change which adds functionality)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
