### PR TITLE
fix(styling): turn @o3r/core dependency to optional

### DIFF
--- a/packages/@o3r/styling/package.json
+++ b/packages/@o3r/styling/package.json
@@ -52,6 +52,9 @@
     "@angular/material": {
       "optional": true
     },
+    "@o3r/core": {
+      "optional": true
+    },
     "@o3r/dynamic-content": {
       "optional": true
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8826,6 +8826,8 @@ __metadata:
       optional: true
     "@angular/material":
       optional: true
+    "@o3r/core":
+      optional: true
     "@o3r/dynamic-content":
       optional: true
     "@o3r/extractors":


### PR DESCRIPTION
The purpose is to simplifying the usage of the Sass helper without requiring Otter Core