### PR TITLE
fix: fix wrong ng-packagr schema for secondary entry points

### DIFF
--- a/packages/@o3r/analytics/src/fixtures/jasmine/ng-package.json
+++ b/packages/@o3r/analytics/src/fixtures/jasmine/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
+  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-entrypoint.schema.json",
   "lib": {
     "entryFile": "./index.ts"
   }

--- a/packages/@o3r/analytics/src/fixtures/jest/ng-package.json
+++ b/packages/@o3r/analytics/src/fixtures/jest/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
+  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-entrypoint.schema.json",
   "lib": {
     "entryFile": "index.ts"
   }

--- a/packages/@o3r/analytics/src/ng-package.json
+++ b/packages/@o3r/analytics/src/ng-package.json
@@ -1,4 +1,3 @@
-
 {
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",

--- a/packages/@o3r/apis-manager/ng-package.json
+++ b/packages/@o3r/apis-manager/ng-package.json
@@ -1,4 +1,3 @@
-
 {
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "./dist",

--- a/packages/@o3r/application/ng-package.json
+++ b/packages/@o3r/application/ng-package.json
@@ -1,4 +1,3 @@
-
 {
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "./dist",

--- a/packages/@o3r/components/src/ng-package.json
+++ b/packages/@o3r/components/src/ng-package.json
@@ -1,4 +1,3 @@
-
 {
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",

--- a/packages/@o3r/components/src/rules-engine/ng-package.json
+++ b/packages/@o3r/components/src/rules-engine/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
+  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-entrypoint.schema.json",
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/packages/@o3r/configuration/src/fixtures/jasmine/ng-package.json
+++ b/packages/@o3r/configuration/src/fixtures/jasmine/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
+  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-entrypoint.schema.json",
   "lib": {
     "entryFile": "index.ts"
   }

--- a/packages/@o3r/configuration/src/fixtures/jest/ng-package.json
+++ b/packages/@o3r/configuration/src/fixtures/jest/ng-package.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
-  "dest": "dist/services/fixture/jest",
+  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-entrypoint.schema.json",
   "lib": {
     "entryFile": "index.ts"
   }

--- a/packages/@o3r/configuration/src/ng-package.json
+++ b/packages/@o3r/configuration/src/ng-package.json
@@ -1,4 +1,3 @@
-
 {
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",

--- a/packages/@o3r/configuration/src/rules-engine/ng-package.json
+++ b/packages/@o3r/configuration/src/rules-engine/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
+  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-entrypoint.schema.json",
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/packages/@o3r/core/ng-package.json
+++ b/packages/@o3r/core/ng-package.json
@@ -1,4 +1,3 @@
-
 {
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "./dist",

--- a/packages/@o3r/dynamic-content/src/fixtures/jasmine/ng-package.json
+++ b/packages/@o3r/dynamic-content/src/fixtures/jasmine/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
+  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-entrypoint.schema.json",
   "lib": {
     "entryFile": "index.ts"
   }

--- a/packages/@o3r/dynamic-content/src/fixtures/jest/ng-package.json
+++ b/packages/@o3r/dynamic-content/src/fixtures/jest/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
+  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-entrypoint.schema.json",
   "lib": {
     "entryFile": "index.ts"
   }

--- a/packages/@o3r/dynamic-content/src/ng-package.json
+++ b/packages/@o3r/dynamic-content/src/ng-package.json
@@ -1,4 +1,3 @@
-
 {
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",

--- a/packages/@o3r/dynamic-content/src/rules-engine/ng-package.json
+++ b/packages/@o3r/dynamic-content/src/rules-engine/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
+  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-entrypoint.schema.json",
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/packages/@o3r/forms/ng-package.json
+++ b/packages/@o3r/forms/ng-package.json
@@ -1,4 +1,3 @@
-
 {
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "./dist",

--- a/packages/@o3r/localization/src/ng-package.json
+++ b/packages/@o3r/localization/src/ng-package.json
@@ -1,4 +1,3 @@
-
 {
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",

--- a/packages/@o3r/localization/src/rules-engine/ng-package.json
+++ b/packages/@o3r/localization/src/rules-engine/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
+  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-entrypoint.schema.json",
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/packages/@o3r/logger/src/ng-package.json
+++ b/packages/@o3r/logger/src/ng-package.json
@@ -1,4 +1,3 @@
-
 {
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",

--- a/packages/@o3r/logger/src/services/fullstory-logger-client/ng-package.json
+++ b/packages/@o3r/logger/src/services/fullstory-logger-client/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
+  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-entrypoint.schema.json",
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/packages/@o3r/logger/src/services/logrocket-logger-client/ng-package.json
+++ b/packages/@o3r/logger/src/services/logrocket-logger-client/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
+  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-entrypoint.schema.json",
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/packages/@o3r/logger/src/services/smartlook-logger-client/ng-package.json
+++ b/packages/@o3r/logger/src/services/smartlook-logger-client/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
+  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-entrypoint.schema.json",
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/packages/@o3r/routing/src/ng-package.json
+++ b/packages/@o3r/routing/src/ng-package.json
@@ -1,4 +1,3 @@
-
 {
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",

--- a/packages/@o3r/rules-engine/src/fixtures/jasmine/ng-package.json
+++ b/packages/@o3r/rules-engine/src/fixtures/jasmine/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
+  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-entrypoint.schema.json",
   "lib": {
     "entryFile": "index.ts"
   }

--- a/packages/@o3r/rules-engine/src/fixtures/jest/ng-package.json
+++ b/packages/@o3r/rules-engine/src/fixtures/jest/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
+  "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-entrypoint.schema.json",
   "lib": {
     "entryFile": "index.ts"
   }

--- a/packages/@o3r/rules-engine/src/ng-package.json
+++ b/packages/@o3r/rules-engine/src/ng-package.json
@@ -1,4 +1,3 @@
-
 {
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",

--- a/packages/@o3r/store-sync/ng-package.json
+++ b/packages/@o3r/store-sync/ng-package.json
@@ -1,4 +1,3 @@
-
 {
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "./dist",

--- a/packages/@o3r/styling/ng-package.json
+++ b/packages/@o3r/styling/ng-package.json
@@ -1,4 +1,3 @@
-
 {
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "./dist",


### PR DESCRIPTION
## Proposed change

Fix one build issue of https://github.com/AmadeusITGroup/otter/pull/1243
Linked to https://github.com/ng-packagr/ng-packagr/commit/5ff4afde43b4984bf7f64ce991dfe255b1fb9373

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
