### PR TITLE
fix(publish): copy npmignore into the dist folder

### DIFF
--- a/packages/@ama-sdk/core/.npmignore
+++ b/packages/@ama-sdk/core/.npmignore
@@ -1,0 +1,1 @@
+schematics/ng-add/mocks/

--- a/packages/@o3r/core/.npmignore
+++ b/packages/@o3r/core/.npmignore
@@ -1,0 +1,1 @@
+schematics/store/*/mocks

--- a/tools/@o3r/build-helpers/scripts/prepare-publish.mjs
+++ b/tools/@o3r/build-helpers/scripts/prepare-publish.mjs
@@ -6,7 +6,7 @@
  */
 
 import minimist from 'minimist';
-import { copyFileSync, existsSync, readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { copyFileSync, existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 
 const argv = minimist(process.argv.slice(2));
@@ -59,15 +59,15 @@ const findReadme = (currentFolder) => {
 };
 
 /**
- * Update package.json, copy README.md and LICENSE into dist folder
+ * Update package.json, copy .npmignore, README.md and LICENSE into dist folder
  *
- * @param {string} root
+ * @param {string} rootPath
  * @param {string} distPath
  * @param {string} packageJsonPath
  */
-function preparePublish(root, distPath, packageJsonPath) {
-  const privatePackageJson = findPrivatePackage(root);
-  const distPackageJson = resolve(root, packageJsonPath);
+function preparePublish(rootPath, distPath, packageJsonPath) {
+  const privatePackageJson = findPrivatePackage(rootPath);
+  const distPackageJson = resolve(rootPath, packageJsonPath);
 
   if (!packageJsonPath || !existsSync(distPackageJson)) {
     throw new Error(`No package.json found for ${distPackageJson}`);
@@ -84,6 +84,11 @@ function preparePublish(root, distPath, packageJsonPath) {
 
   writeFileSync(distPackageJson, JSON.stringify(packageJson, null, 2));
   copyFileSync(resolve(dirname(privatePackageJson.path), 'LICENSE'), resolve(distPath, 'LICENSE'));
+
+  const npmIgnoreFilePath = resolve(rootPath, '.npmignore');
+  if (existsSync(npmIgnoreFilePath)) {
+    copyFileSync(npmIgnoreFilePath, resolve(distPath, '.npmignore'));
+  }
 
   const readmeDistPath = resolve(distPath, 'README.md');
   const readmeBasePath = findReadme(distPath);


### PR DESCRIPTION
## Proposed change

Copy .npmignore into the dist folder

## Related issues

- :bug: Fixes #1006