### PR TITLE
feat: do not synchronize untouched state with the localstorage [perf]

### DIFF
--- a/packages/@o3r/mobile/package.json
+++ b/packages/@o3r/mobile/package.json
@@ -44,6 +44,7 @@
     "@o3r/schematics": "workspace:^",
     "@o3r/store-sync": "workspace:^",
     "@schematics/angular": "~16.2.0",
+    "fast-deep-equal": "^3.1.3",
     "rxjs": "^7.8.1"
   },
   "peerDependenciesMeta": {
@@ -100,6 +101,7 @@
     "eslint-plugin-jsdoc": "~46.5.0",
     "eslint-plugin-prefer-arrow": "~1.2.3",
     "eslint-plugin-unicorn": "^47.0.0",
+    "fast-deep-equal": "^3.1.3",
     "jest": "~29.6.2",
     "jest-environment-jsdom": "~29.6.2",
     "jest-junit": "~16.0.0",

--- a/packages/@o3r/store-sync/package.json
+++ b/packages/@o3r/store-sync/package.json
@@ -27,6 +27,7 @@
     "@o3r/dev-tools": "workspace:^",
     "@o3r/logger": "workspace:^",
     "@o3r/schematics": "workspace:^",
+    "fast-deep-equal": "^3.1.3",
     "rxjs": "^7.8.1"
   },
   "peerDependenciesMeta": {
@@ -76,6 +77,7 @@
     "eslint-plugin-jsdoc": "~46.5.0",
     "eslint-plugin-prefer-arrow": "~1.2.3",
     "eslint-plugin-unicorn": "^47.0.0",
+    "fast-deep-equal": "^3.1.3",
     "jest": "~29.6.2",
     "jest-environment-jsdom": "~29.6.2",
     "jest-junit": "~16.0.0",

--- a/packages/@o3r/store-sync/src/core/interfaces.ts
+++ b/packages/@o3r/store-sync/src/core/interfaces.ts
@@ -36,5 +36,11 @@ export interface AsyncStorageSyncOptions extends Omit<SyncStorageConfig, 'storag
   storage?: AsyncStorage;
 }
 
-/** Options for storage sync */
+/** Options for storage sync method */
 export type StorageSyncOptions = SyncStorageConfig | AsyncStorageSyncOptions;
+
+/**
+ * Options that can be set on the Storage sync constructor
+ * postProcess and syncKeyCondition will be handled by the StorageSync class if smart sync is activated
+ */
+export type StorageSyncConstructorOptions = Omit<StorageSyncOptions, 'postProcess' | 'syncKeyCondition'>;

--- a/packages/@o3r/store-sync/src/core/storage-sync.ts
+++ b/packages/@o3r/store-sync/src/core/storage-sync.ts
@@ -1,8 +1,10 @@
-import { INIT, UPDATE } from '@ngrx/store';
-import { deepFill } from '@o3r/core';
-import type { StorageSyncOptions } from './interfaces';
-import { isLocalStorageConfig, isSerializer, rehydrateAction } from './storage-sync.helpers';
-import { syncStorage } from '../sync-storage';
+import {INIT, UPDATE} from '@ngrx/store';
+import {deepFill} from '@o3r/core';
+import equal from 'fast-deep-equal';
+import type {StorageSyncOptions} from './interfaces';
+import {isLocalStorageConfig, isSerializer, rehydrateAction} from './storage-sync.helpers';
+import {syncStorage} from '../sync-storage';
+import {StorageSyncConstructorOptions} from './interfaces';
 
 /**
  * Storage synchronizer
@@ -10,13 +12,24 @@ import { syncStorage } from '../sync-storage';
 export class StorageSync {
   private alreadyHydratedStoreSlices: Set<string> = new Set();
   private hasHydrated = false;
+  private storeImage: { [key: string]: any } = {};
 
   public options: StorageSyncOptions;
 
-  constructor(options?: Partial<StorageSyncOptions>) {
+  constructor(options?: StorageSyncConstructorOptions, extraOptions?: {disableSmartSync: boolean}) {
     this.options = {
       keys: [],
+      ...(extraOptions?.disableSmartSync ? {} : {
+        syncKeyCondition: (key, state) => !equal(this.storeImage[key], state[key]),
+        postProcess: (state) => {
+          this.options.keys.forEach(key => {
+            const keyName: string = typeof key === 'object' ? Object.keys(key)[0] : key;
+            this.storeImage[keyName] = state[keyName];
+          });
+        }
+      }),
       ...options,
+      storage: options?.storage as unknown as Storage,
       mergeReducer: typeof options?.mergeReducer !== 'function' ? this.mergeReducer : options.mergeReducer
     };
   }
@@ -53,17 +66,18 @@ export class StorageSync {
    * Returns a meta reducer that handles storage sync
    */
   public localStorageSync = () => {
+    const base = (reducer: any) => syncStorage({
+      ...this.options,
+      rehydrate: false,
+      storage: this.options.storage as unknown as Storage,
+      syncCondition: () => this.hasHydrated
+    })(reducer);
+
     return (reducer: any) => {
       if (isLocalStorageConfig(this.options)) {
         return syncStorage(this.options)(reducer);
       }
 
-      const base = syncStorage({
-        ...this.options,
-        rehydrate: false,
-        storage: this.options.storage as unknown as Storage,
-        syncCondition: () => this.hasHydrated
-      })(reducer);
 
       return (state: any, action: any) => {
         let hydratedState = state;
@@ -93,7 +107,7 @@ export class StorageSync {
             hydratedState = { ...state, ...overrides };
           }
         }
-        return base(hydratedState, action);
+        return base(reducer)(hydratedState, action);
       };
     };
   };

