### PR TITLE
feat: Update JSON schema (config) for widget configuration + required field

### DIFF
--- a/packages/@o3r/configuration/schemas/configuration.metadata.schema.json
+++ b/packages/@o3r/configuration/schemas/configuration.metadata.schema.json
@@ -129,6 +129,44 @@
                 ]
               }
             },
+            "required": {
+              "type": "boolean"
+            },
+            "widget": {
+              "type": "object",
+              "description": "Widget used to display the property",
+              "required": [
+                "type"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "parameters": {
+                  "type": "object",
+                  "description": "map of widget parameters. Each parameter can be a string, number or boolean or an array of those",
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^[a-zA-Z0-9-_:.]+$": {
+                      "type": [
+                        "string",
+                        "number",
+                        "boolean",
+                        "array"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "number",
+                          "boolean"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
             "reference": {
               "library": "string",
               "name": "string"


### PR DESCRIPTION
Improve JSON schema for the config in order to improve the CMS UI thanks to widgets configuration

Here is an example of a generated config compatible with the update:
```
{
  "name": "myProperty",
  "description": "my description",
  "type": "string",
  "value": "default-value",
  "label": "Label!",
  "required": true,
  "widget": {
    "type": "STRING",
    "parameters": {
      "pattern": "[a-zA-Z0-9]+",
      "arrayExample": ["val1", "val2"]
    }
  }
},
```