### PR TITLE
fix(sdk-core): add typings for deep import

### DIFF
--- a/packages/@ama-sdk/core/package.json
+++ b/packages/@ama-sdk/core/package.json
@@ -34,6 +34,13 @@
       "require": "./dist/cjs/clients/*.js"
     }
   },
+  "typesVersions": {
+    "*": {
+      "clients/*": [
+        "src/clients/*.d.ts"
+      ]
+    }
+  },
   "scripts": {
     "nx": "nx",
     "ng": "yarn nx",


### PR DESCRIPTION
## Proposed change

Add typings for deep import path for classic node module resolution