### PR TITLE
feat(eslint-plugin): yarnrc version harmonize

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,3 +12,4 @@ generated-doc/
 /.vscode
 /tools/github-actions/*/packaged-action/
 /**/src/**/package.json
+!/.yarnrc.yml

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
         'jest/no-jasmine-globals': 'off'
       }
     },
+
     {
       'parser': require.resolve('jsonc-eslint-parser'),
       'files': [
@@ -48,6 +49,24 @@ module.exports = {
           'buildTargets': ['build', 'build-builders', 'compile', 'test'],
           'checkObsoleteDependencies': false
         }]
+      }
+    },
+
+    {
+      'parser': require.resolve('yaml-eslint-parser'),
+      'files': [
+        '**/*.y{a,}ml'
+      ]
+    },
+    {
+      'files': [
+        '**/.yarnrc.yml'
+      ],
+      'plugins': [
+        '@o3r'
+      ],
+      'rules': {
+        '@o3r/yarnrc-package-extensions-harmonize': ['error']
       }
     }
   ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,7 +46,8 @@
   "eslint.validate": [
     "javascript",
     "typescript",
-    "json"
+    "json",
+    "yaml"
   ],
   "eslint.probe": [
     "javascript",
@@ -54,7 +55,8 @@
     "typescriptreact",
     "html",
     "markdown",
-    "json"
+    "json",
+    "yaml"
   ],
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "nxConsole.generatorAllowlist": [

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,17 +7,17 @@ nodeLinker: pnp
 packageExtensions:
   "@design-factory/design-factory@*":
     peerDependencies:
-      "@angular/router": ^17.0.0
+      "@angular/router": ~17.0.4
   "@nx/angular@^17.1.1":
     dependencies:
-      "@angular-devkit/build-angular": ^17.0.0
-      "@angular-devkit/core": ^17.0.0
-      "@angular-devkit/schematics": ^17.0.0
-      "@angular/compiler": ^17.0.0
-      "@angular/compiler-cli": ^17.0.0
-      "@schematics/angular": ^17.0.0
-      "@types/node": ^17.0.23
-      esbuild: ^0.17.5
+      "@angular-devkit/build-angular": ~17.0.3
+      "@angular-devkit/core": ~17.0.3
+      "@angular-devkit/schematics": ~17.0.3
+      "@angular/compiler": ~17.0.4
+      "@angular/compiler-cli": ~17.0.4
+      "@schematics/angular": ~17.0.3
+      "@types/node": ^18.0.0
+      esbuild: ~0.19.0
       eslint: ^8.42.0
       nx: ^17.1.1
       rxjs: ^7.8.1
@@ -47,12 +47,12 @@ packageExtensions:
       typescript: ~5.2.2
   "@nx/webpack@^17.1.1":
     dependencies:
-      "@types/node": ^17.0.23
+      "@types/node": ^18.0.0
       nx: ^17.1.1
       typescript: ~5.2.2
   postcss-loader@^7.2.4:
     dependencies:
-      "@types/node": ^17.0.23
+      "@types/node": ^18.0.0
   probot@*:
     dependencies:
       body-parser: ^1.20.2

--- a/docs/linter/eslint-plugin/rules/json-dependency-versions-harmonize.md
+++ b/docs/linter/eslint-plugin/rules/json-dependency-versions-harmonize.md
@@ -14,8 +14,11 @@ Example of a ESLint configuration:
   "plugins": [
     "@o3r"
   ],
+  "files": [
+    "**/package.json"
+  ],
   "extends": [
-    "@o3r:recommended-json"
+    "@o3r:json-recommended"
   ]
 }
 ```

--- a/docs/linter/eslint-plugin/rules/yarnrc-package-extensions-harmonize.md
+++ b/docs/linter/eslint-plugin/rules/yarnrc-package-extensions-harmonize.md
@@ -1,0 +1,103 @@
+# Verify that the yarn package extensions versions
+
+This rule checks the `.yarnrc.yml` file to ensure that each version defined in the `packageExtensions` are aligned with the one used in the `package.json` files of the project.
+
+## Prerequisite
+
+The linter is dedicated to YAML files and requires the setup of the [yaml-eslint-parser](https://www.npmjs.com/package/yaml-eslint-parser).
+
+Example of a ESLint configuration:
+
+```json
+{
+  "parser": "yaml-eslint-parser",
+  "plugins": [
+    "@o3r"
+  ],
+
+  "files": [
+    "**/.yarnrc.yml"
+  ],
+  "extends": [
+    "@o3r:yarn-recommended"
+  ]
+}
+```
+
+## Options
+
+### dependencyTypesInPackages
+
+List of dependency types to check in the package.json
+
+**Default**: ['optionalDependencies', 'dependencies', 'devDependencies', 'peerDependencies', 'generatorDependencies']*
+
+**Usage**:
+
+```json
+{
+  "@o3r/yarnrc-package-extensions-harmonize": [
+    "error",
+    {
+      "dependencyTypesInPackages": ["dependencies", "peerDependencies"]
+    }
+  ]
+}
+```
+
+### ignoredDependencies
+
+List of dependencies to ignore.
+
+**Default**: *[]*
+
+**Usage**:
+
+```json
+{
+  "@o3r/yarnrc-package-extensions-harmonize": [
+    "error",
+    {
+      "ignoredDependencies": ["rxjs", "@angular/*"]
+    }
+  ]
+}
+```
+
+### excludePackages
+
+List of package name to ignore when determining the dependencies versions.
+
+**Default**: *[]*
+
+**Usage**:
+
+```json
+{
+  "@o3r/yarnrc-package-extensions-harmonize": [
+    "error",
+    {
+      "excludePackages": ["@o3r/core"]
+    }
+  ]
+}
+```
+
+### yarnrcDependencyTypes
+
+List of package extension types to check in the yarnrc.
+
+**Default**: *['peerDependencies', 'dependencies']*
+
+**Usage**:
+
+```json
+{
+  "@o3r/yarnrc-package-extensions-harmonize": [
+    "error",
+    {
+      "yarnrcDependencyTypes": ["dependencies"]
+    }
+  ]
+}
+```

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build:storybook": "yarn doc:generate:json && yarn ng run storybook:extract-style && build-storybook",
     "clear": "rimraf -g './{packages,tools,apps}/{@*/,}{amaterasu/,}*/{dist,build,dist-*}/'",
     "set:version": "yarn o3r-set-version --placeholder 0.0.0-placeholder --include '{apps,packages}/**/dist/package.json'",
-    "harmonize:version": "eslint '**/package.json*' --quiet --fix",
+    "harmonize:version": "eslint '**/package.json*' '.yarnrc.yml' --quiet --fix",
     "doc:packages": "yarn nx run-many --target=documentation --parallel $(yarn get:cpus-number)",
     "doc:root": "yarn prepare-doc-root-menu-template && yarn update-doc-summary ./docs && yarn compodoc",
     "doc:generate": "rimraf ./generated-doc && yarn doc:root && yarn doc:packages && yarn doc-links --docs ./docs --generated-doc ./generated-doc",
@@ -47,6 +47,9 @@
       "eslint --quiet --fix"
     ],
     "**/package.json": [
+      "eslint --quiet --fix"
+    ],
+    "**/.yarnrc.yml": [
       "eslint --quiet --fix"
     ],
     "*": [
@@ -237,7 +240,8 @@
     "typescript": "~5.2.2",
     "uuid": "^9.0.0",
     "webpack": "~5.89.0",
-    "winston": "^3.8.2"
+    "winston": "^3.8.2",
+    "yaml-eslint-parser": "^1.2.2"
   },
   "engines": {
     "npm": "please-use-yarn",

--- a/packages/@o3r/eslint-plugin/package.json
+++ b/packages/@o3r/eslint-plugin/package.json
@@ -32,6 +32,9 @@
     },
     "jsonc-eslint-parser": {
       "optional": true
+    },
+    "yaml-eslint-parser": {
+      "optional": true
     }
   },
   "peerDependencies": {
@@ -41,7 +44,8 @@
     "@typescript-eslint/eslint-plugin": "^6.11.0",
     "@typescript-eslint/parser": "^6.11.0",
     "eslint": "^8.22.0",
-    "jsonc-eslint-parser": "~2.4.0"
+    "jsonc-eslint-parser": "~2.4.0",
+    "yaml-eslint-parser": "^1.2.2"
   },
   "devDependencies": {
     "@angular-devkit/core": "~17.0.3",
@@ -74,7 +78,8 @@
     "rimraf": "^5.0.1",
     "ts-jest": "~29.1.1",
     "type-fest": "^3.12.0",
-    "typescript": "~5.2.2"
+    "typescript": "~5.2.2",
+    "yaml-eslint-parser": "^1.2.2"
   },
   "schematics": "./collection.json"
 }

--- a/packages/@o3r/eslint-plugin/src/index.ts
+++ b/packages/@o3r/eslint-plugin/src/index.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import noFolderImportForModule from './rules/typescript/no-folder-import-for-module/no-folder-import-for-module';
 import o3rWidgetTags from './rules/typescript/o3r-widget-tags/o3r-widget-tags';
+import matchingConfigurationName from './rules/typescript/matching-configuration-name/matching-configuration-name';
 import noInnerHTML from './rules/template/no-inner-html/no-inner-html';
 import templateAsyncNumberLimitation from './rules/template/template-async-number-limitation/template-async-number-limitation';
 import jsonDependencyVersionsHarmonize from './rules/json/json-dependency-versions-harmonize/json-dependency-versions-harmonize';
-import matchingConfigurationName from './rules/typescript/matching-configuration-name/matching-configuration-name';
+import yarnrcPackageExtensionHarmonize from './rules/yaml/yarnrc-package-extensions-harmonize/yarnrc-package-extensions-harmonize';
 
 module.exports = {
   rules: {
@@ -13,7 +14,8 @@ module.exports = {
     'template-async-number-limitation': templateAsyncNumberLimitation,
     'o3r-widget-tags': o3rWidgetTags,
     'json-dependency-versions-harmonize': jsonDependencyVersionsHarmonize,
-    'matching-configuration-name': matchingConfigurationName
+    'matching-configuration-name': matchingConfigurationName,
+    'yarnrc-package-extensions-harmonize': yarnrcPackageExtensionHarmonize
   },
   configs: {
     '@o3r/no-folder-import-for-module': 'error',
@@ -39,6 +41,12 @@ module.exports = {
     'json-recommended': {
       rules: {
         '@o3r/json-dependency-versions-harmonize': 'error'
+      }
+    },
+
+    'yarn-recommended': {
+      rules: {
+        '@o3r/yarnrc-package-extensions-harmonize': 'error'
       }
     }
   }

--- a/packages/@o3r/eslint-plugin/src/rules/json/json-dependency-versions-harmonize/json-dependency-versions-harmonize.ts
+++ b/packages/@o3r/eslint-plugin/src/rules/json/json-dependency-versions-harmonize/json-dependency-versions-harmonize.ts
@@ -46,6 +46,7 @@ export default createRule<[Options, ...any], 'versionUpdate' | 'error', any>({
           dependencyTypes: {
             type: 'array',
             description: 'List of dependency types to update',
+            default: defaultOptions[0].dependencyTypes,
             items: {
               type: 'string'
             }

--- a/packages/@o3r/eslint-plugin/src/rules/json/utils.ts
+++ b/packages/@o3r/eslint-plugin/src/rules/json/utils.ts
@@ -11,7 +11,7 @@ interface JsoncParserServices extends ParserServices {
  * @param parserServices Parser services object
  */
 export function isJsoncParserServices(parserServices: any): parserServices is JsoncParserServices {
-  return !!parserServices;
+  return !!parserServices && typeof parserServices.isJSON !== undefined;
 }
 
 /**

--- a/packages/@o3r/eslint-plugin/src/rules/yaml/utils.ts
+++ b/packages/@o3r/eslint-plugin/src/rules/yaml/utils.ts
@@ -1,0 +1,49 @@
+import { ParserServices, TSESLint } from '@typescript-eslint/experimental-utils';
+
+/** Basic interface for the Parser Services object provided by yaml-eslint-parser */
+interface YamlParserServices extends ParserServices {
+  isYAML: boolean;
+}
+
+/**
+ * Determine if yaml-eslint-parser is used
+ * @param parserServices Parser services object
+ */
+export function isYamlParserServices(parserServices: any): parserServices is YamlParserServices {
+  return !!parserServices && parserServices.isYAML;
+}
+
+/**
+ * Retrieve the yaml parser services object or throw if the invalid parser is used
+ * @param context Rule context
+ */
+export function getYamlParserServices(context: Readonly<TSESLint.RuleContext<string, readonly unknown[]>>) {
+  const parserService = context.parserServices;
+  if (!isYamlParserServices(parserService)) {
+    /*
+     * The user needs to have configured "parser" in their eslint config and set it
+     * to yaml-eslint-parser
+     */
+    throw new Error(
+      'You have used a rule which requires \'yaml-eslint-parser\' to be used as the \'parser\' in your ESLint config.'
+    );
+  }
+  return parserService;
+}
+
+/**
+ * Utility for rule authors to ensure that their rule is correctly being used with yaml-eslint-parser
+ * If yaml-eslint-parser is not the configured parser when the function is invoked it will throw
+ * @param context
+ */
+export function ensureJsoncParser(context: Readonly<TSESLint.RuleContext<string, readonly unknown[]>>): void {
+  if (!(context.parserServices)) {
+    /*
+     * The user needs to have configured "parser" in their eslint config and set it
+     * to yaml-eslint-parser
+     */
+    throw new Error(
+      'You have used a rule which requires \'yaml-eslint-parser\' to be used as the \'parser\' in your ESLint config.'
+    );
+  }
+}

--- a/packages/@o3r/eslint-plugin/src/rules/yaml/yarnrc-package-extensions-harmonize/yarnrc-package-extensions-harmonize.spec.ts
+++ b/packages/@o3r/eslint-plugin/src/rules/yaml/yarnrc-package-extensions-harmonize/yarnrc-package-extensions-harmonize.spec.ts
@@ -1,0 +1,151 @@
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { TSESLint } from '@typescript-eslint/experimental-utils';
+import yamlDependencyVersionsHarmonize from './yarnrc-package-extensions-harmonize';
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: require.resolve('yaml-eslint-parser'),
+  parserOptions: {
+    defaultYAMLVersion: '1.2'
+  }
+});
+
+const packageJsonWorkspace = {
+  workspaces: [
+    './packages/*'
+  ],
+  dependencies: {
+    myDep: '^2.0.0'
+  }
+};
+
+const packageJson2 = {
+  name: 'testPackage',
+  dependencies: {
+    myDep: '^1.0.0',
+    myOtherDep: '~2.0.0'
+  }
+};
+
+
+const yamlToUpdate = `
+nodeLinker: pnp
+
+packageExtensions:
+  "myOtherDep@~1.0.0":
+    peerDependencies:
+      "myDep": ~1.0.0
+  "@nx/angular@^17.1.1":
+    dependencies:
+      "myDep": ^1.0.0
+  "@nx/core@^17.1.1":
+    toIgnore:
+      "myDep": ~1.0.0
+`;
+
+const bestVersionYaml = `
+nodeLinker: pnp
+
+packageExtensions:
+  "myOtherDep@~1.0.0":
+    peerDependencies:
+      "myDep": ^2.0.0
+  "@nx/angular@^17.1.1":
+    dependencies:
+      "myDep": ^2.0.0
+  "@nx/core@^17.1.1":
+    toIgnore:
+      "myDep": ~1.0.0
+`;
+
+
+const packageToLint = path.resolve(__dirname, 'local', '.yarnrc.yml');
+
+beforeAll(() => {
+  fs.mkdirSync(path.resolve(__dirname, 'local'));
+  fs.writeFileSync(path.resolve(__dirname, 'local', 'package.json'), JSON.stringify(packageJsonWorkspace));
+
+  fs.mkdirSync(path.resolve(__dirname, 'local', 'packages'));
+  fs.mkdirSync(path.resolve(__dirname, 'local', 'packages', 'my-package'));
+  fs.mkdirSync(path.resolve(__dirname, 'local', 'packages', 'my-package-2'));
+  fs.writeFileSync(path.resolve(__dirname, 'local', 'packages', 'my-package-2', 'package.json'), JSON.stringify(packageJson2));
+});
+
+afterAll(() => {
+  fs.rmSync(path.resolve(__dirname, 'local'), {recursive: true, force: true});
+});
+
+ruleTester.run('json-dependency-versions-harmonize', yamlDependencyVersionsHarmonize, {
+  valid: [
+    { code: bestVersionYaml, filename: packageToLint }
+  ],
+  invalid: [
+    {
+      filename: packageToLint,
+      output: bestVersionYaml,
+      code: yamlToUpdate,
+      errors: [
+        {
+          messageId: 'error',
+          data: {
+            depName: 'myDep',
+            packageJsonFile: path.resolve(__dirname, 'local', 'package.json'),
+            version: '^2.0.0'
+          },
+          suggestions: [
+            {
+              messageId: 'versionUpdate',
+              output: `
+nodeLinker: pnp
+
+packageExtensions:
+  "myOtherDep@~1.0.0":
+    peerDependencies:
+      "myDep": ^2.0.0
+  "@nx/angular@^17.1.1":
+    dependencies:
+      "myDep": ^1.0.0
+  "@nx/core@^17.1.1":
+    toIgnore:
+      "myDep": ~1.0.0
+`,
+              data: {
+                version: '^2.0.0'
+              }
+            }
+          ]
+        },
+        {
+          messageId: 'error',
+          data: {
+            depName: 'myDep',
+            packageJsonFile: path.resolve(__dirname, 'local', 'package.json'),
+            version: '^2.0.0'
+          },
+          suggestions: [
+            {
+              messageId: 'versionUpdate',
+              output: `
+nodeLinker: pnp
+
+packageExtensions:
+  "myOtherDep@~1.0.0":
+    peerDependencies:
+      "myDep": ~1.0.0
+  "@nx/angular@^17.1.1":
+    dependencies:
+      "myDep": ^2.0.0
+  "@nx/core@^17.1.1":
+    toIgnore:
+      "myDep": ~1.0.0
+`,
+              data: {
+                version: '^2.0.0'
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+});

--- a/packages/@o3r/eslint-plugin/src/rules/yaml/yarnrc-package-extensions-harmonize/yarnrc-package-extensions-harmonize.ts
+++ b/packages/@o3r/eslint-plugin/src/rules/yaml/yarnrc-package-extensions-harmonize/yarnrc-package-extensions-harmonize.ts
@@ -1,0 +1,138 @@
+import * as path from 'node:path';
+import * as semver from 'semver';
+import { createRule } from '../../utils';
+import { getYamlParserServices } from '../utils';
+import { type AST, getStaticYAMLValue } from 'yaml-eslint-parser';
+import { findWorkspacePackageJsons, /* getBestRange,*/ getBestRanges } from '../../json/json-dependency-versions-harmonize/version-harmonize';
+
+interface Options {
+  /** List of package.json to ignore when determining the dependencies versions */
+  excludePackages: string[];
+
+  /** List of dependency types in package.json to parse */
+  dependencyTypesInPackages: string[];
+
+  /** List of dependencies to ignore */
+  ignoredDependencies: string[];
+
+  /** List of dependency types to validate in .yarnrc.yml */
+  yarnrcDependencyTypes: string[];
+}
+
+const defaultOptions: [Options] = [{
+  ignoredDependencies: [],
+  excludePackages: [],
+  yarnrcDependencyTypes: ['peerDependencies', 'dependencies'],
+  dependencyTypesInPackages: ['optionalDependencies', 'dependencies', 'devDependencies', 'peerDependencies', 'generatorDependencies']
+}];
+
+export default createRule<[Options, ...any], 'versionUpdate' | 'error', any>({
+  name: 'yarnrc-package-extensions-harmonize',
+  meta: {
+    hasSuggestions: true,
+    type: 'problem',
+    docs: {
+      description: 'Ensure that the package extension versions are aligned with range defined in packages.',
+      recommended: 'error'
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          excludePackages: {
+            type: 'array',
+            description: 'List of package.json to ignore when determining the dependencies versions',
+            items: {
+              type: 'string'
+            }
+          },
+          yarnrcDependencyTypes: {
+            type: 'array',
+            description: 'List of dependency types to validate in .yarnrc.yml',
+            default: defaultOptions[0].yarnrcDependencyTypes,
+            items: {
+              type: 'string'
+            }
+          },
+          dependencyTypesInPackages: {
+            type: 'array',
+            description: 'List of dependency types in package.json to parse',
+            default: defaultOptions[0].dependencyTypesInPackages,
+            items: {
+              type: 'string'
+            }
+          },
+          ignoredDependencies: {
+            type: 'array',
+            description: 'List of dependencies to ignore',
+            items: {
+              type: 'string'
+            }
+          }
+        },
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      versionUpdate: 'Set version {{version}}',
+      error: '{{depName}} should be updated to version {{version}} (from: {{packageJsonFile}})'
+    },
+    fixable: 'code'
+  },
+  defaultOptions,
+  create: (context, [options]: [Options]) => {
+    const parserServices = getYamlParserServices(context);
+    const dirname = path.dirname(context.getFilename());
+    const workspace = findWorkspacePackageJsons(dirname);
+    const bestRanges = workspace ?
+      getBestRanges(options.dependencyTypesInPackages, workspace.packages.filter(({ content }) => !content.name || !options.excludePackages.includes(content.name))) :
+      {};
+    const ignoredDependencies = options.ignoredDependencies.map((dep) => new RegExp(dep.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*')));
+
+    if (parserServices.isYAML) {
+      return {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'YAMLPair': (node: AST.YAMLPair) => {
+
+          if (node.value) {
+            const range = getStaticYAMLValue(node.value)?.toString();
+            const parent = node.parent.parent && node.parent.parent.type === 'YAMLPair' && getStaticYAMLValue(node.parent.parent.key!)?.toString();
+            const baseNode = node.parent.parent.parent.parent?.parent?.parent;
+            const isCorrectNode = baseNode && baseNode.type === 'YAMLPair' && getStaticYAMLValue(baseNode.key!)?.toString() === 'packageExtensions';
+            if (isCorrectNode && semver.validRange(range) && parent && options.yarnrcDependencyTypes.some((t) => t === parent)) {
+              const depName = node.key && getStaticYAMLValue(node.key)?.toString();
+              if (!depName || !bestRanges[depName] || ignoredDependencies.some((ignore) => ignore.test(depName))) {
+                return;
+              }
+              const minYarnrcVersion = semver.minVersion(range!);
+              const minBestRangeVersion = semver.minVersion(bestRanges[depName].range);
+              if (minYarnrcVersion && minBestRangeVersion && semver.lt(minYarnrcVersion, minBestRangeVersion)) {
+                const version = bestRanges[depName].range;
+                const packageJsonFile = bestRanges[depName].path;
+                context.report({
+                  loc: node.value.loc,
+                  messageId: 'error',
+                  data: {
+                    depName,
+                    version,
+                    packageJsonFile
+                  },
+                  fix: (fixer) => fixer.replaceTextRange(node.value!.range, `${version}`),
+                  suggest: [
+                    {
+                      messageId: 'versionUpdate',
+                      data: {
+                        version
+                      },
+                      fix: (fixer) => fixer.replaceTextRange(node.value!.range, `${version}`)
+                    }
+                  ]
+                });
+              }
+            }
+          }
+        }
+      };
+    }
+  }
+});

--- a/packages/@o3r/styling/package.json
+++ b/packages/@o3r/styling/package.json
@@ -29,6 +29,7 @@
     "@angular-devkit/architect": "~0.1700.0",
     "@angular-devkit/core": "~17.0.0",
     "@angular-devkit/schematics": "~17.0.0",
+    "@angular/cdk": "~17.0.1",
     "@angular/core": "~17.0.2",
     "@angular/material": "~17.0.0",
     "@o3r/core": "workspace:^",
@@ -47,6 +48,9 @@
       "optional": true
     },
     "@angular-devkit/schematics": {
+      "optional": true
+    },
+    "@angular/cdk": {
       "optional": true
     },
     "@angular/material": {

--- a/packages/@o3r/workspace/package.json
+++ b/packages/@o3r/workspace/package.json
@@ -16,8 +16,8 @@
     "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest",
     "postbuild": "patch-package-json-main"
   },
-  "default": "./src/public_api.js",
-  "types": "./src/public_api.d.ts",
+  "main": "./dist/src/public_api.js",
+  "types": "./dist/src/public_api.d.ts",
   "peerDependencies": {
     "@angular-devkit/architect": "~0.1700.0",
     "@angular-devkit/core": "~17.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -568,7 +568,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular-devkit/build-angular@npm:^17.0.0, @angular-devkit/build-angular@npm:~17.0.3":
+"@angular-devkit/build-angular@npm:~17.0.3":
   version: 17.0.3
   resolution: "@angular-devkit/build-angular@npm:17.0.3"
   dependencies:
@@ -707,7 +707,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular-devkit/core@npm:17.0.3, @angular-devkit/core@npm:^17.0.0, @angular-devkit/core@npm:~17.0.3":
+"@angular-devkit/core@npm:17.0.3, @angular-devkit/core@npm:~17.0.3":
   version: 17.0.3
   resolution: "@angular-devkit/core@npm:17.0.3"
   dependencies:
@@ -755,7 +755,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular-devkit/schematics@npm:17.0.3, @angular-devkit/schematics@npm:^17.0.0, @angular-devkit/schematics@npm:~17.0.3":
+"@angular-devkit/schematics@npm:17.0.3, @angular-devkit/schematics@npm:~17.0.3":
   version: 17.0.3
   resolution: "@angular-devkit/schematics@npm:17.0.3"
   dependencies:
@@ -912,7 +912,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular/compiler-cli@npm:^17.0.0, @angular/compiler-cli@npm:~17.0.4":
+"@angular/compiler-cli@npm:~17.0.4":
   version: 17.0.4
   resolution: "@angular/compiler-cli@npm:17.0.4"
   dependencies:
@@ -935,7 +935,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular/compiler@npm:^17.0.0, @angular/compiler@npm:~17.0.4":
+"@angular/compiler@npm:~17.0.4":
   version: 17.0.4
   resolution: "@angular/compiler@npm:17.0.4"
   dependencies:
@@ -3331,13 +3331,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm64@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/android-arm64@npm:0.17.19"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@esbuild/android-arm64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/android-arm64@npm:0.18.20"
@@ -3359,13 +3352,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/android-arm@npm:0.17.19"
-  conditions: os=android & cpu=arm
-  languageName: node
-  linkType: hard
-
 "@esbuild/android-arm@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/android-arm@npm:0.18.20"
@@ -3377,13 +3363,6 @@ __metadata:
   version: 0.19.5
   resolution: "@esbuild/android-arm@npm:0.19.5"
   conditions: os=android & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-x64@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/android-x64@npm:0.17.19"
-  conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
 
@@ -3401,13 +3380,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-arm64@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/darwin-arm64@npm:0.17.19"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@esbuild/darwin-arm64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/darwin-arm64@npm:0.18.20"
@@ -3419,13 +3391,6 @@ __metadata:
   version: 0.19.5
   resolution: "@esbuild/darwin-arm64@npm:0.19.5"
   conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/darwin-x64@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/darwin-x64@npm:0.17.19"
-  conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
@@ -3443,13 +3408,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-arm64@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/freebsd-arm64@npm:0.17.19"
-  conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@esbuild/freebsd-arm64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/freebsd-arm64@npm:0.18.20"
@@ -3461,13 +3419,6 @@ __metadata:
   version: 0.19.5
   resolution: "@esbuild/freebsd-arm64@npm:0.19.5"
   conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/freebsd-x64@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/freebsd-x64@npm:0.17.19"
-  conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
@@ -3485,13 +3436,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm64@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/linux-arm64@npm:0.17.19"
-  conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-arm64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/linux-arm64@npm:0.18.20"
@@ -3506,13 +3450,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/linux-arm@npm:0.17.19"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-arm@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/linux-arm@npm:0.18.20"
@@ -3524,13 +3461,6 @@ __metadata:
   version: 0.19.5
   resolution: "@esbuild/linux-arm@npm:0.19.5"
   conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-ia32@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/linux-ia32@npm:0.17.19"
-  conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
 
@@ -3555,13 +3485,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-loong64@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/linux-loong64@npm:0.17.19"
-  conditions: os=linux & cpu=loong64
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-loong64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/linux-loong64@npm:0.18.20"
@@ -3573,13 +3496,6 @@ __metadata:
   version: 0.19.5
   resolution: "@esbuild/linux-loong64@npm:0.19.5"
   conditions: os=linux & cpu=loong64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-mips64el@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/linux-mips64el@npm:0.17.19"
-  conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
 
@@ -3597,13 +3513,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ppc64@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/linux-ppc64@npm:0.17.19"
-  conditions: os=linux & cpu=ppc64
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-ppc64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/linux-ppc64@npm:0.18.20"
@@ -3615,13 +3524,6 @@ __metadata:
   version: 0.19.5
   resolution: "@esbuild/linux-ppc64@npm:0.19.5"
   conditions: os=linux & cpu=ppc64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-riscv64@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/linux-riscv64@npm:0.17.19"
-  conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
@@ -3639,13 +3541,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-s390x@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/linux-s390x@npm:0.17.19"
-  conditions: os=linux & cpu=s390x
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-s390x@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/linux-s390x@npm:0.18.20"
@@ -3657,13 +3552,6 @@ __metadata:
   version: 0.19.5
   resolution: "@esbuild/linux-s390x@npm:0.19.5"
   conditions: os=linux & cpu=s390x
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-x64@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/linux-x64@npm:0.17.19"
-  conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
@@ -3681,13 +3569,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-x64@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/netbsd-x64@npm:0.17.19"
-  conditions: os=netbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/netbsd-x64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/netbsd-x64@npm:0.18.20"
@@ -3699,13 +3580,6 @@ __metadata:
   version: 0.19.5
   resolution: "@esbuild/netbsd-x64@npm:0.19.5"
   conditions: os=netbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/openbsd-x64@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/openbsd-x64@npm:0.17.19"
-  conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
@@ -3723,13 +3597,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/sunos-x64@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/sunos-x64@npm:0.17.19"
-  conditions: os=sunos & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/sunos-x64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/sunos-x64@npm:0.18.20"
@@ -3741,13 +3608,6 @@ __metadata:
   version: 0.19.5
   resolution: "@esbuild/sunos-x64@npm:0.19.5"
   conditions: os=sunos & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-arm64@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/win32-arm64@npm:0.17.19"
-  conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -3765,13 +3625,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-ia32@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/win32-ia32@npm:0.17.19"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
 "@esbuild/win32-ia32@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/win32-ia32@npm:0.18.20"
@@ -3783,13 +3636,6 @@ __metadata:
   version: 0.19.5
   resolution: "@esbuild/win32-ia32@npm:0.19.5"
   conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-x64@npm:0.17.19":
-  version: 0.17.19
-  resolution: "@esbuild/win32-x64@npm:0.17.19"
-  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -7189,6 +7035,7 @@ __metadata:
     tslib: "npm:^2.5.3"
     type-fest: "npm:^3.12.0"
     typescript: "npm:~5.2.2"
+    yaml-eslint-parser: "npm:^1.2.2"
   peerDependencies:
     "@angular-eslint/template-parser": ~17.1.0
     "@angular-eslint/utils": ~17.1.0
@@ -7197,10 +7044,13 @@ __metadata:
     "@typescript-eslint/parser": ^6.11.0
     eslint: ^8.22.0
     jsonc-eslint-parser: ~2.4.0
+    yaml-eslint-parser: ^1.2.2
   peerDependenciesMeta:
     "@angular-eslint/template-parser":
       optional: true
     jsonc-eslint-parser:
+      optional: true
+    yaml-eslint-parser:
       optional: true
   languageName: unknown
   linkType: soft
@@ -7454,6 +7304,7 @@ __metadata:
     uuid: "npm:^9.0.0"
     webpack: "npm:~5.89.0"
     winston: "npm:^3.8.2"
+    yaml-eslint-parser: "npm:^1.2.2"
     zone.js: "npm:~0.14.2"
   languageName: unknown
   linkType: soft
@@ -8404,6 +8255,7 @@ __metadata:
     "@angular-devkit/architect": ~0.1700.0
     "@angular-devkit/core": ~17.0.0
     "@angular-devkit/schematics": ~17.0.0
+    "@angular/cdk": ~17.0.1
     "@angular/core": ~17.0.2
     "@angular/material": ~17.0.0
     "@o3r/core": "workspace:^"
@@ -8419,6 +8271,8 @@ __metadata:
     "@angular-devkit/core":
       optional: true
     "@angular-devkit/schematics":
+      optional: true
+    "@angular/cdk":
       optional: true
     "@angular/material":
       optional: true
@@ -9874,7 +9728,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@schematics/angular@npm:17.0.3, @schematics/angular@npm:^17.0.0, @schematics/angular@npm:~17.0.3":
+"@schematics/angular@npm:17.0.3, @schematics/angular@npm:~17.0.3":
   version: 17.0.3
   resolution: "@schematics/angular@npm:17.0.3"
   dependencies:
@@ -11416,13 +11270,6 @@ __metadata:
   version: 16.18.61
   resolution: "@types/node@npm:16.18.61"
   checksum: ea2fdb3876f77ef8be0bdeee7b0c301a6bf27ab743f55a10486725d8ddd51b84edea7c219e9d09fd24650e8b14c040207a48169bd396915e7a989bac1a7c0bee
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^17.0.23":
-  version: 17.0.45
-  resolution: "@types/node@npm:17.0.45"
-  checksum: b45fff7270b5e81be19ef91a66b764a8b21473a97a8d211218a52e3426b79ad48f371819ab9153370756b33ba284e5c875463de4d2cf48a472e9098d7f09e8a2
   languageName: node
   linkType: hard
 
@@ -17596,83 +17443,6 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: 8cf0b134b4f3d623b35f874ac97de7b7bd9d0184717f298a226d607dcfbcd029be438c1d0d60804944e8486604833de3c0b8ddd5eb3598a5ee70f8121ad50aee
-  languageName: node
-  linkType: hard
-
-"esbuild@npm:^0.17.5":
-  version: 0.17.19
-  resolution: "esbuild@npm:0.17.19"
-  dependencies:
-    "@esbuild/android-arm": "npm:0.17.19"
-    "@esbuild/android-arm64": "npm:0.17.19"
-    "@esbuild/android-x64": "npm:0.17.19"
-    "@esbuild/darwin-arm64": "npm:0.17.19"
-    "@esbuild/darwin-x64": "npm:0.17.19"
-    "@esbuild/freebsd-arm64": "npm:0.17.19"
-    "@esbuild/freebsd-x64": "npm:0.17.19"
-    "@esbuild/linux-arm": "npm:0.17.19"
-    "@esbuild/linux-arm64": "npm:0.17.19"
-    "@esbuild/linux-ia32": "npm:0.17.19"
-    "@esbuild/linux-loong64": "npm:0.17.19"
-    "@esbuild/linux-mips64el": "npm:0.17.19"
-    "@esbuild/linux-ppc64": "npm:0.17.19"
-    "@esbuild/linux-riscv64": "npm:0.17.19"
-    "@esbuild/linux-s390x": "npm:0.17.19"
-    "@esbuild/linux-x64": "npm:0.17.19"
-    "@esbuild/netbsd-x64": "npm:0.17.19"
-    "@esbuild/openbsd-x64": "npm:0.17.19"
-    "@esbuild/sunos-x64": "npm:0.17.19"
-    "@esbuild/win32-arm64": "npm:0.17.19"
-    "@esbuild/win32-ia32": "npm:0.17.19"
-    "@esbuild/win32-x64": "npm:0.17.19"
-  dependenciesMeta:
-    "@esbuild/android-arm":
-      optional: true
-    "@esbuild/android-arm64":
-      optional: true
-    "@esbuild/android-x64":
-      optional: true
-    "@esbuild/darwin-arm64":
-      optional: true
-    "@esbuild/darwin-x64":
-      optional: true
-    "@esbuild/freebsd-arm64":
-      optional: true
-    "@esbuild/freebsd-x64":
-      optional: true
-    "@esbuild/linux-arm":
-      optional: true
-    "@esbuild/linux-arm64":
-      optional: true
-    "@esbuild/linux-ia32":
-      optional: true
-    "@esbuild/linux-loong64":
-      optional: true
-    "@esbuild/linux-mips64el":
-      optional: true
-    "@esbuild/linux-ppc64":
-      optional: true
-    "@esbuild/linux-riscv64":
-      optional: true
-    "@esbuild/linux-s390x":
-      optional: true
-    "@esbuild/linux-x64":
-      optional: true
-    "@esbuild/netbsd-x64":
-      optional: true
-    "@esbuild/openbsd-x64":
-      optional: true
-    "@esbuild/sunos-x64":
-      optional: true
-    "@esbuild/win32-arm64":
-      optional: true
-    "@esbuild/win32-ia32":
-      optional: true
-    "@esbuild/win32-x64":
-      optional: true
-  bin:
-    esbuild: bin/esbuild
-  checksum: 86ada7cad6d37a3445858fee31ca39fc6c0436c7c00b2e07b9ce308235be67f36aefe0dda25da9ab08653fde496d1e759d6ad891ce9479f9e1fb4964c8f2a0fa
   languageName: node
   linkType: hard
 
@@ -32208,6 +31978,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yaml-eslint-parser@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "yaml-eslint-parser@npm:1.2.2"
+  dependencies:
+    eslint-visitor-keys: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    yaml: "npm:^2.0.0"
+  checksum: 286de5b26011ff828d726189a38b8cd942a97f3ea5f777a6c87294906c580c438079ce393566d4f490201c5cfd274aef0f878d30f83c8e929d768aa1c47fde66
+  languageName: node
+  linkType: hard
+
 "yaml@npm:2.3.1":
   version: 2.3.1
   resolution: "yaml@npm:2.3.1"
@@ -32222,7 +32003,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.2.1":
+"yaml@npm:^2.0.0, yaml@npm:^2.2.1":
   version: 2.3.4
   resolution: "yaml@npm:2.3.4"
   checksum: f8207ce43065a22268a2806ea6a0fa3974c6fde92b4b2fa0082357e487bc333e85dc518910007e7ac001b532c7c84bd3eccb6c7757e94182b564028b0008f44b


### PR DESCRIPTION
## Proposed change

Provides a linter rule to align yarn package extensions versions with monorepo's one

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :rocket: Feature resolves #933 

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
