### PR TITLE
fix: state not syncing with storage for feature modules

### DIFF
--- a/packages/@o3r/store-sync/src/sync-storage/interfaces.ts
+++ b/packages/@o3r/store-sync/src/sync-storage/interfaces.ts
@@ -16,6 +16,8 @@ export interface SyncStorageSyncOptions {
   filter?: string[];
   /** Spacing for serializer */
   space?: string | number;
+  /** Defines whether the store is loaded as forFeature */
+  syncForFeature?: boolean;
 }
 
 /**

--- a/packages/@o3r/store-sync/src/sync-storage/storage-sync.spec.ts
+++ b/packages/@o3r/store-sync/src/sync-storage/storage-sync.spec.ts
@@ -1,7 +1,7 @@
 import { INIT } from '@ngrx/store';
 import type { ActionReducer } from '@ngrx/store';
 import { deepFill } from '@o3r/core';
-import { SyncStorageConfig } from './interfaces';
+import { StorageKeys, SyncStorageConfig } from './interfaces';
 import { dateReviver, rehydrateApplicationState, syncStateUpdate, syncStorage } from './storage-sync';
 
 class TypeB {
@@ -80,7 +80,15 @@ describe('ngrxLocalStorage', () => {
 
   const initialStateJson = JSON.stringify(initialState);
 
+  const featureInitialState = {...t1};
+
+  const featureInitialStateJson = JSON.stringify(featureInitialState);
+
   const undefinedState: { state: any } = { state: undefined };
+
+  const featureKeys: StorageKeys = [{'featureState': {syncForFeature: true}}];
+
+  let featureUndefinedState: any;
 
   beforeEach(() => {
     localStorage.clear();
@@ -88,8 +96,6 @@ describe('ngrxLocalStorage', () => {
 
   it('simple', () => {
     // This tests a very simple state object syncing to mock Storage
-    // Since we're not specifying anything for rehydration, the roundtrip
-    // loses type information...
 
     const s = new MockStorage();
     const skr = mockStorageKeySerializer;
@@ -106,6 +112,24 @@ describe('ngrxLocalStorage', () => {
     expect(finalState.simple instanceof TypeA).toBeFalsy();
   });
 
+  it('simple (feature store)', () => {
+    // This tests a very simple state object of a feature store syncing to mock Storage
+
+    const s = new MockStorage();
+    const skr = mockStorageKeySerializer;
+
+    syncStateUpdate(featureInitialState, featureKeys, s, skr, false, undefined, undefined);
+
+    const raw = s.getItem('featureState');
+    expect(raw).toEqual(featureInitialStateJson);
+
+    const finalState: any = rehydrateApplicationState(featureKeys, s, skr, true, undefined);
+    expect(JSON.stringify(finalState)).toEqual(featureInitialStateJson);
+
+    expect(t1 instanceof TypeA).toBeTruthy();
+    expect(finalState instanceof TypeA).toBeFalsy();
+  });
+
   it('simple string', () => {
     const primitiveStr = 'string is not an object';
     const initialStatePrimitiveStr = { state: primitiveStr };
@@ -120,6 +144,22 @@ describe('ngrxLocalStorage', () => {
 
     const finalState: any = rehydrateApplicationState(['state'], s, skr, true);
     expect(finalState.state).toEqual(primitiveStr);
+  });
+
+  it('simple string (feature Store)', () => {
+    const primitiveStr = 'string is not an object';
+    const initialFeatureStatePrimitiveStr = primitiveStr;
+
+    const s = new MockStorage();
+    const skr = mockStorageKeySerializer;
+
+    syncStateUpdate(initialFeatureStatePrimitiveStr, featureKeys, s, skr, false, undefined, undefined);
+
+    const raw = s.getItem('featureState');
+    expect(raw).toEqual(primitiveStr);
+
+    const finalState: any = rehydrateApplicationState(featureKeys, s, skr, true, undefined);
+    expect(finalState).toEqual(primitiveStr);
   });
 
   [true, false].forEach((bool) => {
@@ -140,11 +180,26 @@ describe('ngrxLocalStorage', () => {
     });
   });
 
+  [true, false].forEach((bool) => {
+    it(`simple ${bool ? 'true' : 'false'} boolean (feature Store)`, () => {
+      const primitiveBool = bool;
+      const initialFeatureStatePrimitiveBool = bool;
+
+      const s = new MockStorage();
+      const skr = mockStorageKeySerializer;
+
+      syncStateUpdate(initialFeatureStatePrimitiveBool, featureKeys, s, skr, false, undefined, undefined);
+
+      const raw = s.getItem('featureState');
+      expect(JSON.parse(raw)).toEqual(primitiveBool);
+
+      const finalState: any = rehydrateApplicationState(featureKeys, s, skr, true, undefined);
+      expect(finalState).toEqual(primitiveBool);
+    });
+  });
+
   it('filtered', () => {
-    // Use the filter by field option to round-trip an object while
-    // filtering out the anumber and adate filed
-    // Since we're not specifiying anything for rehydration, the roundtrip
-    // loses type information...
+    // Use the filter by field option to filter out the anumber and adate filed
 
     const s = new MockStorage();
     const skr = mockStorageKeySerializer;
@@ -161,6 +216,25 @@ describe('ngrxLocalStorage', () => {
 
     expect(t1 instanceof TypeA).toBeTruthy();
     expect(finalState.state instanceof TypeA).toBeFalsy();
+  });
+
+  it('filtered (feature Store)', () => {
+    // Use the filter by field option to filter out the anumber and adate filed for a feature Store
+
+    const s = new MockStorage();
+    const skr = mockStorageKeySerializer;
+    const keys = [{ 'feature': {filter: ['astring', 'aclass'], syncForFeature: true} }];
+
+    syncStateUpdate(featureInitialState, keys, s, skr, false, undefined, undefined);
+
+    const raw = s.getItem('feature');
+    expect(raw).toEqual(JSON.stringify(t1Filtered));
+
+    const finalState: any = rehydrateApplicationState(keys, s, skr, true, undefined);
+    expect(JSON.stringify(finalState)).toEqual(JSON.stringify(t1Filtered));
+
+    expect(t1 instanceof TypeA).toBeTruthy();
+    expect(finalState instanceof TypeA).toBeFalsy();
   });
 
   it('filtered - multiple keys at root - should properly revive partial state', () => {
@@ -190,6 +264,45 @@ describe('ngrxLocalStorage', () => {
     expect(raw2).toEqual(JSON.stringify({ 'slice21': true, 'slice22': [1, 2] }));
   });
 
+  it('filtered - multiple keys at root - should properly revive partial state (feature Store)', () => {
+    const s = new MockStorage();
+    const skr = mockStorageKeySerializer;
+
+    // state at any given moment, subject to sync selectively
+    const nestedState = {
+      app: { app1: true, app2: [1, 2], app3: { anyValue: 'thing' } },
+      feature1: { slice11: true, slice12: [1, 2], slice13: { anyValue: 'thing' } },
+      feature2: { slice21: true, slice22: [1, 2], slice23: { anyValue: 'thing' } }
+    };
+
+    // test selective write to storage for individual feature states
+    syncStateUpdate(
+      nestedState.feature1,
+      [{ feature1: {filter: ['slice11', 'slice12'], syncForFeature: true} }],
+      s,
+      skr,
+      false,
+      undefined,
+      undefined
+    );
+
+    syncStateUpdate(
+      nestedState.feature2,
+      [{ feature2: {filter: ['slice21', 'slice22'], syncForFeature: true} }],
+      s,
+      skr,
+      false,
+      undefined,
+      undefined
+    );
+
+    const raw1 = s.getItem('feature1');
+    expect(raw1).toEqual(JSON.stringify({ 'slice11': true, 'slice12': [1, 2] }));
+
+    const raw2 = s.getItem('feature2');
+    expect(raw2).toEqual(JSON.stringify({ 'slice21': true, 'slice22': [1, 2] }));
+  });
+
   it('reviver', () => {
     // Use the reviver option to restore including classes
 
@@ -204,6 +317,23 @@ describe('ngrxLocalStorage', () => {
     expect(JSON.stringify(finalState)).toEqual(JSON.stringify(initialStateT1));
     expect(finalState.state instanceof TypeA).toBeTruthy();
     expect(finalState.state.aclass instanceof TypeB).toBeTruthy();
+  });
+
+  it('reviver (feature Store)', () => {
+    // Use the reviver option to restore including classes for a feature state
+
+    const s = new MockStorage();
+    const skr = mockStorageKeySerializer;
+
+    const keys = [{ 'feature': {reviver: TypeA.reviver, syncForFeature: true} }];
+
+    syncStateUpdate(featureInitialState, keys, s, skr, false, undefined, undefined);
+
+    const finalState: any = rehydrateApplicationState(keys, s, skr, true, undefined);
+
+    expect(JSON.stringify(finalState)).toEqual(JSON.stringify(featureInitialState));
+    expect(finalState instanceof TypeA).toBeTruthy();
+    expect(finalState.aclass instanceof TypeB).toBeTruthy();
   });
 
   it('reviver-object', () => {
@@ -222,9 +352,23 @@ describe('ngrxLocalStorage', () => {
     expect(finalState.state.aclass instanceof TypeB).toBeTruthy();
   });
 
+  it('reviver-object (feature Store)', () => {
+    // Use the reviver in the object options to restore including classes for a feature state
+
+    const s = new MockStorage();
+    const skr = mockStorageKeySerializer;
+    const keys = [{ 'feature': { reviver: TypeA.reviver, syncForFeature: true } }];
+
+    syncStateUpdate(featureInitialState, keys, s, skr, false, undefined, undefined);
+
+    const finalState: any = rehydrateApplicationState(keys, s, skr, true, undefined);
+    expect(JSON.stringify(finalState)).toEqual(JSON.stringify(featureInitialState));
+    expect(finalState instanceof TypeA).toBeTruthy();
+    expect(finalState.aclass instanceof TypeB).toBeTruthy();
+  });
+
   it('filter-object', () => {
-    // Use the filter by field option to round-trip an object while
-    // filtering out the anumber and adate filed
+    // Use the filter by field option to filter out the anumber and adate filed
 
     const s = new MockStorage();
     const skr = mockStorageKeySerializer;
@@ -238,11 +382,26 @@ describe('ngrxLocalStorage', () => {
 
     const finalState: any = rehydrateApplicationState(keys, s, skr, true);
     expect(JSON.stringify(finalState)).toEqual(JSON.stringify({ filtered: t1Filtered }));
-
-    // Since we're not specifiying anything for rehydration, the roundtrip
-    //  loses type information...
     expect(t1 instanceof TypeA).toBeTruthy();
     expect(finalState.filtered instanceof TypeA).toBeFalsy();
+  });
+
+  it('filter-object (feature Store)', () => {
+    // Use the filter by field option to filter out the anumber and adate filed for a feature state
+
+    const s = new MockStorage();
+    const skr = mockStorageKeySerializer;
+    const keys = [{ filtered: { filter: ['astring', 'aclass'], syncForFeature: true } }];
+
+    syncStateUpdate(featureInitialState, keys, s, skr, false, undefined, undefined);
+
+    const raw = s.getItem('filtered');
+    expect(raw).toEqual(JSON.stringify(t1Filtered));
+
+    const finalState: any = rehydrateApplicationState(keys, s, skr, true, undefined);
+    expect(JSON.stringify(finalState)).toEqual(JSON.stringify(t1Filtered));
+    expect(t1 instanceof TypeA).toBeTruthy();
+    expect(finalState instanceof TypeA).toBeFalsy();
   });
 
   it('replacer-function', () => {
@@ -260,6 +419,22 @@ describe('ngrxLocalStorage', () => {
 
     expect(t1 instanceof TypeA).toBeTruthy();
     expect(finalState.replacer instanceof TypeA).toBeFalsy();
+  });
+
+  it('replacer-function (feature Store)', () => {
+    // Use the replacer function to filter a feature state
+
+    const s = new MockStorage();
+    const skr = mockStorageKeySerializer;
+    const keys = [{ replacer: { reviver: TypeA.replacer, syncForFeature: true } }];
+
+    syncStateUpdate(featureInitialState, keys, s, skr, false, undefined, undefined);
+
+    const finalState: any = rehydrateApplicationState(keys, s, skr, true, undefined);
+    expect(JSON.stringify(finalState)).toEqual(JSON.stringify(t1Filtered));
+
+    expect(t1 instanceof TypeA).toBeTruthy();
+    expect(finalState instanceof TypeA).toBeFalsy();
   });
 
   it('replacer-array', () => {
@@ -291,6 +466,34 @@ describe('ngrxLocalStorage', () => {
     expect(finalState.replacer instanceof TypeA).toBeFalsy();
   });
 
+  it('replacer-array (feature Store)', () => {
+    // Use the replacer option to do some custom filtering of the class for feature state
+    // Note that this completely loses the idea that the revived object ever contained the
+    //  fields not specified by the replacer, so we have to do some custom comparing
+
+    const s = new MockStorage();
+    const skr = mockStorageKeySerializer;
+    const keys = [{ replacer: { replacer: ['astring', 'adate', 'anumber'], space: 2, syncForFeature: true } }];
+
+    syncStateUpdate(featureInitialState, keys, s, skr, false, undefined, undefined);
+
+    // We want to validate the space parameter, but don't want to trip up on OS specific newlines, so filter the newlines out and
+    //  compare against the literal string.
+    const raw = s.getItem('replacer');
+    expect(raw.replace(/\r?\n|\r/g, '')).toEqual(
+      '{  "astring": "Testing",  "adate": "1968-11-16T12:30:00.000Z",  "anumber": 3.14159}'
+    );
+
+    const finalState: any = rehydrateApplicationState(keys, s, skr, true, undefined);
+
+    expect(JSON.stringify(finalState)).toEqual(
+      '{"astring":"Testing","adate":"1968-11-16T12:30:00.000Z","anumber":3.14159}'
+    );
+
+    expect(t1 instanceof TypeA).toBeTruthy();
+    expect(finalState instanceof TypeA).toBeFalsy();
+  });
+
   it('serializer', () => {
     // Use the serialize/deserialize options to save and restore including classes
 
@@ -307,6 +510,21 @@ describe('ngrxLocalStorage', () => {
     expect(finalState.state.aclass instanceof TypeB).toBeTruthy();
   });
 
+  it('serializer (feature store)', () => {
+    // Use the serialize/deserialize options to save and restore including classes
+
+    const s = new MockStorage();
+    const skr = mockStorageKeySerializer;
+    const keys = [{ state: { serialize: TypeA.serialize, deserialize: TypeA.deserialize, syncForFeature: true } }];
+
+    syncStateUpdate(featureInitialState, keys, s, skr, false, undefined, undefined);
+
+    const finalState: any = rehydrateApplicationState(keys, s, skr, true, undefined);
+    expect(JSON.stringify(finalState)).toEqual(featureInitialStateJson);
+    expect(finalState instanceof TypeA).toBeTruthy();
+    expect(finalState.aclass instanceof TypeB).toBeTruthy();
+  });
+
   it('removeOnUndefined', () => {
     // This tests that the state slice is removed when the state it's undefined
     const s = new MockStorage();
@@ -319,6 +537,22 @@ describe('ngrxLocalStorage', () => {
 
     // ensure that it's erased
     syncStateUpdate(undefinedState, ['state'], s, skr, true);
+    raw = s.getItem('state');
+    expect(raw).toBeFalsy();
+  });
+
+  it('removeOnUndefined (feature Store)', () => {
+    // This tests that the state slice is removed when the state it's undefined for a feature state
+    const s = new MockStorage();
+    const skr = mockStorageKeySerializer;
+    syncStateUpdate(featureInitialState, [{'state': {syncForFeature: true}}], s, skr, true, undefined, undefined);
+
+    // do update
+    let raw = s.getItem('state');
+    expect(raw).toEqual(t1Json);
+
+    // ensure that it's erased
+    syncStateUpdate(featureUndefinedState, ['state'], s, skr, true, undefined, undefined);
     raw = s.getItem('state');
     expect(raw).toBeFalsy();
   });
@@ -339,6 +573,22 @@ describe('ngrxLocalStorage', () => {
     expect(raw).toEqual(t1Json);
   });
 
+  it('keepOnUndefined (feature Store)', () => {
+    // This tests that the state slice is keeped when the state it's undefined
+    const s = new MockStorage();
+    const skr = mockStorageKeySerializer;
+    syncStateUpdate(featureInitialState, [{'state': {syncForFeature: true}}], s, skr, false, undefined, undefined);
+
+    // do update
+    let raw = s.getItem('state');
+    expect(raw).toEqual(t1Json);
+
+    // test update doesn't erase when it's undefined
+    syncStateUpdate(featureUndefinedState, ['state'], s, skr, false, undefined, undefined);
+    raw = s.getItem('state');
+    expect(raw).toEqual(t1Json);
+  });
+
   it('not restoreDates', () => {
     // Tests that dates are not revived when the flag is set to false
 
@@ -350,6 +600,19 @@ describe('ngrxLocalStorage', () => {
 
     const finalState: any = rehydrateApplicationState(['state'], s, skr, false);
     expect(finalState).toEqual(initalState);
+  });
+
+  it('not restoreDates (feature Store)', () => {
+    // Tests that dates are not revived when the flag is set to false
+
+    const s = new MockStorage();
+    const featureInitalState = {...t1Simple};
+    const skr = mockStorageKeySerializer;
+
+    syncStateUpdate(t1Simple, [{'state': {syncForFeature: true}}], s, skr, false, undefined, undefined);
+
+    const finalState: any = rehydrateApplicationState([{'state': {syncForFeature: true}}], s, skr, false, undefined);
+    expect(finalState).toEqual(featureInitalState);
   });
 
   it('storageKeySerializer', () => {
@@ -366,6 +629,22 @@ describe('ngrxLocalStorage', () => {
 
     expect(t1 instanceof TypeA).toBeTruthy();
     expect(finalState.simple instanceof TypeA).toBeFalsy();
+  });
+
+  it('storageKeySerializer (feature Store)', () => {
+    // This tests that storage key serializer are working.
+    const s = new MockStorage();
+    const skr = (key: string | number) => `this_key${key}`;
+    syncStateUpdate(featureInitialState, [{'state': {syncForFeature: true}}], s, skr, false, undefined, undefined);
+
+    const raw = s.getItem('1232342');
+    expect(raw).toBeNull();
+
+    const finalState: any = rehydrateApplicationState([{'state': {syncForFeature: true}}], s, skr, true, undefined);
+    expect(JSON.stringify(finalState)).toEqual(featureInitialStateJson);
+
+    expect(t1 instanceof TypeA).toBeTruthy();
+    expect(finalState instanceof TypeA).toBeFalsy();
   });
 
   it('syncCondition', () => {
@@ -410,6 +689,48 @@ describe('ngrxLocalStorage', () => {
     expect(JSON.stringify(finalState)).toEqual(initialStateJson);
   });
 
+  it('syncCondition (feature Store)', () => {
+    // Test that syncCondition can selectively trigger a sync state update
+    const s = new MockStorage();
+    const skr = mockStorageKeySerializer;
+
+    // Selector always returns false - meaning it should never sync
+    const shouldNotSyncSelector = (_state: any) => {
+      return false;
+    };
+
+    syncStateUpdate(featureInitialState, [{'state': {syncForFeature: true}}], s, skr, false, shouldNotSyncSelector, undefined);
+
+    let raw = s.getItem('state');
+    expect(raw).toEqual(null);
+
+    let finalState: any = rehydrateApplicationState([{'state': {syncForFeature: true}}], s, skr, true, undefined);
+    expect(JSON.stringify(finalState)).toEqual('{}');
+
+    // Selector should error - so still no sync
+    const errorSelector = (state: any) => {
+      return state.doesNotExist;
+    };
+
+    syncStateUpdate(featureInitialState, [{'state': {syncForFeature: true}}], s, skr, false, errorSelector, undefined);
+
+    raw = s.getItem('state');
+    expect(raw).toEqual(null);
+
+    // Selector always returns true - so it should sync
+    const shouldSyncSelector = (_state: any) => {
+      return true;
+    };
+
+    syncStateUpdate(featureInitialState, [{'state': {syncForFeature: true}}], s, skr, false, shouldSyncSelector, undefined);
+
+    raw = s.getItem('state');
+    expect(raw).toEqual(t1Json);
+
+    finalState = rehydrateApplicationState([{'state': {syncForFeature: true}}], s, skr, true, undefined);
+    expect(JSON.stringify(finalState)).toEqual(featureInitialStateJson);
+  });
+
   it('merge initial state and rehydrated state', () => {
     // localStorage starts out in a "bad" state. This could happen if our application state schema
     // changes. End users may have the old schema and a software update has the new schema.
@@ -420,9 +741,24 @@ describe('ngrxLocalStorage', () => {
     const metaReducer = syncStorage({ keys: ['state'], rehydrate: true });
     const action = { type: INIT };
 
-    // Resultant state should merge the oldstring state and our initual state
+    // Resultant state should merge the oldstring state and our initial state
     const finalState = metaReducer(reducer)(initialState, action);
     expect(finalState.state.astring).toEqual(initialState.state.astring);
+  });
+
+  it('merge initial state and rehydrated state (feature Store)', () => {
+    // localStorage starts out in a "bad" state. This could happen if our application state schema
+    // changes. End users may have the old schema and a software update has the new schema.
+    localStorage.setItem('state', JSON.stringify({ oldstring: 'foo' }));
+
+    // Set up reducers
+    const reducer = (state = initialState, _action: any) => state;
+    const metaReducer = syncStorage({ keys: [{'state': {syncForFeature: true}}], rehydrate: true });
+    const action = { type: INIT };
+
+    // Resultant state should merge the oldstring state and our initial state
+    const finalState = metaReducer(reducer)(featureInitialState, action);
+    expect(finalState.astring).toEqual(featureInitialState.astring);
   });
 
   it('should merge selectively saved state and rehydrated state', () => {


### PR DESCRIPTION
## Proposed change

This PR introduces a fix for the issue: state not syncing with storage for feature modules

## Related issues

- :bug: Fixes #(https://github.com/AmadeusITGroup/otter/issues/534)

## Description

The basic difference between syncing a state in the root app module via StoreModule.forRoot versus in a feature through StoreModule.forFeature is the fact that in the former, the syncStateUpdate method receives the entire State where each feature is described by key-value pairs (eg: {cart: {items: []} checkout: {methods: []}}), whereas in the latter, the syncStateUpdate method receives the respective feature slice state (eg: {items: []} for cart and {methods: []} for checkout).

PFA the screenshots describing the same:

**Syncing in the app module**

![image](https://github.com/AmadeusITGroup/otter/assets/15943209/a04ad7b9-e352-4b12-bfb1-980c4b646584)


**Syncing in the feature module**

![image](https://github.com/AmadeusITGroup/otter/assets/15943209/65c5a4cc-79da-4b61-b64e-fba0757d1445)

Therefore, the latter scenario was not handled as it always looked for the key specified in the config and fetch the corresponding state for the key.

The fix introduces a new boolean property to the `StorageConfig` called `forFeature` which when enabled, handles the state syncing for feature stores.

> Note: PFA a stackblitz that illustrates the behavior after the fix: https://stackblitz.com/edit/angular-ivy-bdu1sx?file=README.md

