### PR TITLE
fix: jest config extends path

### DIFF
--- a/packages/@o3r/core/schematics/sdk/index.ts
+++ b/packages/@o3r/core/schematics/sdk/index.ts
@@ -31,7 +31,7 @@ export function generateSdk(options: NgGenerateSdkSchema): Rule {
     const addModuleSpecificFiles = () => mergeWith(apply(url('./templates'), [
       template({
         ...options,
-        rootRelativePath: path.relative(targetPath, tree.root.path.replace(/^\//, './'))
+        rootRelativePath: path.posix.relative(targetPath, tree.root.path.replace(/^\//, './'))
       }),
       move(targetPath),
       renameTemplateFiles()

--- a/packages/@o3r/testing/schematics/ng-add/index.ts
+++ b/packages/@o3r/testing/schematics/ng-add/index.ts
@@ -114,7 +114,7 @@ export function ngAdd(options: NgAddSchematicsSchema): Rule {
           const jestConfigFilesForProject = () => mergeWith(apply(url('./templates/project'), [
             template({
               ...options,
-              rootRelativePath: path.relative(workingDirectory, tree.root.path.replace(/^\//, './'))
+              rootRelativePath: path.posix.relative(workingDirectory, tree.root.path.replace(/^\//, './'))
             }),
             move(workingDirectory),
             renameTemplateFiles()


### PR DESCRIPTION
## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->

before
`const getJestConfig = require('..\../jest.config.ut').getJestConfig;`
 now                                   
`const getJestConfig = require('../../jest.config.ut').getJestConfig;`