### PR TITLE
fix: remove mandatory @o3r/schematics dependency on @ama-sdk/core

### DIFF
--- a/packages/@ama-sdk/core/package.json
+++ b/packages/@ama-sdk/core/package.json
@@ -47,7 +47,6 @@
     "prepare:publish": "prepare-publish ./dist"
   },
   "dependencies": {
-    "@o3r/schematics": "workspace:^",
     "@swc/helpers": "^0.5.0",
     "tslib": "^2.5.3",
     "uuid": "^9.0.0"
@@ -56,6 +55,7 @@
     "@angular-devkit/schematics": "~16.2.0",
     "@angular/cli": "~16.2.0",
     "@angular/common": "~16.2.0",
+    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~16.2.0",
     "isomorphic-fetch": "^3.0.0",
     "rxjs": "^7.8.1",
@@ -69,6 +69,9 @@
       "optional": true
     },
     "@angular/common": {
+      "optional": true
+    },
+    "@o3r/schematics": {
       "optional": true
     },
     "@schematics/angular": {

--- a/packages/@ama-sdk/core/schematics/ng-add/index.ts
+++ b/packages/@ama-sdk/core/schematics/ng-add/index.ts
@@ -1,4 +1,4 @@
-import { chain, Rule, Tree } from '@angular-devkit/schematics';
+import {chain, Rule, SchematicContext, Tree} from '@angular-devkit/schematics';
 import * as ts from 'typescript';
 
 /**
@@ -7,36 +7,52 @@ import * as ts from 'typescript';
  */
 export function ngAdd(): Rule {
 
-  const removeImports = async () => {
-    const {removePackages} = await import('@o3r/schematics');
-    return removePackages(['@dapi/sdk-core']);
+  const removeImports = async (_: Tree, context: SchematicContext) => {
+    try {
+      const {removePackages} = await import('@o3r/schematics');
+      return removePackages(['@dapi/sdk-core']);
+    } catch (e) {
+      // o3r extractors needs o3r/core as peer dep. o3r/core will install o3r/schematics
+      context.logger.error(`[ERROR]: Adding @ama-sdk/core has failed.
+      If the error is related to missing @o3r dependencies you need to install '@o3r/schematics' to be able to use the @ama-sdk/core ng add. Please run 'ng add @o3r/schematics' .
+      Otherwise, use the error message as guidance.`);
+      throw (e);
+    }
   };
 
   /* ng add rules */
-  const updateImports = async (tree: Tree) => {
-    const {getFilesInFolderFromWorkspaceProjectsInTree} = await import('@o3r/schematics');
-    const files = getFilesInFolderFromWorkspaceProjectsInTree(tree, '', 'ts');
-    files.forEach((file) => {
-      const sourceFile = ts.createSourceFile(
-        file,
-        tree.readText(file),
-        ts.ScriptTarget.ES2015,
-        true
-      );
-      const dapiSdkCodeImports = sourceFile.statements.filter((node): node is ts.ImportDeclaration =>
-        ts.isImportDeclaration(node)
-        && !!node.moduleSpecifier.getText().match(/['"]@dapi\/sdk-core['"]/)
-      );
-      if (dapiSdkCodeImports.length) {
-        const recorder = tree.beginUpdate(file);
-        dapiSdkCodeImports.forEach((imp) => {
-          recorder.remove(imp.moduleSpecifier.getStart(), imp.moduleSpecifier.getWidth());
-          recorder.insertRight(imp.moduleSpecifier.getStart(), '\'@ama-sdk/core\'');
-        });
-        tree.commitUpdate(recorder);
-      }
-      return tree;
-    });
+  const updateImports = async (tree: Tree, context: SchematicContext) => {
+    try {
+      const {getFilesInFolderFromWorkspaceProjectsInTree} = await import('@o3r/schematics');
+      const files = getFilesInFolderFromWorkspaceProjectsInTree(tree, '', 'ts');
+      files.forEach((file) => {
+        const sourceFile = ts.createSourceFile(
+          file,
+          tree.readText(file),
+          ts.ScriptTarget.ES2015,
+          true
+        );
+        const dapiSdkCodeImports = sourceFile.statements.filter((node): node is ts.ImportDeclaration =>
+          ts.isImportDeclaration(node)
+          && !!node.moduleSpecifier.getText().match(/['"]@dapi\/sdk-core['"]/)
+        );
+        if (dapiSdkCodeImports.length) {
+          const recorder = tree.beginUpdate(file);
+          dapiSdkCodeImports.forEach((imp) => {
+            recorder.remove(imp.moduleSpecifier.getStart(), imp.moduleSpecifier.getWidth());
+            recorder.insertRight(imp.moduleSpecifier.getStart(), '\'@ama-sdk/core\'');
+          });
+          tree.commitUpdate(recorder);
+        }
+        return tree;
+      });
+    } catch (e) {
+      // o3r extractors needs o3r/core as peer dep. o3r/core will install o3r/schematics
+      context.logger.error(`[ERROR]: Adding @ama-sdk/core has failed.
+      If the error is related to missing @o3r dependencies you need to install '@o3r/schematics' to be able to use the @ama-sdk/core ng add. Please run 'ng add @o3r/schematics' .
+      Otherwise, use the error message as guidance.`);
+      throw (e);
+    }
   };
   return chain([
     removeImports,

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/package.json.template
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/package.json.template
@@ -78,6 +78,7 @@
     "@commitlint/config-conventional": "^17.0.0",
     "@ama-sdk/schematics": "~<%= sdkCoreVersion %>",
     "@ama-sdk/core": "~<%= sdkCoreVersion %>",
+    "@o3r/schematics": "^<%= sdkCoreVersion %>",
     "@o3r/eslint-config-otter": "^<%= sdkCoreVersion %>",
     "@o3r/eslint-plugin": "^<%= sdkCoreVersion %>",
     "@openapitools/openapi-generator-cli": "<%= versions['@openapitools/openapi-generator-cli'] %>",

--- a/packages/@o3r/mobile/src/capacitor/storage/rehydrater.module.ts
+++ b/packages/@o3r/mobile/src/capacitor/storage/rehydrater.module.ts
@@ -1,6 +1,6 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
 import { StoreModule } from '@ngrx/store';
-import { StorageSyncOptions } from '@o3r/store-sync';
+import type { StorageSyncOptions } from '@o3r/store-sync';
 import { LoggerModule } from '@o3r/logger';
 import { CapacitorRehydrater, STORAGE_SYNC_OPTIONS } from './rehydrater';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,7 +80,6 @@ __metadata:
     "@o3r/build-helpers": "workspace:^"
     "@o3r/dev-tools": "workspace:^"
     "@o3r/eslint-plugin": "workspace:^"
-    "@o3r/schematics": "workspace:^"
     "@schematics/angular": ~16.2.0
     "@swc/cli": ^0.1.57
     "@swc/core": ^1.3.66
@@ -115,6 +114,7 @@ __metadata:
     "@angular-devkit/schematics": ~16.2.0
     "@angular/cli": ~16.2.0
     "@angular/common": ~16.2.0
+    "@o3r/schematics": "workspace:^"
     "@schematics/angular": ~16.2.0
     isomorphic-fetch: ^3.0.0
     rxjs: ^7.8.1
@@ -125,6 +125,8 @@ __metadata:
     "@angular/cli":
       optional: true
     "@angular/common":
+      optional: true
+    "@o3r/schematics":
       optional: true
     "@schematics/angular":
       optional: true


### PR DESCRIPTION
## Proposed change

@o3r/schematics is only required to install @ama-sdk/core via the ng-add command and should not be a mandatory dependency but an optional peer dependency
