### PR TITLE
feat(config): support global configuration categories

### DIFF
--- a/apps/showcase/project.json
+++ b/apps/showcase/project.json
@@ -147,7 +147,10 @@
         "name": "showcase",
         "libraries": [],
         "placeholdersMetadataFilePath": "apps/showcase/placeholders.metadata.manual.json",
-        "exposedComponentSupport": true
+        "exposedComponentSupport": true,
+        "globalConfigCategories": [
+          { "name": "globalCategory", "label": "Global category" }
+        ]
       },
       "dependsOn": [
         "compile"

--- a/apps/showcase/src/components/showcase/configuration/configuration-pres.config.ts
+++ b/apps/showcase/src/components/showcase/configuration/configuration-pres.config.ts
@@ -16,10 +16,14 @@ export interface DestinationConfiguration extends NestedConfiguration {
 
 /**
  * Component configuration example
+ * <o3rCategories>
+ *  <localCategory>Local category 8</localCategory>
+ * </o3rCategories>
  */
 export interface ConfigurationPresConfig extends Configuration {
   /**
    * Default date selected compare to today
+   * @o3rCategory localCategory
    */
   inXDays: number;
   /**
@@ -33,6 +37,7 @@ export interface ConfigurationPresConfig extends Configuration {
   destinations: DestinationConfiguration[];
   /**
    * Propose round trip
+   * @o3rCategory globalCategory
    */
   shouldProposeRoundTrip: boolean;
 }

--- a/packages/@o3r/components/builders/component-extractor/index.ts
+++ b/packages/@o3r/components/builders/component-extractor/index.ts
@@ -67,7 +67,7 @@ export default createBuilder<ComponentExtractorBuilderSchema>(async (options, co
 
     context.reportProgress(1, STEP_NUMBER, 'Generating component parser');
     const libraryName = options.name || defaultLibraryName(context.currentDirectory);
-    const parser = new ComponentParser(libraryName, tsConfig, context.logger, options.strictMode, options.libraries);
+    const parser = new ComponentParser(libraryName, tsConfig, context.logger, options.strictMode, options.libraries, options.globalConfigCategories);
 
     context.reportProgress(2, STEP_NUMBER, 'Gathering project data');
     const parserOutput = await parser.parse();

--- a/packages/@o3r/components/builders/component-extractor/schema.json
+++ b/packages/@o3r/components/builders/component-extractor/schema.json
@@ -61,6 +61,27 @@
       "type": "string",
       "description": "Path to the placeholders data file",
       "default": "placeholders.metadata.json"
+    },
+    "globalConfigCategories": {
+      "type": "array",
+      "description": "List of categories with description",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "label"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Configuration category name"
+          },
+          "label": {
+            "type": "string",
+            "description": "Configuration category description"
+          }
+        }
+      }
     }
   },
   "additionalProperties": false,

--- a/packages/@o3r/components/builders/component-extractor/schema.ts
+++ b/packages/@o3r/components/builders/component-extractor/schema.ts
@@ -1,4 +1,5 @@
 import type { JsonObject } from '@angular-devkit/core';
+import type { CategoryDescription } from '@o3r/core';
 
 export interface ComponentExtractorBuilderSchema extends JsonObject {
 
@@ -34,4 +35,10 @@ export interface ComponentExtractorBuilderSchema extends JsonObject {
 
   /** Include placeholder metadata file */
   placeholdersMetadataFilePath: string | null;
+
+  /**
+   * List of global categories with description
+   */
+  /* Adding `& JsonObject` as workaround */
+  globalConfigCategories: (CategoryDescription & JsonObject)[];
 }


### PR DESCRIPTION
## Context
Today categories are defined on each interface, listing for each one a mapping between the key and the displayed value.
It means that even if those categories are used application wise, they needs to be copy/pasted on all the config interfaces that uses it.

## Proposed change
Define global categories in the extractor options.