### PR TITLE
fix: missing types when linting showcase-sdk

### DIFF
--- a/packages/@ama-sdk/showcase-sdk/tsconfig.build.json
+++ b/packages/@ama-sdk/showcase-sdk/tsconfig.build.json
@@ -24,24 +24,6 @@
     "composite": true,
     "declaration": true,
     "declarationMap": false,
-    "rootDir": "./src",
-    "baseUrl": ".",
-    "paths": {
-      "@ama-sdk/showcase-sdk/helpers/*": [
-        "./src/helpers/*"
-      ],
-      "@ama-sdk/showcase-sdk/helpers": [
-        "./src/helpers/index"
-      ],
-      "@ama-sdk/showcase-sdk": [
-        "./src/index"
-      ],
-      "@ama-sdk/showcase-sdk/*": [
-        "./src/*"
-      ],
-      "@ama-sdk/showcase-sdk/spec": [
-        "./src/spec/index"
-      ]
-    }
+    "rootDir": "./src"
   }
 }


### PR DESCRIPTION
## Proposed change

When linting showcase-sdk, if the build of dependent packages was not done (which is the case in CI), types of dependent packages are interpreted by typescript as `any` because the tsconfig in showcase-sdk overrides paths defined in the root of the repository and, as a consequence, typescript does not find the source files defining the types.

## Related issues

This PR supersedes #1306 
