### PR TITLE
ci: disable it-tests for windows-latest,yarn

### DIFF
--- a/.github/workflows/it-tests.yml
+++ b/.github/workflows/it-tests.yml
@@ -52,6 +52,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         packageManager: [yarn, npm]
+        exclude:
+          - os: windows-latest
+            packageManager: yarn
     runs-on: ${{ matrix.os }}
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}


### PR DESCRIPTION
## Proposed change

In the current state, the run of it-tests on `[windows-latest, yarn]` is slow and fails most of the time (related to concurrent access to the disk)
This specific combination does not bring a lot of value since we already cover `[linux, yarn]` and `[windows, npm]`, so I propose to disable it, at least until we find a way to make it reliable 

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
