### PR TITLE
feat: matches basic operator

### DIFF
--- a/docs/rules-engine/operators.md
+++ b/docs/rules-engine/operators.md
@@ -59,6 +59,7 @@ Example of usage :
 | Number[]    | allRangeNumber            | all between            | Check if every values of the variable are included in a specified range |
 | Number[]    | oneRangeNumber            | one between            | Check if one of the values of the variable is included in a specified range |
 | String      | inString                  | within                 | Check if the text variable is part of the specified value |
+| String      | matchesPattern            | matches                | Check if the text variable matches a specific pattern |
 | String      | notInString               | not within             | Check if the text variable is not part in the specified value |
 | String      | stringContains            | contains               | Check if the specified text value is included in the text variable |
 | String      | notStringContains         | does not contain       | Check if the specified text value is not included in the text variable |
@@ -71,6 +72,14 @@ Example of usage :
 | All[]       | lengthGreaterThanOrEquals | number of ≥            | Check if the number of values of the variable is greater or equal to a specific value |
 | All[]       | lengthGreaterThan         | number of >            | Check if the number of values of the variable is greater than a specific value |
 
+> **Note**: For the operators comparing a text variable to a pattern (such as `matchesPattern`, `oneMatches`, and `allMatch`), 
+> we support the ES RegExp `/^myRegExp.*$/i` (containing the pattern and optional flags) or just the RegExp content `^myregexp.*$`.
+> 
+> The special characters used in the pattern should contain a double backslash (`\\`).
+> For example, to check if a string contains a `\t`, the pattern would need to include `\\t`.
+> 
+> > Also, to avoid the wrong detection of an ES RegExp instead of RegExp content, a content beginning with a slash `/` character
+> > (such as a path `/path/to/file`) should be preceded by a double backslash `\\` (for example `\\/path/to/file`)
 
 You can create your own operator in your application and add it to the engine.
 Note that the @title provides a string for the operator that can be displayed in an edition UI for better clarity (ex: < for lessThan).
