### PR TITLE
feat: add schema for CMS.json and Style metadata

### DIFF
--- a/packages/@o3r/application/migration.json
+++ b/packages/@o3r/application/migration.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular_devkit/schematics/collection-schema.json",
+  "schematics": {
+    "ng-update": {
+      "version": "10.0.0-alpha.0",
+      "description": "Updates of the Otter Application module to v10.0.x",
+      "factory": "./schematics/ng-update/index#ngUpdate"
+    }
+  }
+}

--- a/packages/@o3r/application/package.json
+++ b/packages/@o3r/application/package.json
@@ -16,7 +16,7 @@
     "nx": "nx",
     "ng": "yarn nx",
     "build": "yarn nx build application",
-    "prepare:build:builders": "yarn cpy 'schematics/**/*.json' dist/schematics && yarn cpy 'collection.json' dist",
+    "prepare:build:builders": "yarn cpy 'schematics/**/*.json' dist/schematics && yarn cpy '{collection,migration}.json' dist",
     "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest",
     "prepare:publish": "prepare-publish ./dist"
   },
@@ -97,5 +97,8 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "schematics": "./collection.json"
+  "schematics": "./collection.json",
+  "ng-update": {
+    "migrations": "./migration.json"
+  }
 }

--- a/packages/@o3r/application/schemas/cms.schema.json
+++ b/packages/@o3r/application/schemas/cms.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "CmsMetadataSchema",
+  "type": "object",
+  "title": "Schema of CMS application configuration",
+  "description": "Schema used to indicate the configuration to the CMS when the application is loaded by it",
+  "additionalProperties": false,
+  "properties": {
+    "assetsFolder": {
+      "type": "string",
+      "description": "The relative path to the assets folder to import",
+      "default": "dist/assets"
+    },
+    "localisationsFolder": {
+      "type": "string",
+      "description": "The relative path to the localizations (.json files) folder to import"
+    },
+    "placeholderCssFiles": {
+      "type": "array",
+      "description": "An array of the CSS files which are used by placeholders at runtime. These files will be used in the placeholder editor",
+      "items": {
+        "type": "string"
+      }
+    },
+    "defaultLanguage": {
+      "type": "string",
+      "description": "The language code present in the localisation.metadata.json file",
+      "default": "en"
+    },
+    "functionalContentsFolder": {
+      "type": "string",
+      "description": "The relative path to the functional contents metadata folder to import"
+    }
+  }
+}

--- a/packages/@o3r/application/schematics/ng-add/helpers/cms-registration.ts
+++ b/packages/@o3r/application/schematics/ng-add/helpers/cms-registration.ts
@@ -1,0 +1,24 @@
+import { apply, MergeStrategy, mergeWith, move, renameTemplateFiles, Rule, template, url } from '@angular-devkit/schematics';
+import type { NgAddSchematicsSchema } from '../schema';
+import { getWorkspaceConfig } from '@o3r/schematics';
+import { resolve } from 'node:path';
+
+/**
+ * Register Otter Application module to the application
+ * @param options
+ */
+export const generateCmsConfigFile = (options: NgAddSchematicsSchema): Rule => {
+  return (tree, context) => {
+    const workingDirectory = options?.projectName && getWorkspaceConfig(tree)?.projects[options.projectName]?.root || '.';
+    const templateSource = apply(
+      url(resolve(__dirname, 'templates')),
+      [
+        template({}),
+        renameTemplateFiles(),
+        move(workingDirectory)
+      ]
+    );
+
+    return mergeWith(templateSource, MergeStrategy.Default)(tree, context);
+  };
+};

--- a/packages/@o3r/application/schematics/ng-add/helpers/templates/cms.json.template
+++ b/packages/@o3r/application/schematics/ng-add/helpers/templates/cms.json.template
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://github.com/AmadeusITGroup/otter/blob/main/packages/@o3r/application/schemas/cms.json"
+}

--- a/packages/@o3r/application/schematics/ng-add/index.ts
+++ b/packages/@o3r/application/schematics/ng-add/index.ts
@@ -3,6 +3,7 @@ import { chain } from '@angular-devkit/schematics';
 import * as path from 'node:path';
 import type { NgAddSchematicsSchema } from './schema';
 import { registerDevtools } from './helpers/devtools-registration';
+import { generateCmsConfigFile } from './helpers/cms-registration';
 
 
 /**
@@ -81,7 +82,8 @@ export function ngAdd(options: NgAddSchematicsSchema): Rule {
           workingDirectory
         }),
         addAngularAnimationPreferences,
-        registerDevtoolRule
+        registerDevtoolRule,
+        generateCmsConfigFile(options)
       ])(tree, context);
     } catch (e) {
       // o3r application needs o3r/core as peer dep. o3r/core will install o3r/schematics

--- a/packages/@o3r/application/schematics/ng-add/ng-update/index.ts
+++ b/packages/@o3r/application/schematics/ng-add/ng-update/index.ts
@@ -1,0 +1,16 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable camelcase */
+
+import { chain, Rule } from '@angular-devkit/schematics';
+import { updateCmsJsonFile } from './v10.0/update-cms-config';
+
+/**
+ * update of Otter library V10.0
+ */
+export function updateV10_0(): Rule {
+  const updateRules: Rule[] = [
+    updateCmsJsonFile()
+  ];
+
+  return chain(updateRules);
+}

