### PR TITLE
ci: add schematics folder to unit tests nx-inputs

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -127,6 +127,8 @@
     "test": {
       "inputs": [
         {"env": "RUNNER_OS"},
+        "builders",
+        "schematics",
         "specs",
         "^specs"
       ],

--- a/packages/@ama-sdk/generator-sdk/src/generators/shell/templates/base/package.json
+++ b/packages/@ama-sdk/generator-sdk/src/generators/shell/templates/base/package.json
@@ -109,7 +109,7 @@
     "rimraf": "^5.0.1",
     "standard-version": "^9.0.0",
     "ts-jest": "~29.1.1",
-    "typedoc": "~0.24.8",
+    "typedoc": "~0.25.0",
     "tsc-watch": "^6.0.0",
     "typescript": "~5.1.6",
     "yo": "~4.3.0"

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/package.json.template
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/package.json.template
@@ -103,7 +103,7 @@
     "rimraf": "^5.0.1",
     "standard-version": "^9.0.0",
     "ts-jest": "<%= versions['ts-jest'] %>",
-    "typedoc": "~0.24.8",
+    "typedoc": "~0.25.0",
     "tsc-watch": "^6.0.0",
     "typescript": "<%= versions['typescript'] %>"
   },

--- a/packages/@o3r/rules-engine/schematics/facts-service/index.spec.ts
+++ b/packages/@o3r/rules-engine/schematics/facts-service/index.spec.ts
@@ -27,7 +27,7 @@ describe('Generate facts service', () => {
 
     expect(tree.files.filter((f) => f.startsWith('/src/facts/first-example')).length).toBe(2);
     const factsFile = tree.readText('/src/facts/first-example/first-example.facts.ts');
-    expect(factsFile).toContain('import { FactDefinitions } from \'@o3r/rules-engine\';');
+    expect(factsFile).toContain('import type { FactDefinitions } from \'@o3r/rules-engine\';');
     expect(factsFile).toContain('export interface FirstExampleFacts extends FactDefinitions');
 
     const serviceFile = tree.readText('/src/facts/first-example/first-example-facts.service.ts');


### PR DESCRIPTION
## Proposed change

Add `schematics` folder to inputs of nx task `test` to make sure the cache won't be reused when a file on schematics has been updated

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