--- a/packages/@o3r/store-sync/src/sync-storage/interfaces.ts
+++ b/packages/@o3r/store-sync/src/sync-storage/interfaces.ts
@@ -49,12 +49,16 @@ export interface SyncStorageConfig {
   restoreDates?: boolean;
   /** Callback to define the serialization strategy for the store keys */
   storageKeySerializer?: (key: string) => string;
-  /** Callback to defined the condition to the synchronization */
+  /** Callback to define the condition to the synchronization */
   syncCondition?: (state: any) => any;
+  /** Callback to define the condition to the key synchronization */
+  syncKeyCondition?: (key: string, state: any) => boolean;
   /** check the availability of the storage */
   checkStorageAvailability?: boolean;
   /** Merge reducer to use to deserialize the store */
   mergeReducer?: (state: any, rehydratedState: any, action: any) => any;
   /** Logger to report messages */
   logger?: Logger;
+  /** Post process after sync storage execution */
+  postProcess?: (state: any) => void;
 }

--- a/packages/@o3r/store-sync/src/sync-storage/storage-sync.ts
+++ b/packages/@o3r/store-sync/src/sync-storage/storage-sync.ts
@@ -333,7 +333,10 @@ export const syncStorage = (config: SyncStorageConfig) => (reducer: any) => {
     if (action.type !== INIT) {
       syncStateUpdate(
         nextState,
-        stateKeys,
+        (typeof config.syncKeyCondition === 'function') ? stateKeys.filter(key => {
+          const keyName = typeof key === 'object' ? Object.keys(key)[0] : key;
+          return config.syncKeyCondition!(keyName, nextState);
+        }) : stateKeys,
         config.storage,
         config.storageKeySerializer as (key: string | number) => string,
         config.removeOnUndefined,
@@ -341,7 +344,9 @@ export const syncStorage = (config: SyncStorageConfig) => (reducer: any) => {
         logger
       );
     }
-
+    if (config.postProcess) {
+      config.postProcess(nextState);
+    }
     return nextState;
   };
 };

--- a/packages/@o3r/store-sync/tsconfig.build.json
+++ b/packages/@o3r/store-sync/tsconfig.build.json
@@ -2,6 +2,8 @@
   "extends": "../../../tsconfig.build",
   "compilerOptions": {
     "incremental": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     // "composite": true, not supported by ng-packger
     "outDir": "./dist",
     "rootDir": "src",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8280,6 +8280,7 @@ __metadata:
     eslint-plugin-jsdoc: ~46.5.0
     eslint-plugin-prefer-arrow: ~1.2.3
     eslint-plugin-unicorn: ^47.0.0
+    fast-deep-equal: ^3.1.3
     form-data: ^4.0.0
     jest: ~29.6.2
     jest-environment-jsdom: ~29.6.2
@@ -8307,6 +8308,7 @@ __metadata:
     "@o3r/schematics": "workspace:^"
     "@o3r/store-sync": "workspace:^"
     "@schematics/angular": ~16.2.0
+    fast-deep-equal: ^3.1.3
     rxjs: ^7.8.1
   peerDependenciesMeta:
     "@angular-devkit/schematics":
@@ -8618,6 +8620,7 @@ __metadata:
     eslint-plugin-jsdoc: ~46.5.0
     eslint-plugin-prefer-arrow: ~1.2.3
     eslint-plugin-unicorn: ^47.0.0
+    fast-deep-equal: ^3.1.3
     jest: ~29.6.2
     jest-environment-jsdom: ~29.6.2
     jest-junit: ~16.0.0
@@ -8637,6 +8640,7 @@ __metadata:
     "@o3r/dev-tools": "workspace:^"
     "@o3r/logger": "workspace:^"
     "@o3r/schematics": "workspace:^"
+    fast-deep-equal: ^3.1.3
     rxjs: ^7.8.1
   peerDependenciesMeta:
     "@angular-devkit/core":


### PR DESCRIPTION
## Proposed change
Only synchronize with the localstorage states that do not match the version already stored.
Keep an internal representation of the state to avoid extra read operations that would slow the application

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
