### PR TITLE
fix: cleanup refx refs

### DIFF
--- a/packages/@o3r/artifactory-tools/README.md
+++ b/packages/@o3r/artifactory-tools/README.md
@@ -91,7 +91,7 @@ Options:
 
   --artifactory-url <artifactoryUrl>   Artifact URL (Required)
   -a, --duration-kept <durationKept>   All the artifact which have been created since more time than this value(ms) will be deleted (Default to 10080000ms (i.e. 7 days))
-  -r, --repositories <repositories>    Artifact repositories to clean up (coma separated) ex : npm-otter-pr,npm-refx-pr (Default to npm-otter-pr)
+  -r, --repositories <repositories>    Artifact repositories to clean up (coma separated) ex : npm-otter-pr,npm-o3r-pr (Default to npm-otter-pr)
   -t, --type-filter <typeFilter>       List of artifact type that should be deleted coma separated (ex: jar,tgz) (Default : tgz)
   --dry-run <dryRun>                   List all files that should be deleted without actually deleting them. (Default to false)
   -h, --help                           Output usage information

--- a/packages/@o3r/artifactory-tools/src/cli/artifact-cleaner.ts
+++ b/packages/@o3r/artifactory-tools/src/cli/artifact-cleaner.ts
@@ -13,7 +13,7 @@ program
   .option('-d, --duration-kept <durationKept>', 'All artifacts which have not been downloaded and are older than this value(ms) will be deleted. Default to 10080000ms (7 days)', '604800000')
   .option(
     '-r, --repositories <repositories>',
-    'Artifact repositories to clean up (coma separated) ex : npm-otter-pr,npm-refx-pr (Default to npm-otter-pr)',
+    'Artifact repositories to clean up (coma separated) ex : npm-otter-pr,npm-o3r-pr (Default to npm-otter-pr)',
     (repos: string) => repos.split(','),
     ['npm-otter-pr']
   )

