### PR TITLE
fix: do not export empty type on index with models

### DIFF
--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/model/index.mustache
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/model/index.mustache
@@ -4,6 +4,6 @@ export type { {{classname}} } from './{{#kebabCase}}{{classname}}{{/kebabCase}}'
 {{^isEnum}}export { revive{{classname}} } from './{{#kebabCase}}{{classname}}{{/kebabCase}}.reviver';{{/isEnum}}
 {{/model}}
 {{/models}}
-{{^models.length}}
+{{^models.size}}
 export type { };
-{{/models.length}}
+{{/models.size}}


### PR DESCRIPTION
size is the Java property for list length, not length

## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