--- a/packages/@o3r/application/schematics/ng-add/ng-update/v10.0/update-cms-config.ts
+++ b/packages/@o3r/application/schematics/ng-add/ng-update/v10.0/update-cms-config.ts
@@ -1,0 +1,30 @@
+import type { Rule } from '@angular-devkit/schematics';
+import { basename } from 'node:path';
+
+/**
+ * Update Otter cms.json in an Angular Project
+ */
+export function updateCmsJsonFile(): Rule {
+  return (tree, context) => {
+    const filesToUpdate: Record<string, any> = {};
+
+    tree.visit((path) => {
+      if (basename(path) === 'cms.json') {
+        try {
+          const contentObj: any = tree.readJson(path);
+          if (typeof contentObj === 'object' && !contentObj.$schema) {
+            filesToUpdate[path] = contentObj;
+          }
+        } catch {
+          context.logger.warn(`Failed to parse '${path}'`);
+        }
+      }
+    });
+
+    Object.entries(filesToUpdate).forEach(([path, contentObj]) => {
+      contentObj.$schema = 'https://github.com/AmadeusITGroup/otter/blob/main/packages/@o3r/application/schemas/cms.json';
+      tree.overwrite(path, JSON.stringify(contentObj, null, 2));
+    });
+    return tree;
+  };
+}

--- a/packages/@o3r/design/src/core/design-token/design-token.spec.ts
+++ b/packages/@o3r/design/src/core/design-token/design-token.spec.ts
@@ -198,8 +198,7 @@ describe('Design Token generator', () => {
       expect(() => JSON.parse(result)).not.toThrow();
       expect(metadataSchema).toBeDefined();
       expect(validate).toBeDefined();
-      // TODO Uncomment when #1042 is fixed
-      // expect(validate(JSON.stringify(result), metadataSchema).errors).toHaveLength(0);
+      expect(validate(JSON.parse(result), metadataSchema).errors).toHaveLength(0);
     });
   });
 });

--- a/packages/@o3r/styling/schemas/style.metadata.schema.json
+++ b/packages/@o3r/styling/schemas/style.metadata.schema.json
@@ -3,6 +3,7 @@
   "$id": "StyleMetadataSchema",
   "description": "Schema of Application style",
   "type": "object",
+  "additionalItems": false,
   "properties": {
     "variables": {
       "additionalProperties": {
@@ -12,15 +13,76 @@
   },
   "required": ["variables"],
   "definitions": {
+    "StyleReferenceSchema": {
+      "type": "object",
+      "required": [
+        "name",
+        "defaultValue"
+      ],
+      "additionalItems": true,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the variable referred in the parse value"
+        },
+        "defaultValue": {
+          "type": "string",
+          "description": "Default CSS value used"
+        }
+      }
+    },
+    "StyleMetadataComponentSchema": {
+      "type": "object",
+      "required": [
+        "library",
+        "name"
+      ],
+      "additionalItems": false,
+      "description": "Component reference if the variable is linked to one",
+      "properties": {
+        "library": {
+          "type": "string",
+          "description": "Name of the library containing the component"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the component"
+        }
+      }
+    },
     "StyleMetadataValueSchema": {
       "type": "object",
       "required": [
         "defaultValue"
       ],
+      "additionalItems": true,
       "properties": {
+        "description": {
+          "type": "string",
+          "description": "Description of the variable"
+        },
+        "label": {
+          "type": "string",
+          "description": "Label of the variable, it will be used to display the variable name in the CMS if specified"
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the variable",
+          "enum": [
+            "string",
+            "color"
+          ]
+        },
+        "category": {
+          "type": "string",
+          "description": "Category of the variable"
+        },
         "defaultValue": {
           "type": "string",
-          "description": "Default value of the variable"
+          "description": "Default value of CSS Value used"
+        },
+        "component": {
+          "$ref": "#/definitions/StyleMetadataComponentSchema"
         },
         "tags": {
           "type": "array",
@@ -33,7 +95,7 @@
           "type": "array",
           "description": "List of CSS variables used in the value expression",
           "items": {
-            "$ref": "#/definitions/StyleMetadataValueSchema"
+            "$ref": "#/definitions/StyleReferenceSchema"
           }
         }
       }


### PR DESCRIPTION
## Proposed change

Add the JSON Schema for the styling metadata and the cms.json file
Creation of the `cms.json` file by the `ngAdd` of the `@o3r/application` package.

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :rocket: Feature resolves #1042 

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
