### PR TITLE
fix: disable nx cloud for release branches

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -8,10 +8,19 @@ on:
         required: false
         default: false
         description: Run test only on affective packages if true
+      skipNxCache:
+        type: boolean
+        default: false
+        required: false
+        description: Skip the nx cache
     secrets:
       NX_CLOUD_ACCESS_TOKEN:
         required: false
         description: Token to use Nx Cloud token
+
+env:
+  NX_SKIP_NX_CACHE: ${{ inputs.skipNxCache }}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+      NX_SKIP_NX_CACHE: ${{ github.event_name == 'push' && startsWith(github.ref, 'release') }}
     steps:
       - uses: actions/checkout@v3
       - uses: ./tools/github-actions/setup
@@ -59,12 +60,15 @@ jobs:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     with:
       affected: ${{ github.event_name == 'pull_request' }}
+      skipNxCache: ${{ github.event_name == 'push' && startsWith(github.ref, 'release') }}
 
   test-publish:
     uses: ./.github/workflows/test-publish.yml
     secrets:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     needs: [build]
+    with:
+      skipNxCache: ${{ github.event_name == 'push' && startsWith(github.ref, 'release') }}
 
   publish-packages:
     uses: ./.github/workflows/publish.yml
@@ -77,6 +81,7 @@ jobs:
     with:
       version: ${{ needs.version.outputs.nextVersionTag }}
       prerelease: ${{ needs.version.outputs.isPreRelease == 'true' }}
+      skipNxCache: ${{ github.event_name == 'push' && startsWith(github.ref, 'release') }}
   publish-packages-pr:
     uses: ./.github/workflows/publish.yml
     if: ${{ github.event_name == 'pull_request' }}
@@ -88,6 +93,7 @@ jobs:
     with:
       version: ${{ needs.version.outputs.nextVersionTag }}
       prerelease: ${{ needs.version.outputs.isPreRelease == 'true' }}
+      skipNxCache: ${{ github.event_name == 'push' && startsWith(github.ref, 'release') }}
 
   documentation-main:
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,11 @@ on:
         default: false
         required: false
         description: Version of the artifact to publish
+      skipNxCache:
+        type: boolean
+        default: false
+        required: false
+        description: Skip the nx cache
     secrets:
       AZURE_VSC_EXT_TOKEN:
         required: false
@@ -31,6 +36,9 @@ on:
       CASCADING_AZURE_APP_PUBLISH_PROFILE:
         required: false
         description: Profile authentication to publish the Cascading Application
+
+env:
+  NX_SKIP_NX_CACHE: ${{ inputs.skipNxCache }}
 
 jobs:
   publish:

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -2,11 +2,20 @@ name: Test publish
 
 on:
   workflow_call:
+    inputs:
+      skipNxCache:
+        type: boolean
+        default: false
+        required: false
+        description: Skip the nx cache
     secrets:
       NX_CLOUD_ACCESS_TOKEN:
         required: false
         description: Token to use Nx Cloud token
 
+env:
+  NX_SKIP_NX_CACHE: ${{ inputs.skipNxCache }}
+  
 jobs:
   test-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Proposed change
disable nx cache on release branches, to prevent any issues on published packaged linked to input/output of nx configuration (force the failure instead)
It's sad but it seems that there is no clean way to reuse env variable defined in the main workflow in reusable ones (cf: https://github.com/orgs/community/discussions/26671#discussioncomment-3931817)

