### PR TITLE
fix: enhance error message for the Otter Chrome Extension

### DIFF
--- a/apps/chrome-devtools/src/components/app-connection/app-connection.component.html
+++ b/apps/chrome-devtools/src/components/app-connection/app-connection.component.html
@@ -4,7 +4,7 @@
   </div>
 
   <div *ngSwitchCase="'timeout'" class="alert alert-danger m-2" role="alert">
-    The application does not seem to be compatible with the Otter Chrome DevTools.
+    The application does not seem to be compatible with the Otter Chrome DevTools or the Otter Chrome Extesion does not have permission to access this page.
   </div>
 
   <ng-container *ngSwitchCase="'connected'">


### PR DESCRIPTION
## Proposed change

Some users think the Chrome Extension isn't working but in fact they didn't give permissions to access their Otter based app. The goal of this PR is to enhance the error message when the Extension cannot reach the app.

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
