### PR TITLE
ci: publish-pr on external workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,17 +77,7 @@ jobs:
     with:
       version: ${{ needs.version.outputs.nextVersionTag }}
       prerelease: ${{ needs.version.outputs.isPreRelease == 'true' }}
-  publish-packages-pr:
-    uses: ./.github/workflows/publish.yml
-    if: ${{ github.event_name == 'pull_request' }}
-    permissions:
-      packages: write
-      contents: read
-    secrets: inherit
-    needs: [version, build]
-    with:
-      version: ${{ needs.version.outputs.nextVersionTag }}
-      prerelease: ${{ needs.version.outputs.isPreRelease == 'true' }}
+      isPullRequest: false
 
   documentation-main:
     secrets: inherit

--- a/.github/workflows/publish-pr.yml
+++ b/.github/workflows/publish-pr.yml
@@ -1,0 +1,69 @@
+name: Publish PR
+
+on:
+  workflow_run:
+    workflows: ['Main CI']
+    types:
+      - completed
+
+jobs:
+  version:
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    permissions:
+      actions: read
+    runs-on: ubuntu-latest
+    outputs:
+      nextVersionTag: ${{ steps.newVersion.outputs.nextVersionTag }}
+    steps:
+      - name: get logs from workflow run
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let download = await github.rest.actions.downloadWorkflowRunLogs({
+               ...context.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/logs.zip`, Buffer.from(download.data));
+      - run: unzip logs.zip
+      - name: extract version from logs
+        id: newVersion
+        run: echo nextVersionTag=$(find *_version.txt | xargs grep -hiPo '(?<=nextVersionTag variable has been set with ).*$') >> "$GITHUB_OUTPUT"
+
+  publish-packages-pr:
+    uses: ./.github/workflows/publish.yml
+    needs: [version]
+    permissions:
+      packages: write
+      contents: read
+    secrets: inherit
+    with:
+      version: ${{ needs.version.outputs.nextVersionTag }}
+      prerelease: true
+      isPullRequest: true
+
+  notify-parent:
+    runs-on: ubuntu-latest
+    needs: [publish-packages-pr]
+    if: success() || failure()
+    permissions:
+      checks: write
+    steps:
+      - name: Update triggering workflow
+        uses: actions/github-script@v6
+        env:
+          PUBLISH_RESULT: ${{ needs.publish-packages-pr.result }}
+        with:
+          script: |
+            const backUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/attempts/${context.runAttempt || 1}`;
+            await github.rest.checks.create({
+               ...context.repo,
+               head_sha: context.payload.workflow_run.head_commit.id,
+               name: 'publish-packages-pr',
+               conclusion: process.env.PUBLISH_RESULT,
+               status: 'completed',
+               output: {
+                  title: 'publish-packages-pr',
+                  summary: `${process.env.PUBLISH_RESULT} publish [${backUrl}](${backUrl})`
+               }
+            });

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,10 @@ on:
         default: false
         required: false
         description: Version of the artifact to publish
+      isPullRequest:
+        type: boolean
+        default: ${{ github.event_name == 'pull_request' }}
+        required: false
     secrets:
       AZURE_VSC_EXT_TOKEN:
         required: false
@@ -37,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-    environment: ${{github.event_name == 'pull_request' && 'development' || 'production'}}
+    environment: ${{inputs.isPullRequest && 'development' || 'production'}}
     permissions:
       packages: write
       contents: read
@@ -55,7 +59,7 @@ jobs:
           is-prerelease: ${{ inputs.prerelease }}
           version: ${{ inputs.version }}
       - name: Publish
-        run: yarn run publish --tag=${{ github.event_name == 'pull_request' && 'pr' || steps.get-npm-tag.outputs.tag }} ${{ github.event_name == 'pull_request' && '--userconfig=./.npmrc.pr' || ''}} --always-auth=true
+        run: yarn run publish --tag=${{ inputs.isPullRequest && 'pr' || steps.get-npm-tag.outputs.tag }} ${{ inputs.isPullRequest && '--userconfig=./.npmrc.pr' || ''}} --always-auth=true
         env:
           GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -64,7 +68,7 @@ jobs:
           AZURE_EMAIL: ${{ secrets.AZURE_EMAIL }}
 
   publish-cascading:
-    if: github.event_name != 'pull_request'
+    if: '!inputs.isPullRequest'
     runs-on: ubuntu-latest
     env:
       APP_PATH: 'apps/github-cascading-app/dist'
@@ -100,7 +104,7 @@ jobs:
 
   publish-extensions:
     runs-on: ubuntu-latest
-    environment: ${{github.event_name == 'pull_request' && 'development' || 'production'}}
+    environment: ${{inputs.isPullRequest && 'development' || 'production'}}
     permissions:
       packages: write
       contents: read

--- a/tools/github-actions/download-build-output/action.yml
+++ b/tools/github-actions/download-build-output/action.yml
@@ -1,14 +1,42 @@
 name: Download Build Output
 description: Download and restore the `dist` folders from github artifact (check ../upload-build-output)
+inputs:
+  artifactName:
+    description: Name of the artifact on which the outputs are published
+    default: dist
+    required: false
 
 runs:
   using: 'composite'
   steps:
     - uses: actions/download-artifact@v3
+      if: github.event_name != 'workflow_run'
       with:
-        name: dist
+        name: ${{ inputs.artifactName }}
         path: '.'
-    - run: unzip -q -n dist.zip
+
+    - name: 'Download artifact'
+      uses: actions/github-script@v6
+      if: github.event_name == 'workflow_run'
+      with:
+        script: |
+          let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+             ...context.repo,
+             run_id: context.payload.workflow_run.id,
+          });
+          let matchArtifact = allArtifacts.data.artifacts.find((artifact) => artifact.name === '${{ inputs.artifactName }}');
+          if (!matchArtifact) {
+            throw new Error('Could not find an artifact with name "${{ inputs.artifactName }}" for workflow_run ${context.payload.workflow_run.id}');
+          }
+          let download = await github.rest.actions.downloadArtifact({
+             ...context.repo,
+             artifact_id: matchArtifact.id,
+             archive_format: 'zip',
+          });
+          let fs = require('fs');
+          fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/${{ inputs.artifactName }}.zip`, Buffer.from(download.data));
+
+    - run: unzip -q -n ${{ inputs.artifactName }}.zip
       shell: bash
-    - run: rm -f dist.zip
+    - run: rm -f ${{ inputs.artifactName }}.zip
       shell: bash

--- a/tools/github-actions/upload-build-output/action.yml
+++ b/tools/github-actions/upload-build-output/action.yml
@@ -1,14 +1,19 @@
 name: Upload Build Output
 description: Upload a github artifact containing all `dist` outputs
+inputs:
+  artifactName:
+    description: Name of the artifact on which the outputs are published
+    default: dist
+    required: false
 
 runs:
   using: 'composite'
   steps:
-    - run: zip -q -r dist.zip . -i "apps/*/dist/*" "packages/*/dist/*" -x "*/node_modules/*" ".cache/*"
+    - run: zip -q -r ${{ inputs.artifactName }}.zip . -i "apps/*/dist/*" "packages/*/dist/*" -x "*/node_modules/*" ".cache/*"
       shell: bash
     - uses: actions/upload-artifact@v3
       with:
-        name: dist
-        path: dist.zip
-    - run: rm -f dist.zip
+        name: ${{ inputs.artifactName }}
+        path: ${{ inputs.artifactName }}.zip
+    - run: rm -f ${{ inputs.artifactName }}.zip
       shell: bash


### PR DESCRIPTION
## Proposed change

Currently, for external contributions, the workflow is not able to access secrets variables, so the job `publish-pr` is failing

One solution is to create another workflow triggered by `workflow_run`:`completed` that handle the publication

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
