### PR TITLE
fix: sdk generator - support native return types

### DIFF
--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/api.mustache
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/api.mustache
@@ -101,7 +101,7 @@ export class {{classname}} implements Api {
     const options = await this.client.prepareOptions(basePathUrl, '{{httpMethod}}', getParams, headers, body || undefined, tokenizedOptions, metadata);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
-    const ret = this.client.processCall<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>(url, options, {{#tags.0.extensions.x-api-type}}ApiTypes.{{tags.0.extensions.x-api-type}}{{/tags.0.extensions.x-api-type}}{{^tags.0.extensions.x-api-type}}ApiTypes.DEFAULT{{/tags.0.extensions.x-api-type}}, {{classname}}.apiName{{#returnType}}, revive{{returnBaseType}}{{/returnType}}{{^returnType}}, undefined{{/returnType}}, '{{nickname}}');
+    const ret = this.client.processCall<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>(url, options, {{#tags.0.extensions.x-api-type}}ApiTypes.{{tags.0.extensions.x-api-type}}{{/tags.0.extensions.x-api-type}}{{^tags.0.extensions.x-api-type}}ApiTypes.DEFAULT{{/tags.0.extensions.x-api-type}}, {{classname}}.apiName{{^returnTypeIsPrimitive}}, revive{{returnBaseType}}{{/returnTypeIsPrimitive}}{{#returnTypeIsPrimitive}}, undefined{{/returnTypeIsPrimitive}}, '{{nickname}}');
     return ret;
   }
 


### PR DESCRIPTION
## Bug
* Current behavior fails when we put a native type as return type of an api request, generating a revive for it
## Proposed change
* Check the right property to determine whether to call the revive or not
