### PR TITLE
ci: checkout base branch for publish-pr

### DIFF
--- a/.github/workflows/publish-pr.yml
+++ b/.github/workflows/publish-pr.yml
@@ -42,6 +42,7 @@ jobs:
       version: ${{ needs.version.outputs.nextVersionTag }}
       prerelease: true
       isPullRequest: true
+      gitRef: ${{ github.event.workflow_run.pull_requests[0].base.ref }}
 
   notify-parent:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,11 @@ on:
         default: false
         required: false
         description: Skip the nx cache
+      gitRef:
+        type: string
+        default: ''
+        required: false
+        description: Checkout a specific git ref
     secrets:
       AZURE_VSC_EXT_TOKEN:
         required: false
@@ -58,6 +63,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          ref: ${{ inputs.gitRef }}
       - uses: ./tools/github-actions/download-build-output
       - uses: ./tools/github-actions/setup
       - run: yarn set:version ${{ inputs.version }}


### PR DESCRIPTION
## Proposed change

Fix publish-pr when targeting a base branch other than `main`

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
