### PR TITLE
fix: fallback on missing status code from API response

### DIFF
--- a/packages/@ama-sdk/core/src/fwk/api.helper.spec.ts
+++ b/packages/@ama-sdk/core/src/fwk/api.helper.spec.ts
@@ -1,0 +1,66 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable no-console */
+import {getResponseReviver, ReviverType} from '@ama-sdk/core';
+
+describe('getResponseReviver - revivers by status code', () => {
+  const revivers: { [key: number]: ReviverType<any> | undefined } = {
+    202: jest.fn(),
+    201: jest.fn()
+  } as any;
+
+  beforeEach(() => {
+    jest.spyOn(console, 'error');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not return a reviver for a non ok response', () => {
+    expect(getResponseReviver(revivers, {status: 300, ok: false})).toBe(undefined);
+  });
+
+  it('should return a reason but not reviver for a 204 No Content Response', () => {
+    expect(getResponseReviver(revivers, {status: 204, ok: true})).toBe(undefined);
+    expect(console.error).toHaveBeenCalledWith('API status code error for unknown endpoint - 204 response is not defined in the API specification');
+
+  });
+
+  it('should return the status code\'s reviver', () => {
+    expect(getResponseReviver(revivers, {status: 202, ok: true}, 'myEndpoint')).toBe(revivers[202]);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('should fallback on the first defined status if the status code\'s reviver is not defined', () => {
+    expect(getResponseReviver(revivers, {status: undefined, ok: true}, 'myEndpoint')).toBe(revivers[201]);
+    expect(console.error).toHaveBeenCalledWith('API status code error for myEndpoint endpoint - Unknown undefined code returned by the API - Fallback to 201\'s reviver');
+  });
+
+  it('should not fallback on 204 (No Content)\'s reviver', () => {
+    const reviversWith204 = {204: jest.fn(), 206: jest.fn()};
+    const fallback = getResponseReviver(reviversWith204, {status: 201, ok: true}, 'myEndpoint');
+    expect(fallback).toBe(reviversWith204[206]);
+    expect(fallback).not.toBe(reviversWith204[204]);
+    expect(console.error).toHaveBeenCalledWith('API status code error for myEndpoint endpoint - Unknown 201 code returned by the API - Fallback to 206\'s reviver');
+  });
+
+  it('should not fallback if the feature is deactivated', () => {
+    jest.spyOn(console, 'log');
+    expect(getResponseReviver(revivers, {status: 206, ok: true}, 'myEndpoint', {disableFallback: true, log: console.log})).toBe(undefined);
+    expect(console.error).not.toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith('API status code error for myEndpoint endpoint - Missing 206 from API specification - fallback is deactivated, no revive will run on this response');
+  });
+});
+
+describe('getResponseReviver - reviver as function', () => {
+  const reviver = jest.fn();
+
+  it('should not return a reviver for a non ok response', () => {
+    expect(getResponseReviver(reviver, {status: 300, ok: false})).toBe(undefined);
+  });
+
+  it('should only return the reviver if the endpoint reviver is a function or an undefined object', () => {
+    expect(getResponseReviver(reviver, {status: 200, ok: true})).toBe(reviver);
+    expect(getResponseReviver(undefined, {status: 200, ok: true})).toBe(undefined);
+  });
+});

--- a/packages/@ama-sdk/core/src/fwk/api.helpers.ts
+++ b/packages/@ama-sdk/core/src/fwk/api.helpers.ts
@@ -1,4 +1,5 @@
-import { TokenizedOptions } from '../plugins/core/request-plugin';
+import {TokenizedOptions} from '../plugins/core/request-plugin';
+import type {ReviverType} from './Reviver';
 
 /**
  * prepares the url to be called
@@ -30,7 +31,7 @@ export function extractQueryParams<T extends { [key: string]: any }>(data: T, na
       const prop = data[name];
       acc[name] = (typeof prop.toJSON === 'function') ? prop.toJSON() : prop.toString();
       return acc;
-    }, {} as {[p in keyof T]: string});
+    }, {} as { [p in keyof T]: string });
 }
 
 /**
@@ -39,10 +40,10 @@ export function extractQueryParams<T extends { [key: string]: any }>(data: T, na
  * @param object JSON object to filter
  * @returns an object without undefined values
  */
-export function filterUndefinedValues(object: {[key: string]: string | undefined}): {[key: string]: string} {
+export function filterUndefinedValues(object: { [key: string]: string | undefined }): { [key: string]: string } {
   return Object.keys(object)
     .filter((objectKey) => typeof object[objectKey] !== 'undefined')
-    .reduce<{[key: string]: string}>((acc, objectKey) => {
+    .reduce<{ [key: string]: string }>((acc, objectKey) => {
       acc[objectKey] = object[objectKey] as string;
       return acc;
     }, {});
@@ -105,7 +106,7 @@ export function computePiiParameterTokens(piiParameterNames: string[]): { [key: 
  */
 export function tokenizeRequestOptions(tokenizedUrl: string, queryParameters: { [key: string]: string }, piiParamTokens: { [key: string]: string }, data: any): TokenizedOptions {
   const values: Record<string, string> = {};
-  const tokenizedQueryParams = { ...queryParameters };
+  const tokenizedQueryParams = {...queryParameters};
   Object.entries(piiParamTokens).filter(([parameterName, _token]) => data[parameterName] !== undefined).forEach(([parameterName, token]) => {
     if (tokenizedQueryParams[parameterName]) {
       tokenizedQueryParams[parameterName] = token;
@@ -114,4 +115,49 @@ export function tokenizeRequestOptions(tokenizedUrl: string, queryParameters: { 
   });
 
   return {values, url: tokenizedUrl, queryParams: tokenizedQueryParams};
+}
+
+/**
+ * Compute the reviver to use in case the success response code returned by the API does not match the API
+ * Fallback to the lowest status code's reviver.
+ * Does not try to match non-successful responses as error are handled separately
+ *
+ * @param revivers
+ * @param endpoint
+ * @param response
+ * @param options
+ */
+export function getResponseReviver<T>(revivers: { [statusCode: number]: ReviverType<T> | undefined } | undefined | ReviverType<T>, response: { status: number; ok: boolean } | undefined,
+  // eslint-disable-next-line no-console
+  endpoint?: string | undefined, options: { disableFallback?: boolean; log?: (...args: any[]) => void } = {disableFallback: false, log: console.error}): ReviverType<T> | undefined {
+  const logPrefix = `API status code error for ${endpoint || 'unknown'} endpoint`;
+  const logMsg = options.log || (() => {});
+  if (!response || !response.ok) {
+    return undefined;
+  }
+  if (typeof revivers === 'function' || typeof revivers === 'undefined') {
+    return revivers;
+  }
+  if (response.status && revivers[response.status]) {
+    return revivers[response.status];
+  }
+  if (options?.disableFallback) {
+    logMsg(`${logPrefix} - Missing ${response.status} from API specification - fallback is deactivated, no revive will run on this response`);
+    return undefined;
+  }
+  if (response.status === 204) {
+    logMsg(`${logPrefix} - 204 response is not defined in the API specification`);
+    return undefined;
+  }
+  const fallback = Object.entries(revivers).reduce((acc: { statusCode: number; reviver: ReviverType<T> | undefined }, [statusCode, reviver]) => {
+    const code = +statusCode;
+    if (code < acc.statusCode && code !== 204) {
+      acc.statusCode = code;
+      acc.reviver = reviver;
+    }
+    return acc;
+  }, {statusCode: Number.MAX_SAFE_INTEGER, reviver: undefined});
+  const fallbackLog = Number.MAX_SAFE_INTEGER !== fallback.statusCode ? `Fallback to ${fallback.statusCode}'s reviver` : 'No fallback found';
+  logMsg(`${logPrefix} - Unknown ${response.status || 'undefined'} code returned by the API - ${fallbackLog}`);
+  return fallback.reviver;
 }

--- a/packages/@ama-sdk/core/src/fwk/clients/api-beacon-client.ts
+++ b/packages/@ama-sdk/core/src/fwk/clients/api-beacon-client.ts
@@ -108,7 +108,7 @@ export class ApiBeaconClient implements ApiClient {
   }
 
   /** @inheritdoc */
-  public processCall(url: string, options: RequestOptions, _apiType: string | ApiTypes, _apiName: string, _reviver?: unknown, _operationId?: unknown): Promise<any> {
+  public processCall(url: string, options: RequestOptions, _apiType: string | ApiTypes, _apiName: string, _revivers?: unknown, _operationId?: unknown): Promise<any> {
     const headers = {
       type: 'application/json',
       ...options.headers.entries()

--- a/packages/@ama-sdk/core/src/fwk/core/api-client.ts
+++ b/packages/@ama-sdk/core/src/fwk/core/api-client.ts
@@ -1,7 +1,7 @@
 import {RequestBody, RequestMetadata, RequestOptions, TokenizedOptions} from '../../plugins/index';
-import { ApiTypes } from '../api';
-import { ReviverType } from '../Reviver';
-import { BaseApiClientOptions } from './base-api-constructor';
+import {ApiTypes} from '../api';
+import {ReviverType} from '../Reviver';
+import {BaseApiClientOptions} from './base-api-constructor';
 
 /**
  * API Client used by the SDK's APIs to call the server
@@ -32,17 +32,17 @@ export interface ApiClient {
   prepareUrl(url: string, queryParameters?: { [key: string]: string | undefined }): string;
 
 
-/**
- * Returns tokenized request options:
- * URL/query parameters for which sensitive parameters are replaced by tokens and the corresponding token-value associations
- *
- * @param tokenizedUrl URL for which parameters containing PII have been replaced by tokens
- * @param queryParameters Original query parameters
- * @param piiParamTokens Tokens of the parameters containing PII
- * @param data Data to provide to the API call
- * @returns the tokenized request options if tokenization is enabled, undefined otherwise
- */
-  tokenizeRequestOptions(url: string, queryParameters: { [key: string]: string | undefined }, piiParamTokens:{ [statusCode: string]: string }, data: any): TokenizedOptions | undefined;
+  /**
+   * Returns tokenized request options:
+   * URL/query parameters for which sensitive parameters are replaced by tokens and the corresponding token-value associations
+   *
+   * @param tokenizedUrl URL for which parameters containing PII have been replaced by tokens
+   * @param queryParameters Original query parameters
+   * @param piiParamTokens Tokens of the parameters containing PII
+   * @param data Data to provide to the API call
+   * @returns the tokenized request options if tokenization is enabled, undefined otherwise
+   */
+  tokenizeRequestOptions(url: string, queryParameters: { [key: string]: string | undefined }, piiParamTokens: { [statusCode: string]: string }, data: any): TokenizedOptions | undefined;
 
   /**
    * Receives an object containing key/value pairs
@@ -51,7 +51,7 @@ export interface ApiClient {
   processFormData(data: any, type: string): FormData | string;
 
   /** Process HTTP call */
-  processCall<T>(url: string, options: RequestOptions, apiType: ApiTypes | string, apiName: string, reviver?: ReviverType<T> | undefined |
+  processCall<T>(url: string, options: RequestOptions, apiType: ApiTypes | string, apiName: string, revivers?: ReviverType<T> | undefined |
     {[key: number]: ReviverType<T> | undefined}, operationId?: string): Promise<T>;
 }
 

--- a/packages/@ama-sdk/core/src/fwk/core/base-api-constructor.ts
+++ b/packages/@ama-sdk/core/src/fwk/core/base-api-constructor.ts
@@ -14,6 +14,8 @@ export interface BaseApiClientOptions {
   replyPlugins: ReplyPlugin<any>[];
   /** Indicates if the tokenization is enabled and if the tokenized request options should be computed */
   enableTokenization?: boolean;
+  /** Disable the fallback on the first success code reviver if the response returned by the API does not match the list of expected success codes */
+  disableFallback?: boolean;
 }
 
 /** Interface of the constructor configuration object */


### PR DESCRIPTION
## Proposed change

If the API returns a success status code not described in the specification, fallback to the first defined success response code
## Related issues

- :bug: 


<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
