### PR TITLE
feat: propagate the argument to the ng add otter schematic

### DIFF
--- a/packages/@o3r/create/package.json
+++ b/packages/@o3r/create/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@angular/cli": "~16.2.0",
+    "@schematics/angular": "~16.2.0",
     "minimist": "^1.2.6"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7145,6 +7145,7 @@ __metadata:
     "@o3r/dev-tools": "workspace:^"
     "@o3r/eslint-config-otter": "workspace:^"
     "@o3r/eslint-plugin": "workspace:^"
+    "@schematics/angular": ~16.2.0
     "@types/jest": ~29.5.2
     "@types/minimist": ^1.2.2
     "@types/node": ^18.0.0


### PR DESCRIPTION
## Proposed change

Propagate the argument to the ng add otter schematic

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :rocket: Feature #723

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
