### PR TITLE
ci: it-tests improvements

### DIFF
--- a/.github/workflows/it-tests.yml
+++ b/.github/workflows/it-tests.yml
@@ -75,15 +75,8 @@ jobs:
             !.cache/test-app/cache/@ama-terasu*
             !.cache/test-app/cache/@o3r*
           key: ${{ runner.os }}-test-app-${{ matrix.packageManager }}-${{ env.currentMonth }}
-      - name: Cache test-sdk yarn
-        uses: actions/cache@v3
-        with:
-          path: |
-            .cache/test-sdk
-            !.cache/test-sdk/@ama-sdk*
-            !.cache/test-sdk/@ama-terasu*
-            !.cache/test-sdk/@o3r*
-          key: ${{ runner.os }}-test-sdk-${{ matrix.packageManager }}-${{ env.currentMonth }}
+      - name: Make sure that internal packages are not cached for whatever reason
+        run: npx --yes rimraf -g ".cache/test-app/cache/@{o3r,ama-sdk,ama-terasu}-*"
       - uses: actions/download-artifact@v3
         name: Download verdaccio storage prepared in the previous job
         with:

--- a/.verdaccio/conf/config-without-docker.yaml
+++ b/.verdaccio/conf/config-without-docker.yaml
@@ -24,21 +24,18 @@ auth:
     file: ../storage/htpasswd
     algorithm: bcrypt
 
-uplinks:
-  npmjs:
-    url: https://registry.npmjs.org/
-
 packages:
-  '**':
+  '@o3r/*':
     access: $all
     publish: $authenticated
-    unpublish: $authenticated
-    proxy: npmjs
-  '@o3r/*':
     proxy: no-proxy
   '@ama-sdk/*':
+    access: $all
+    publish: $authenticated
     proxy: no-proxy
   '@ama-terasu/*':
+    access: $all
+    publish: $authenticated
     proxy: no-proxy
 
 no_proxy: localhost,127.0.0.1

--- a/.verdaccio/conf/config.yaml
+++ b/.verdaccio/conf/config.yaml
@@ -24,21 +24,18 @@ auth:
     file: /verdaccio/storage/htpasswd
     algorithm: bcrypt
 
-uplinks:
-  npmjs:
-    url: https://registry.npmjs.org/
-
 packages:
-  '**':
+  '@o3r/*':
     access: $all
     publish: $authenticated
-    unpublish: $authenticated
-    proxy: npmjs
-  '@o3r/*':
     proxy: no-proxy
   '@ama-sdk/*':
+    access: $all
+    publish: $authenticated
     proxy: no-proxy
   '@ama-terasu/*':
+    access: $all
+    publish: $authenticated
     proxy: no-proxy
 
 no_proxy: localhost,127.0.0.1

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "storybook": "yarn doc:generate:json && yarn ng run storybook:extract-style && start-storybook -p 6006",
     "verdaccio:start": "docker run -d -it --rm --name verdaccio -p 4873:4873 -v \"$(shx pwd)/.verdaccio/conf\":/verdaccio/conf verdaccio/verdaccio",
     "verdaccio:start-persistent": "docker run -d -it --rm --name verdaccio -p 4873:4873 -v \"$(shx pwd)/.verdaccio/conf\":/verdaccio/conf -v \"$(shx pwd)/.verdaccio/storage\":/verdaccio/storage:z verdaccio/verdaccio",
-    "verdaccio:clean": "rimraf ./.verdaccio/storage",
+    "verdaccio:clean": "rimraf -g \".verdaccio/storage/@{o3r,ama-sdk,ama-terasu}\"",
     "verdaccio:login": "yarn cpy --cwd=./.verdaccio/conf .npmrc . --rename=.npmrc-logged && npx --yes npm-cli-login -u verdaccio -p verdaccio -e test@test.com -r http://127.0.0.1:4873 --config-path \".verdaccio/conf/.npmrc-logged\"",
-    "verdaccio:publish": "yarn set:version 999.0.0 --include \"!**/!(dist)/package.json\" --include !package.json && yarn verdaccio:login && yarn run publish --userconfig \".verdaccio/conf/.npmrc-logged\" --tag=latest --@o3r:registry=http://127.0.0.1:4873 --@ama-sdk:registry=http://127.0.0.1:4873",
+    "verdaccio:publish": "yarn verdaccio:clean && yarn set:version 999.0.0 --include \"!**/!(dist)/package.json\" --include !package.json && yarn verdaccio:login && yarn run publish --userconfig \".verdaccio/conf/.npmrc-logged\" --tag=latest --@o3r:registry=http://127.0.0.1:4873 --@ama-sdk:registry=http://127.0.0.1:4873",
     "verdaccio:stop": "docker container stop $(docker ps -a -q --filter=\"name=verdaccio\")",
     "watch:vscode-extension": "yarn nx run vscode-extension:compile:watch",
     "workspaces:list": "yarn workspaces list --no-private --json | shx sed \"s/.*\\\"location\\\":\\\"(.*?)\\\".*/\\$1/\""

--- a/packages/@o3r/test-helpers/src/test-environments/create-test-environment-angular.ts
+++ b/packages/@o3r/test-helpers/src/test-environments/create-test-environment-angular.ts
@@ -98,6 +98,11 @@ export async function createTestEnvironmentAngular(inputOptions: Partial<CreateT
         // eslint-disable-next-line @typescript-eslint/naming-convention
         {...execAppOptions, cwd: options.cwd});
       setPackagerManagerConfig(options, execAppOptions);
+      packageManagerInstall(execAppOptions);
+    }
+    packageManagerExec('ng config cli.cache.environment all', execAppOptions);
+    if (options.globalFolderPath) {
+      packageManagerExec(`ng config cli.cache.path "${path.join(options.globalFolderPath, '.angular', 'cache')}"`, execAppOptions);
     }
 
     // Add dependencies


### PR DESCRIPTION
## Proposed change

- fix an issue when running it-tests on yarn, sometimes the internal packages (@o3r, @ama-sdk,..) were included in the cache
- add angular cache from it-tests to the cache artifact reused between builds
- removed uplink feature from verdaccio to make sure we always target local packages (also make the local publish faster)

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
