### PR TITLE
fix: set enableScripts to false by default

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,7 @@
 compressionLevel: mixed
 
+enableScripts: false
+
 enableGlobalCache: false
 
 nodeLinker: pnp


### PR DESCRIPTION
## Proposed change

By default, any third party dependency can execute arbitrary code during the install process (with `postinstall` script)

We only want to allow that if needed for packages that we can trust
It can be re-activated for a specific package using `dependenciesMeta`

(It does not impact the `postinstall` scripts of the workspace which are considered safe)

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
