### PR TITLE
ci: invalidate angular-webpack cache when cleaning npm cache on it-tests

### DIFF
--- a/.github/workflows/it-tests.yml
+++ b/.github/workflows/it-tests.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Make sure that internal packages are not cached for whatever reason - npm
         run: |
           npm cache --cache=.cache/test-app/npm-cache ls | grep 127.0.0.1:4873 | xargs -d'\n' -r -n 1 npm cache --cache=.cache/test-app/npm-cache clean || true
+          npx --yes rimraf -g .cache/test-app/.angular/cache/*/angular-webpack
         shell: bash
       - uses: actions/download-artifact@v3
         name: Download verdaccio storage prepared in the previous job


### PR DESCRIPTION
## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
