### PR TITLE
fix: carret on peer dep and remove useless dep

### DIFF
--- a/packages/@ama-sdk/core/package.json
+++ b/packages/@ama-sdk/core/package.json
@@ -42,17 +42,13 @@
     "uuid": "^9.0.0"
   },
   "peerDependencies": {
-    "@angular-devkit/schematics": "~16.0.5",
-    "@angular/cli": "~16.0.5",
-    "@schematics/angular": "~16.0.5",
+    "@angular-devkit/schematics": "^16.0.5",
+    "@schematics/angular": "^16.0.5",
     "isomorphic-fetch": "^3.0.0",
     "typescript": "~5.0.2"
   },
   "peerDependenciesMeta": {
     "@angular-devkit/schematics": {
-      "optional": true
-    },
-    "@angular/cli": {
       "optional": true
     },
     "@schematics/angular": {
@@ -69,7 +65,6 @@
     "@angular-devkit/core": "~16.0.5",
     "@angular-devkit/schematics": "~16.0.5",
     "@angular-eslint/eslint-plugin": "~16.0.3",
-    "@angular/cli": "~16.0.5",
     "@nx/jest": "~16.5.0",
     "@o3r/build-helpers": "workspace:^",
     "@o3r/dev-tools": "workspace:^",

--- a/packages/@ama-sdk/schematics/package.json
+++ b/packages/@ama-sdk/schematics/package.json
@@ -27,9 +27,6 @@
     "@angular-devkit/schematics-cli": {
       "optional": true
     },
-    "@angular/cli": {
-      "optional": true
-    },
     "@angular/compiler": {
       "optional": true
     },
@@ -42,12 +39,11 @@
   },
   "peerDependencies": {
     "@ama-sdk/core": "workspace:^",
-    "@angular-devkit/core": "~16.0.5",
-    "@angular-devkit/schematics": "~16.0.5",
-    "@angular-devkit/schematics-cli": "~16.0.5",
-    "@angular/cli": "~16.0.5",
+    "@angular-devkit/core": "^16.0.5",
+    "@angular-devkit/schematics": "^16.0.5",
+    "@angular-devkit/schematics-cli": "^16.0.5",
     "@openapitools/openapi-generator-cli": "~2.7.0",
-    "@schematics/angular": "~16.0.5"
+    "@schematics/angular": "^16.0.5"
   },
   "dependencies": {
     "@angular-devkit/core": "~16.0.5",

--- a/packages/@o3r/dev-tools/src/cli/version-harmonize.ts
+++ b/packages/@o3r/dev-tools/src/cli/version-harmonize.ts
@@ -60,7 +60,7 @@ const getLatestRange = (dependencies: DependencyInfo[], dependencyName: string):
         } else if (!minAccVersion) {
           return current;
         }
-        return semver.lt(minCurrentVersion, minAccVersion) ? acc : current;
+        return semver.lte(minCurrentVersion, minAccVersion) ? acc : current;
       }
     }, undefined);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,7 +66,6 @@ __metadata:
     "@angular-devkit/core": ~16.0.5
     "@angular-devkit/schematics": ~16.0.5
     "@angular-eslint/eslint-plugin": ~16.0.3
-    "@angular/cli": ~16.0.5
     "@nx/jest": ~16.5.0
     "@o3r/build-helpers": "workspace:^"
     "@o3r/dev-tools": "workspace:^"
@@ -100,15 +99,12 @@ __metadata:
     typescript: ~5.0.2
     uuid: ^9.0.0
   peerDependencies:
-    "@angular-devkit/schematics": ~16.0.5
-    "@angular/cli": ~16.0.5
-    "@schematics/angular": ~16.0.5
+    "@angular-devkit/schematics": ^16.0.5
+    "@schematics/angular": ^16.0.5
     isomorphic-fetch: ^3.0.0
     typescript: ~5.0.2
   peerDependenciesMeta:
     "@angular-devkit/schematics":
-      optional: true
-    "@angular/cli":
       optional: true
     "@schematics/angular":
       optional: true
@@ -276,18 +272,15 @@ __metadata:
     typescript: ~5.0.2
   peerDependencies:
     "@ama-sdk/core": "workspace:^"
-    "@angular-devkit/core": ~16.0.5
-    "@angular-devkit/schematics": ~16.0.5
-    "@angular-devkit/schematics-cli": ~16.0.5
-    "@angular/cli": ~16.0.5
+    "@angular-devkit/core": ^16.0.5
+    "@angular-devkit/schematics": ^16.0.5
+    "@angular-devkit/schematics-cli": ^16.0.5
     "@openapitools/openapi-generator-cli": ~2.7.0
-    "@schematics/angular": ~16.0.5
+    "@schematics/angular": ^16.0.5
   peerDependenciesMeta:
     "@ama-sdk/core":
       optional: true
     "@angular-devkit/schematics-cli":
-      optional: true
-    "@angular/cli":
       optional: true
     "@angular/compiler":
       optional: true


### PR DESCRIPTION
## Proposed change
* Change ~ by ^ on schematics peer dep to allow more flexibility for users, a minor should not break the schematics
* get rid of useless dep on angular cli for generator sdk schematics package