### PR TITLE
feat(extractor): add mapping between localization key and component (localizationKeys)

### DIFF
--- a/packages/@o3r/components/builders/component-extractor/helpers/component/component-class.extractor.ts
+++ b/packages/@o3r/components/builders/component-extractor/helpers/component/component-class.extractor.ts
@@ -1,6 +1,8 @@
 import { logging } from '@angular-devkit/core';
 import type { ComponentStructure } from '@o3r/components';
+import { getLocalizationFileFromAngularElement } from '@o3r/extractors';
 import { isO3rClassComponent } from '@o3r/schematics';
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as ts from 'typescript';
 
@@ -29,6 +31,8 @@ export interface ComponentInformation {
   templateUrl?: string;
   /** Determine if the component is activating a ruleset */
   linkableToRuleset: boolean;
+  /** List of localization keys used in the component */
+  localizationKeys?: string[];
 }
 
 /**
@@ -188,7 +192,18 @@ export class ComponentClassExtractor {
       this.logger.debug(`${name!} is ignored because it is not a configurable component`);
     }
 
-    return name && type ? { name, configName, contextName, isDynamicConfig: isDynamic, type, selector, templateUrl, linkableToRuleset } : undefined;
+    const localizationFiles = getLocalizationFileFromAngularElement(classNode);
+
+    const localizationKeys = (localizationFiles || []).reduce((acc: string[], file) => {
+      const resolvedFilePath = path.resolve(path.dirname(this.filePath), file);
+      const data = JSON.parse(fs.readFileSync(resolvedFilePath, 'utf-8'));
+      return acc.concat(Object.keys(data));
+    }, []);
+
+    return name && type ? {
+      name, configName, contextName, isDynamicConfig: isDynamic, type, selector, templateUrl, linkableToRuleset,
+      ...(localizationKeys.length ? { localizationKeys } : {})
+    } : undefined;
   }
 
   /**

--- a/packages/@o3r/components/builders/component-extractor/helpers/component/component.extractor.ts
+++ b/packages/@o3r/components/builders/component-extractor/helpers/component/component.extractor.ts
@@ -233,7 +233,8 @@ export class ComponentExtractor {
           type: parsedItemRef.component.type,
           context,
           config,
-          linkableToRuleset: parsedItemRef.component.linkableToRuleset
+          linkableToRuleset: parsedItemRef.component.linkableToRuleset,
+          localizationKeys: parsedItemRef.component.localizationKeys
         };
 
       });

--- a/packages/@o3r/components/schemas/component.metadata.schema.json
+++ b/packages/@o3r/components/schemas/component.metadata.schema.json
@@ -125,6 +125,13 @@
       "linkableToRuleset": {
         "type": "boolean",
         "description": "Determine if the component is activating a ruleset"
+      },
+      "localizationKeys": {
+        "type": "array",
+        "description": "List of localization keys declared by the component",
+        "items": {
+          "type": "string"
+        }
       }
     }
   }

--- a/packages/@o3r/components/src/core/component.output.ts
+++ b/packages/@o3r/components/src/core/component.output.ts
@@ -77,6 +77,8 @@ export interface ComponentClassOutput extends Output {
   placeholders?: PlaceholderData[];
   /** Determine if the component is activating a ruleset */
   linkableToRuleset: boolean;
+  /** List of localization keys used in the component */
+  localizationKeys?: string[];
 }
 
 /**

--- a/packages/@o3r/extractors/src/utils/index.ts
+++ b/packages/@o3r/extractors/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './common';
 export * from './config-doc';
+export * from './localization';
 export * from './parser-factory';
 export * from './tsdoc';
 export * from './validator';

--- a/packages/@o3r/extractors/src/utils/localization.ts
+++ b/packages/@o3r/extractors/src/utils/localization.ts
@@ -1,0 +1,37 @@
+import * as ts from 'typescript';
+
+const localizationDecoratorName = 'Localization';
+
+/**
+ * Retrieve the localization json files from TS Code
+ *
+ * @param node TSNode of the angular component class
+ */
+export function getLocalizationFileFromAngularElement(node: ts.ClassDeclaration): string[] | undefined {
+  const localizationPaths: string[] = [];
+  node.forEachChild((item) => {
+    if (!ts.isPropertyDeclaration(item)) {
+      return;
+    }
+
+    item.forEachChild((decorator) => {
+      if (
+        !ts.isDecorator(decorator)
+        || !ts.isCallExpression(decorator.expression)
+        || !ts.isIdentifier(decorator.expression.expression)
+        || decorator.expression.expression.escapedText !== localizationDecoratorName
+      ) {
+        return;
+      }
+
+      const firstArg = decorator.expression.arguments[0];
+      if (!firstArg || !ts.isStringLiteral(firstArg)) {
+        return;
+      }
+
+      localizationPaths.push(firstArg.text);
+    });
+  });
+
+  return localizationPaths.length ? localizationPaths : undefined;
+}


### PR DESCRIPTION
## Proposed change
Add mapping between localization key and component to allow contextualization in CMS

- [x] Validate format with the CMS team  (other proposal https://github.com/AmadeusITGroup/otter/pull/913)

Example of component class metadata 
![image](https://github.com/AmadeusITGroup/otter/assets/52541061/fe70f222-a5a7-4cae-8485-db2d4b36c091)
