### PR TITLE
fix: ngrx-local-storage strict range

### DIFF
--- a/apps/showcase/package.json
+++ b/apps/showcase/package.json
@@ -60,7 +60,7 @@
     "bootstrap-icons": "^1.10.5",
     "highlight.js": "^11.8.0",
     "intl-messageformat": "~10.5.1",
-    "ngrx-store-localstorage": "^16.0.0",
+    "ngrx-store-localstorage": "~16.0.0",
     "ngx-highlightjs": "^10.0.0",
     "pixelmatch": "^5.2.1",
     "pngjs": "^7.0.0",

--- a/packages/@o3r/core/package.json
+++ b/packages/@o3r/core/package.json
@@ -38,7 +38,7 @@
     "@schematics/angular": "~16.2.0",
     "chokidar": "^3.5.2",
     "globby": "^11.1.0",
-    "ngrx-store-localstorage": "^16.0.0",
+    "ngrx-store-localstorage": "~16.0.0",
     "rxjs": "^7.8.1",
     "semver": "^7.5.2",
     "typescript": "~5.1.6"
@@ -126,7 +126,7 @@
     "jsonc-eslint-parser": "~2.4.0",
     "memfs": "~4.6.0",
     "minimist": "^1.2.6",
-    "ngrx-store-localstorage": "^16.0.0",
+    "ngrx-store-localstorage": "~16.0.0",
     "nx": "~16.10.0",
     "pid-from-port": "^1.1.3",
     "rxjs": "^7.8.1",

--- a/packages/@o3r/workspace/package.json
+++ b/packages/@o3r/workspace/package.json
@@ -93,7 +93,6 @@
     "jest-junit": "~16.0.0",
     "jest-preset-angular": "~13.1.1",
     "minimist": "^1.2.6",
-    "ngrx-store-localstorage": "^16.0.0",
     "nx": "~16.10.0",
     "pid-from-port": "^1.1.3",
     "rxjs": "^7.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7194,7 +7194,7 @@ __metadata:
     jsonc-eslint-parser: "npm:~2.4.0"
     memfs: "npm:~4.6.0"
     minimist: "npm:^1.2.6"
-    ngrx-store-localstorage: "npm:^16.0.0"
+    ngrx-store-localstorage: "npm:~16.0.0"
     nx: "npm:~16.10.0"
     pid-from-port: "npm:^1.1.3"
     rxjs: "npm:^7.8.1"
@@ -7227,7 +7227,7 @@ __metadata:
     "@schematics/angular": ~16.2.0
     chokidar: ^3.5.2
     globby: ^11.1.0
-    ngrx-store-localstorage: ^16.0.0
+    ngrx-store-localstorage: ~16.0.0
     rxjs: ^7.8.1
     semver: ^7.5.2
     typescript: ~5.1.6
@@ -8590,7 +8590,7 @@ __metadata:
     jest-junit: "npm:~16.0.0"
     jest-preset-angular: "npm:~13.1.1"
     jsonc-eslint-parser: "npm:~2.4.0"
-    ngrx-store-localstorage: "npm:^16.0.0"
+    ngrx-store-localstorage: "npm:~16.0.0"
     ngx-highlightjs: "npm:^10.0.0"
     pixelmatch: "npm:^5.2.1"
     pngjs: "npm:^7.0.0"
@@ -9195,7 +9195,6 @@ __metadata:
     jest-junit: "npm:~16.0.0"
     jest-preset-angular: "npm:~13.1.1"
     minimist: "npm:^1.2.6"
-    ngrx-store-localstorage: "npm:^16.0.0"
     nx: "npm:~16.10.0"
     pid-from-port: "npm:^1.1.3"
     rxjs: "npm:^7.8.1"
@@ -25467,7 +25466,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ngrx-store-localstorage@npm:^16.0.0":
+"ngrx-store-localstorage@npm:~16.0.0":
   version: 16.0.0
   resolution: "ngrx-store-localstorage@npm:16.0.0"
   dependencies:


### PR DESCRIPTION
## Proposed change
ngrx-local-storage bumped ng version to 17 in their 16.1 minor
https://github.com/btroncone/ngrx-store-localstorage/releases/tag/v16.1.0

this brings peer deps issues as in o3r v9.x we have ng 16

Result: block the minor version of ngrx-local-storage peer dep

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
