### PR TITLE
fix: log antibot exceptions as errors

### DIFF
--- a/packages/@ama-sdk/core/src/plugins/bot-protection-fingerprint/bot-protection-fingerprint.request.ts
+++ b/packages/@ama-sdk/core/src/plugins/bot-protection-fingerprint/bot-protection-fingerprint.request.ts
@@ -79,7 +79,8 @@ If the application runs on a domain that is not protected by Imperva, this plugi
       try {
         protection = await getProtection();
       } catch (e) {
-        console.warn(e);
+        // eslint-disable-next-line no-console
+        console.error(e);
         return;
       }
     }
@@ -87,7 +88,8 @@ If the application runs on a domain that is not protected by Imperva, this plugi
     try {
       return await protection.token(tokenTimeout);
     } catch (e) {
-      console.warn('[SDK][Plug-in][BotProtectionFingerprintRequest] Timeout: no Token was received in time.');
+      // eslint-disable-next-line no-console
+      console.error('[SDK][Plug-in][BotProtectionFingerprintRequest] Timeout: no Token was received in time.');
       return;
     }
   };

--- a/packages/@ama-sdk/core/src/plugins/bot-protection-fingerprint/bot-protection-fingerprint.spec.ts
+++ b/packages/@ama-sdk/core/src/plugins/bot-protection-fingerprint/bot-protection-fingerprint.spec.ts
@@ -14,7 +14,7 @@ describe('BotProtectionFingerprint', () => {
   describe('Retrievers', () => {
 
     describe('impervaProtectionRetrieverFactory', () => {
-      const consoleMock = jest.spyOn(console, 'error');
+      const consoleMock = jest.spyOn(console, 'error').mockImplementation();
       let windowBackup: any;
       let tokenValue: string;
       let retriever: BotProtectionFingerprintRetriever;

--- a/packages/@ama-sdk/core/src/plugins/bot-protection-fingerprint/bot-protection-fingerprint.spec.ts
+++ b/packages/@ama-sdk/core/src/plugins/bot-protection-fingerprint/bot-protection-fingerprint.spec.ts
@@ -14,7 +14,7 @@ describe('BotProtectionFingerprint', () => {
   describe('Retrievers', () => {
 
     describe('impervaProtectionRetrieverFactory', () => {
-      const consoleMock = jest.spyOn(console, 'warn');
+      const consoleMock = jest.spyOn(console, 'error');
       let windowBackup: any;
       let tokenValue: string;
       let retriever: BotProtectionFingerprintRetriever;
@@ -52,21 +52,24 @@ describe('BotProtectionFingerprint', () => {
 
       it('Should return undefined and log if no Protection object is received.', async () => {
         expect(await retriever()).toBeUndefined();
-        expect(console.warn).toHaveBeenCalledTimes(1);
+        // eslint-disable-next-line no-console
+        expect(console.error).toHaveBeenCalledTimes(1);
       });
 
       it('Should return undefined and log if no Protection object is received within configured timeout.', async () => {
         registerEvent(protectionResolve, 100);
 
         expect(await retriever()).toBeUndefined();
-        expect(console.warn).toHaveBeenCalledTimes(1);
+        // eslint-disable-next-line no-console
+        expect(console.error).toHaveBeenCalledTimes(1);
       });
 
       it('Should return undefined and log if token promise rejected.', async () => {
         registerEvent(protectionReject);
 
         expect(await retriever()).toBeUndefined();
-        expect(console.warn).toHaveBeenCalledTimes(1);
+        // eslint-disable-next-line no-console
+        expect(console.error).toHaveBeenCalledTimes(1);
       });
 
       it('Should return the token if everything happened within timeout values.', async () => {
@@ -77,7 +80,8 @@ describe('BotProtectionFingerprint', () => {
         tokenValue = 'newToken';
 
         expect(await retriever()).toBe(tokenValue);
-        expect(console.warn).not.toHaveBeenCalled();
+        // eslint-disable-next-line no-console
+        expect(console.error).not.toHaveBeenCalled();
       });
 
     });


### PR DESCRIPTION
## Proposed change

Errors can be caught in angular error handling and logged properly

Logging in sdk should be enhanced in a dedicated feature

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
