### PR TITLE
fix: telemetry package description

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-O3R-ISSUE-FORM.yaml
+++ b/.github/ISSUE_TEMPLATE/1-O3R-ISSUE-FORM.yaml
@@ -43,6 +43,7 @@ body:
         storybook,
         stylelint-plugin,
         styling,
+        telemetry,
         testing,
         third-party,
         workspace

--- a/packages/@o3r/telemetry/README.md
+++ b/packages/@o3r/telemetry/README.md
@@ -9,5 +9,5 @@ This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/ot
 
 ## Description
 
-A set of helpers to retrieve tool usage metrics
+A set of helpers to retrieve tool usage metrics.
 

--- a/packages/@o3r/telemetry/package.json
+++ b/packages/@o3r/telemetry/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@o3r/telemetry",
   "version": "0.0.0-placeholder",
+  "description": "A set of helpers to retrieve tool usage metrics.",
   "keywords": [
     "otter-module"
   ],


### PR DESCRIPTION
## Proposed change

The description is missing for the new `@o3r/telemetry` package.
This results in a funny back, the message for the `ng add` is taken from the `README.md`.
<img width="993" alt="image" src="https://github.com/AmadeusITGroup/otter/assets/86055112/521f5c3e-e5ab-4b25-90aa-019d0f794a9b">

Also added the package in the GH issue creation template.

