### PR TITLE
fix: o3r schematics build fails because it uses its own dist as input

### DIFF
--- a/packages/@o3r/schematics/src/modules/modules.display.rule.ts
+++ b/packages/@o3r/schematics/src/modules/modules.display.rule.ts
@@ -1,6 +1,6 @@
 import type { Rule } from '@angular-devkit/schematics';
 import { EOL } from 'node:os';
-import { OTTER_MODULE_KEYWORD, OTTER_MODULE_SUPPORTED_SCOPES } from './modules.constants';
+import {OTTER_KEYWORD_CMS, OTTER_MODULE_KEYWORD, OTTER_MODULE_SUPPORTED_SCOPES} from './modules.constants';
 import { getPackageManagerExecutor, getWorkspaceConfig } from '../utility';
 import { formatModuleDescription, getAvailableModulesWithLatestPackage } from './modules.helpers';
 
@@ -34,7 +34,6 @@ export function displayModuleListRule(options?: Partial<DisplayModuleListOptions
   const keyword = options?.keyword || OTTER_MODULE_KEYWORD;
 
   return async (tree, context) => {
-    const { OTTER_KEYWORD_CMS } = await import('@o3r/schematics');
     const tagMap: Record<string, string> = { [OTTER_KEYWORD_CMS]: 'CMS enabler' };
 
     // const { getAvailableModulesWithLatestPackage, formatModuleDescription, getWorkspaceConfig, getPackageManagerExecutor } = await import('@o3r/schematics');


### PR DESCRIPTION
## Proposed change
Do not target its own sources as a package.

Fix following error:
```
    ×  nx run schematics:compile
       Compiling TypeScript files for project "schematics"...
error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/index.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/interfaces/angular-workspace.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/interfaces/index.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/interfaces/schematic-option.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/modules/index.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/modules/modules.constants.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/modules/modules.display.rule.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/modules/modules.helpers.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/public_api.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/rule-factories/add-imports/index.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/rule-factories/check-packages-peers/index.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/rule-factories/dev-tools/devtools-registration.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/rule-factories/dev-tools/index.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/rule-factories/eslint-fix/index.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/rule-factories/get-test-frameworks/index.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/rule-factories/index.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/rule-factories/interfaces.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/rule-factories/ng-add/index.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/rule-factories/remove-packages/index.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/rule-factories/update-imports/index.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/rule-factories/update-imports/list-of-vars.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/rule-factories/update-imports/update-imports-with-scope.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/rule-factories/update-imports/update-ts-imports.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/rule-factories/update-imports/v7-to-v8-map-object.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/rule-factories/vscode-extensions/index.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/rules/index.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/rules/install.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/tasks/eslint/index.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/tasks/index.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/tasks/link/index.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/tasks/ng-add/index.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/tasks/package-manager/add-dev-dependency.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/tasks/package-manager/index.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/tasks/package-manager/interfaces.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/tasks/package-manager/npm-install.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/ast.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/collection.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/component.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/dependencies.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/environment.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/error.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/file-info.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/generation.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/gitignore.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/index.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/loaders.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/logo.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/matching-peers.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/modules.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/monorepo.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/package-manager-runner.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/package-version.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/question.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/routes.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/sub-entry.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/template-property.helper.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
       error TS5055: Cannot write file 'c:/git_clones/otter-public/packages/@o3r/schematics/dist/src/utility/update-imports.d.ts' because it would overwrite input file.
         Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
```

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)
