### PR TITLE
ci: fix some ut instability

### DIFF
--- a/apps/chrome-devtools/jest.config.js
+++ b/apps/chrome-devtools/jest.config.js
@@ -21,6 +21,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   globalSetup: 'jest-preset-angular/global-setup',
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/apps/github-cascading-app/jest.config.js
+++ b/apps/github-cascading-app/jest.config.js
@@ -20,6 +20,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   globalSetup: 'jest-preset-angular/global-setup',
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/apps/vscode-extension/jest.config.js
+++ b/apps/vscode-extension/jest.config.js
@@ -18,6 +18,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     '^.+\\.tsx?$': [

--- a/packages/@ama-sdk/core/jest.config.js
+++ b/packages/@ama-sdk/core/jest.config.js
@@ -16,6 +16,11 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true,
+    // TODO try to make date utils work with fake Date
+    doNotFake: ['Date']
+  },
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     '^.+\\.tsx?$': [

--- a/packages/@ama-sdk/core/src/plugins/bot-protection-fingerprint/bot-protection-fingerprint.spec.ts
+++ b/packages/@ama-sdk/core/src/plugins/bot-protection-fingerprint/bot-protection-fingerprint.spec.ts
@@ -14,7 +14,7 @@ describe('BotProtectionFingerprint', () => {
   describe('Retrievers', () => {
 
     describe('impervaProtectionRetrieverFactory', () => {
-      const consoleMock = jest.spyOn(console, 'warn');
+      let consoleMock;
       let windowBackup: any;
       let tokenValue: string;
       let retriever: BotProtectionFingerprintRetriever;
@@ -37,6 +37,7 @@ describe('BotProtectionFingerprint', () => {
       };
 
       beforeEach(() => {
+        consoleMock = jest.spyOn(console, 'warn').mockImplementation();
         windowBackup = global.window;
         // eslint-disable-next-line no-global-assign
         global.window = {} as any;
@@ -51,32 +52,42 @@ describe('BotProtectionFingerprint', () => {
       });
 
       it('Should return undefined and log if no Protection object is received.', async () => {
-        expect(await retriever()).toBeUndefined();
+        const promise = retriever();
+        await jest.runAllTimersAsync();
+        expect(await promise).toBeUndefined();
         expect(console.warn).toHaveBeenCalledTimes(1);
       });
 
       it('Should return undefined and log if no Protection object is received within configured timeout.', async () => {
         registerEvent(protectionResolve, 100);
 
-        expect(await retriever()).toBeUndefined();
+        const promise = retriever();
+        await jest.runAllTimersAsync();
+        expect(await promise).toBeUndefined();
         expect(console.warn).toHaveBeenCalledTimes(1);
       });
 
       it('Should return undefined and log if token promise rejected.', async () => {
         registerEvent(protectionReject);
 
-        expect(await retriever()).toBeUndefined();
+        const promise = retriever();
+        await jest.runAllTimersAsync();
+        expect(await promise).toBeUndefined();
         expect(console.warn).toHaveBeenCalledTimes(1);
       });
 
       it('Should return the token if everything happened within timeout values.', async () => {
         registerEvent(protectionResolve, 25);
 
-        expect(await retriever()).toBe(tokenValue);
+        const promise = retriever();
+        await jest.runAllTimersAsync();
+        expect(await promise).toBe(tokenValue);
 
         tokenValue = 'newToken';
 
-        expect(await retriever()).toBe(tokenValue);
+        const newPromise = retriever();
+        await jest.runAllTimersAsync();
+        expect(await newPromise).toBe(tokenValue);
         expect(console.warn).not.toHaveBeenCalled();
       });
 
@@ -281,14 +292,12 @@ describe('BotProtectionFingerprint', () => {
         pollOnlyOnce: false
       }).load();
 
-      const before = Date.now();
-      const newRequest = await plugin.transform(mockedRequest);
-      const timeDiff = Date.now() - before;
+      const newRequestPromise = plugin.transform(mockedRequest);
+      await jest.advanceTimersByTimeAsync(1000);
+      const newRequest = await newRequestPromise;
 
       expect(newRequest.headers.has(destinationHeaderName)).toBeFalsy();
       expect(fingerprintRetriever).toHaveBeenCalledTimes(5);
-      expect(timeDiff).toBeLessThan(1100 + 10);
-      expect(timeDiff).not.toBeLessThan(1000 - 10);
     });
 
     it('Should add the fingerprint header if initially not found but added before the poller ended.', async () => {
@@ -303,7 +312,11 @@ describe('BotProtectionFingerprint', () => {
       }).load();
       setTimeout(() => mockedFingerprint = 'fingerprint', 350);
 
-      const newRequest = await plugin.transform(mockedRequest);
+      const newRequestPromise = plugin.transform(mockedRequest);
+      await jest.advanceTimersByTimeAsync(350);
+      mockedFingerprint = 'fingerprint';
+      await jest.runAllTimersAsync();
+      const newRequest = await newRequestPromise;
 
       expect(newRequest.headers.get(destinationHeaderName)).toBe(mockedFingerprint);
       expect(fingerprintRetriever).toHaveBeenCalledTimes(3);
@@ -320,11 +333,16 @@ describe('BotProtectionFingerprint', () => {
         pollOnlyOnce: false
       }).load();
 
-      await plugin.transform(mockedRequest);
+
+      let promise = plugin.transform(mockedRequest);
+      await jest.runAllTimersAsync();
+      await promise;
 
       expect(fingerprintRetriever).toHaveBeenCalledTimes(5);
 
-      await plugin.transform(mockedRequest);
+      promise = plugin.transform(mockedRequest);
+      await jest.runAllTimersAsync();
+      await promise;
 
       expect(fingerprintRetriever).toHaveBeenCalledTimes(10);
     });
@@ -340,11 +358,15 @@ describe('BotProtectionFingerprint', () => {
         pollOnlyOnce: true
       }).load();
 
-      await plugin.transform(mockedRequest);
+      let promise = plugin.transform(mockedRequest);
+      await jest.runAllTimersAsync();
+      await promise;
 
       expect(fingerprintRetriever).toHaveBeenCalledTimes(5);
 
-      await plugin.transform(mockedRequest);
+      promise = plugin.transform(mockedRequest);
+      await jest.runAllTimersAsync();
+      await promise;
 
       expect(fingerprintRetriever).toHaveBeenCalledTimes(6);
     });

--- a/packages/@ama-sdk/core/src/plugins/client-facts/client-facts.spec.ts
+++ b/packages/@ama-sdk/core/src/plugins/client-facts/client-facts.spec.ts
@@ -140,7 +140,9 @@ describe('Client Facts request plugin', () => {
       }
     });
 
-    const newSpecificOptions = await plugin.load().transform(specificOptions);
+    const promise = plugin.load().transform(specificOptions);
+    await jest.runAllTimersAsync();
+    const newSpecificOptions = await promise;
 
     expect(newSpecificOptions.headers.has(defaultHeader)).toBeTruthy();
     expect(newSpecificOptions.headers.get(defaultHeader)).toEqual(jwtFactsEncoder(specificFacts));

--- a/packages/@ama-sdk/core/src/plugins/concurrent/concurrent.spec.ts
+++ b/packages/@ama-sdk/core/src/plugins/concurrent/concurrent.spec.ts
@@ -34,12 +34,15 @@ describe('Concurrent Fetch Plugin', () => {
 
     void plugin.load({} as any).transform(call0);
     const runner1 = plugin.load({} as any);
+    const canStart1 = runner1.canStart();
+    await jest.runAllTimersAsync();
 
-    expect(await runner1.canStart()).toBe(true);
+    expect(await canStart1).toBe(true);
     void runner1.transform(call1);
 
     const runner2 = plugin.load({} as any);
     const pCanStart2 = runner2.canStart();
+    await jest.runAllTimersAsync();
 
     expect((plugin as any).waitingResolvers.length).toBe(1);
 
@@ -51,7 +54,7 @@ describe('Concurrent Fetch Plugin', () => {
 
     resolves[1]();
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await jest.advanceTimersByTimeAsync(500);
 
     expect((plugin as any).waitingResolvers.length).toBe(0);
   });

--- a/packages/@ama-sdk/core/src/plugins/mock-intercept/mock-intercept.spec.ts
+++ b/packages/@ama-sdk/core/src/plugins/mock-intercept/mock-intercept.spec.ts
@@ -130,11 +130,12 @@ describe('Mock intercept', () => {
           })
         }
       });
-      const beforeTime = new Date().getTime();
-      await loadedPlugin.transform(Promise.resolve({} as any));
-      const afterTime = new Date().getTime();
-
-      expect(afterTime - beforeTime).toBeGreaterThanOrEqual(695);
+      const callback = jest.fn();
+      loadedPlugin.transform(Promise.resolve({} as any)).then(callback);
+      await jest.advanceTimersByTimeAsync(699);
+      expect(callback).not.toHaveBeenCalled();
+      await jest.advanceTimersByTimeAsync(1);
+      expect(callback).toHaveBeenCalled();
     });
 
     it('should delay the response based on callback', async () => {
@@ -149,11 +150,12 @@ describe('Mock intercept', () => {
           })
         }
       });
-      const beforeTime = new Date().getTime();
-      await loadedPlugin.transform(Promise.resolve({} as any));
-      const afterTime = new Date().getTime();
-
-      expect(afterTime - beforeTime).toBeGreaterThanOrEqual(795);
+      const callback = jest.fn();
+      loadedPlugin.transform(Promise.resolve({} as any)).then(callback);
+      await jest.advanceTimersByTimeAsync(799);
+      expect(callback).not.toHaveBeenCalled();
+      await jest.advanceTimersByTimeAsync(1);
+      expect(callback).toHaveBeenCalled();
     });
   });
 });

