### PR TITLE
fix(showcase): unset dynamicpath when not in dynamic-content page

### DIFF
--- a/apps/showcase/src/app/app.component.ts
+++ b/apps/showcase/src/app/app.component.ts
@@ -52,9 +52,13 @@ export class AppComponent implements OnDestroy {
       map((event) => event.urlAfterRedirects),
       shareReplay({bufferSize: 1, refCount: true})
     );
-    this.subscriptions.add(onNavigationEnd$.subscribe(() => {
+    this.subscriptions.add(onNavigationEnd$.subscribe((event) => {
       if (this.offcanvasRef) {
         this.offcanvasRef.dismiss();
+      }
+      if (!/dynamic-content/.test(event.urlAfterRedirects) && localStorage.getItem('dynamicPath')) {
+        localStorage.removeItem('dynamicPath');
+        location.reload();
       }
     }));
   }


### PR DESCRIPTION
## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
