### PR TITLE
feat: update version-harmonize documentation

### DIFF
--- a/docs/dev-tools/DEV_TOOLS.md
+++ b/docs/dev-tools/DEV_TOOLS.md
@@ -99,7 +99,7 @@ Options:
 ## Set Version
 
 Replace the packages version in a monorepo
-  
+
 ### Usage
 
 ```shell
@@ -163,7 +163,7 @@ Example : yarn pr-artifact-cleaner -b thisismybase64tokenwithuserandencryptedpas
 
 ## Peer dependencies updater
 
-Update a package.json with the given dependencies versions and their respective peer dependencies.  
+Update a package.json with the given dependencies versions and their respective peer dependencies.
 Relies on `npm info` to retrieve package information.
 
 ### Usage
@@ -179,17 +179,12 @@ Options:
   --verbose                          Display debug log message
   --silent                           Do not exit with error in case of metadata fetch error
 
-Example : peer-dependencies-updater "@random/package@~2.21.0" "@o3r/core" 
+Example : peer-dependencies-updater "@random/package@~2.21.0" "@o3r/core"
 ```
 
 ## Scripts
 
 This package provide generic helpers to support the build chain of Otter and Ama sdk packages
-
-### Scripts available
-
-* **yarn-check** : Check if the current NPM client used is [Yarn](https://yarnpkg.com/en/) (`exit(1)` if not the case).
-* **version-harmonize** : Harmonize the version of the dependencies (in a Monorepo) between the main packages and the children packages.
 
 ## Set Version
 
@@ -210,6 +205,8 @@ Options:
 ```
 
 ## Version Harmonize
+
+> :warning: **Deprecate**: This script is deprecated and will be removed in Otter v12, it is replaced by the JSON ESLint rule [@o3r/json-dependency-versions-harmonize](https://github.com/AmadeusITGroup/otter/blob/main/docs/linter/eslint-plugin/rules/json-dependency-versions-harmonize.md).
 
 Replace the dependencies version in a monorepo.
 This aligns the dependencies range of each packages of a yarn monorepo to the latest range detected in the monorepo.

--- a/packages/@o3r/dev-tools/README.md
+++ b/packages/@o3r/dev-tools/README.md
@@ -114,7 +114,7 @@ Options:
 ## Set Version
 
 Replaces the value of the `version` field of the `package.json` matched by the pattern provided to the `--include` options.
-  
+
 ### Usage
 
 ```shell
@@ -178,7 +178,7 @@ Example : yarn pr-artifact-cleaner -b thisismybase64tokenwithuserandencryptedpas
 
 ## Peer dependencies updater
 
-Updates a package.json with the given dependencies' versions and their respective peer dependencies.  
+Updates a package.json with the given dependencies' versions and their respective peer dependencies.
 Relies on `npm info` to retrieve package information.
 
 ### Usage
@@ -194,7 +194,7 @@ Options:
   --verbose                          Display debug log message
   --silent                           Do not exit with error in case of metadata fetch error
 
-Example : peer-dependencies-updater "@random/package@~2.21.0" "@o3r/core" 
+Example : peer-dependencies-updater "@random/package@~2.21.0" "@o3r/core"
 ```
 
 ## Scripts
@@ -225,6 +225,8 @@ Options:
 ```
 
 ## Version Harmonize
+
+> :warning: **Deprecate**: This script is deprecated and will be removed in Otter v12, it is replaced by the JSON ESLint rule [@o3r/json-dependency-versions-harmonize](../linter/eslint-plugin/rules/json-dependency-versions-harmonize.md).
 
 Replaces the dependencies' version in a monorepos.
 This align the dependencies' range of each package of a yarn monorepo to the latest range detected in the monorepo.

--- a/packages/@o3r/dev-tools/src/cli/version-harmonize.ts
+++ b/packages/@o3r/dev-tools/src/cli/version-harmonize.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
-import { bold, grey } from 'chalk';
+import { blue, bold, green, grey } from 'chalk';
 import { program } from 'commander';
 import * as globby from 'globby';
 import { promises as fs } from 'node:fs';
@@ -19,6 +19,8 @@ const logger = winston.createLogger({
   ),
   transports: new winston.transports.Console()
 });
+
+logger.warn(`Version-harmonize is ${bold.yellow('deprecated')}, please use the ${green('@o3r/json-dependency-versions-harmonize')} from ESLint ${blue('@o3r/eslint-plugin')} plugin`);
 
 program
   .description('Replace the dependencies version in a monorepos')

--- a/packages/@o3r/eslint-config-otter/schematics/ng-add/index.ts
+++ b/packages/@o3r/eslint-config-otter/schematics/ng-add/index.ts
@@ -32,7 +32,16 @@ export function ngAdd(options: NgAddSchematicsSchema): Rule {
           workingDirectory
         }),
         ngAddPeerDependencyPackages(
-          ['eslint', '@angular-eslint/builder', '@typescript-eslint/parser', '@typescript-eslint/eslint-plugin', 'eslint-plugin-jsdoc', 'eslint-plugin-prefer-arrow', 'eslint-plugin-unicorn'],
+          [
+            'eslint',
+            '@angular-eslint/builder',
+            '@typescript-eslint/parser',
+            '@typescript-eslint/eslint-plugin',
+            'eslint-plugin-jsdoc',
+            'eslint-plugin-prefer-arrow',
+            'eslint-plugin-unicorn',
+            'jsonc-eslint-parser'
+          ],
           path.resolve(__dirname, '..', '..', 'package.json'),
           NodeDependencyType.Dev,
           {...options, workingDirectory, skipNgAddSchematicRun: true},

--- a/packages/@o3r/eslint-config-otter/schematics/ng-add/linter/templates/.eslintrc.js.template
+++ b/packages/@o3r/eslint-config-otter/schematics/ng-add/linter/templates/.eslintrc.js.template
@@ -17,6 +17,34 @@ module.exports = {
     'es6': true,
     'jasmine': true
   },
+  'overrides': [
+    {
+      'files': [
+        '*.{m,c,}{t,j}s'
+      ],
+      'parser': require.resolve('@typescript-eslint/parser'),
+      'extends': ['@o3r/eslint-config-otter'].map(require.resolve)
+    },
+    {
+      'parser': require.resolve('jsonc-eslint-parser'),
+      'files': [
+        '**/*.json'
+      ]
+    },
+    {
+      'files': [
+        '**/package.json'
+      ],
+      'plugins': [
+        '@o3r'
+      ],
+      'rules': {
+        '@o3r/json-dependency-versions-harmonize': ['error', {
+          ignoredPackages: [],
+          alignPeerDependencies: false
+        }]
+      }
+  ]
   'extends': [
     '@o3r/eslint-config-otter'
   ].map(require.resolve)


### PR DESCRIPTION
feat: setup new version-harmonize in linter rules

## Proposed change

Update documentation of the ESLint rule replacing the `version-harmonize`.

## Related issues

- :rocket: Feature #960

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
