### PR TITLE
feat: #583: exclude only incompatible properties and not the full config

### DIFF
--- a/packages/@o3r/components/builders/component-extractor/helpers/component/component.extractor.ts
+++ b/packages/@o3r/components/builders/component-extractor/helpers/component/component.extractor.ts
@@ -4,7 +4,7 @@ import type {
   ComponentConfigOutput,
   ComponentModuleOutput,
   ComponentOutput,
-  ComponentStructure, PlaceholdersMetadata
+  ComponentStructure, ConfigProperty, PlaceholdersMetadata
 } from '@o3r/components';
 import { CmsMedataData, getLibraryCmsMetadata } from '@o3r/extractors';
 import * as fs from 'node:fs';
@@ -36,8 +36,9 @@ export class ComponentExtractor {
    * @param libraries List of libraries to extract metadata from
    * @param logger
    * @param workspaceRoot
+   * @param strictMode
    */
-  constructor(private libraryName: string, libraries: string[], private logger: logging.LoggerApi, private workspaceRoot: string) {
+  constructor(private libraryName: string, libraries: string[], private logger: logging.LoggerApi, private workspaceRoot: string, private strictMode = false) {
     this.libraries = libraries
       .map((lib) => getLibraryCmsMetadata(lib, ''));
   }
@@ -263,20 +264,44 @@ export class ComponentExtractor {
     if (!options.exposedComponentSupport) {
       supportedTypes.delete('EXPOSED_COMPONENT');
     }
-    return configs.filter((config) => {
+    return configs.reduce((acc: ComponentConfigOutput[], config) => {
       if (!supportedTypes.has(config.type)) {
         this.logger.warn(`Config type "${config.type}" is not supported for ${config.library}#${config.name}. Excluding it`);
-        return false;
+        return acc;
       }
 
-      const propertiesWithoutDefaultValue = config.properties.filter((property) => property.values === undefined && property.value === undefined);
+      const { propertiesWithDefaultValue, propertiesWithoutDefaultValue } = config.properties.reduce((properties: {
+        propertiesWithDefaultValue: ConfigProperty[];
+        propertiesWithoutDefaultValue: ConfigProperty[];
+      }, property) => {
+        if (property.values === undefined && property.value === undefined) {
+          properties.propertiesWithoutDefaultValue = properties.propertiesWithoutDefaultValue.concat(property);
+        } else {
+          properties.propertiesWithDefaultValue = properties.propertiesWithDefaultValue.concat(property);
+        }
+        return properties;
+      }, {
+        propertiesWithDefaultValue: [],
+        propertiesWithoutDefaultValue: []
+      });
       if (propertiesWithoutDefaultValue.length) {
-        this.logger.warn(`"${config.library}#${config.name}" has no default value for ${propertiesWithoutDefaultValue.map((prop) => prop.name).join(', ')}. Excluding it`);
-        return false;
+        const message = `"${config.library}#${config.name}" has no default value for ${
+          propertiesWithoutDefaultValue.map((prop) => prop.name).join(', ')
+        }. Excluding ${propertiesWithoutDefaultValue.length > 1 ? 'them' : 'it'}`;
+        if (!this.strictMode) {
+          this.logger.warn(message);
+        } else {
+          throw new Error(message);
+        }
+        const configWithoutIncompatibleProperties: ComponentConfigOutput = {
+          ...config,
+          properties: propertiesWithDefaultValue
+        };
+        return acc.concat(configWithoutIncompatibleProperties);
       }
 
-      return true;
-    });
+      return acc.concat(config);
+    }, []);
 
   }
 

--- a/packages/@o3r/components/builders/component-extractor/index.ts
+++ b/packages/@o3r/components/builders/component-extractor/index.ts
@@ -77,7 +77,7 @@ export default createBuilder<ComponentExtractorBuilderSchema>(async (options, co
         error: 'Parsing failed'
       };
     } else {
-      const componentExtractor = new ComponentExtractor(libraryName, options.libraries, context.logger, context.workspaceRoot);
+      const componentExtractor = new ComponentExtractor(libraryName, options.libraries, context.logger, context.workspaceRoot, options.strictMode);
       try {
         context.reportProgress(3, STEP_NUMBER, 'Extracting component metadata');
         const componentMetadata = await componentExtractor.extract(parserOutput, options);


### PR DESCRIPTION
## Proposed change

exclude only incompatible properties and not the full config

## Related issues
- :rocket: Feature #583 
