### PR TITLE
chore: reverting removed lint dependency on build in nx.json

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -98,7 +98,8 @@
       },
       "executor": "@nx/eslint:lint",
       "inputs": ["lint"],
-      "cache": true
+      "cache": true,
+      "dependsOn": ["^build"]
     },
     "test": {
       "inputs": [


### PR DESCRIPTION
## Proposed change

Commit eb8aec15798664fa475bbe13bc574d1456b3ed30 broke the `yarn nx run ama-sdk-showcase-sdk:lint` command
(when run from an empty cache).
This PR reverts the specific change that caused the issue.
The issue was hidden until now in CI because of the reused cache.