### PR TITLE
fix: do not export ama-sdk-core as es module by default

### DIFF
--- a/packages/@ama-sdk/core/package.json
+++ b/packages/@ama-sdk/core/package.json
@@ -29,9 +29,9 @@
     "build": "yarn nx build ama-sdk-core",
     "build:cjs": "swc src -d dist/cjs -C module.type=commonjs -q",
     "build:esm2015": "swc src -d dist/esm2015 -C module.type=es6 -q",
-    "build:esm2020": "tsc -b tsconfig.esm2020.json",
+    "build:esm2020": "tsc -b tsconfig.build.json",
     "postbuild": "patch-package-json-main",
-    "prepare:build:builders": "yarn cpy 'schematics/**/*.json' dist/schematics && yarn cpy 'collection.json' dist",
+    "prepare:build:builders": "yarn cpy 'schematics/**/*.json' dist/schematics && yarn cpy '{collection,package}.json' dist",
     "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest",
     "prepare:publish": "prepare-publish ./dist"
   },

--- a/packages/@ama-sdk/core/project.json
+++ b/packages/@ama-sdk/core/project.json
@@ -16,7 +16,7 @@
       },
       "dependsOn": [
         "build-builders",
-        "compile",
+        "build-esm2020",
         "build-esm2015",
         "build-cjs"
       ]
@@ -27,7 +27,7 @@
         "script": "build:esm2015"
       },
       "dependsOn": [
-        "compile"
+        "build-esm2020"
       ],
       "outputs": [
         "{projectRoot}/dist/esm2015"
@@ -39,26 +39,20 @@
         "script": "build:cjs"
       },
       "dependsOn": [
-        "compile"
+        "build-esm2020"
       ],
       "outputs": [
         "{projectRoot}/dist/cjs"
       ]
     },
-    "compile": {
-      "executor": "@nx/js:tsc",
-      "outputs": [
-        "{projectRoot}/dist/src",
-        "{projectRoot}/dist/package.json",
-        "{projectRoot}/build/.tsbuildinfo"
-      ],
+    "build-esm2020": {
+      "executor": "nx:run-script",
       "options": {
-        "main": "packages/@ama-sdk/core/src/public_api.ts",
-        "tsConfig": "packages/@ama-sdk/core/tsconfig.esm2020.json",
-        "outputPath": "packages/@ama-sdk/core/dist",
-        "updateBuildableProjectDepsInPackageJson": false,
-        "clean": false
-      }
+        "script": "build:esm2020"
+      },
+      "outputs": [
+        "{projectRoot}/dist/src"
+      ]
     },
     "lint": {
       "executor": "@nx/linter:eslint",

--- a/packages/@ama-sdk/core/tsconfig.build.json
+++ b/packages/@ama-sdk/core/tsconfig.build.json
@@ -4,14 +4,19 @@
     "sourceMap": true,
     "incremental": true,
     "composite": true,
-    "rootDir": "./src",
+    "rootDir": ".",
     "lib": [
       "dom",
       "dom.iterable",
       "scripthost",
       "es2017.object",
       "esnext"
-    ]
+    ],
+    "declarationMap": true,
+    "target": "es2020",
+    "module": "es2020",
+    "tsBuildInfoFile": "./build/tsconfig.tsbuildinfo",
+    "outDir": "./dist"
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
