### PR TITLE
fix: #1232 Enum revivers and unused imports

### DIFF
--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/java/com/amadeus/codegen/ts/AbstractTypeScriptClientCodegen.java
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/java/com/amadeus/codegen/ts/AbstractTypeScriptClientCodegen.java
@@ -566,6 +566,7 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
         }
         boolean containsExtensions = false;
         ArrayList<List<CodegenProperty>> group = new ArrayList<List<CodegenProperty>>();
+        group.add(model.allVars);
         group.add(model.vars);
         group.add(model.requiredVars);
         group.add(model.optionalVars);
@@ -632,6 +633,7 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
         }
         boolean nonObjectDefinition = false;
         ArrayList<List<CodegenProperty>> group = new ArrayList<List<CodegenProperty>>();
+        group.add(model.allVars);
         group.add(model.vars);
         group.add(model.requiredVars);
         group.add(model.optionalVars);

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/model/reviver.mustache
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/model/reviver.mustache
@@ -120,8 +120,6 @@ export function revive{{classname}}<T extends {{classname}} = {{classname}}>(dat
         {{#allVars}}
           {{^isPrimitiveType}}
             {{#complexType}}
-              {{^isEnum}}
-                {{^isEnumRef}}
                 {{#isMap}}
                   {{#vendorExtensions}}
                     {{^nonObjectDefinition}}
@@ -145,8 +143,6 @@ export function revive{{classname}}<T extends {{classname}} = {{classname}}>(dat
                     {{/vendorExtensions}}
                   {{/isArray}}
                 {{/isMap}}
-                {{/isEnumRef}}
-              {{/isEnum}}
             {{/complexType}}
             {{^complexType}}
               {{^isEnum}}


### PR DESCRIPTION
## Context
To avoid reviving non object models in the revivers, the generator checks the nonObjectDefinition vendor of the property. This means that the property is based on a model which is not an object and therefore cannot be revive, the revival will be skipped.

As a reviver should handle both the model properties and the ones inherited from the parents, it is based on the allVars property which was forgotten prior to this PR. 
Today, we do not add the correct vendor on the allVar property used in the templates but rely on the isEnumRef and isEnum property of the models. Unfortunately, they are false in case of Maps and Arrays.

## Proposed change
Add nonObjectModel vendor to the allVars properties and remove the logic to detect enum within Map and Array as it is faulty.
An additional fix cleans the unused import to avoid any reference to unused or non-existant models

## Related issues

- :bug: Fixes #1232 
