### PR TITLE
ci(renovate): exclude packages that wont be updated on main

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -187,6 +187,13 @@
           ".yarn/sdks/**"
         ]
       }
+    },
+    {
+      "matchPackageNames": [
+        "zone.js",
+        "bootstrap"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Proposed change

We won't be updating `zone.js` and `bootstrap` on Otter 9
This will be put back on Otter 10

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
