### PR TITLE
fix(schematics): o3r create command not working for yarn 1

### DIFF
--- a/packages/@o3r/workspace/schematics/ng-add/project-setup.ts
+++ b/packages/@o3r/workspace/schematics/ng-add/project-setup.ts
@@ -46,7 +46,6 @@ export const prepareProject = (options: NgAddSchematicsSchema): Rule => {
       generateRenovateConfig(ownSchematicsFolder),
       addVsCodeRecommendations(vsCodeExtensions),
       updateGitIgnore(workspaceConfig),
-      addWorkspacesToProject(),
       filterPackageJsonScripts,
       ngAddPackages(internalPackagesToInstallWithNgAdd, {
         skipConfirmation: true,
@@ -61,6 +60,7 @@ export const prepareProject = (options: NgAddSchematicsSchema): Rule => {
         dependencyType: NodeDependencyType.Dev
       }),
       !options.skipLinter && installOtterLinter ? applyEsLintFix() : noop(),
+      addWorkspacesToProject(),
       options.skipInstall ? noop() : install
     ])(tree, context);
   };


### PR DESCRIPTION
## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #1189

## Explanation

In `@o3r/workspace` ng-add script, `addWorkspacesToProject` is adding the `workspaces` field to the root `package.json`.
We should execute this step last, after adding all other dependencies, otherwise yarn gets confused and doesn't know where to add the dependencies (to the root or to a workspace).

