### PR TITLE
fix: ng g application with yarn 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "verdaccio:login": "yarn cpy --cwd=./.verdaccio/conf .npmrc . --rename=.npmrc-logged && npx --yes npm-cli-login -u verdaccio -p verdaccio -e test@test.com -r http://127.0.0.1:4873 --config-path \".verdaccio/conf/.npmrc-logged\"",
     "verdaccio:publish": "yarn verdaccio:clean && yarn set:version 999.0.0 --include \"!**/!(dist)/package.json\" --include !package.json && yarn verdaccio:login && yarn run publish --userconfig \".verdaccio/conf/.npmrc-logged\" --tag=latest --@o3r:registry=http://127.0.0.1:4873 --@ama-sdk:registry=http://127.0.0.1:4873 --@ama-terasu:registry=http://127.0.0.1:4873",
     "verdaccio:stop": "docker container stop $(docker ps -a -q --filter=\"name=verdaccio\")",
+    "verdaccio:all": "yarn verdaccio:stop && yarn verdaccio:start && yarn verdaccio:publish",
     "watch:vscode-extension": "yarn nx run vscode-extension:compile:watch",
     "workspaces:list": "yarn workspaces list --no-private --json | shx sed \"s/.*\\\"location\\\":\\\"(.*?)\\\".*/\\$1/\""
   },

