### PR TITLE
fix(ama-sdk-schematics): add target folder to nx inputs of prepare-bu…

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -3,3 +3,4 @@ packages/@ama-sdk/generator-sdk/src/**/templates/**/*.{j,t}s
 packages/@*/*/{builders,schematics}/**/templates/**/*.ts
 packages/@*/*/{builders,schematics}/**/mocks/**/*.ts
 packages/@*/*/build/**
+!**/schematics/**/target


### PR DESCRIPTION
…ild-builders

## Proposed change

Any gitignored file will not be considered for the inputs of Nx tasks
An easy fix is to add an exception to the `.nxignore` file

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
