### PR TITLE
feat: captcha support on sdk plugins

### DIFF
--- a/packages/@ama-sdk/core/src/clients/api-fetch-client.ts
+++ b/packages/@ama-sdk/core/src/clients/api-fetch-client.ts
@@ -115,7 +115,7 @@ export class ApiFetchClient implements ApiClient {
     // Execute call
     try {
 
-      const controller = typeof AbortController !== 'undefined' ? new AbortController() : undefined;
+      const controller = new AbortController();
       if (controller) {
         options.signal = controller.signal;
       }

--- a/packages/@ama-sdk/core/src/plugins/core/fetch-plugin.ts
+++ b/packages/@ama-sdk/core/src/plugins/core/fetch-plugin.ts
@@ -21,6 +21,7 @@ export interface FetchPluginContext {
   /** Api Client processing the call the the API */
   apiClient: ApiClient;
 
+  // TODO Now supported for all the o modern browser - should become mandatory in @ama-sdk/core@10.0
   /** Abort controller to abort fetch call */
   controller?: AbortController;
 }

--- a/packages/@ama-sdk/core/src/plugins/timeout/timeout.fetch.ts
+++ b/packages/@ama-sdk/core/src/plugins/timeout/timeout.fetch.ts
@@ -1,5 +1,71 @@
-import { ResponseTimeoutError } from '../../fwk/errors';
-import { FetchCall, FetchPlugin, FetchPluginContext } from '../core';
+import {ResponseTimeoutError} from '../../fwk/errors';
+import {FetchCall, FetchPlugin, FetchPluginContext} from '../core';
+
+/**
+ * Representation of an Imperva Captcha message
+ */
+type ImpervaCaptchaMessageData = {
+  impervaChallenge: {
+    type: 'captcha';
+    status: 'started' | 'ended';
+    timeout: number;
+    url: string;
+  };
+};
+
+/**
+ * Type to describe the timer status of the {@see TimeoutFetch} plugin.
+ * Today, only the stop and restart of the timer is supported which match the following events:
+ * - stop: stop the timeout timer
+ * - start: reset the timer and restart it
+ */
+export type TimeoutStatus = 'timeoutStopped' | 'timeoutStarted';
+
+/**
+ * Check if a message can be cast as an {@link ImpervaCaptchaMessage}
+ * @param message
+ */
+function isImpervaCaptchaMessage(message: any): message is ImpervaCaptchaMessageData {
+  return Object.prototype.hasOwnProperty.call(message, 'impervaChallenge') &&
+    Object.prototype.hasOwnProperty.call(message.impervaChallenge, 'status') &&
+    Object.prototype.hasOwnProperty.call(message.impervaChallenge, 'type') && message.impervaChallenge.type === 'captcha';
+}
+
+/**
+ * Event handler that will emit event to pause the timeout
+ * Today the timeout only
+ */
+export type TimeoutPauseEventHandler = ((timeoutPauseCallback: (timeoutStatus: TimeoutStatus) => void, context: any) => () => void);
+/**
+ * Factory to generate a {@see TimeoutPauseEventHandler} depending on various configurations
+ */
+export type TimeoutPauseEventHandlerFactory<T> = (config?: Partial<T>) => TimeoutPauseEventHandler;
+
+/**
+ * Captures Imperva captcha events and calls the event callback
+ * It can only be used for browser's integrating imperva captcha
+ *
+ * @param config: list of host names that can trigger a captcha event
+ *
+ * @return removeEventListener
+ */
+export const impervaCaptchaEventHandlerFactory: TimeoutPauseEventHandlerFactory<{ whiteListedHostNames: string[] }> = (config) =>
+  (timeoutPauseCallback: (timeoutStatus: TimeoutStatus) => void) => {
+    const onImpervaCaptcha = ((event: MessageEvent<any>) => {
+      const originHostname = (new URL(event.origin)).hostname;
+      if (originHostname !== location.hostname && (config?.whiteListedHostNames || []).indexOf(originHostname) === -1) {
+        return;
+      }
+      const message = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
+      if (message && isImpervaCaptchaMessage(message)) {
+        timeoutPauseCallback(message.impervaChallenge.status === 'started' ? 'timeoutStopped' : 'timeoutStarted');
+      }
+    });
+    addEventListener('message', onImpervaCaptcha);
+    return () => {
+      removeEventListener('message', onImpervaCaptcha);
+    };
+  };
 
 /**
  * Plugin to fire an exception on timeout
@@ -8,14 +74,23 @@ export class TimeoutFetch implements FetchPlugin {
 
   /** Fetch timeout (in millisecond) */
   public timeout: number;
+  private timerSubscription: ((pauseStatus: TimeoutStatus) => void)[] = [];
+  private timerPauseState: TimeoutStatus = 'timeoutStarted';
 
   /**
    * Timeout Fetch plugin.
    *
    * @param timeout Timeout in millisecond
+   * @param timeoutPauseEvent Event that will trigger the pause and reset of the timeout
    */
-  constructor(timeout = 60000) {
+  constructor(timeout = 60000, private timeoutPauseEvent?: TimeoutPauseEventHandler) {
     this.timeout = timeout;
+    if (this.timeoutPauseEvent) {
+      this.timeoutPauseEvent((pausedStatus: TimeoutStatus) => {
+        this.timerPauseState = pausedStatus;
+        this.timerSubscription.forEach((timer) => timer.call(this, pausedStatus));
+      }, this);
+    }
   }
 
   public load(context: FetchPluginContext) {
@@ -23,29 +98,36 @@ export class TimeoutFetch implements FetchPlugin {
       transform: (fetchCall: FetchCall) =>
         // eslint-disable-next-line no-async-promise-executor
         new Promise<Response>(async (resolve, reject) => {
-          let didTimeOut = false;
-
-          const timer = setTimeout(() => {
-            didTimeOut = true;
+          const timeoutCallback = () => {
             reject(new ResponseTimeoutError(`in ${this.timeout}ms`));
-            if (context.controller) {
-              context.controller.abort();
+            // Fetch abort controller is now supported by all modern browser and node 15+. It should always be defined
+            context.controller?.abort();
+          };
+          let timer = this.timerPauseState === 'timeoutStopped' ? undefined : setTimeout(timeoutCallback, this.timeout);
+          const timerCallback = (pauseStatus: TimeoutStatus) => {
+            if (timer && pauseStatus === 'timeoutStopped') {
+              clearTimeout(timer);
+              timer = undefined;
+            } else if (!timer && pauseStatus === 'timeoutStarted') {
+              timer = setTimeout(timeoutCallback, this.timeout);
             }
-          }, this.timeout);
+          };
+          this.timerSubscription.push(timerCallback);
 
           try {
             const response = await fetchCall;
-
-            if (!didTimeOut) {
+            if (!context.controller?.signal.aborted) {
               resolve(response);
             }
           } catch (ex) {
             reject(ex);
           } finally {
-            clearTimeout(timer);
+            if (timer) {
+              clearTimeout(timer);
+            }
+            this.timerSubscription = this.timerSubscription.filter(callback => timerCallback !== callback);
           }
         })
     };
   }
-
 }

--- a/packages/@ama-sdk/core/src/plugins/timeout/timeout.spec.ts
+++ b/packages/@ama-sdk/core/src/plugins/timeout/timeout.spec.ts
@@ -1,12 +1,12 @@
 import {EmptyResponseError, ResponseTimeoutError} from '../../fwk/errors';
-import {TimeoutFetch} from './timeout.fetch';
+import {TimeoutFetch, TimeoutStatus} from './timeout.fetch';
 
 describe('Timeout Fetch Plugin', () => {
 
   it('should reject on timeout', async () => {
     const plugin = new TimeoutFetch(100);
 
-    const runner = plugin.load({} as any);
+    const runner = plugin.load({controller: new AbortController()} as any);
     const call = new Promise<any>((resolve) => setTimeout(() => resolve(undefined), 1000));
 
     const callback = jest.fn();
@@ -20,7 +20,7 @@ describe('Timeout Fetch Plugin', () => {
   it('should not reject on fetch rejection', async () => {
     const plugin = new TimeoutFetch(6000);
 
-    const runner = plugin.load({} as any);
+    const runner = plugin.load({controller: new AbortController()} as any);
     const call = new Promise<any>((_resolve, reject) => setTimeout(() => reject(new EmptyResponseError('')), 100));
 
 
@@ -33,7 +33,7 @@ describe('Timeout Fetch Plugin', () => {
   it('should forward the fetch response', async () => {
     const plugin = new TimeoutFetch(2000);
 
-    const runner = plugin.load({} as any);
+    const runner = plugin.load({controller: new AbortController()} as any);
     const call = new Promise<any>((resolve) => setTimeout(() => resolve({test: true}), 100));
 
     const promise = runner.transform(call);
@@ -42,4 +42,43 @@ describe('Timeout Fetch Plugin', () => {
     expect(await promise).toEqual({test: true} as any);
   });
 
+  it('should not reject if the timeout has been paused and reject if restarted', async () => {
+    const timeoutPauseEvent = {
+      emitEvent: (_status: TimeoutStatus) => {},
+      handler: (timeoutPauseCallbacl: (status: TimeoutStatus) => void) => {
+        timeoutPauseEvent.emitEvent = timeoutPauseCallbacl;
+        return () => {};
+      }
+    };
+    const plugin = new TimeoutFetch(100, timeoutPauseEvent.handler);
+
+    const runner = plugin.load({controller: new AbortController()} as any);
+    const call = new Promise<any>((resolve) => setTimeout(() => resolve({test: true}), 500));
+    const callback = jest.fn();
+    runner.transform(call).catch(callback);
+    timeoutPauseEvent.emitEvent('timeoutStopped');
+    await jest.advanceTimersByTimeAsync(200);
+    timeoutPauseEvent.emitEvent('timeoutStarted');
+    await jest.advanceTimersByTimeAsync(200);
+    expect(callback).toHaveBeenCalledWith(new ResponseTimeoutError('in 100ms'));
+  });
+
+  it('should take into account pause events triggered before the call', async () => {
+    const timeoutPauseEvent = {
+      emitEvent: (_status: TimeoutStatus) => {},
+      handler: (timeoutPauseCallback: (status: TimeoutStatus) => void) => {
+        timeoutPauseEvent.emitEvent = timeoutPauseCallback;
+        return () => {};
+      }
+    };
+    const plugin = new TimeoutFetch(250, timeoutPauseEvent.handler);
+
+    const runner = plugin.load({controller: new AbortController()} as any);
+    const call = new Promise<any>((resolve) => setTimeout(() => resolve({test: true}), 500));
+    timeoutPauseEvent.emitEvent('timeoutStopped');
+    const promise = runner.transform(call);
+    await jest.runAllTimersAsync();
+
+    expect(await promise).toEqual({test: true} as any);
+  });
 });


### PR DESCRIPTION
## Proposed change

Stop and restart the timeout fetch plugin in case a specific event interrumpts the fetch request. 
Add event emitter to pause the timeout if an imperva captcha has been detected.
