### PR TITLE
feat: option to generate the sdk at sdk creation inside monorepo

### DIFF
--- a/packages/@ama-sdk/generator-sdk/src/generators/shell/templates/base/package.json
+++ b/packages/@ama-sdk/generator-sdk/src/generators/shell/templates/base/package.json
@@ -96,7 +96,7 @@
     "cpx": "^1.5.0",
     "eslint": "^8.42.0",
     "eslint-plugin-jest": "~27.2.3",
-    "eslint-plugin-jsdoc": "~46.5.0",
+    "eslint-plugin-jsdoc": "~46.6.0",
     "eslint-plugin-prefer-arrow": "~1.2.3",
     "eslint-plugin-unicorn": "^47.0.0",
     "glob": "^8.0.0",

--- a/packages/@o3r/core/schematics/sdk/index.ts
+++ b/packages/@o3r/core/schematics/sdk/index.ts
@@ -1,13 +1,14 @@
-import { apply, chain, externalSchematic, MergeStrategy, mergeWith, move, renameTemplateFiles, Rule, strings, template, url } from '@angular-devkit/schematics';
+import { apply, chain, externalSchematic, MergeStrategy, mergeWith, move, noop, renameTemplateFiles, Rule, SchematicContext, strings, template, Tree, url } from '@angular-devkit/schematics';
 import * as path from 'node:path';
 import { getPackageManager, getPackagesBaseRootFolder, getWorkspaceConfig, isNxContext } from '@o3r/schematics';
 import { NgGenerateSdkSchema } from './schema';
-import type { NgGenerateTypescriptSDKShellSchematicsSchema } from '@ama-sdk/schematics';
+import type { NgGenerateTypescriptSDKCoreSchematicsSchema, NgGenerateTypescriptSDKShellSchematicsSchema } from '@ama-sdk/schematics';
 import type { PackageJson } from 'type-fest';
 import { ngRegisterProjectTasks } from './rules/rules.ng';
 import { nxRegisterProjectTasks } from './rules/rules.nx';
 import { updateTsConfig } from './rules/update-ts-paths.rule';
 import { cleanStandaloneFiles } from './rules/clean-standalone.rule';
+import { RunSchematicTask } from '@angular-devkit/schematics/tasks';
 
 /**
  * Add an Otter compatible SDK to a monorepo
@@ -48,7 +49,15 @@ export function generateSdk(options: NgGenerateSdkSchema): Rule {
       isNx ? nxRegisterProjectTasks(options, targetPath, cleanName) : ngRegisterProjectTasks(options, targetPath, cleanName),
       updateTsConfig(targetPath, cleanName, scope),
       cleanStandaloneFiles(targetPath),
-      addModuleSpecificFiles()
+      addModuleSpecificFiles(),
+      options.specPath ? (_host: Tree, c: SchematicContext) => {
+        c.addTask(new RunSchematicTask<Partial<NgGenerateTypescriptSDKCoreSchematicsSchema>>('@ama-sdk/schematics', 'typescript-core', {
+          ...options,
+          specPath: options.specPath,
+          directory: targetPath,
+          packageManager: getPackageManager({workspaceConfig})
+        }));
+      } : noop
     ])(tree, context);
   };
 }

--- a/packages/@o3r/core/schematics/sdk/schema.json
+++ b/packages/@o3r/core/schematics/sdk/schema.json
@@ -26,6 +26,10 @@
       "type": "string",
       "description": "Target directory to generate the module"
     },
+    "specPath": {
+      "type": "string",
+      "description": "Path to the swagger specification used to generate the SDK; If not provided, sdk shell will be generated"
+    },
     "skipLinter": {
       "type": "boolean",
       "description": "Skip the linter process",

--- a/packages/@o3r/core/schematics/sdk/schema.ts
+++ b/packages/@o3r/core/schematics/sdk/schema.ts
@@ -19,4 +19,7 @@ export interface NgGenerateSdkSchema extends SchematicOptionObject {
 
   /** Do not install dependency packages. */
   skipInstall: boolean;
+
+  /** Path to the swagger specification used to generate the SDK; If not provided, sdk shell will be generated */
+  specPath?: string | undefined;
 }


### PR DESCRIPTION
## Proposed change

When creating an sdk inside a monorepo, add the possibility to generate the sdk based on specs passed via a new input.

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
