### PR TITLE
ci: publish a new artifact when re-running the workflow

### DIFF
--- a/.github/workflows/publish-pr.yml
+++ b/.github/workflows/publish-pr.yml
@@ -40,7 +40,7 @@ jobs:
       id-token: write
     secrets: inherit
     with:
-      version: ${{ needs.version.outputs.nextVersionTag }}
+      version: ${{ needs.version.outputs.nextVersionTag }}-${{ github.event.workflow_run.run_attempt }}
       prerelease: true
       isPullRequest: true
       gitRef: ${{ github.event.workflow_run.pull_requests[0].base.ref }}

--- a/tools/github-actions/download-build-output/action.yml
+++ b/tools/github-actions/download-build-output/action.yml
@@ -16,7 +16,7 @@ runs:
         path: '.'
 
     - name: 'Download artifact'
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       if: github.event_name == 'workflow_run'
       with:
         script: |
@@ -24,7 +24,7 @@ runs:
              ...context.repo,
              run_id: context.payload.workflow_run.id,
           });
-          let matchArtifact = allArtifacts.data.artifacts.find((artifact) => artifact.name === '${{ inputs.artifactName }}');
+          let matchArtifact = allArtifacts.data.artifacts.findLast((artifact) => artifact.name === '${{ inputs.artifactName }}');
           if (!matchArtifact) {
             throw new Error('Could not find an artifact with name "${{ inputs.artifactName }}" for workflow_run ${context.payload.workflow_run.id}');
           }


### PR DESCRIPTION
## Proposed change

Publish a new artifact for each run attempt or a PR
The latest successful build will be used to populate the dist before publish
So if we re-run only a test for example, a new artifact will be published with the same content as the previous

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