--- a/packages/@o3r/configuration/src/devkit/configuration-devtools.console.service.ts
+++ b/packages/@o3r/configuration/src/devkit/configuration-devtools.console.service.ts
@@ -71,7 +71,7 @@ export class ConfigurationDevtoolsConsoleService implements DevtoolsServiceInter
 
   /**
    * Display the list of configurations loaded in the store and the library they originate from
-   * @returns array with the configurations and libraries for example: ["RefxComponentsCommonRuntimeConfig from @refx/shared-common"]
+   * @returns array with the configurations and libraries for example: ["LibComponentsCommonRuntimeConfig from @my-lib/shared-common"]
    */
   public async displayComponentsWithConfiguration() {
     const selectors = await this.configurationDevtools.getComponentsWithConfiguration();
@@ -80,8 +80,8 @@ export class ConfigurationDevtoolsConsoleService implements DevtoolsServiceInter
 
   /**
    * Display the configuration for a specific component
-   * @param selector Selector for a component configuration. It can be a string in the form library#configurationName (i.e: '@refx/shared-components#HeaderContConfig')
-   * or an object with the configuration and library names (i.e: {library:"@refx/shared-components", componentName:'HeaderContConfig'}).
+   * @param selector Selector for a component configuration. It can be a string in the form library#configurationName (i.e: '@my-lib/shared-components#HeaderContConfig')
+   * or an object with the configuration and library names (i.e: {library:"@my-lib/shared-components", componentName:'HeaderContConfig'}).
    * Note the object input componentName expects a configuration name not a component name.
    * @returns Configuration object (i.e: {airlineLogoPath: "img/airlines/icon-BH.svg", displayLanguageSelector: false})
    */

--- a/packages/@o3r/configuration/src/devkit/configuration-devtools.service.ts
+++ b/packages/@o3r/configuration/src/devkit/configuration-devtools.service.ts
@@ -50,10 +50,10 @@ export class OtterConfigurationDevtools {
 
   /**
    * Get configuration name based on input information
-   * @param selector Selector for a component configuration. It can be a string in the form library#componentName (i.e: @refx/shared-components#HeaderContComponent)
-   * or an object with the component and library names (i.e: {library:"@refx/shared-components", componentName:'HeaderContComponent'})
+   * @param selector Selector for a component configuration. It can be a string in the form library#componentName (i.e: @my-lib/shared-components#HeaderContComponent)
+   * or an object with the component and library names (i.e: {library:"@my-lib/shared-components", componentName:'HeaderContComponent'})
    * @param isFallbackName Determine if the name requested is a fallback name
-   * @returns string in the format library#componentName (i.e: "@refx/shared-components#HeaderContComponent")
+   * @returns string in the format library#componentName (i.e: "@my-lib/shared-components#HeaderContComponent")
    */
   public getComponentConfigName(selector: string | { library?: string; componentName: string }, isFallbackName = false) {
     if (!isFallbackName) {
@@ -99,8 +99,8 @@ export class OtterConfigurationDevtools {
 
   /**
    * Get the configuration for a specific component
-   * @param selector Selector for a component configuration. It can be a string in the form library#configurationName (i.e: @refx/shared-components#HeaderPresConfig)
-   * or an object with the configuration and library names (i.e: {library:"@refx/shared-components", componentName:'HeaderPresConfig'})
+   * @param selector Selector for a component configuration. It can be a string in the form library#configurationName (i.e: @my-lib/shared-components#HeaderPresConfig)
+   * or an object with the configuration and library names (i.e: {library:"@my-lib/shared-components", componentName:'HeaderPresConfig'})
    */
   public getCurrentConfigurationFor(selector: string | { library?: string; componentName: string }): Promise<Configuration> {
     return firstValueFrom(

--- a/packages/@o3r/configuration/src/services/configuration/configuration.base.service.spec.ts
+++ b/packages/@o3r/configuration/src/services/configuration/configuration.base.service.spec.ts
@@ -22,7 +22,7 @@ const additionalConfig = {
   additionalField: 10
 };
 
-const globalConfig = {'demo-cabinCodeEco': 'ECO1', 'refx-priceDisplay': 'short'};
+const globalConfig = {'demo-cabinCodeEco': 'ECO1', 'priceDisplay': 'short'};
 
 const staticConfig: CustomConfig[] = [{
   name: 'SearchTypePresenter',

--- a/packages/@o3r/dev-tools/README.md
+++ b/packages/@o3r/dev-tools/README.md
@@ -144,7 +144,7 @@ Options:
 
   --artifactory-url <artifactoryUrl>   Artifact URL (Required)
   -a, --duration-kept <durationKept>   All the artifact which have been created since more time than this value(ms) will be deleted (Default to 10080000ms (i.e. 7 days))
-  -r, --repositories <repositories>    Artifact repositories to clean up (coma separated) ex : npm-otter-pr,npm-refx-pr (Default to npm-otter-pr)
+  -r, --repositories <repositories>    Artifact repositories to clean up (coma separated) ex : npm-otter-pr,npm-o3r-pr (Default to npm-otter-pr)
   -t, --type-filter <typeFilter>       List of artifact type that should be deleted coma separated (ex: jar,tgz) (Default : tgz)
   --dry-run <dryRun>                   List all files that should be deleted without actually deleting them. (Default to false)
   -h, --help                           Output usage information

--- a/packages/@o3r/extractors/src/utils/common.ts
+++ b/packages/@o3r/extractors/src/utils/common.ts
@@ -42,7 +42,7 @@ export function getReflectionDefaultValue(reflection: DeclarationReflection) {
 
 /**
  * Get absolute path of a provided library
- * @param libraryName Library name (ex: @refx/components)
+ * @param libraryName Library name (ex: @my-lib/components)
  * @param executionDir
  */
 export function getLibraryModulePath(libraryName: string, executionDir: string = process.cwd()) {
@@ -78,7 +78,7 @@ export function getLibraryModulePath(libraryName: string, executionDir: string =
 
 /**
  * Get cms metadata files from the node_modules package of the provided library
- * @param modulePath Absolute path of the library (ex: my/absolute/path/@refx/components)
+ * @param modulePath Absolute path of the library (ex: my/absolute/path/@my-lib/components)
  */
 export function getLibraryCmsMetadataFileNames(modulePath: string) {
   return JSON.parse(fs.readFileSync(path.join(modulePath, 'package.json')).toString()).cmsMetadata || {};
@@ -86,7 +86,7 @@ export function getLibraryCmsMetadataFileNames(modulePath: string) {
 
 /**
  * Get cms metadata file paths from the node_modules package of the provided library
- * @param libraryName Library name (ex: @refx/components)
+ * @param libraryName Library name (ex: @my-lib/components)
  * @param executionDir
  */
 export function getLibraryCmsMetadata(libraryName: string, executionDir: string = process.cwd()) {

--- a/tools/github-actions/cascading/action.yml
+++ b/tools/github-actions/cascading/action.yml
@@ -25,7 +25,7 @@ inputs:
     required: false
     default: 'main.yml'
   conflictsIgnoredPackages:
-    description: 'The list of packages changes to ignore if the conflict is only about them, separated by a coma (ex: @otter/common,@otter/core,@refx/booking-common,@refx/booking-components)'
+    description: 'The list of packages changes to ignore if the conflict is only about them, separated by a coma (ex: @otter/common,@otter/core,@my-lib/booking-common,@my-lib/booking-components)'
     required: false
     default: ''
 runs:

--- a/tools/github-actions/cascading/src/cascading.ts
+++ b/tools/github-actions/cascading/src/cascading.ts
@@ -32,7 +32,7 @@ export interface CascadingOptions<T extends BaseLogger> {
   /** Whether to assign the first committer to the cascading failure PR */
   assignCommitter: string;
 
-  /** The list of packages changes to ignore if the conflict is only about them (ex: ['@otter/common','@otter/core','@refx/booking-common','@refx/booking-components']) */
+  /** The list of packages changes to ignore if the conflict is only about them (ex: ['@otter/common','@otter/core','@my-lib/booking-common','@my-lib/booking-components']) */
   conflictsIgnoredPackages: string[];
 
   /** Access token for GitHub API authentication */


### PR DESCRIPTION
## Proposed change
Similarly to https://github.com/AmadeusITGroup/otter/issues/1190, the goal is to cleanup references to RefX.

There are still references in the:
- [ ] theming part
- [ ] amaterasu

To be discussed if those references are to be kept or not. 
