### PR TITLE
fix: ignore files when generating with yarn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 /.env
 
 ### yarn ###
-# https://yarnpkg.com/advanced/qa#which-files-should-be-gitignored
+# https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
 
 .yarn/*
 !.yarn/releases

--- a/packages/@o3r/core/schematics/ng-add/project-setup/index.ts
+++ b/packages/@o3r/core/schematics/ng-add/project-setup/index.ts
@@ -43,7 +43,8 @@ export const prepareProject = (options: NgAddSchematicsSchema) => async (tree: T
     readPackageJson, removePackages, renamedPackagesV7toV8, updateImports, isMultipackagesContext, getO3rPeerDeps
   } = await import('@o3r/schematics');
   const installOtterLinter = await shouldOtterLinterBeInstalled(context);
-  const workspaceProject = options.projectName && getWorkspaceConfig(tree)?.projects?.[options.projectName] || undefined;
+  const workspaceConfig = getWorkspaceConfig(tree);
+  const workspaceProject = options.projectName && workspaceConfig?.projects?.[options.projectName] || undefined;
   const projectType = workspaceProject?.projectType;
   const depsInfo = getO3rPeerDeps(corePackageJsonPath);
   const internalPackagesToInstallWithNgAdd = Array.from(new Set([
@@ -105,7 +106,7 @@ export const prepareProject = (options: NgAddSchematicsSchema) => async (tree: T
     ];
   }
   const commonRules = [
-    genericUpdates(),
+    genericUpdates(workspaceConfig),
     o3rBasicUpdates(options.projectName, o3rCoreVersion, projectType),
     ngAddPackages(internalPackagesToInstallWithNgAdd,
       { skipConfirmation: true, version: o3rCoreVersion, parentPackageInfo: '@o3r/core - setup', projectName: options.projectName, dependencyType: type, workingDirectory: projectDirectory }

--- a/packages/@o3r/core/schematics/rule-factories/generic-updates/index.ts
+++ b/packages/@o3r/core/schematics/rule-factories/generic-updates/index.ts
@@ -1,9 +1,12 @@
 import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { getPackageManager, WorkspaceSchema } from '@o3r/schematics';
 
 /**
  * Generic basic updates to be done on a repository
+ *
+ * @param workspaceConfig
  */
-export function genericUpdates(): Rule {
+export function genericUpdates(workspaceConfig?: WorkspaceSchema | null): Rule {
 
   const updateGitIgnore = (tree: Tree, _context: SchematicContext) => {
     // update gitignore
@@ -20,6 +23,29 @@ ${folderToExclude}
         `;
         }
       });
+      const packageManager = getPackageManager({workspaceConfig});
+      if (packageManager === 'yarn') {
+        gitignore += `
+
+### yarn ###
+# https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
+
+.yarn/*
+!.yarn/releases
+!.yarn/patches
+!.yarn/plugins
+!.yarn/sdks
+!.yarn/versions
+
+# if you are NOT using Zero-installs, then:
+# comment the following lines
+# !.yarn/cache
+
+# and uncomment the following lines
+.pnp.*
+
+`;
+      }
       tree.overwrite('/.gitignore', gitignore);
     }
     return tree;


### PR DESCRIPTION
## Proposed change
- updates on _gitignore_ when package manager is yarn
- sdk generator in monorepo to not touch yarn config

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
