### PR TITLE
fix: invalid peer dependencies

### DIFF
--- a/packages/@o3r/stylelint-plugin/package.json
+++ b/packages/@o3r/stylelint-plugin/package.json
@@ -21,7 +21,6 @@
     "tslib": "^2.5.3"
   },
   "peerDependencies": {
-    "jest-preset-stylelint": "~6.2.0",
     "postcss": "^8.4.5",
     "stylelint": "^15.10.1"
   },

--- a/packages/@o3r/testing/package.json
+++ b/packages/@o3r/testing/package.json
@@ -139,6 +139,12 @@
     "@schematics/angular": {
       "optional": true
     },
+    "pixelmatch": {
+      "optional": true
+    },
+    "pngjs": {
+      "optional": true
+    },
     "protractor": {
       "optional": true
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8631,7 +8631,6 @@ __metadata:
     tslib: ^2.5.3
     typescript: ~5.1.6
   peerDependencies:
-    jest-preset-stylelint: ~6.2.0
     postcss: ^8.4.5
     stylelint: ^15.10.1
   languageName: unknown
@@ -8879,6 +8878,10 @@ __metadata:
     "@playwright/test":
       optional: true
     "@schematics/angular":
+      optional: true
+    pixelmatch:
+      optional: true
+    pngjs:
       optional: true
     protractor:
       optional: true


### PR DESCRIPTION
## Proposed change

- Remove jest-preset-stylint from the peer dependencies of @o3r/stylelint-plugin as it is only used for testing of the module (kept as devDependencies)
- Set pixelmatch and pngjs as optional in @o3r/testing as there are only used in the @o3r/testing/visual-test subpackage