### PR TITLE
fix: use refcount for sharereplay when relevant

### DIFF
--- a/apps/chrome-devtools/src/app-devtools/component-panel/component-panel-pres.component.ts
+++ b/apps/chrome-devtools/src/app-devtools/component-panel/component-panel-pres.component.ts
@@ -39,7 +39,7 @@ export class ComponentPanelPresComponent implements OnDestroy {
     rulesetHistoryService: RulesetHistoryService,
     private cd: ChangeDetectorRef
   ) {
-    const selectedComponentInfoMessage$ = connectionService.message$.pipe(filter(isSelectedComponentInfoMessage), shareReplay(1));
+    const selectedComponentInfoMessage$ = connectionService.message$.pipe(filter(isSelectedComponentInfoMessage), shareReplay({bufferSize: 1, refCount: true}));
     this.hasContainer$ = selectedComponentInfoMessage$.pipe(map((info) => !!info.container));
     this.subscription.add(
       selectedComponentInfoMessage$.subscribe((info) => {
@@ -52,7 +52,7 @@ export class ComponentPanelPresComponent implements OnDestroy {
       this.isLookingToContainer$
     ]).pipe(
       map(([info, isLookingToContainer]) => isLookingToContainer ? info.container : info),
-      shareReplay(1)
+      shareReplay({bufferSize: 1, refCount: true})
     );
 
     this.config$ = combineLatest([

--- a/apps/chrome-devtools/src/services/ruleset-history.service.ts
+++ b/apps/chrome-devtools/src/services/ruleset-history.service.ts
@@ -18,7 +18,7 @@ export class RulesetHistoryService {
    */
   public readonly rulesetExecutions$: Observable<RulesetExecutionDebug[]> = this.ruleEngineDebugEvents$.pipe(
     map(({events, rulesetMap}) => rulesetReportToHistory(events, rulesetMap)),
-    shareReplay(1)
+    shareReplay({bufferSize: 1, refCount: true})
   );
 
   /**

--- a/apps/showcase/src/app/app.component.ts
+++ b/apps/showcase/src/app/app.component.ts
@@ -50,7 +50,7 @@ export class AppComponent implements OnDestroy {
     );
     this.activeUrl$ = onNavigationEnd$.pipe(
       map((event) => event.urlAfterRedirects),
-      shareReplay(1)
+      shareReplay({bufferSize: 1, refCount: true})
     );
     this.subscriptions.add(onNavigationEnd$.subscribe(() => {
       if (this.offcanvasRef) {

--- a/packages/@o3r/dynamic-content/src/services/dynamic-content/dynamic-content.service.ts
+++ b/packages/@o3r/dynamic-content/src/services/dynamic-content/dynamic-content.service.ts
@@ -69,7 +69,7 @@ export class DynamicContentService {
       map((entities) => assetPath && entities && entities[assetPath] ? entities[assetPath] : assetPath),
       map((finalAssetPath) => this.getMediaPath(finalAssetPath)),
       distinctUntilChanged(),
-      shareReplay(1)
+      shareReplay({bufferSize: 1, refCount: true})
     );
   }
 }


### PR DESCRIPTION
## Proposed change

The default `refCount: false` on shareReplay never closes the observable stream even if all subscriptions are properly unsubscribed
In most cases we don't want to keep it open

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
