### PR TITLE
feat: add description for "required" properties in config/fc schemas

### DIFF
--- a/packages/@o3r/application/schemas/functional-content.metadata.schema.json
+++ b/packages/@o3r/application/schemas/functional-content.metadata.schema.json
@@ -209,7 +209,8 @@
           ]
         },
         "required": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "If true, the property input will be flagged as mandatory in the CMS view"
         }
       }
     },
@@ -241,7 +242,8 @@
           ]
         },
         "required": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "If true, the property input will be flagged as mandatory in the CMS view"
         }
       }
     },
@@ -275,7 +277,8 @@
           ]
         },
         "required": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "If true, the property input will be flagged as mandatory in the CMS view"
         }
       }
     },

--- a/packages/@o3r/configuration/schemas/configuration.metadata.schema.json
+++ b/packages/@o3r/configuration/schemas/configuration.metadata.schema.json
@@ -130,7 +130,8 @@
               }
             },
             "required": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "If true, the property input will be flagged as mandatory in the CMS view"
             },
             "widget": {
               "type": "object",


### PR DESCRIPTION
## Proposed change

Add a description for the properties named "required" for configuration and functional content metadata schemas
