### PR TITLE
fix: ruleset json schema did not allow array values for operators rhs

### DIFF
--- a/packages/@o3r/rules-engine/schemas/rulesets.schema.json
+++ b/packages/@o3r/rules-engine/schemas/rulesets.schema.json
@@ -471,13 +471,13 @@
             "value": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "type": ["string", "number", "boolean"]
                 },
                 {
-                  "type": "number"
-                },
-                {
-                  "type": "boolean"
+                  "type": "array",
+                  "items": {
+                    "type": ["string", "number", "boolean"]
+                  }
                 }
               ]
             }


### PR DESCRIPTION
## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
