### PR TITLE
feat(config): support jsdoc for categories declaration

### DIFF
--- a/apps/showcase/src/components/showcase/configuration/configuration-pres.config.ts
+++ b/apps/showcase/src/components/showcase/configuration/configuration-pres.config.ts
@@ -16,10 +16,12 @@ export interface DestinationConfiguration extends NestedConfiguration {
 
 /**
  * Component configuration example
+ * @o3rCategories localCategory Local category
  */
 export interface ConfigurationPresConfig extends Configuration {
   /**
    * Default date selected compare to today
+   * @o3rCategory localCategory
    */
   inXDays: number;
   /**
@@ -33,6 +35,7 @@ export interface ConfigurationPresConfig extends Configuration {
   destinations: DestinationConfiguration[];
   /**
    * Propose round trip
+   * @o3rCategory globalCategory
    */
   shouldProposeRoundTrip: boolean;
 }

--- a/docs/configuration/CONFIGURATION_SUPPORTED_EXTRACTOR.md
+++ b/docs/configuration/CONFIGURATION_SUPPORTED_EXTRACTOR.md
@@ -246,8 +246,28 @@ export interface MyConfig extends Configuration {
 
 ### Configuration categories
 
-Starting Otter v5.2 categories can be added on configuration properties. This can be achieved by adding the `@o3rCategory` tag in the JSDoc on the configuration property.
-Moreover, categories can be described using the `<o3rCategories>` tag on the configuration interface. Please note that blank lines are not supported for category descriptions - even if the syntax is HTML-like, this text will be interpreted in a JSDoc context.
+Categories can be added on configuration properties. This can be achieved by adding the `@o3rCategory` tag in the JSDoc on the configuration property.
+The categories added on the configuration properties must be defined either globally or in the configuration interface. 
+
+For the first case, the global categories can be defined in the `angular.json` of your project by adding the `globalConfigCategories` property to the options of `@o3r/components:extractor`, for example:
+
+```json
+// in angular.json 
+"extract-components": {
+  "builder": "@o3r/components:extractor",
+  "options": {
+    //...
+    "globalConfigCategories": [
+      { "name": "globalCategory", "label": "Global category" }
+    ]
+  }
+}
+```
+
+
+For the second case, the categories can be described using the `@o3rCategories` tag in the JSDoc on the configuration interface.
+Their syntax is the tag `@o3rCategories` followed by the category name and an optional label (if the label is not provided, it will be assigned
+the value of the category name with the first letter capitalized, for example `@o3rCategories categoryName` is equivalent to `@o3rCategories categoryName CategoryName`).
 
 Example:
 
@@ -257,10 +277,8 @@ Example:
  *
  * @tags [one, two, three]
  *
- * <o3rCategories>
- *   <presentation>configuration linked to display</presentation>
- *   <localization>configuration related to languages and translations</localization>
- * </o3rCategories>
+ * @o3rCategories presentation configuration linked to display
+ * @o3rCategories localization configuration related to languages and translations
  */
 export interface SimpleHeaderPresConfig extends Configuration {
   /**
@@ -274,6 +292,12 @@ export interface SimpleHeaderPresConfig extends Configuration {
    * @o3rCategory localization
    */
   showLanguageSelector: boolean;
+
+  /**
+   * Propose round trip
+   * @o3rCategory globalCategory
+   */
+  shouldProposeRoundTrip: boolean;
 }
 ```
 

--- a/packages/@o3r/components/src/core/component.output.ts
+++ b/packages/@o3r/components/src/core/component.output.ts
@@ -121,7 +121,7 @@ export interface ComponentConfigOutput extends Output {
   tags?: string[];
   /** Configuration fields */
   properties: ConfigProperty[];
-  /** Category (taken from <o3rCategories> tag) */
+  /** Category (taken from @o3rCategories tag) */
   categories?: CategoryDescription[];
 }
 

--- a/packages/@o3r/extractors/migration.json
+++ b/packages/@o3r/extractors/migration.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular_devkit/schematics/collection-schema.json",
+  "schematics": {
+    "migration-v10_0": {
+      "version": "10.0.0-alpha.0",
+      "description": "Updates of the Otter Extractors module to v10.0.x",
+      "factory": "./schematics/ng-update/v10-0/index#updateV10_0"
+    }
+  }
+}

--- a/packages/@o3r/extractors/package.json
+++ b/packages/@o3r/extractors/package.json
@@ -8,12 +8,15 @@
     "extractors",
     "otter"
   ],
+  "ng-update": {
+    "migrations": "./migration.json"
+  },
   "scripts": {
     "nx": "nx",
     "ng": "yarn nx",
     "build": "yarn nx build extractors",
     "postbuild": "patch-package-json-main",
-    "prepare:build:builders": "yarn cpy 'schematics/**/*.json' dist/schematics && yarn cpy 'collection.json' dist",
+    "prepare:build:builders": "yarn cpy 'schematics/**/*.json' dist/schematics && yarn cpy '{collection,migration}.json' dist",
     "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest",
     "prepare:publish": "prepare-publish ./dist"
   },

--- a/packages/@o3r/extractors/schematics/ng-update/v10-0/configuration-extractor-categories/configuration-extractor-categories.spec.ts
+++ b/packages/@o3r/extractors/schematics/ng-update/v10-0/configuration-extractor-categories/configuration-extractor-categories.spec.ts
@@ -1,0 +1,34 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { lastValueFrom } from 'rxjs';
+import { updateConfigurationExtractorCategories } from './configuration-extractor-categories';
+
+const collectionPath = path.join(__dirname, '..', '..', '..', '..', 'migration.json');
+
+describe('Update categories in configuration extractor', () => {
+
+  let initialTree: Tree;
+
+  beforeEach(() => {
+    initialTree = Tree.empty();
+    initialTree.create('angular.json', fs.readFileSync(path.resolve(__dirname, 'mocks', 'angular.mocks.json.template')));
+    initialTree.create('/src/mock.config.ts', fs.readFileSync(path.resolve(__dirname, 'mocks', 'config.mocks.ts.template')));
+    initialTree.create('/src/mock.component.ts', fs.readFileSync(path.resolve(__dirname, 'mocks', 'config.mocks.ts.template')));
+  });
+
+  it('should not update non-config files', async () => {
+    const runner = new SchematicTestRunner('migrations', collectionPath);
+    const tree = await lastValueFrom(runner.callRule(updateConfigurationExtractorCategories(), initialTree));
+
+    expect(tree.readText('/src/mock.component.ts')).toBe(fs.readFileSync(path.resolve(__dirname, 'mocks', 'config.mocks.ts.template'), {encoding: 'utf-8'}));
+  });
+
+  it('should update config files', async () => {
+    const runner = new SchematicTestRunner('migrations', collectionPath);
+    const tree = await lastValueFrom(runner.callRule(updateConfigurationExtractorCategories(), initialTree));
+
+    expect(tree.readText('/src/mock.config.ts')).toBe(fs.readFileSync(path.resolve(__dirname, 'mocks', 'config.mocks.result.ts.template'), { encoding: 'utf-8' }));
+  });
+});

--- a/packages/@o3r/extractors/schematics/ng-update/v10-0/configuration-extractor-categories/configuration-extractor-categories.ts
+++ b/packages/@o3r/extractors/schematics/ng-update/v10-0/configuration-extractor-categories/configuration-extractor-categories.ts
@@ -1,0 +1,33 @@
+import { Rule } from '@angular-devkit/schematics';
+import { getFilesInFolderFromWorkspaceProjectsInTree } from '@o3r/schematics';
+
+/**
+ * Replace the XML format to specify categories in the configuration extractor (<o3rCategories>) to JSDoc annotations (@o3rCategories)
+ */
+export function updateConfigurationExtractorCategories(): Rule {
+  const update: Rule = (tree) => {
+    const configFiles = getFilesInFolderFromWorkspaceProjectsInTree(tree, '/', 'config.ts');
+    configFiles.forEach((configFile) => {
+      const content = tree.readText(configFile);
+      const categoriesString = content.match(/ \* <o3rCategories>\n(.+)\* <\/o3rCategories>\n /s);
+      if (categoriesString) {
+        let newCategoriesString = categoriesString[1].replace(/\* +/g, '* ');
+        const categoriesArray = categoriesString[1].match(/<(\w+)>([^\n]+)/gs);
+        if (categoriesArray) {
+          for (const catStringWithDesc of categoriesArray) {
+            const catWithDesc = catStringWithDesc.match(/<(\w+)>([^<]+)/s);
+            if (catWithDesc && catWithDesc[1] && catWithDesc[2]) {
+              const category = catWithDesc[1];
+              const description = catWithDesc[2].replace(/\r?\n \*/g, '').trim();
+              newCategoriesString = newCategoriesString.replace(catStringWithDesc, `@o3rCategories ${category} ${description}`);
+            }
+          }
+        }
+        tree.overwrite(configFile, content.replace(categoriesString[0], newCategoriesString));
+      }
+    });
+    return tree;
+  };
+
+  return update;
+}

--- a/packages/@o3r/extractors/schematics/ng-update/v10-0/configuration-extractor-categories/mocks/angular.mocks.json.template
+++ b/packages/@o3r/extractors/schematics/ng-update/v10-0/configuration-extractor-categories/mocks/angular.mocks.json.template
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "newProjectRoot": ".",
+  "projects": {
+    "test-project": {
+      "projectType": "application",
+      "root": ".",
+      "sourceRoot": "./src",
+      "prefix": "tst",
+      "architect": {
+      }
+    }
+  }
+}

--- a/packages/@o3r/extractors/schematics/ng-update/v10-0/configuration-extractor-categories/mocks/config.mocks.result.ts.template
+++ b/packages/@o3r/extractors/schematics/ng-update/v10-0/configuration-extractor-categories/mocks/config.mocks.result.ts.template
@@ -1,0 +1,25 @@
+/**
+ * Component configuration example
+ * @o3rCategories localCategory Local category
+ */
+export interface ConfigurationPresConfig extends Configuration {
+  /**
+   * Default date selected compare to today
+   * @o3rCategory localCategory
+   */
+  inXDays: number;
+  /**
+   * Proposed destinations
+   * @o3rWidget DESTINATION_ARRAY
+   * @o3rWidgetParam minItems 1
+   * @o3rWidgetParam allDestinationsDifferent true
+   * @o3rWidgetParam atLeastOneDestinationAvailable true
+   * @o3rWidgetParam destinationPattern "[A-Z][a-zA-Z-' ]+"
+   */
+  destinations: DestinationConfiguration[];
+  /**
+   * Propose round trip
+   * @o3rCategory globalCategory
+   */
+  shouldProposeRoundTrip: boolean;
+}

--- a/packages/@o3r/extractors/schematics/ng-update/v10-0/configuration-extractor-categories/mocks/config.mocks.ts.template
+++ b/packages/@o3r/extractors/schematics/ng-update/v10-0/configuration-extractor-categories/mocks/config.mocks.ts.template
@@ -1,0 +1,27 @@
+/**
+ * Component configuration example
+ * <o3rCategories>
+ *  <localCategory>Local category</localCategory>
+ * </o3rCategories>
+ */
+export interface ConfigurationPresConfig extends Configuration {
+  /**
+   * Default date selected compare to today
+   * @o3rCategory localCategory
+   */
+  inXDays: number;
+  /**
+   * Proposed destinations
+   * @o3rWidget DESTINATION_ARRAY
+   * @o3rWidgetParam minItems 1
+   * @o3rWidgetParam allDestinationsDifferent true
+   * @o3rWidgetParam atLeastOneDestinationAvailable true
+   * @o3rWidgetParam destinationPattern "[A-Z][a-zA-Z-' ]+"
+   */
+  destinations: DestinationConfiguration[];
+  /**
+   * Propose round trip
+   * @o3rCategory globalCategory
+   */
+  shouldProposeRoundTrip: boolean;
+}

--- a/packages/@o3r/extractors/schematics/ng-update/v10-0/index.ts
+++ b/packages/@o3r/extractors/schematics/ng-update/v10-0/index.ts
@@ -1,0 +1,19 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable camelcase */
+
+import { chain, Rule } from '@angular-devkit/schematics';
+import { updateConfigurationExtractorCategories } from './configuration-extractor-categories/configuration-extractor-categories';
+
+/**
+ * Default 10.0.0 update function
+ */
+export function updateV10_0(): Rule {
+  return (tree, context) => {
+
+    const updateRules: Rule[] = [
+      updateConfigurationExtractorCategories()
+    ];
+
+    return chain(updateRules)(tree, context);
+  };
+}

--- a/packages/@o3r/extractors/src/utils/config-doc.spec.ts
+++ b/packages/@o3r/extractors/src/utils/config-doc.spec.ts
@@ -1,4 +1,4 @@
-import { getWidgetInformationFromDocComment } from './config-doc';
+import { getCategoriesFromDocText, getWidgetInformationFromDocComment } from './config-doc';
 
 describe('config doc', () => {
   describe('getWidgetInformationFromDocComment', () => {
@@ -43,6 +43,26 @@ describe('config doc', () => {
          * @o3rWidgetParam param1 invalid-value
          */
       `)).toThrow();
