### PR TITLE
fix(styling): sass export paths

### DIFF
--- a/packages/@o3r/styling/package.json
+++ b/packages/@o3r/styling/package.json
@@ -22,7 +22,7 @@
       "sass": "./_index.scss"
     },
     "./otter-theme": {
-      "sass": "./theming/otter-theme/_index.scss"
+      "sass": "./scss/theming/otter-theme/_index.scss"
     }
   },
   "peerDependencies": {

--- a/packages/@o3r/styling/scss/theming/otter-theme/_functions.scss
+++ b/packages/@o3r/styling/scss/theming/otter-theme/_functions.scss
@@ -26,7 +26,7 @@
 }
 
 /// Convert a Meta theme to an Otter theme
-/// @deprecated
+/// @access public
 /// @param {map} $meta-theme Meta theme
 @function meta-theme-to-otter($meta-theme: ()) {
   @return _meta-theme-to-otter($meta-theme, '');

--- a/packages/@o3r/styling/scss/theming/otter-theme/_material.scss
+++ b/packages/@o3r/styling/scss/theming/otter-theme/_material.scss
@@ -6,6 +6,7 @@
 
 /// Generate a map with all the mandatory variables for any implementation with their default values (no theme applied).
 /// It is up to the implementation to override it to fit the application needs.
+/// @access public
 @function generate-theme-variables($is-dark-theme, $implementation-override: ()) {
   $default: (
     primary-background: #FFF,


### PR DESCRIPTION
fix(styling): un-deprecate miss deprecated function
fix(styling): sass export paths

## Related issues

- :bug: Fixes #889

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
