### PR TITLE
fix: Localization service sets the fallback language as the default language ignoring the language specified in the configuration

### DIFF
--- a/packages/@o3r/localization/src/tools/localization.service.spec.ts
+++ b/packages/@o3r/localization/src/tools/localization.service.spec.ts
@@ -27,7 +27,7 @@ describe('LocalizationService', () => {
       localizationService.configure();
     });
 
-    it('should be used for transulations (en)', () => {
+    it('should be used for translations (en)', () => {
       const expectedLanguage = 'en';
 
       expect(localizationService.getCurrentLanguage()).toEqual(expectedLanguage);
@@ -100,6 +100,70 @@ describe('LocalizationService', () => {
       expect(localizationService.getCurrentLanguage()).toEqual(expectedLanguage);
     });
 
+  });
+
+  describe('language to use is specified in the configuration and supported', () => {
+
+    const configurationFactory: () => LocalizationConfiguration = () => ({
+      ...DEFAULT_LOCALIZATION_CONFIGURATION,
+      supportedLocales: ['en-GB', 'fr-FR', 'fr-CA', 'ar-AR'],
+      fallbackLanguage: 'en-GB',
+      language: 'fr-FR'
+    });
+
+    let translateServiceSpy: jest.SpyInstance;
+    let localizationService: LocalizationService;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [
+          LocalizationModule.forRoot(configurationFactory),
+          TranslateModule.forRoot()
+        ],
+        providers: [LocalizationService]
+      }).compileComponents();
+      localizationService = TestBed.inject(LocalizationService);
+      const translateService = localizationService.getTranslateService();
+      translateServiceSpy = jest.spyOn(translateService, 'setDefaultLang');
+      localizationService.configure();
+    });
+
+    it('should translate to the language provided in the configuration, when a supported language is provided', () => {
+      expect(translateServiceSpy).toHaveBeenCalledWith('fr-FR');
+      expect(localizationService.getCurrentLanguage()).toEqual('fr-FR');
+    });
+  });
+
+  describe('language to use is specified in the configuration and not supported', () => {
+
+    const configurationFactory: () => LocalizationConfiguration = () => ({
+      ...DEFAULT_LOCALIZATION_CONFIGURATION,
+      supportedLocales: ['en-GB', 'fr-FR', 'fr-CA', 'ar-AR'],
+      fallbackLanguage: 'en-GB',
+      language: 'es-ES'
+    });
+
+    let translateServiceSpy: jest.SpyInstance;
+    let localizationService: LocalizationService;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [
+          LocalizationModule.forRoot(configurationFactory),
+          TranslateModule.forRoot()
+        ],
+        providers: [LocalizationService]
+      }).compileComponents();
+      localizationService = TestBed.inject(LocalizationService);
+      const translateService = localizationService.getTranslateService();
+      translateServiceSpy = jest.spyOn(translateService, 'setDefaultLang');
+      localizationService.configure();
+    });
+
+    it('should translate to the fallback language provided in the configuration, when a non supported language is provided', () => {
+      expect(translateServiceSpy).toHaveBeenCalledWith('en-GB');
+      expect(localizationService.getCurrentLanguage()).toEqual('en-GB');
+    });
   });
 
   describe('fallbackLocalesMap configuration available', () => {

--- a/packages/@o3r/localization/src/tools/localization.service.ts
+++ b/packages/@o3r/localization/src/tools/localization.service.ts
@@ -135,10 +135,10 @@ export class LocalizationService {
    * Configures TranslateService and registers locales. This method is called from the application level.
    */
   public configure() {
+    const language = this.checkFallbackLocalesMap(this.configuration.language || this.configuration.fallbackLanguage);
     this.translateService.addLangs(this.configuration.supportedLocales);
-    this.translateService.setDefaultLang(this.configuration.fallbackLanguage);
-
-    this.useLanguage(this.configuration.language || this.configuration.fallbackLanguage);
+    this.translateService.setDefaultLang(language);
+    this.useLanguage(language);
   }
 
   /**


### PR DESCRIPTION
## Proposed change

The idea is to check if the specified language in the `LocalizationConfiguration` is defined in the supported locales and then set it as the default language of the `TranslateService` if supported.

## Related issues

- :bug: Fixes #(608) https://github.com/AmadeusITGroup/otter/issues/608
