### PR TITLE
fix: Use tagname for mat-option in fixtures

### DIFF
--- a/packages/@o3r/testing/src/core/playwright/angular-materials/autocomplete-material.ts
+++ b/packages/@o3r/testing/src/core/playwright/angular-materials/autocomplete-material.ts
@@ -16,7 +16,7 @@ export class MatAutocomplete extends O3rElement implements MatAutocompleteProfil
     await this.setValue(value);
     await this.click();
     const element = this.sourceElement.page;
-    const matOptions = element.locator('.mat-option');
+    const matOptions = element.locator('.mat-option, mat-option');
     await matOptions.first().waitFor({state: 'attached', timeout});
     const matOptionsCount = await matOptions.count();
     const options: (string | undefined)[] = [];
@@ -32,6 +32,6 @@ export class MatAutocomplete extends O3rElement implements MatAutocompleteProfil
       return this.sourceElement.element.press('Tab');
     }
 
-    return Promise.reject('Element with selector .mat-option not found.');
+    return Promise.reject('Element with selector .mat-option, mat-option not found.');
   }
 }

--- a/packages/@o3r/testing/src/core/protractor/angular-materials/autocomplete-material.ts
+++ b/packages/@o3r/testing/src/core/protractor/angular-materials/autocomplete-material.ts
@@ -16,7 +16,7 @@ export class MatAutocomplete extends O3rElement implements MatAutocompleteProfil
   public async selectByValue(value: string, _timeout?: number) {
     await this.setValue(value);
     await this.click();
-    const matOption = element(By.css('.mat-option'));
+    const matOption = element(By.css('.mat-option, mat-option'));
     return new O3rElement(matOption).click();
   }
 }


### PR DESCRIPTION
## Proposed change

Using mat option tagname instead of class as the class changed with MDC 

## Related issues

- :bug: Fixes #520 
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
