### PR TITLE
fix(rules-engine): avoid evaluating conditions when not needed

### DIFF
--- a/packages/@o3r/rules-engine/src/engine/ruleset-executor.ts
+++ b/packages/@o3r/rules-engine/src/engine/ruleset-executor.ts
@@ -189,8 +189,8 @@ export class RulesetExecutor {
       return !this.evaluateCondition(nestedCondition.not, factsValue, runtimeFactValues);
     }
     if (nestedCondition.all || nestedCondition.any) {
-      const children = (nestedCondition.all || nestedCondition.any).map((condition) => this.evaluateCondition(condition, factsValue, runtimeFactValues));
-      return isAllConditions(nestedCondition) ? children.every((value) => value) : children.some((value) => value);
+      const evaluate = (condition: NestedCondition) => this.evaluateCondition(condition, factsValue, runtimeFactValues);
+      return isAllConditions(nestedCondition) ? nestedCondition.all.every(evaluate) : nestedCondition.any.some(evaluate);
     }
     throw new Error(`Unknown condition block met : ${JSON.stringify(nestedCondition)}`);
   }

--- a/packages/@o3r/rules-engine/testing/mocks/oneruleset-tworules-any-and-all.mock.ts
+++ b/packages/@o3r/rules-engine/testing/mocks/oneruleset-tworules-any-and-all.mock.ts
@@ -1,0 +1,111 @@
+import type { Ruleset } from '@o3r/rules-engine';
+
+export const jsonOneRulesetTwoRulesAnyAndAll: {ruleSets: Ruleset[]} = {
+  'ruleSets': [
+    {
+      'id': 'e5th46e84-5e4th-54eth65seth46se8th8',
+      'name': 'ALL and ANY ruleset',
+      'rules': [
+        {
+          'id': '6e8t54h6s4e-6erth46sre8th4-d46t8s13t5j1',
+          'name': 'the first rule with ALL',
+          'inputRuntimeFacts': [],
+          'inputFacts': ['foieGrasPrice'],
+          'outputRuntimeFacts': [],
+          'rootElement': {
+            'elementType': 'RULE_BLOCK',
+            'blockType': 'IF_ELSE',
+            'condition': {
+              'all': [
+                {
+                  'lhs': {
+                    'type': 'FACT',
+                    'value': 'foieGrasPrice'
+                  },
+                  'operator': 'isDefined'
+                },
+                {
+                  'lhs': {
+                    'type': 'FACT',
+                    'value': 'foieGrasPrice'
+                  },
+                  'rhs': {
+                    'type': 'LITERAL',
+                    'value': 0
+                  },
+                  'operator': 'greaterThan'
+                }
+              ]
+            },
+            'successElements': [
+              {
+                'elementType': 'ACTION',
+                'actionType': 'SET_FACT',
+                'fact': 'andOutput',
+                'value': true
+              }
+            ],
+            'failureElements': [
+              {
+                'elementType': 'ACTION',
+                'actionType': 'SET_FACT',
+                'fact': 'andOutput',
+                'value': false
+              }
+            ]
+          }
+        },
+
+        {
+          'id': '6e8t54h6s4e-6erth46sre8th4-d46t8s13t5j2',
+          'name': 'the second rule with ANY',
+          'inputRuntimeFacts': [],
+          'inputFacts': ['foieGrasPrice'],
+          'outputRuntimeFacts': [],
+          'rootElement': {
+            'elementType': 'RULE_BLOCK',
+            'blockType': 'IF_ELSE',
+            'condition': {
+              'any': [
+                {
+                  'lhs': {
+                    'type': 'FACT',
+                    'value': 'foieGrasPrice'
+                  },
+                  'operator': 'isNotDefined'
+                },
+                {
+                  'lhs': {
+                    'type': 'FACT',
+                    'value': 'foieGrasPrice'
+                  },
+                  'rhs': {
+                    'type': 'LITERAL',
+                    'value': 0
+                  },
+                  'operator': 'greaterThan'
+                }
+              ]
+            },
+            'successElements': [
+              {
+                'elementType': 'ACTION',
+                'actionType': 'SET_FACT',
+                'fact': 'anyOutput',
+                'value': true
+              }
+            ],
+            'failureElements': [
+              {
+                'elementType': 'ACTION',
+                'actionType': 'SET_FACT',
+                'fact': 'anyOutput',
+                'value': false
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+};


### PR DESCRIPTION
## Proposed change

We can stop evaluating conditions as soon as one is false in an 'ALL' condition (as soon as one true for 'ANY' condition)
This avoid unnecessary errors when combining `isDefined` with another operator that expects the input fact to be defined for example

E.g.
```json
{
  "elementType": "RULE_BLOCK",
  "blockType": "IF_ELSE",
  "condition": {
  "all": [
    {
	  "lhs": {
	    "type": "FACT",
	    "value": "outboundDate"
	  },
	  "operator": "isDefined"
    },
    {
	  "lhs": {
	    "type": "FACT",
	    "value": "outboundDate"
	  },
	  "operator": "duringSummer"
    }
  ]
}
```
this is currently throwing an error that should not be thrown when `outboundDate` is undefined
`Error: Invalid left operand : undefined`

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