--- a/packages/@ama-sdk/core/src/plugins/public-facts/public-facts.spec.ts
+++ b/packages/@ama-sdk/core/src/plugins/public-facts/public-facts.spec.ts
@@ -127,7 +127,9 @@ describe('Public Facts request plugin', () => {
       }
     });
 
-    const newSpecificOptions = await plugin.load().transform(specificOptions);
+    const promise = plugin.load().transform(specificOptions);
+    await jest.runAllTimersAsync();
+    const newSpecificOptions = await promise;
 
     expect(newSpecificOptions.headers.has(defaultHeader)).toBeTruthy();
     expect(newSpecificOptions.headers.get(defaultHeader)).toEqual(jwtFactsEncoder(specificFacts));

--- a/packages/@ama-sdk/core/src/plugins/retry/retry.spec.ts
+++ b/packages/@ama-sdk/core/src/plugins/retry/retry.spec.ts
@@ -41,14 +41,11 @@ describe('Retry Fetch Plugin', () => {
     runners.push(runner);
     const call = Promise.reject({text: 'test', ok: true});
 
-    try {
-      const res = runner.transform(call as any);
-      await res;
-    } catch (error) {
-      expect(error).not.toBeUndefined();
-    } finally {
-      expect(condition).toHaveBeenCalledTimes(2);
-    }
+    const callback = jest.fn();
+    runner.transform(call as any).catch(callback);
+    await jest.runAllTimersAsync();
+    expect(callback).toHaveBeenCalledWith(expect.objectContaining({}));
+    expect(condition).toHaveBeenCalledTimes(2);
   });
 
   it('should retry on fetch rejection with wait', async () => {
@@ -61,18 +58,13 @@ describe('Retry Fetch Plugin', () => {
     runners.push(runner);
     const call = Promise.reject({text: 'test', ok: true});
 
-    const startDate = Date.now();
-    try {
-      const res = runner.transform(call as any);
-      await res;
-    } catch (error) {
-      expect(error).not.toBeUndefined();
-    } finally {
-      expect(condition).toHaveBeenCalledTimes(2);
-      const endDate = Date.now();
-
-      expect(endDate).toBeGreaterThanOrEqual(startDate + 2 * delay);
-    }
+    const callback = jest.fn();
+    runner.transform(call as any).catch(callback);
+    await jest.advanceTimersByTimeAsync(delay);
+    expect(callback).not.toHaveBeenCalled();
+    await jest.advanceTimersByTimeAsync(delay);
+    expect(callback).toHaveBeenCalledWith(expect.objectContaining({}));
+    expect(condition).toHaveBeenCalledTimes(2);
   });
 
   it('should retry on not ok call', async () => {
@@ -84,14 +76,11 @@ describe('Retry Fetch Plugin', () => {
     runners.push(runner);
     const call = Promise.resolve({text: 'test', ok: false});
 
-    try {
-      const res = runner.transform(call as any);
-      await res;
-    } catch (error) {
-      expect(error).not.toBeUndefined();
-    } finally {
-      expect(condition).toHaveBeenCalledTimes(3);
-    }
+    const callback = jest.fn();
+    runner.transform(call as any).catch(callback);
+    await jest.runAllTimersAsync();
+    expect(callback).toHaveBeenCalledWith(expect.objectContaining({}));
+    expect(condition).toHaveBeenCalledTimes(3);
   });
 
   it('should retry on not ok call with wait', async () => {
@@ -104,18 +93,13 @@ describe('Retry Fetch Plugin', () => {
     runners.push(runner);
     const call = Promise.resolve({text: 'test', ok: false});
 
-    const startDate = Date.now();
-    try {
-      const res = runner.transform(call as any);
-      await res;
-    } catch (error) {
-      expect(error).not.toBeUndefined();
-    } finally {
-      expect(condition).toHaveBeenCalledTimes(3);
-      const endDate = Date.now();
-
-      expect(endDate).toBeGreaterThanOrEqual(startDate + 3 * delay);
-    }
+    const callback = jest.fn();
+    runner.transform(call as any).catch(callback);
+    await jest.advanceTimersByTimeAsync(2 * delay);
+    expect(callback).not.toHaveBeenCalled();
+    await jest.advanceTimersByTimeAsync(delay);
+    expect(callback).toHaveBeenCalledWith(expect.objectContaining({}));
+    expect(condition).toHaveBeenCalledTimes(3);
   });
 
 });

--- a/packages/@ama-sdk/core/src/plugins/timeout/timeout.spec.ts
+++ b/packages/@ama-sdk/core/src/plugins/timeout/timeout.spec.ts
@@ -3,39 +3,43 @@ import {TimeoutFetch} from './timeout.fetch';
 
 describe('Timeout Fetch Plugin', () => {
 
-  it('should reject on timeout', () => {
+  it('should reject on timeout', async () => {
     const plugin = new TimeoutFetch(100);
 
     const runner = plugin.load({} as any);
     const call = new Promise<any>((resolve) => setTimeout(() => resolve(undefined), 1000));
 
-    return runner.transform(call)
-      .catch((err) => {
-        expect(err).toEqual(new ResponseTimeoutError('in 100ms'));
-      });
+    const callback = jest.fn();
+    runner.transform(call).catch(callback);
+    await jest.advanceTimersByTimeAsync(99);
+    expect(callback).not.toHaveBeenCalled();
+    await jest.advanceTimersByTimeAsync(1);
+    expect(callback).toHaveBeenCalledWith(new ResponseTimeoutError('in 100ms'));
   });
 
-  it('should not reject on fetch rejection', () => {
+  it('should not reject on fetch rejection', async () => {
     const plugin = new TimeoutFetch(6000);
 
     const runner = plugin.load({} as any);
     const call = new Promise<any>((_resolve, reject) => setTimeout(() => reject(new EmptyResponseError('')), 100));
 
-    return runner.transform(call)
-      .catch((err) => {
-        expect(err).toEqual(new EmptyResponseError(''));
-      });
+
+    const callback = jest.fn();
+    runner.transform(call).catch(callback);
+    await jest.advanceTimersByTimeAsync(6000);
+    expect(callback).toHaveBeenCalledWith(new EmptyResponseError(''));
   });
 
-  it('should forward the fecth response', async () => {
+  it('should forward the fetch response', async () => {
     const plugin = new TimeoutFetch(2000);
 
     const runner = plugin.load({} as any);
     const call = new Promise<any>((resolve) => setTimeout(() => resolve({test: true}), 100));
 
-    const response = await runner.transform(call);
+    const promise = runner.transform(call);
+    await jest.runAllTimersAsync();
 
-    expect(response).toEqual({test: true} as any);
+    expect(await promise).toEqual({test: true} as any);
   });
 
 });

--- a/packages/@ama-sdk/core/src/plugins/wait-for/wait-for.spec.ts
+++ b/packages/@ama-sdk/core/src/plugins/wait-for/wait-for.spec.ts
@@ -8,9 +8,10 @@ describe('Wait For Fetch Plugin', () => {
     const plugin = new WaitForFetch(() => ({result: new Promise<boolean>((resolve) => setTimeout(() => resolve(true), 2000))}), 100);
 
     const runner = plugin.load(defaultContext);
-    const canStart = await runner.canStart();
+    const canStart = runner.canStart();
+    await jest.runAllTimersAsync();
 
-    expect(canStart).toBe(false);
+    expect(await canStart).toBe(false);
   });
 
   it('should start if promise condition passed', async () => {

--- a/packages/@ama-sdk/generator-sdk/jest.config.js
+++ b/packages/@ama-sdk/generator-sdk/jest.config.js
@@ -15,6 +15,10 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    // TODO enable fake timers
+    // enableGlobally: true
+  },
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     '^.+\\.tsx?$': [

--- a/packages/@ama-sdk/schematics/jest.config.js
+++ b/packages/@ama-sdk/schematics/jest.config.js
@@ -15,6 +15,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     '^.+\\.tsx?$': [

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/index.spec.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/index.spec.ts
@@ -82,7 +82,7 @@ describe('Typescript Shell Generator', () => {
       skipInstall: true,
       packageManager: 'npm'
     }, Tree.empty());
-  });
+  }, 10000);
 
   it('should generate basic SDK package', () => {
     expect(yarnTree.files.sort()).toEqual(baseFileList.sort());

--- a/packages/@ama-sdk/swagger-builder/jest.config.js
+++ b/packages/@ama-sdk/swagger-builder/jest.config.js
@@ -12,6 +12,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     '^.+\\.tsx?$': [

--- a/packages/@ama-terasu/cli/jest.config.js
+++ b/packages/@ama-terasu/cli/jest.config.js
@@ -16,6 +16,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     '^.+\\.tsx?$': [

--- a/packages/@ama-terasu/core/jest.config.js
+++ b/packages/@ama-terasu/core/jest.config.js
@@ -16,6 +16,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     '^.+\\.tsx?$': [

--- a/packages/@ama-terasu/schematics/jest.config.js
+++ b/packages/@ama-terasu/schematics/jest.config.js
@@ -16,6 +16,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     '^.+\\.tsx?$': [

--- a/packages/@o3r/analytics/jest.config.js
+++ b/packages/@o3r/analytics/jest.config.js
@@ -22,6 +22,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   globalSetup: 'jest-preset-angular/global-setup',
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/@o3r/apis-manager/jest.config.js
+++ b/packages/@o3r/apis-manager/jest.config.js
@@ -20,6 +20,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   globalSetup: 'jest-preset-angular/global-setup',
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/@o3r/application/jest.config.js
+++ b/packages/@o3r/application/jest.config.js
@@ -22,6 +22,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   globalSetup: 'jest-preset-angular/global-setup',
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/@o3r/components/jest.config.js
+++ b/packages/@o3r/components/jest.config.js
@@ -28,6 +28,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   globalSetup: 'jest-preset-angular/global-setup',
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/@o3r/configuration/jest.config.js
+++ b/packages/@o3r/configuration/jest.config.js
@@ -22,6 +22,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   globalSetup: 'jest-preset-angular/global-setup',
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/@o3r/core/jest.config.js
+++ b/packages/@o3r/core/jest.config.js
@@ -24,6 +24,11 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true,
+    // TODO try to make date utils work with fake Date
+    doNotFake: ['Date']
+  },
   globalSetup: 'jest-preset-angular/global-setup',
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/@o3r/dev-tools/jest.config.js
+++ b/packages/@o3r/dev-tools/jest.config.js
@@ -18,6 +18,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     '^.+\\.tsx?$': [

--- a/packages/@o3r/dynamic-content/jest.config.js
+++ b/packages/@o3r/dynamic-content/jest.config.js
@@ -25,6 +25,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   globalSetup: 'jest-preset-angular/global-setup',
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/@o3r/eslint-plugin/jest.config.js
+++ b/packages/@o3r/eslint-plugin/jest.config.js
@@ -12,6 +12,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     '^.+\\.tsx?$': [

--- a/packages/@o3r/extractors/jest.config.js
+++ b/packages/@o3r/extractors/jest.config.js
@@ -16,6 +16,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     '^.+\\.tsx?$': [

--- a/packages/@o3r/forms/jest.config.js
+++ b/packages/@o3r/forms/jest.config.js
@@ -24,6 +24,11 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true,
+    // TODO try to make date utils work with fake Date
+    doNotFake: ['Date']
+  },
   globalSetup: 'jest-preset-angular/global-setup',
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/@o3r/localization/jest.config.js
+++ b/packages/@o3r/localization/jest.config.js
@@ -19,6 +19,9 @@ module.exports = {
     '<rootDir>/.*/templates/.*',
     '\\.it\\.spec\\.ts$'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   reporters: [
     'default',
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],

--- a/packages/@o3r/logger/jest.config.js
+++ b/packages/@o3r/logger/jest.config.js
@@ -25,6 +25,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   globalSetup: 'jest-preset-angular/global-setup',
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/@o3r/mobile/jest.config.js
+++ b/packages/@o3r/mobile/jest.config.js
@@ -21,6 +21,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   globalSetup: 'jest-preset-angular/global-setup',
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/@o3r/routing/jest.config.js
+++ b/packages/@o3r/routing/jest.config.js
@@ -22,6 +22,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   globalSetup: 'jest-preset-angular/global-setup',
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/@o3r/rules-engine/jest.config.js
+++ b/packages/@o3r/rules-engine/jest.config.js
@@ -24,6 +24,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   globalSetup: 'jest-preset-angular/global-setup',
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/@o3r/rules-engine/src/engine/engine.spec.ts
+++ b/packages/@o3r/rules-engine/src/engine/engine.spec.ts
@@ -37,12 +37,10 @@ describe('Rx Rule Engine', () => {
 
       expect(factValue$).toBeDefined();
 
-      const startDate = new Date().getTime();
+      const promise = firstValueFrom(factValue$);
+      await jest.advanceTimersByTimeAsync(500);
 
-      await expect(firstValueFrom(factValue$)).resolves.toBe(undefined);
-      const endDate = new Date().getTime();
-
-      expect(endDate - startDate).toBeGreaterThanOrEqual(500);
+      await expect(promise).resolves.toBe(undefined);
     });
   });
 });

--- a/packages/@o3r/rules-engine/src/engine/helpers/filter-ruleset-event.operator.spec.ts
+++ b/packages/@o3r/rules-engine/src/engine/helpers/filter-ruleset-event.operator.spec.ts
@@ -184,7 +184,7 @@ describe('Filter rulesets event operator', () => {
 
   });
 
-  test('should not emit if ruleset id does not match any registered ruleset', (done) => {
+  test('should not emit if ruleset id does not match any registered ruleset', async () => {
 
     let emittedActions: ActionBlock[] | undefined;
 
@@ -194,10 +194,8 @@ describe('Filter rulesets event operator', () => {
       emittedActions = data;
     });
 
-    setTimeout(() =>{
-      expect(emittedActions).toBe(undefined);
-      done();
-    }, 500);
+    await jest.advanceTimersByTimeAsync(500);
+    expect(emittedActions).toBe(undefined);
   });
 
 });

--- a/packages/@o3r/rules-engine/src/fact/fact.spec.ts
+++ b/packages/@o3r/rules-engine/src/fact/fact.spec.ts
@@ -29,16 +29,16 @@ describe('Rules engine fact', () => {
 
   it('should register the facts', async () => {
     factsService.register();
-    await new Promise<void>((resolve) => setTimeout(() => resolve(), 0));
+    await jest.runAllTimersAsync();
 
     expect(mockEngine.upsertFacts).toHaveBeenCalledTimes(1);
   });
 
   it('should update the value of a fact', async () => {
     factsService.register();
-    await new Promise<void>((resolve) => setTimeout(() => resolve(), 0));
+    await jest.runAllTimersAsync();
     subjectFact.next('test4');
-    await new Promise<void>((resolve) => setTimeout(() => resolve(), 0));
+    await jest.runAllTimersAsync();
 
     expect(mockEngine.upsertFacts).toHaveBeenCalledTimes(1);
   });

--- a/packages/@o3r/schematics/jest.config.js
+++ b/packages/@o3r/schematics/jest.config.js
@@ -16,6 +16,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     '^.+\\.tsx?$': [

--- a/packages/@o3r/store-sync/jest.config.js
+++ b/packages/@o3r/store-sync/jest.config.js
@@ -24,6 +24,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   globalSetup: 'jest-preset-angular/global-setup',
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/@o3r/storybook/jest.config.js
+++ b/packages/@o3r/storybook/jest.config.js
@@ -12,6 +12,9 @@ module.exports = {
     ['jest-junit', {outputDirectory: resolve(__dirname, 'dist-test'), outputName: 'ut-report.xml'}],
     'github-actions'
   ],
+  fakeTimers: {
+    enableGlobally: true
+  },
   transform: {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     '^.+\\.tsx?$': [


### PR DESCRIPTION
## Proposed change

Relying on real timers for tests makes them slow and indeterministic
There is an option on jest to use fake timers that we can use to mock all the calls to `setTimeout`, `setInterval`, ...

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
