### PR TITLE
perf: make component generators rely on tree instead of file system

### DIFF
--- a/packages/@o3r/core/schematics/component/container/index.spec.ts
+++ b/packages/@o3r/core/schematics/component/container/index.spec.ts
@@ -4,6 +4,7 @@ import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 import { getComponentSelectorWithoutSuffix, TYPES_DEFAULT_FOLDER } from '@o3r/schematics';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import type { PackageJson } from 'type-fest';
 import { CONTAINER_FOLDER } from './index';
 
 const collectionPath = path.join(__dirname, '..', '..', '..', 'collection.json');
@@ -41,16 +42,6 @@ describe('Component container', () => {
     runner = new SchematicTestRunner('schematics', collectionPath);
     const angularPackageJson = require.resolve('@schematics/angular/package.json');
     runner.registerCollection('@schematics/angular', path.resolve(path.dirname(angularPackageJson), require(angularPackageJson).schematics));
-    // eslint-disable-next-line no-underscore-dangle
-    (fs as any).__mockFiles({
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      './package.json': JSON.stringify({
-        devDependencies: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          '@o3r/core': 'latest'
-        }
-      }, null, 2)
-    });
   });
 
   it('should generate a container component in the default component folder', async () => {
@@ -191,18 +182,10 @@ describe('Component container', () => {
   });
 
   it('should generate a container component with rules engine', async () => {
-    // eslint-disable-next-line no-underscore-dangle
-    (fs as any).__mockFiles({
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      './package.json': JSON.stringify({
-        devDependencies: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          '@o3r/core': 'latest',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          '@o3r/rules-engine': 'latest'
-        }
-      }, null, 2)
-    });
+    const packageJson = initialTree.readJson('package.json') as PackageJson;
+    packageJson.dependencies ??= {};
+    packageJson.dependencies['@o3r/rules-engine'] = '0.0.0';
+    initialTree.overwrite('package.json', JSON.stringify(packageJson));
     const externalSchematicsSpy = jest.fn((tree: Tree) => tree);
     const externalCollection = {
       createSchematic: () => externalSchematicsSpy

--- a/packages/@o3r/core/schematics/component/container/index.ts
+++ b/packages/@o3r/core/schematics/component/container/index.ts
@@ -64,7 +64,7 @@ export function ngGenerateComponentContainer(options: NgGenerateComponentContain
 
   const fullStructureRequested = options.componentStructure === 'full';
 
-  const generateFiles = async (tree: Tree, context: SchematicContext) => {
+  const generateFiles = (tree: Tree, context: SchematicContext) => {
 
     const workspaceProject = getProjectFromTree(tree);
 
@@ -256,33 +256,24 @@ class Mock${properties.presenterComponentName} {}
       );
     }
 
-    const configurationRules = await getAddConfigurationRules(
-      componentPath,
-      options,
-      context
+    rules.push(
+      getAddConfigurationRules(
+        componentPath,
+        options
+      ),
+      getAddFixtureRules(
+        componentPath,
+        options
+      ),
+      getAddContextRules(
+        componentPath,
+        options
+      ),
+      getAddRulesEngineRules(
+        path.posix.join(componentDestination, `${properties.name}.component.ts`),
+        options
+      )
     );
-    rules.push(...configurationRules);
-
-    const fixtureRules = await getAddFixtureRules(
-      componentPath,
-      options,
-      context
-    );
-    rules.push(...fixtureRules);
-
-    const contextRules = await getAddContextRules(
-      componentPath,
-      options,
-      context
-    );
-    rules.push(...contextRules);
-
-    const rulesEngineRules = await getAddRulesEngineRules(
-      path.posix.join(componentDestination, `${properties.name}.component.ts`),
-      options,
-      context
-    );
-    rules.push(...rulesEngineRules);
 
     return chain(rules);
   };

--- a/packages/@o3r/core/schematics/component/presenter/index.spec.ts
+++ b/packages/@o3r/core/schematics/component/presenter/index.spec.ts
@@ -42,16 +42,6 @@ describe('Component presenter', () => {
     runner = new SchematicTestRunner('schematics', collectionPath);
     const angularPackageJson = require.resolve('@schematics/angular/package.json');
     runner.registerCollection('@schematics/angular', path.resolve(path.dirname(angularPackageJson), require(angularPackageJson).schematics));
-    // eslint-disable-next-line no-underscore-dangle
-    (fs as any).__mockFiles({
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      './package.json': JSON.stringify({
-        devDependencies: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          '@o3r/core': 'latest'
-        }
-      }, null, 2)
-    });
   });
 
   it('should generate a presenter component in the default component folder', async () => {

--- a/packages/@o3r/core/schematics/component/presenter/index.ts
+++ b/packages/@o3r/core/schematics/component/presenter/index.ts
@@ -67,7 +67,7 @@ export function ngGenerateComponentPresenter(options: NgGenerateComponentSchemat
 
   const fullStructureRequested = options.componentStructure === 'full';
 
-  const generateFiles = async (tree: Tree, context: SchematicContext) => {
+  const generateFiles = (tree: Tree, _context: SchematicContext) => {
 
     const workspaceProject = getProjectFromTree(tree);
 
@@ -166,47 +166,32 @@ export function ngGenerateComponentPresenter(options: NgGenerateComponentSchemat
       })
     );
 
-    const configurationRules = await getAddConfigurationRules(
-      componentPath,
-      options,
-      context
+    rules.push(
+      getAddConfigurationRules(
+        componentPath,
+        options
+      ),
+      getAddThemingRules(
+        o3rStylePath,
+        options
+      ),
+      getAddLocalizationRules(
+        componentPath,
+        options
+      ),
+      getAddFixtureRules(
+        componentPath,
+        options
+      ),
+      getAddAnalyticsRules(
+        componentPath,
+        options
+      ),
+      getAddContextRules(
+        componentPath,
+        options
+      )
     );
-    rules.push(...configurationRules);
-
-    const themingRules = await getAddThemingRules(
-      o3rStylePath,
-      options,
-      context
-    );
-    rules.push(...themingRules);
-
-    const localizationRules = await getAddLocalizationRules(
-      componentPath,
-      options,
-      context
-    );
-    rules.push(...localizationRules);
-
-    const fixtureRules = await getAddFixtureRules(
-      componentPath,
-      options,
-      context
-    );
-    rules.push(...fixtureRules);
-
-    const analyticsRules = await getAddAnalyticsRules(
-      componentPath,
-      options,
-      context
-    );
-
-    rules.push(...analyticsRules);
-    const contextRules = await getAddContextRules(
-      componentPath,
-      options,
-      context
-    );
-    rules.push(...contextRules);
 
     return chain(rules);
   };

--- a/packages/@o3r/core/schematics/rule-factories/component/analytics.ts
+++ b/packages/@o3r/core/schematics/rule-factories/component/analytics.ts
@@ -1,18 +1,16 @@
-import { Rule, SchematicContext } from '@angular-devkit/schematics';
-import { NgGenerateComponentSchematicsSchema } from '../../component/schema';
+import type { Rule } from '@angular-devkit/schematics';
+import type { NgGenerateComponentSchematicsSchema } from '../../component/schema';
 import { askQuestionsToGetRulesOrThrowIfPackageNotAvailable } from './common';
 
 export const getAddAnalyticsRules = (
   componentPath: string,
-  options: NgGenerateComponentSchematicsSchema,
-  context: SchematicContext
-): Promise<Rule[]> => askQuestionsToGetRulesOrThrowIfPackageNotAvailable(
+  options: NgGenerateComponentSchematicsSchema
+): Rule => askQuestionsToGetRulesOrThrowIfPackageNotAvailable(
   componentPath,
   'useOtterAnalytics',
   options.useOtterAnalytics,
   'Generate component with Otter analytics?',
   ['@o3r/core:component', '@o3r/core:component-presenter'],
-  context,
   '@o3r/analytics',
   'analytics-to-component',
   {

--- a/packages/@o3r/core/schematics/rule-factories/component/common.ts
+++ b/packages/@o3r/core/schematics/rule-factories/component/common.ts
@@ -1,7 +1,7 @@
-import { externalSchematic, Rule, schematic, SchematicContext } from '@angular-devkit/schematics';
+import { chain, externalSchematic, noop, Rule, schematic, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { askConfirmation, askQuestion } from '@angular/cli/src/utilities/prompt';
 import { SchematicOptionObject, setupSchematicsDefaultParams } from '@o3r/schematics';
-import { readFileSync } from 'node:fs';
+import type { PackageJson } from 'type-fest';
 
 /**
  * Ask questions to get rules to execute
@@ -12,85 +12,85 @@ import { readFileSync } from 'node:fs';
  * @param defaultApplyRule should the rule be applied by default
  * @param ruleQuestion the question to ask
  * @param schematicsNameToUpdate list of schematics to update
- * @param context schematic runner context
  * @param packageName package name of the schematic to execute
  * @param schematicName schematic name to execute
  * @param schematicOptions options of the schematic to execute
  */
-export const askQuestionsToGetRulesOrThrowIfPackageNotAvailable = async (
+export const askQuestionsToGetRulesOrThrowIfPackageNotAvailable = (
   path: string,
   optionName: string,
   defaultApplyRule: boolean | null | undefined,
   ruleQuestion: string,
   schematicsNameToUpdate: string[],
-  context: SchematicContext,
   packageName: string,
   schematicName: string,
   schematicOptions: any = {}
-): Promise<Rule[]> => {
+): Rule => {
   let applyRule = defaultApplyRule;
   let alwaysApplyRule: string | null = null;
-  try {
-    const packageJson = JSON.parse(readFileSync('./package.json', {encoding: 'utf8'}));
-    if (!packageJson.dependencies?.[packageName] && !packageJson.devDependencies?.[packageName]) {
-      throw new Error(`Package ${packageName} not installed`);
-    }
-    if (typeof applyRule !== 'boolean' && context.interactive) {
-      applyRule = await askConfirmation(ruleQuestion, true);
-      if (applyRule) {
-        alwaysApplyRule = await askQuestion(`Generate future components with ${optionName} by default?`, [
-          {
-            type: 'choice',
-            name: 'Yes, always',
-            value: 'yes'
-          },
-          {
-            type: 'choice',
-            name: 'Ask me again next time',
-            value: 'ask-again'
-          },
-          {
-            type: 'choice',
-            name: `No, don't apply ${optionName} by default`,
-            value: 'no'
-          }
-        ], 0, 'yes');
-      } else {
-        context.logger.info(`
+  return async (tree: Tree, context: SchematicContext) => {
+    try {
+      const packageJson = tree.readJson('./package.json') as PackageJson;
+      if (!packageJson.dependencies?.[packageName] && !packageJson.devDependencies?.[packageName]) {
+        throw new Error(`Package ${packageName} not installed`);
+      }
+      if (typeof applyRule !== 'boolean' && context.interactive) {
+        applyRule = await askConfirmation(ruleQuestion, true);
+        if (applyRule) {
+          alwaysApplyRule = await askQuestion(`Generate future components with ${optionName} by default?`, [
+            {
+              type: 'choice',
+              name: 'Yes, always',
+              value: 'yes'
+            },
+            {
+              type: 'choice',
+              name: 'Ask me again next time',
+              value: 'ask-again'
+            },
+            {
+              type: 'choice',
+              name: `No, don't apply ${optionName} by default`,
+              value: 'no'
+            }
+          ], 0, 'yes');
+        } else {
+          context.logger.info(`
           You can add it later to this component via this command:
           ng g ${packageName}:${schematicName} --path="${path}"
         `);
+        }
       }
-    }
-  } catch {
-    if (applyRule) {
-      throw new Error(`
+    } catch {
+      if (applyRule) {
+        throw new Error(`
         You need to install '${packageName}' to be able to generate component with the option ${optionName}.
         Please run 'ng add ${packageName}'.
       `);
+      }
+      applyRule = false;
     }
-    applyRule = false;
-  }
 
-  const options = {
-    path,
-    ...schematicOptions
+    const options = {
+      path,
+      ...schematicOptions
+    };
+
+    return applyRule ? chain([
+      packageName !== '@o3r/core'
+        ? externalSchematic(packageName, schematicName, options)
+        : schematic(schematicName, options),
+      ...(alwaysApplyRule !== 'ask-again' ? [
+        setupSchematicsDefaultParams(
+          schematicsNameToUpdate.reduce((acc: Record<string, SchematicOptionObject>, schematicToUpdateName) => {
+            acc[schematicToUpdateName] = {
+              [optionName]: alwaysApplyRule === 'yes'
+            };
+            return acc;
+          }, {})
+        )
+      ] : [])
+    ]) : noop;
   };
-
-  return applyRule ? [
-    packageName !== '@o3r/core'
-      ? externalSchematic(packageName, schematicName, options)
-      : schematic(schematicName, options),
-    ...(alwaysApplyRule !== 'ask-again' ? [
-      setupSchematicsDefaultParams(
-        schematicsNameToUpdate.reduce((acc: Record<string, SchematicOptionObject>, schematicToUpdateName) => {
-          acc[schematicToUpdateName] = {
-            [optionName]: alwaysApplyRule === 'yes'
-          };
-          return acc;
-        }, {})
-      )
-    ] : [])
-  ] : [];
 };
 

--- a/packages/@o3r/core/schematics/rule-factories/component/configuration.ts
+++ b/packages/@o3r/core/schematics/rule-factories/component/configuration.ts
@@ -1,19 +1,16 @@
-import { Rule, SchematicContext } from '@angular-devkit/schematics';
-import { NgGenerateComponentSchematicsSchema } from '../../component/schema';
+import type { Rule } from '@angular-devkit/schematics';
+import type { NgGenerateComponentSchematicsSchema } from '../../component/schema';
 import { askQuestionsToGetRulesOrThrowIfPackageNotAvailable } from './common';
-
 
 export const getAddConfigurationRules = (
   componentPath: string,
-  options: Pick<NgGenerateComponentSchematicsSchema, 'useOtterConfig' | 'skipLinter' | 'projectName'> & Partial<Pick<NgGenerateComponentSchematicsSchema, 'componentStructure'>>,
-  context: SchematicContext
-): Promise<Rule[]> => askQuestionsToGetRulesOrThrowIfPackageNotAvailable(
+  options: Pick<NgGenerateComponentSchematicsSchema, 'useOtterConfig' | 'skipLinter' | 'projectName'> & Partial<Pick<NgGenerateComponentSchematicsSchema, 'componentStructure'>>
+): Rule => askQuestionsToGetRulesOrThrowIfPackageNotAvailable(
   componentPath,
   'useOtterConfig',
   options.useOtterConfig,
   'Generate component with Otter configuration?',
   ['@o3r/core:component', '@o3r/core:component-presenter', '@o3r/core:component-container'],
-  context,
   '@o3r/configuration',
   'configuration-to-component',
   {

--- a/packages/@o3r/core/schematics/rule-factories/component/context.ts
+++ b/packages/@o3r/core/schematics/rule-factories/component/context.ts
@@ -1,18 +1,16 @@
-import { Rule, SchematicContext } from '@angular-devkit/schematics';
-import { NgGenerateComponentSchematicsSchema } from '../../component/schema';
+import type { Rule } from '@angular-devkit/schematics';
+import type { NgGenerateComponentSchematicsSchema } from '../../component/schema';
 import { askQuestionsToGetRulesOrThrowIfPackageNotAvailable } from './common';
 
-export const getAddContextRules = async (
+export const getAddContextRules = (
   componentPath: string,
-  options: Pick<NgGenerateComponentSchematicsSchema, 'useContext' | 'skipLinter'>,
-  context: SchematicContext
-): Promise<Rule[]> => askQuestionsToGetRulesOrThrowIfPackageNotAvailable(
+  options: Pick<NgGenerateComponentSchematicsSchema, 'useContext' | 'skipLinter'>
+): Rule => askQuestionsToGetRulesOrThrowIfPackageNotAvailable(
   componentPath,
   'useContext',
   options.useContext,
   'Generate component with Otter context?',
   ['@o3r/core:component', '@o3r/core:component-container', '@o3r/core:component-presenter'],
-  context,
   '@o3r/core',
   'context-to-component',
   {

--- a/packages/@o3r/core/schematics/rule-factories/component/fixture.ts
+++ b/packages/@o3r/core/schematics/rule-factories/component/fixture.ts
@@ -1,20 +1,17 @@
-import { Rule, SchematicContext } from '@angular-devkit/schematics';
-import { NgGenerateComponentSchematicsSchema } from '../../component/schema';
+import type { Rule } from '@angular-devkit/schematics';
+import type { NgGenerateComponentSchematicsSchema } from '../../component/schema';
 import { askQuestionsToGetRulesOrThrowIfPackageNotAvailable } from './common';
-
 
 export const getAddFixtureRules = (
   componentPath: string,
   options: Pick<NgGenerateComponentSchematicsSchema, 'useComponentFixtures' | 'skipLinter'>,
-  context: SchematicContext,
   isPage = false
-): Promise<Rule[]> => askQuestionsToGetRulesOrThrowIfPackageNotAvailable(
+): Rule => askQuestionsToGetRulesOrThrowIfPackageNotAvailable(
   componentPath,
   'useComponentFixtures',
   options.useComponentFixtures,
   'Generate component with Otter fixture?',
   ['@o3r/core:component', '@o3r/core:component-presenter', '@o3r/core:component-container'],
-  context,
   '@o3r/testing',
   'fixture-to-component',
   {

--- a/packages/@o3r/core/schematics/rule-factories/component/localization.ts
+++ b/packages/@o3r/core/schematics/rule-factories/component/localization.ts
@@ -1,19 +1,16 @@
-import { Rule, SchematicContext } from '@angular-devkit/schematics';
-import { NgGenerateComponentSchematicsSchema } from '../../component/schema';
+import type { Rule } from '@angular-devkit/schematics';
+import type { NgGenerateComponentSchematicsSchema } from '../../component/schema';
 import { askQuestionsToGetRulesOrThrowIfPackageNotAvailable } from './common';
-
 
 export const getAddLocalizationRules = (
   componentPath: string,
-  options: Pick<NgGenerateComponentSchematicsSchema, 'useLocalization' | 'skipLinter' | 'activateDummy'>,
-  context: SchematicContext
-): Promise<Rule[]> => askQuestionsToGetRulesOrThrowIfPackageNotAvailable(
+  options: Pick<NgGenerateComponentSchematicsSchema, 'useLocalization' | 'skipLinter' | 'activateDummy'>
+): Rule => askQuestionsToGetRulesOrThrowIfPackageNotAvailable(
   componentPath,
   'useLocalization',
   options.useLocalization,
   'Generate component with Otter localization?',
   ['@o3r/core:component', '@o3r/core:component-presenter', '@o3r/core:component-container'],
-  context,
   '@o3r/localization',
   'localization-to-component',
   {

--- a/packages/@o3r/core/schematics/rule-factories/component/rules-engine.ts
+++ b/packages/@o3r/core/schematics/rule-factories/component/rules-engine.ts
@@ -1,18 +1,16 @@
-import { Rule, SchematicContext } from '@angular-devkit/schematics';
-import { NgGenerateComponentSchematicsSchema } from '../../component/schema';
+import type { Rule } from '@angular-devkit/schematics';
+import type { NgGenerateComponentSchematicsSchema } from '../../component/schema';
 import { askQuestionsToGetRulesOrThrowIfPackageNotAvailable } from './common';
 
-export const getAddRulesEngineRules = async (
+export const getAddRulesEngineRules = (
   componentPath: string,
-  options: Pick<NgGenerateComponentSchematicsSchema, 'useRulesEngine' | 'skipLinter' | 'projectName' | 'componentStructure'>,
-  context: SchematicContext
-): Promise<Rule[]> => askQuestionsToGetRulesOrThrowIfPackageNotAvailable(
+  options: Pick<NgGenerateComponentSchematicsSchema, 'useRulesEngine' | 'skipLinter' | 'projectName' | 'componentStructure'>
+): Rule => askQuestionsToGetRulesOrThrowIfPackageNotAvailable(
   componentPath,
   'useRulesEngine',
   options.useRulesEngine,
   'Generate component with rules-engine?',
   ['@o3r/core:component', '@o3r/core:component-container'],
-  context,
   '@o3r/rules-engine',
   'rules-engine-to-component',
   {

--- a/packages/@o3r/core/schematics/rule-factories/component/theming.ts
+++ b/packages/@o3r/core/schematics/rule-factories/component/theming.ts
@@ -1,19 +1,16 @@
-import { Rule, SchematicContext } from '@angular-devkit/schematics';
-import { NgGenerateComponentSchematicsSchema } from '../../component/schema';
+import type { Rule } from '@angular-devkit/schematics';
+import type { NgGenerateComponentSchematicsSchema } from '../../component/schema';
 import { askQuestionsToGetRulesOrThrowIfPackageNotAvailable } from './common';
-
 
 export const getAddThemingRules = (
   stylePath: string,
-  options: Pick<NgGenerateComponentSchematicsSchema, 'useOtterTheming'>,
-  context: SchematicContext
-): Promise<Rule[]> => askQuestionsToGetRulesOrThrowIfPackageNotAvailable(
+  options: Pick<NgGenerateComponentSchematicsSchema, 'useOtterTheming'>
+): Rule => askQuestionsToGetRulesOrThrowIfPackageNotAvailable(
   stylePath,
   'useOtterTheming',
   options.useOtterTheming,
   'Generate component with Otter theming?',
   ['@o3r/core:component', '@o3r/core:component-presenter'],
-  context,
   '@o3r/styling',
   'theming-to-component'
 );

--- a/packages/@o3r/core/testing/mocks/package.mocks.json
+++ b/packages/@o3r/core/testing/mocks/package.mocks.json
@@ -1,5 +1,8 @@
 {
   "name": "test-project",
   "version": "0.0.0",
-  "description": "Test project"
+  "description": "Test project",
+  "dependencies": {
+    "@o3r/core": "0.0.0"
+  }
 }


### PR DESCRIPTION
## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
