### PR TITLE
fix: keep angular signatures for currency pipe

### DIFF
--- a/packages/@o3r/localization/src/tools/localized-currency.pipe.ts
+++ b/packages/@o3r/localization/src/tools/localized-currency.pipe.ts
@@ -26,6 +26,10 @@ export class LocalizedCurrencyPipe extends CurrencyPipe implements OnDestroy, Pi
   public transform(value: number | string, currencyCode?: string, display?: 'code' | 'symbol' | 'symbol-narrow' | string | boolean, digitsInfo?: string, locale?: string): string | null;
   public transform(value: null | undefined, currencyCode?: string, display?: 'code' | 'symbol' | 'symbol-narrow' | string | boolean, digitsInfo?: string, locale?: string): null;
   public transform(
+    // Expose same signatures as angular CurencyPipe
+    // eslint-disable-next-line @typescript-eslint/unified-signatures
+    value: number | string | null | undefined, currencyCode?: string, display?: 'code' | 'symbol' | 'symbol-narrow' | string | boolean, digitsInfo?: string, locale?: string): string | null;
+  public transform(
     value: number | string | null | undefined, currencyCode?: string, display?: 'code' | 'symbol' | 'symbol-narrow' | string | boolean, digitsInfo?: string, locale?: string): string | null {
     return super.transform(value, currencyCode, display, digitsInfo, locale || this.localizationService.getCurrentLanguage());
   }


### PR DESCRIPTION
## Proposed change

Keep the same signatures exposed for the transform function of otter Currency pipe as the angular Currency pipe.
For that, a duplication of the third signature is needed, because this one is a superset of the others, but in angular Currency pipe it is exposed too.

## Related issues

- :bug: Fixes #293
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
