### PR TITLE
fix: it-tests

### DIFF
--- a/packages/@o3r/application/package.json
+++ b/packages/@o3r/application/package.json
@@ -8,8 +8,8 @@
     "otter-module"
   ],
   "exports": {
-    "./schemas/*": {
-      "default": "./schemas/*"
+    "./schemas/*.json": {
+      "default": "./schemas/*.json"
     }
   },
   "scripts": {

--- a/packages/@o3r/components/builders/component-extractor/index.ts
+++ b/packages/@o3r/components/builders/component-extractor/index.ts
@@ -94,7 +94,7 @@ export default createBuilder<ComponentExtractorBuilderSchema>(async (options, co
         // Validate components part of components metadata
         validateJson(
           componentMetadata.components,
-          require('@o3r/components/schemas/component.metadata.schema.json'),
+          require('../../schemas/component.metadata.schema.json'),
           'The output of components metadata is not valid regarding the json schema, please check the details below : \n',
           options.strictMode
         );

--- a/packages/@o3r/components/package.json
+++ b/packages/@o3r/components/package.json
@@ -8,6 +8,11 @@
     "otter-module",
     "otter-cms"
   ],
+  "exports": {
+    "./schemas/*.json": {
+      "default": "./schemas/*.json"
+    }
+  },
   "scripts": {
     "nx": "nx",
     "ng": "yarn nx",

--- a/packages/@o3r/configuration/package.json
+++ b/packages/@o3r/configuration/package.json
@@ -12,8 +12,8 @@
     "./middlewares": {
       "default": "./middlewares/index.js"
     },
-    "./schemas/*": {
-      "default": "./schemas/*"
+    "./schemas/*.json": {
+      "default": "./schemas/*.json"
     }
   },
   "scripts": {

--- a/packages/@o3r/localization/builders/localization-extractor/index.ts
+++ b/packages/@o3r/localization/builders/localization-extractor/index.ts
@@ -76,7 +76,7 @@ export default createBuilder<LocalizationExtractorBuilderSchema>(async (options,
 
       validateJson(
         metadata,
-        require('@o3r/localization/schemas/localization.metadata.schema.json'),
+        require('../../schemas/localization.metadata.schema.json'),
         'The output of localization metadata is not valid regarding the json schema, please check the details below : \n',
         options.strictMode
       );

--- a/packages/@o3r/localization/package.json
+++ b/packages/@o3r/localization/package.json
@@ -8,6 +8,11 @@
     "otter-module",
     "otter-cms"
   ],
+  "exports": {
+    "./schemas/*.json": {
+      "default": "./schemas/*.json"
+    }
+  },
   "scripts": {
     "nx": "nx",
     "ng": "yarn nx",

--- a/packages/@o3r/rules-engine/package.json
+++ b/packages/@o3r/rules-engine/package.json
@@ -8,6 +8,11 @@
     "otter-module",
     "otter-cms"
   ],
+  "exports": {
+    "./schemas/*.json": {
+      "default": "./schemas/*.json"
+    }
+  },
   "scripts": {
     "nx": "nx",
     "ng": "yarn nx",

--- a/packages/@o3r/styling/package.json
+++ b/packages/@o3r/styling/package.json
@@ -23,6 +23,9 @@
     },
     "./otter-theme": {
       "sass": "./scss/theming/otter-theme/_index.scss"
+    },
+    "./schemas/*.json": {
+      "default": "./schemas/*.json"
     }
   },
   "peerDependencies": {


### PR DESCRIPTION
## Proposed change

Fix issue with builders requiring JSON schemas that are not exported in the package.json
> Error: Package subpath './schemas/localization.metadata.schema.json' is not defined by \"exports\"


## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