+    });
+  });
+  describe('getCategoriesFromDocText', () => {
+    it('should get the categories information', () => {
+      const categoriesInfo = getCategoriesFromDocText(`
+        /**
+         * @o3rCategories test1 description of test 1
+         * @o3rCategories test2
+         */
+      `);
+      expect(categoriesInfo).toEqual([
+        {
+          name: 'test1',
+          label: 'description of test 1'
+        },
+        {
+          name: 'test2',
+          label: 'Test2'
+        }
+      ]);
     });
   });
 });

--- a/packages/@o3r/extractors/src/utils/config-doc.ts
+++ b/packages/@o3r/extractors/src/utils/config-doc.ts
@@ -21,7 +21,7 @@ export interface ConfigDocInformation {
   /** Category (taken from `@o3rCategory` tag) */
   category?: string;
 
-  /** Category (taken from <o3rCategories> tag) */
+  /** Category (taken from @o3rCategories tag) */
   categories?: CategoryDescription[];
 
   /** Widget information (taken from `@o3rWidget` and `@o3rWidgetParam` tag) */
@@ -143,27 +143,26 @@ function getCategoryFromDocText(docComment: string): string | undefined {
 }
 
 /**
- * Get category from a given DocComment.
+ * Get categories from a given DocComment.
  *
- *  The category is extracted from <o3rCategories> tag.
+ * The categories are extracted from the @o3rCategories tags.
  *
- * @param docComment The DocComment to get category from
+ * @param docComment The DocComment to get categories from
  */
-function getCategoriesFromDocText(docComment: string): CategoryDescription[] | undefined {
+export function getCategoriesFromDocText(docComment: string): CategoryDescription[] | undefined {
   const categoriesWithDescription: CategoryDescription[] = [];
-  const categoriesString = docComment.match(/<o3rCategories>(.+)<\/o3rCategories>/s);
+  const categoriesString = Array.from(docComment.matchAll(/@o3rCategories (.*)/g)).map((match) => match[1].trim());
   if (categoriesString) {
-    const categoriesArray = categoriesString[1].match(/<(\w+)>([^<]+)/gs);
-    if (categoriesArray) {
-      for (const catStringWithDesc of categoriesArray) {
-        const catWithDesc = catStringWithDesc.match(/<(\w+)>(.+)/s);
-        if (catWithDesc && catWithDesc[1] && catWithDesc[2]) {
-          const category = catWithDesc[1];
-          const description = catWithDesc[2].replace(/\r?\n \*/g, '').trim();
-          categoriesWithDescription.push({label: description, name: category});
-        } else {
-          throw Error(`Invalid categories description format: ${categoriesString[1]}`);
-        }
+    for (const category of categoriesString) {
+      const firstSpaceIndex = category.indexOf(' ');
+      if (firstSpaceIndex === -1) {
+        const categoryName = category;
+        const categoryLabel = category.charAt(0).toUpperCase() + category.slice(1);
+        categoriesWithDescription.push({name: categoryName, label: categoryLabel});
+      } else {
+        const categoryName = category.slice(0, firstSpaceIndex);
+        const categoryLabel = category.slice(firstSpaceIndex + 1);
+        categoriesWithDescription.push({name: categoryName, label: categoryLabel});
       }
     }
   }

--- a/packages/@o3r/styling/package.json
+++ b/packages/@o3r/styling/package.json
@@ -29,6 +29,7 @@
     "@angular-devkit/architect": "~0.1700.0",
     "@angular-devkit/core": "~17.0.0",
     "@angular-devkit/schematics": "~17.0.0",
+    "@angular/cdk": "~17.0.1",
     "@angular/core": "~17.0.2",
     "@angular/material": "~17.0.0",
     "@o3r/core": "workspace:^",
@@ -47,6 +48,9 @@
       "optional": true
     },
     "@angular-devkit/schematics": {
+      "optional": true
+    },
+    "@angular/cdk": {
       "optional": true
     },
     "@angular/material": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8404,6 +8404,7 @@ __metadata:
     "@angular-devkit/architect": ~0.1700.0
     "@angular-devkit/core": ~17.0.0
     "@angular-devkit/schematics": ~17.0.0
+    "@angular/cdk": ~17.0.1
     "@angular/core": ~17.0.2
     "@angular/material": ~17.0.0
     "@o3r/core": "workspace:^"
@@ -8419,6 +8420,8 @@ __metadata:
     "@angular-devkit/core":
       optional: true
     "@angular-devkit/schematics":
+      optional: true
+    "@angular/cdk":
       optional: true
     "@angular/material":
       optional: true


### PR DESCRIPTION
## Context

Today we use the xml format to specify categories in the configuration extractor.

## Proposed change

Support JSDoc description as well for categories, to ensure consistency.

## Related issues

:rocket: Feature linked to #1119 
