### PR TITLE
feat(renovate): activate lockfileMaintenance once per week

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -42,6 +42,12 @@
   ],
   "automerge": true,
   "platformAutomerge": true,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": [
+      "before 4am on monday"
+    ]
+  },
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
## Proposed change

Activate Renovate [lockfileMaintenance](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance) once per week

## Related issues

- :rocket: Feature resolves #971 

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
