### PR TITLE
feat: add design token file to component generation

### DIFF
--- a/.verdaccio/.gitignore
+++ b/.verdaccio/.gitignore
@@ -1,2 +1,2 @@
-conf/.npmrc-logged
+conf/**/.npmrc-logged
 storage

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,10 @@ const { getJestProjects } = require('@o3r/workspace');
 
 /** @type {import('ts-jest/dist/types').JestConfigWithTsJest} */
 module.exports = {
-  projects: getJestProjects(__dirname),
+  projects: [
+    ...getJestProjects(__dirname),
+    ...getJestProjects(__dirname, 'testing/jest.config.it.{j,t}s')
+  ],
   globalSetup: 'jest-preset-angular/global-setup',
   reporters: [
     'default',

--- a/packages/@o3r/core/package.json
+++ b/packages/@o3r/core/package.json
@@ -142,9 +142,9 @@
   "generatorDependencies": {
     "@angular-eslint/eslint-plugin": "~17.2.0",
     "@angular/material": "~17.0.1",
-    "@ngrx/router-store": "~17.0.0",
-    "@ngrx/effects": "~17.0.0",
-    "@ngrx/store-devtools": "~17.0.0",
+    "@ngrx/router-store": "~17.1.0",
+    "@ngrx/effects": "~17.1.0",
+    "@ngrx/store-devtools": "~17.1.0",
     "@o3r/store-sync": "workspace:^",
     "@types/jest": "~29.5.2",
     "nx": "~17.2.0",

--- a/packages/@o3r/core/schematics/component/presenter/index.ts
+++ b/packages/@o3r/core/schematics/component/presenter/index.ts
@@ -31,6 +31,7 @@ import { getAddContextRules } from '../../rule-factories/component/context';
 import { getAddFixtureRules } from '../../rule-factories/component/fixture';
 import { getAddLocalizationRules } from '../../rule-factories/component/localization';
 import { getAddThemingRules } from '../../rule-factories/component/theming';
+import { getAddDesignTokenRules } from '../../rule-factories/component/design-token';
 import { NgGenerateComponentSchematicsSchema } from '../schema';
 import { ComponentStructureDef } from '../structures.types';
 
@@ -83,6 +84,7 @@ function ngGenerateComponentPresenterFn(options: NgGenerateComponentSchematicsSc
     const o3rSpecPath = path.posix.join(componentDestination, `${properties.name}.spec.ts`);
     const ngStylePath = path.posix.join(componentDestination, `${properties.name}.component.scss`);
     const o3rStylePath = path.posix.join(componentDestination, `${properties.name}.style.scss`);
+    const o3rDesignTokenPath = path.posix.join(componentDestination, `${properties.name}.theme.json`);
     const ngTemplatePath = path.posix.join(componentDestination, `${properties.name}.component.html`);
     const o3rTemplatePath = path.posix.join(componentDestination, `${properties.name}.template.html`);
     const componentSelector = `${properties.componentSelector}${properties.suffix ? ('-' + properties.suffix) : ''}`;
@@ -177,6 +179,11 @@ function ngGenerateComponentPresenterFn(options: NgGenerateComponentSchematicsSc
       ),
       getAddThemingRules(
         o3rStylePath,
+        options
+      ),
+      getAddDesignTokenRules(
+        o3rStylePath,
+        o3rDesignTokenPath,
         options
       ),
       getAddLocalizationRules(

--- a/packages/@o3r/core/schematics/component/schema.ts
+++ b/packages/@o3r/core/schematics/component/schema.ts
@@ -26,6 +26,9 @@ export interface NgGenerateComponentSchematicsSchema extends SchematicOptionObje
   /** Indicates if the component should use otter theming architecture */
   useOtterTheming?: boolean | undefined;
 
+  /** Indicates if the component should use Design Token Specifications */
+  useOtterDesignToken?: boolean | undefined;
+
   /** Indicates if the component should use otter configuration */
   useOtterConfig?: boolean | undefined;
 

--- a/packages/@o3r/core/schematics/index.it.spec.ts
+++ b/packages/@o3r/core/schematics/index.it.spec.ts
@@ -1,7 +1,6 @@
 import {
   addImportToAppModule,
   getDefaultExecSyncOptions,
-  packageManagerAdd,
   packageManagerExec,
   packageManagerInstall,
   packageManagerRun,
@@ -110,20 +109,14 @@ describe('new otter application', () => {
 
   describe('monorepo', () => {
     beforeAll(async () => {
-      const workspacePath = await prepareTestEnv(`${appName}-monorepo`, 'angular-monorepo');
+      const workspacePath = await prepareTestEnv(`${appName}-monorepo`, 'angular-monorepo-with-o3r-core');
       appFolderPath = join(workspacePath, 'projects', 'test-app');
       execAppOptions.cwd = workspacePath;
     });
     test('should build empty app', () => {
-      // FIXME workaround for pnp
-      packageManagerAdd(`@o3r/core@${o3rVersion} @o3r/analytics@${o3rVersion}`, execAppOptions);
-      packageManagerAdd(`@o3r/core@${o3rVersion} @o3r/analytics@${o3rVersion}`, { ...execAppOptions, cwd: appFolderPath });
-
-      packageManagerExec(`ng add --skip-confirmation @o3r/core@${o3rVersion}`, execAppOptions);
 
       const projectName = '--project-name=test-app';
       packageManagerExec(`ng add --skip-confirmation @o3r/core@${o3rVersion} --preset=all ${projectName}`, execAppOptions);
-      packageManagerExec(`ng add --skip-confirmation @o3r/analytics@${o3rVersion} ${projectName}`, execAppOptions);
       expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
 
       packageManagerExec(

--- a/packages/@o3r/core/schematics/rule-factories/component/design-token.ts
+++ b/packages/@o3r/core/schematics/rule-factories/component/design-token.ts
@@ -1,0 +1,18 @@
+import type { Rule } from '@angular-devkit/schematics';
+import type { NgGenerateComponentSchematicsSchema } from '../../component/schema';
+import { askQuestionsToGetRulesOrThrowIfPackageNotAvailable } from './common';
+
+export const getAddDesignTokenRules = (
+  designTokenPath: string,
+  stylePath: string,
+  options: Pick<NgGenerateComponentSchematicsSchema, 'useOtterDesignToken'>
+): Rule => askQuestionsToGetRulesOrThrowIfPackageNotAvailable(
+  designTokenPath,
+  'useOtterDesignToken',
+  options.useOtterDesignToken,
+  'Generate component with Design Token specification?',
+  ['@o3r/core:component', '@o3r/core:component-presenter'],
+  '@o3r/design',
+  'design-token-to-component',
+  { stylePath }
+);

--- a/packages/@o3r/core/schematics/shared/presets/all.preset.ts
+++ b/packages/@o3r/core/schematics/shared/presets/all.preset.ts
@@ -14,6 +14,7 @@ export function allPreset(options: PresetOptions) {
     '@o3r/application',
     '@o3r/components',
     '@o3r/configuration',
+    '@o3r/design',
     '@o3r/dynamic-content',
     '@o3r/eslint-config-otter',
     '@o3r/eslint-plugin',

--- a/packages/@o3r/design/collection.json
+++ b/packages/@o3r/design/collection.json
@@ -19,6 +19,14 @@
       "description": "Extract the Design Token specification from SCSS",
       "factory": "./schematics/extract-token/index#extractToken",
       "schema": "./schematics/extract-token/schema.json"
+    },
+    "design-token-to-component": {
+      "description": "Add design token to an Otter component",
+      "factory": "./schematics/design-token-to-component/index#ngAddDesignToken",
+      "schema": "./schematics/design-token-to-component/schema.json",
+      "aliases": [
+        "add-design-token"
+      ]
     }
   }
 }

--- a/packages/@o3r/design/schematics/design-token-to-component/index.spec.ts
+++ b/packages/@o3r/design/schematics/design-token-to-component/index.spec.ts
@@ -1,0 +1,53 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import * as path from 'node:path';
+
+const collectionPath = path.join(__dirname, '..', '..', 'collection.json');
+const stylePath = '/src/components/test/test.style.scss';
+const designTokenPath = '/src/components/test/test.theme.json';
+
+describe('Add Design Token to component', () => {
+  let initialTree: Tree;
+  beforeEach(() => {
+    initialTree = Tree.empty();
+    initialTree.create(stylePath, '');
+  });
+
+  it('should create the design token file', async () => {
+    const runner = new SchematicTestRunner('schematics', collectionPath);
+    const tree = await runner.runSchematic('design-token-to-component', {
+      path: designTokenPath
+    }, initialTree);
+
+    expect(tree.exists(designTokenPath)).toBe(true);
+    const designTokenFileContent = tree.readText(designTokenPath);
+    expect(designTokenFileContent).not.toContain('"o3rTargetFile": "test.style.scss"');
+    expect(designTokenFileContent).toContain('"test":');
+  });
+
+  it('should create the design token file and target styling file', async () => {
+    const runner = new SchematicTestRunner('schematics', collectionPath);
+    const tree = await runner.runSchematic('design-token-to-component', {
+      path: designTokenPath,
+      stylePath
+    }, initialTree);
+
+    expect(tree.exists(designTokenPath)).toBe(true);
+    const designTokenFileContent = tree.readText(designTokenPath);
+    expect(designTokenFileContent).toContain('"o3rTargetFile": "test.style.scss"');
+  });
+
+  it('should create the design token file with correct name', async () => {
+    const designTokenPathTestPath = '/src/components/test/test';
+    const runner = new SchematicTestRunner('schematics', collectionPath);
+    const tree = await runner.runSchematic('design-token-to-component', {
+      path: designTokenPathTestPath,
+      stylePath
+    }, initialTree);
+
+    expect(tree.exists(designTokenPathTestPath + '.json')).toBe(true);
+    const designTokenFileContent = tree.readText(designTokenPathTestPath + '.json');
+    expect(designTokenFileContent).toContain('"o3rTargetFile": "test.style.scss"');
+    expect(designTokenFileContent).toContain('"test":');
+  });
+});

--- a/packages/@o3r/design/schematics/design-token-to-component/index.ts
+++ b/packages/@o3r/design/schematics/design-token-to-component/index.ts
@@ -1,0 +1,40 @@
+import {
+  apply,
+  MergeStrategy,
+  mergeWith,
+  move,
+  renameTemplateFiles,
+  Rule,
+  template,
+  url
+} from '@angular-devkit/schematics';
+import { createSchematicWithMetricsIfInstalled } from '@o3r/schematics';
+import { basename, dirname, relative } from 'node:path';
+import type { NgAddDesignTokenSchematicsSchema } from './schema';
+
+/**
+ * Add Design Token to an existing component
+ * @param options
+ */
+export function ngAddDesignTokenFn(options: NgAddDesignTokenSchematicsSchema): Rule {
+  const fileName = basename(options.path.endsWith('.json') ? options.path : `${options.path}.json`);
+  const name = fileName.slice(0, fileName.indexOf('.') > -1 ? fileName.indexOf('.') : undefined);
+
+  const createDesignTokenFilesRule: Rule = mergeWith(apply(url('./templates'), [
+    template({
+      name,
+      fileName,
+      stylingFile: options.stylePath ? relative(dirname(options.path), options.stylePath) : undefined
+    }),
+    renameTemplateFiles(),
+    move(dirname(options.path))
+  ]), MergeStrategy.Overwrite);
+
+  return createDesignTokenFilesRule;
+}
+
+/**
+ * Add Design Token to an existing component
+ * @param options
+ */
+export const ngAddDesignToken = createSchematicWithMetricsIfInstalled(ngAddDesignTokenFn);

--- a/packages/@o3r/design/schematics/design-token-to-component/schema.json
+++ b/packages/@o3r/design/schematics/design-token-to-component/schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "NgAddDesignTokenSchematicsSchema",
+  "title": "Add Otter Design Token to an existing component",
+  "description": "Add Otter Design Token to an existing component",
+  "properties": {
+    "path": {
+      "type": "string",
+      "description": "Path to the component's Design Token specification file"
+    },
+    "stylePath": {
+      "type": "string",
+      "description": "Path to the Style file to update"
+    }
+  },
+  "additionalProperties": true,
+  "required": [
+    "path"
+  ]
+}

--- a/packages/@o3r/design/schematics/design-token-to-component/schema.ts
+++ b/packages/@o3r/design/schematics/design-token-to-component/schema.ts
@@ -1,0 +1,9 @@
+import type { SchematicOptionObject } from '@o3r/schematics';
+
+export interface NgAddDesignTokenSchematicsSchema extends SchematicOptionObject {
+  /** Path to the component's design token file */
+  path: string;
+
+  /** Path to the Style file to update */
+  stylePath?: string;
+}

--- a/packages/@o3r/design/schematics/design-token-to-component/templates/__fileName__.template
+++ b/packages/@o3r/design/schematics/design-token-to-component/templates/__fileName__.template
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://raw.githubusercontent.com/AmadeusITGroup/otter/main/packages/@o3r/design/schemas/design-token.schema.json",
+  "<%= name %>": {
+    "$extensions": {
+      <% if (stylingFile) { %>"o3rTargetFile": "<%= stylingFile %>"<% } %>
+    }
+  }
+}

--- a/packages/@o3r/design/schematics/generate-css/schema.json
+++ b/packages/@o3r/design/schematics/generate-css/schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "ngAddSchematicsSchema",
-  "title": "Add Otter Design",
-  "description": "ngAdd Otter Design",
+  "$id": "generateCssSchematicsSchema",
+  "title": "Generate CSS from design token",
+  "description": "Generate CSS from design token",
   "properties": {
     "designTokenFilePatterns": {
       "description": "Path patterns to the Design Token JSON files",

--- a/packages/@o3r/design/schematics/ng-add/index.ts
+++ b/packages/@o3r/design/schematics/ng-add/index.ts
@@ -1,15 +1,31 @@
-import { chain, type Rule } from '@angular-devkit/schematics';
+import { chain, noop, type Rule } from '@angular-devkit/schematics';
 import { registerGenerateCssBuilder } from './register-generate-css';
 import { extractToken } from '../ extract-token';
+import { setupSchematicsDefaultParams } from '@o3r/schematics';
+import type { NgAddSchematicsSchema } from './schema';
 
 /**
  * Add Otter design to an Angular Project
  * @param options
  */
-export function ngAdd(): Rule {
+export function ngAdd(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
   return chain([
     registerGenerateCssBuilder(),
-    extractToken({ componentFilePatterns: ['**/*.scss'], includeTags: true })
+    setupSchematicsDefaultParams({
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      '@o3r/core:component': {
+        useOtterDesignToken: true
+      },
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      '@o3r/core:component-presenter': {
+        useOtterDesignToken: true
+      },
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      '*:*': {
+        useOtterDesignToken: true
+      }
+    }),
+    options.extractDesignToken ? extractToken({ componentFilePatterns: ['**/*.scss'], includeTags: true }) : noop
   ]);
 }

--- a/packages/@o3r/design/schematics/ng-add/schema.json
+++ b/packages/@o3r/design/schematics/ng-add/schema.json
@@ -10,6 +10,10 @@
       "$default": {
         "$source": "projectName"
       }
+    },
+    "extractDesignToken": {
+      "type": "boolean",
+      "description": "Extract the design token from Sass file in the project"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/design/schematics/ng-add/schema.ts
+++ b/packages/@o3r/design/schematics/ng-add/schema.ts
@@ -3,4 +3,6 @@ import type { SchematicOptionObject } from '@o3r/schematics';
 export interface NgAddSchematicsSchema extends SchematicOptionObject {
   /** Project name */
   projectName?: string | undefined;
+  /** Extract the design token from Sass file in the project */
+  extractDesignToken?: boolean;
 }

--- a/packages/@o3r/workspace/package.json
+++ b/packages/@o3r/workspace/package.json
@@ -101,9 +101,9 @@
   },
   "generatorDependencies": {
     "@angular/material": "~17.0.1",
-    "@ngrx/router-store": "~17.0.0",
-    "@ngrx/effects": "~17.0.0",
-    "@ngrx/store-devtools": "~17.0.0"
+    "@ngrx/router-store": "~17.1.0",
+    "@ngrx/effects": "~17.1.0",
+    "@ngrx/store-devtools": "~17.1.0"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Proposed change

Add generation of the Design token file with the component when the package is added to the project

## Related issues

- :rocket: Feature #1249 

