### PR TITLE
ci: fix publish-pr failing on rerun

### DIFF
--- a/.github/workflows/publish-pr.yml
+++ b/.github/workflows/publish-pr.yml
@@ -19,9 +19,10 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            let download = await github.rest.actions.downloadWorkflowRunLogs({
+            let download = await github.rest.actions.downloadWorkflowRunAttemptLogs({
                ...context.repo,
                run_id: context.payload.workflow_run.id,
+               attempt_number: 1
             });
             let fs = require('fs');
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/logs.zip`, Buffer.from(download.data));


### PR DESCRIPTION
## Proposed change

The logs only contain the version number on the first attempt

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
