### PR TITLE
ci: downgrade upload-artifact to v3

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -69,7 +69,8 @@ jobs:
         run: yarn ${{ env.testCmd }} --output-style=stream
       - name: Publish tests reports
         if: always()
-        uses: actions/upload-artifact@v4
+        # TODO upgrade to v4 when https://github.com/AmadeusITGroup/otter/issues/1198 is fixed
+        uses: actions/upload-artifact@v3
         with:
           name: ut-reports-${{ matrix.os }}
           path: |

--- a/.github/workflows/it-tests.yml
+++ b/.github/workflows/it-tests.yml
@@ -124,7 +124,8 @@ jobs:
           path: it-tests.zip
       - name: Publish tests reports
         if: always()
-        uses: actions/upload-artifact@v4
+        # TODO upgrade to v4 when https://github.com/AmadeusITGroup/otter/issues/1198 is fixed
+        uses: actions/upload-artifact@v3
         with:
           name: it-reports-${{ matrix.os }}-${{ matrix.packageManager }}
           path: 'packages/**/dist-test/it-report.xml'


### PR DESCRIPTION
## Proposed change

dorny/test-reporter doesn't support artifact v4
https://github.com/AmadeusITGroup/otter/issues/1198

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
