### PR TITLE
chore: fix some peer dep warnings

### DIFF
--- a/packages/@ama-sdk/core/package.json
+++ b/packages/@ama-sdk/core/package.json
@@ -54,13 +54,18 @@
   },
   "peerDependencies": {
     "@angular-devkit/schematics": "~16.2.0",
+    "@angular/cli": "~16.2.0",
     "@angular/common": "~16.2.0",
     "@schematics/angular": "~16.2.0",
     "isomorphic-fetch": "^3.0.0",
+    "rxjs": "^7.8.1",
     "typescript": "~5.1.6"
   },
   "peerDependenciesMeta": {
     "@angular-devkit/schematics": {
+      "optional": true
+    },
+    "@angular/cli": {
       "optional": true
     },
     "@angular/common": {
@@ -70,6 +75,9 @@
       "optional": true
     },
     "isomorphic-fetch": {
+      "optional": true
+    },
+    "rxjs": {
       "optional": true
     },
     "typescript": {

--- a/packages/@ama-sdk/generator-sdk/src/generators/shell/templates/base/package.json
+++ b/packages/@ama-sdk/generator-sdk/src/generators/shell/templates/base/package.json
@@ -96,7 +96,7 @@
     "cpx": "^1.5.0",
     "eslint": "^8.42.0",
     "eslint-plugin-jest": "~27.2.3",
-    "eslint-plugin-jsdoc": "~46.5.0",
+    "eslint-plugin-jsdoc": "~46.6.0",
     "eslint-plugin-prefer-arrow": "~1.2.3",
     "eslint-plugin-unicorn": "^47.0.0",
     "glob": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -111,18 +111,24 @@ __metadata:
     zone.js: ~0.13.1
   peerDependencies:
     "@angular-devkit/schematics": ~16.2.0
+    "@angular/cli": ~16.2.0
     "@angular/common": ~16.2.0
     "@schematics/angular": ~16.2.0
     isomorphic-fetch: ^3.0.0
+    rxjs: ^7.8.1
     typescript: ~5.1.6
   peerDependenciesMeta:
     "@angular-devkit/schematics":
+      optional: true
+    "@angular/cli":
       optional: true
     "@angular/common":
       optional: true
     "@schematics/angular":
       optional: true
     isomorphic-fetch:
+      optional: true
+    rxjs:
       optional: true
     typescript:
       optional: true


### PR DESCRIPTION
## Proposed change
Fix some peer requirements
```shell
➤ YN0002: │ @ama-sdk/core@npm:9.3.0-alpha.25 [0ac57] doesn't provide @angular/cli (pfb8c0), requested by @o3r/schematics
➤ YN0002: │ @ama-sdk/core@npm:9.3.0-alpha.25 [0ac57] doesn't provide rxjs (p98433), requested by @o3r/schematics
➤ YN0002: │ @ama-sdk/core@npm:9.3.0-alpha.25 [e3e22] doesn't provide @angular/cli (p9b54a), requested by @o3r/schematics
➤ YN0002: │ @ama-sdk/core@npm:9.3.0-alpha.25 [e3e22] doesn't provide rxjs (p93e4b), requested by @o3r/schematics
```