@@ -180,4 +189,3 @@ ngOnInit() {
 ```
 
 Here, `CurrentTimeFactsService` also provides a `tick()` method that, when called, it recomputes the current time. It is up to the application to decide how ofter the current time should be recomputed (at a given time interval, on page navigation, etc).
-

--- a/packages/@o3r/rules-engine/src/engine/operator/operator.helpers.spec.ts
+++ b/packages/@o3r/rules-engine/src/engine/operator/operator.helpers.spec.ts
@@ -1,5 +1,5 @@
 import {of} from 'rxjs';
-import {executeOperator, isRangeNumber, isString, isSupportedSimpleTypes, isValidDate, isValidDateInput, isValidDateRange, numberValidator} from './operator.helpers';
+import {executeOperator, isRangeNumber, isString, isSupportedSimpleTypes, isValidDate, isValidDateInput, isValidDateRange, numberValidator, parseRegExp} from './operator.helpers';
 import {Operator} from './operator.interface';
 
 describe('Operator helpers', () => {
@@ -222,6 +222,13 @@ describe('Operator helpers', () => {
 
       expect(isString('some text')).toBeTruthy();
       expect(isString('')).toBeTruthy();
+    });
+  });
+
+  describe('parseRegExp', () => {
+    it('should validate input properly', () => {
+      expect(parseRegExp('test')).toEqual(new RegExp('test'));
+      expect(parseRegExp('/test/gs')).toEqual(new RegExp('test', 'gs'));
     });
   });
 });

--- a/packages/@o3r/rules-engine/src/engine/operator/operator.helpers.ts
+++ b/packages/@o3r/rules-engine/src/engine/operator/operator.helpers.ts
@@ -107,3 +107,19 @@ export function isSupportedSimpleTypes(value: unknown): value is SupportedSimple
 export function isString(value: unknown): value is string {
   return typeof value === 'string';
 }
+
+/**
+ * Parse input to return RegExp
+ *
+ * @param value value to test whether pattern exists (can be string or array of strings)
+ * @param inputString regexp pattern
+ */
+export function parseRegExp(inputRegExp: string) {
+  if (inputRegExp.startsWith('/')) {
+    const finalSlash = inputRegExp.lastIndexOf('/');
+    const regexpPattern = inputRegExp.slice(1, finalSlash);
+    const regexpFlags = inputRegExp.slice(finalSlash + 1);
+    return new RegExp(regexpPattern, regexpFlags);
+  }
+  return new RegExp(inputRegExp);
+}

--- a/packages/@o3r/rules-engine/src/engine/operator/operators/array-based.operators.ts
+++ b/packages/@o3r/rules-engine/src/engine/operator/operators/array-based.operators.ts
@@ -1,4 +1,4 @@
-import {isRangeNumber, isString, isSupportedSimpleTypes, numberValidator} from '../operator.helpers';
+import {isRangeNumber, isString, isSupportedSimpleTypes, numberValidator, parseRegExp} from '../operator.helpers';
 import { Operator, SupportedSimpleTypes } from '../operator.interface';
 
 /**
@@ -118,8 +118,8 @@ export const allLower: Operator<number[], number | string> = {
  */
 export const allMatch: Operator<string[], string> = {
   name: 'allMatch',
-  evaluator: (array, inputString) => {
-    const regExp = new RegExp(inputString);
+  evaluator: (array, inputRegExp) => {
+    const regExp = parseRegExp(inputRegExp);
     return array.every((elementValue) => regExp.test(elementValue));
   },
   validateLhs: Array.isArray,
@@ -196,8 +196,8 @@ export const oneLower: Operator<number[], number | string> = {
  */
 export const oneMatches: Operator<string[], string> = {
   name: 'oneMatches',
-  evaluator: (arrayString, value) => {
-    const regExp = new RegExp(value);
+  evaluator: (arrayString, inputRegExp) => {
+    const regExp = parseRegExp(inputRegExp);
     return arrayString.some((elementValue) => regExp.test(elementValue));
   },
   validateLhs: Array.isArray,

--- a/packages/@o3r/rules-engine/src/engine/operator/operators/basic.operators.spec.ts
+++ b/packages/@o3r/rules-engine/src/engine/operator/operators/basic.operators.spec.ts
@@ -1,4 +1,4 @@
-import {equals, inArray, inString, isDefined, isUndefined, notEquals, notInArray, notInString} from './basic.operators';
+import {equals, inArray, inString, isDefined, isUndefined, matchesPattern, notEquals, notInArray, notInString} from './basic.operators';
 
 describe('Basic operator', () => {
   describe('equals', () => {
@@ -159,6 +159,35 @@ describe('Basic operator', () => {
       expect(isUndefined.evaluator(1)).toBeFalsy();
       expect(isUndefined.evaluator(null as any)).toBeTruthy();
       expect(isUndefined.evaluator(undefined as any)).toBeTruthy();
+    });
+  });
+
+  describe('matchesPattern', () => {
+    test('should have a valid name', () => {
+      expect(matchesPattern.name).toBe('matchesPattern');
+    });
+
+    test('should exclude non-string right hand operand', () => {
+      expect(matchesPattern.validateRhs).toBeDefined();
+      if (!matchesPattern.validateRhs) {
+        return;
+      }
+
+      expect(matchesPattern.validateRhs('test')).toBeTruthy();
+      expect(matchesPattern.validateRhs(/string/ as any)).toBeFalsy();
+      expect(matchesPattern.validateRhs(null as any)).toBeFalsy();
+      expect(matchesPattern.validateRhs(undefined as any)).toBeFalsy();
+      expect(matchesPattern.validateRhs(123 as any)).toBeFalsy();
+    });
+
+    test('should pass if the left hand value matches the right hand value', () => {
+      expect(matchesPattern.evaluator('test', 'T')).toBeFalsy();
+      expect(matchesPattern.evaluator('test', '/T/i')).toBeTruthy();
+      expect(matchesPattern.evaluator('test', '^t[ea]st')).toBeTruthy();
+      expect(matchesPattern.evaluator('test', 'notTest')).toBeFalsy();
+      expect(matchesPattern.evaluator('test/path/to/file', '\\/path/to/file')).toBeTruthy();
+      expect(matchesPattern.evaluator('8000', '^8[0-9]{3}')).toBeTruthy();
+      expect(matchesPattern.evaluator('8000', '/^8[0-9]{3}$/')).toBeTruthy();
     });
   });
 });

--- a/packages/@o3r/rules-engine/src/engine/operator/operators/basic.operators.ts
+++ b/packages/@o3r/rules-engine/src/engine/operator/operators/basic.operators.ts
@@ -1,4 +1,4 @@
-import { isString, isSupportedSimpleTypes } from '../operator.helpers';
+import { isString, isSupportedSimpleTypes, parseRegExp } from '../operator.helpers';
 import { Operator, SupportedSimpleTypes, UnaryOperator } from '../operator.interface';
 
 /**
@@ -91,7 +91,22 @@ export const isUndefined: UnaryOperator<any> = {
   evaluator: (input) => input === undefined || input === null
 };
 
+/**
+ * Check if the text variable matches the specified RegExp pattern
+ *
+ * @title matches the pattern
+ */
+export const matchesPattern: Operator<string, string> = {
+  name: 'matchesPattern',
+  evaluator: (value, inputRegExp) => {
+    const regExp = parseRegExp(inputRegExp);
+    return regExp.test(value);
+  },
+  validateLhs: isString,
+  validateRhs: isString
+};
+
 /** List of all default basic operators */
 export const basicOperators = [
-  equals, inArray, inString, isDefined, isUndefined, notEquals, notInArray, notInString
+  equals, inArray, inString, isDefined, isUndefined, matchesPattern, notEquals, notInArray, notInString
 ];


### PR DESCRIPTION
## Proposed change

Currently it is not possible to have in the conditions something like the following: 

> **stringFact** matches **pattern**

Where "stringFact" is whatever string and "pattern" is a regular expression like "/^8[0-9]{3}/"

## Related issues

- :rocket: Feature #1120 

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
