### PR TITLE
fix(schematics): do not run eslint if not installed

### DIFF
--- a/packages/@o3r/schematics/package.json
+++ b/packages/@o3r/schematics/package.json
@@ -26,6 +26,7 @@
     "@angular-devkit/schematics": "~16.2.0",
     "@angular/cli": "~16.2.0",
     "@schematics/angular": "~16.2.0",
+    "eslint": "^8.42.0",
     "rxjs": "^7.8.1",
     "typescript": "~5.1.6"
   },
@@ -34,6 +35,9 @@
       "optional": true
     },
     "@angular-devkit/core": {
+      "optional": true
+    },
+    "eslint": {
       "optional": true
     }
   },

--- a/packages/@o3r/schematics/src/rule-factories/eslint-fix/index.ts
+++ b/packages/@o3r/schematics/src/rule-factories/eslint-fix/index.ts
@@ -1,4 +1,4 @@
-import { DirEntry, Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { DirEntry, noop, Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { dirname, join } from 'node:path';
 import { EslintFixTask, LinterOptions } from '../../tasks';
 
@@ -11,6 +11,12 @@ import { EslintFixTask, LinterOptions } from '../../tasks';
  * @param options Linter options
  */
 export function applyEsLintFix(_prootPath = '/', extension: string[] = ['ts'], options?: LinterOptions): Rule {
+  try {
+    require.resolve('eslint/package.json');
+  } catch {
+    return noop();
+  }
+
   const linterOptions: LinterOptions = {
     continueOnError: options?.force ?? true,
     force: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8399,12 +8399,15 @@ __metadata:
     "@angular-devkit/schematics": ~16.2.0
     "@angular/cli": ~16.2.0
     "@schematics/angular": ~16.2.0
+    eslint: ^8.42.0
     rxjs: ^7.8.1
     typescript: ~5.1.6
   peerDependenciesMeta:
     "@angular-devkit/architect":
       optional: true
     "@angular-devkit/core":
+      optional: true
+    eslint:
       optional: true
   bin:
     environment: ./dist/src/cli/environment.js


### PR DESCRIPTION
## Proposed change
Currently `eslint` command is run by the schematics even if not installed.
So a check is added before applying the logic to run the `eslint` command.