### PR TITLE
fix(generator-sdk): invalid content-type for form-encoded POST requests

### DIFF
--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/api.mustache
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/api.mustache
@@ -74,7 +74,7 @@ export class {{classname}} implements Api {
     const getParams = this.client.extractQueryParams<{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}RequestData>(data, [{{#trimComma}}{{#queryParams}}'{{baseName}}', {{/queryParams}}{{/trimComma}}]{{^queryParams}} as never[]{{/queryParams}});
     const metadataHeaderAccept = metadata?.headerAccept || '{{#headerJsonMimeType}}{{#produces}}{{mediaType}}{{^-last}}, {{/-last}}{{/produces}}{{/headerJsonMimeType}}';
     const headers: { [key: string]: string | undefined } = { {{#trimComma}}
-      'Content-Type': metadata?.headerContentType || '{{#headerJsonMimeType}}{{#consumes}}{{mediaType}}, {{/consumes}}application/json{{/headerJsonMimeType}}',
+      'Content-Type': metadata?.headerContentType || '{{#headerJsonMimeType}}{{#consumes}}{{mediaType}}{{^-last}}, {{/-last}}{{/consumes}}{{/headerJsonMimeType}}',
       ...(metadataHeaderAccept ? {'Accept': metadataHeaderAccept} : {}),
       {{#headerParams}}'{{baseName}}': data['{{baseName}}'],{{/headerParams}}{{/trimComma}}
     };


### PR DESCRIPTION
## Proposed change

A proposed change to fix #788 consisting on removing the regression in the api.mustache file for openapi generator.