### PR TITLE
fix: sdk generated with inner enums

### DIFF
--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/model/reviver.mustache
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/model/reviver.mustache
@@ -27,7 +27,7 @@ import { utils, reviveArray, reviveMap, reviveDictionarizedArray } from '@ama-sd
 
 {{#models}}
   {{#model}}
-    {{^isEnum}}
+    {{^isEnum}}{{^isEnumRef}}
 export function revive{{classname}}<T extends {{classname}} = {{classname}}>(data: undefined, dictionaries?: any): undefined;
 export function revive{{classname}}(data: {{classname}}, dictionaries?: any): {{classname}} {{#discriminator}}{{#vendorExtensions}}{{#x-discriminator-subtypes}}| {{.}}{{/x-discriminator-subtypes}}{{/vendorExtensions}}{{/discriminator}};
 export function revive{{classname}}(data: any, dictionaries?: any): {{classname}} {{#discriminator}}{{#vendorExtensions}}{{#x-discriminator-subtypes}}| {{.}}{{/x-discriminator-subtypes}}{{/vendorExtensions}}{{/discriminator}} | undefined;
@@ -119,7 +119,7 @@ export function revive{{classname}}<T extends {{classname}} = {{classname}}>(dat
         {{#allVars}}
           {{^isPrimitiveType}}
             {{#complexType}}
-              {{^isEnum}}
+              {{^isEnum}}{{^isEnumRef}}
                 {{#isMap}}
                   {{#vendorExtensions}}
                     {{^nonObjectDefinition}}
@@ -143,12 +143,12 @@ export function revive{{classname}}<T extends {{classname}} = {{classname}}>(dat
                     {{/vendorExtensions}}
                   {{/isArray}}
                 {{/isMap}}
-              {{/isEnum}}
+                {{/isEnumRef}}{{/isEnum}}
             {{/complexType}}
             {{^complexType}}
-              {{^isEnum}}
+              {{^isEnum}}{{^isEnumRef}}
   data{{#propertyAccess}}{{baseName}}{{/propertyAccess}} = data.{{baseName}} ? new {{{dataType}}}(data{{#propertyAccess}}{{baseName}}{{/propertyAccess}}) : undefined;
-              {{/isEnum}}
+              {{/isEnumRef}}{{/isEnum}}
             {{/complexType}}
           {{/isPrimitiveType}}
         {{/allVars}}
@@ -158,7 +158,7 @@ export function revive{{classname}}<T extends {{classname}} = {{classname}}>(dat
   return data as T;
 }
 
-    {{/isEnum}}
+    {{/isEnumRef}}{{/isEnum}}
     {{#isEnum}}
 /** As the definition is not an object, no reviver is needed */
     {{/isEnum}}


### PR DESCRIPTION
## Proposed change
Ensures that no reviver is generated for inner enums.

## Related issues
https://github.com/AmadeusITGroup/otter/issues/771

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