--- a/packages/@ama-sdk/core/schematics/ng-add/index.spec.ts
+++ b/packages/@ama-sdk/core/schematics/ng-add/index.spec.ts
@@ -10,7 +10,7 @@ describe('Ng add @ama-sdk/core', () => {
     initialTree.create('angular.json', readFileSync(join(__dirname, 'mocks', 'angular.mocks.json')));
     initialTree.create('src/example.ts', readFileSync(join(__dirname, 'mocks', 'example.ts.mock')));
     const context: any = { addTask: jest.fn(), logger: { debug: jest.fn() }, schematic: { description: { name: 'schematic', collection: { name: '@scope/test' }}}};
-    const tree = await firstValueFrom(callRule(ngAdd, initialTree, context));
+    const tree = await firstValueFrom(callRule(ngAdd({projectName: 'projectName'}), initialTree, context));
     const newContent = tree.readText('src/example.ts');
     expect(newContent).not.toContain('@dapi/sdk-core');
     expect(newContent).toContain('from \'@ama-sdk/core\'');

--- a/packages/@o3r/apis-manager/schematics/ng-add/index.ts
+++ b/packages/@o3r/apis-manager/schematics/ng-add/index.ts
@@ -1,7 +1,7 @@
 import { chain, noop, Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { createSchematicWithMetricsIfInstalled } from '@o3r/schematics';
 import * as path from 'node:path';
-import { NgAddSchematicsSchema } from './schema';
+import type { NgAddSchematicsSchema } from './schema';
 
 /**
  * Add Otter apis manager to an Angular Project

--- a/packages/@o3r/core/package.json
+++ b/packages/@o3r/core/package.json
@@ -142,9 +142,9 @@
   "generatorDependencies": {
     "@angular-eslint/eslint-plugin": "~17.2.0",
     "@angular/material": "~17.0.1",
-    "@ngrx/router-store": "~17.0.0",
-    "@ngrx/effects": "~17.0.0",
-    "@ngrx/store-devtools": "~17.0.0",
+    "@ngrx/router-store": "~17.1.0",
+    "@ngrx/effects": "~17.1.0",
+    "@ngrx/store-devtools": "~17.1.0",
     "@o3r/store-sync": "workspace:^",
     "@types/jest": "~29.5.2",
     "nx": "~17.2.0",

--- a/packages/@o3r/core/schematics/ng-add/project-setup/index.ts
+++ b/packages/@o3r/core/schematics/ng-add/project-setup/index.ts
@@ -20,7 +20,7 @@ import {
   renamedPackagesV7toV8,
   updateImports
 } from '@o3r/schematics';
-import { NgAddSchematicsSchema } from '../schema';
+import type { NgAddSchematicsSchema } from '../schema';
 import { updateBuildersNames } from '../updates-for-v8/cms-adapters/update-builders-names';
 import { updateOtterGeneratorsNames } from '../updates-for-v8/generators/update-generators-names';
 import { packagesToRemove } from '../updates-for-v8/replaced-packages';

--- a/packages/@o3r/extractors/schematics/ng-add/index.ts
+++ b/packages/@o3r/extractors/schematics/ng-add/index.ts
@@ -3,7 +3,7 @@ import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { createSchematicWithMetricsIfInstalled } from '@o3r/schematics';
 import * as path from 'node:path';
 import { updateCmsAdapter } from '../cms-adapter';
-import { NgAddSchematicsSchema } from './schema';
+import type { NgAddSchematicsSchema } from './schema';
 
 /**
  * Add Otter extractors to an Angular Project

--- a/packages/@o3r/store-sync/schematics/ng-add/index.ts
+++ b/packages/@o3r/store-sync/schematics/ng-add/index.ts
@@ -34,6 +34,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
         (_, ctx) => {
           const peerDepToInstall = getPeerDepWithPattern(path.resolve(__dirname, '..', '..', 'package.json'), ['fast-deep-equal']);
           ctx.addTask(new NodePackageInstallTask({
+            workingDirectory,
             packageName: Object.entries(peerDepToInstall.matchingPackagesVersions)
               // eslint-disable-next-line @typescript-eslint/no-base-to-string, @typescript-eslint/restrict-template-expressions
               .map(([dependency, version]) => `${dependency}@${version || 'latest'}`)

--- a/packages/@o3r/storybook/schematics/ng-add/index.ts
+++ b/packages/@o3r/storybook/schematics/ng-add/index.ts
@@ -1,7 +1,7 @@
 import { chain, noop, Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { createSchematicWithMetricsIfInstalled } from '@o3r/schematics';
 import * as path from 'node:path';
-import { NgAddSchematicsSchema } from './schema';
+import type { NgAddSchematicsSchema } from './schema';
 
 /**
  * Add Otter storybook to an Angular Project

--- a/packages/@o3r/testing/schematics/ng-add/index.ts
+++ b/packages/@o3r/testing/schematics/ng-add/index.ts
@@ -16,7 +16,7 @@ import { NodeDependencyType } from '@schematics/angular/utility/dependencies';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { PackageJson } from 'type-fest';
-import { NgAddSchematicsSchema } from '../../schematics/ng-add/schema';
+import type { NgAddSchematicsSchema } from '../../schematics/ng-add/schema';
 import { updateFixtureConfig } from './fixture';
 import { updatePlaywright } from './playwright';
 

--- a/packages/@o3r/workspace/package.json
+++ b/packages/@o3r/workspace/package.json
@@ -101,9 +101,9 @@
   },
   "generatorDependencies": {
     "@angular/material": "~17.0.1",
-    "@ngrx/router-store": "~17.0.0",
-    "@ngrx/effects": "~17.0.0",
-    "@ngrx/store-devtools": "~17.0.0"
+    "@ngrx/router-store": "~17.1.0",
+    "@ngrx/effects": "~17.1.0",
+    "@ngrx/store-devtools": "~17.1.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/@o3r/workspace/schematics/ng-add/index.ts
+++ b/packages/@o3r/workspace/schematics/ng-add/index.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { PackageJson } from 'type-fest';
 import { createSchematicWithMetricsIfInstalled, getPackageManagerExecutor, getWorkspaceConfig, registerPackageCollectionSchematics } from '@o3r/schematics';
-import { NgAddSchematicsSchema } from './schema';
+import type { NgAddSchematicsSchema } from './schema';
 import { RepositoryInitializerTask } from '@angular-devkit/schematics/tasks';
 import { prepareProject } from './project-setup';
 

--- a/packages/@o3r/workspace/schematics/ng-add/project-setup.ts
+++ b/packages/@o3r/workspace/schematics/ng-add/project-setup.ts
@@ -5,7 +5,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { addWorkspacesToProject, filterPackageJsonScripts } from './helpers/npm-workspace';
 import { generateRenovateConfig } from './helpers/renovate';
-import { NgAddSchematicsSchema } from './schema';
+import type { NgAddSchematicsSchema } from './schema';
 import { shouldOtterLinterBeInstalled } from './helpers/linter';
 import { updateGitIgnore } from './helpers/gitignore-update';
 


### PR DESCRIPTION
## Proposed change

Today, with `yarn 1`

```shell
yarn create @o3r my-workspace
cd my-workspace
yarn ng g application my-app
```
we get:
```shell
✔ Packages installed successfully.
error Running this command will add the dependency to the workspace root rather than the workspace itself, which might not be what you want - if you really meant it, make it explicit by running this command again with the -W flag (or --ignore-workspace-root-check).
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
✖ Package install failed, see above.
The Schematic workflow failed. See above.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

