### PR TITLE
fix: sdk generator - missing export in base shell

### DIFF
--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/helpers/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/helpers/index.ts
@@ -1,1 +1,1 @@
-export { };
+export type { };

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/models/base/enums.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/models/base/enums.ts
@@ -1,2 +1,2 @@
 // This contains enums from the spec, will be filled when the sdk is generated.
-export { };
+export type { };

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/models/base/patterns.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/models/base/patterns.ts
@@ -1,2 +1,2 @@
 // This contains patterns from the spec, will be filled when the sdk is generated.
-export { };
+export type { };

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/models/core/patterns.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/models/core/patterns.ts
@@ -1,2 +1,2 @@
 // Export your core patterns here
-export { };
+export type { };

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/models/custom/enums.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/models/custom/enums.ts
@@ -1,2 +1,2 @@
 // Export your custom enums here
-export { };
+export type { };

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/models/custom/patterns.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/models/custom/patterns.ts
@@ -1,2 +1,2 @@
 // Export your custom patterns here
-export { };
+export type { };

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/spec/api-mock.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/spec/api-mock.ts
@@ -1,2 +1,2 @@
 // This contains testing helpers for api endpoints, will be filled when the sdk is generated from a spec.
-export { };
+export type { };

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/spec/mock-factory/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/spec/mock-factory/index.ts
@@ -1,2 +1,2 @@
 // dummy export for mock factory
-export {};
+export type {};

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/spec/operation-adapter.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/spec/operation-adapter.ts
@@ -1,0 +1,1 @@
+export type {};


### PR DESCRIPTION
## Proposed change

Add missing export in shell from sdk generator
