### PR TITLE
fix: create application not working

### DIFF
--- a/packages/@o3r/workspace/schematics/application/index.ts
+++ b/packages/@o3r/workspace/schematics/application/index.ts
@@ -72,7 +72,7 @@ export function generateApplication(options: NgGenerateApplicationSchema): Rule 
       addProjectSpecificFiles(targetPath, rootDependencies),
       updateProjectTsConfig(targetPath, 'tsconfig.app.json'),
       (_, c) => {
-        c.addTask(new RunSchematicTask('@o3r/core:ng-add', extendedOptions));
+        c.addTask(new RunSchematicTask('@o3r/core', 'ng-add', extendedOptions));
       }
     ])(tree, context);
   };


### PR DESCRIPTION
## Proposed change

Fix error:
> Schematic "@o3r/core:ng-add" not found in collection "@o3r/workspace".

when running ` ng g create application` 

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
