### PR TITLE
fix(create): fail and show error if sub-process exits with non-zero code

### DIFF
--- a/packages/@ama-sdk/create/src/index.it.spec.ts
+++ b/packages/@ama-sdk/create/src/index.it.spec.ts
@@ -65,6 +65,15 @@ describe('Create new sdk command', () => {
       }, { ...execAppOptions, cwd: sdkPackagePath }
       )).not.toThrow();
     expect(() => packageManagerRun({script: 'build'}, { ...execAppOptions, cwd: sdkPackagePath })).not.toThrow();
-    expect(() => packageManagerRun({ script: 'doc:generate'}, { ...execAppOptions, cwd: sdkPackagePath })).not.toThrow();
+    expect(() => packageManagerRun({script: 'doc:generate'}, { ...execAppOptions, cwd: sdkPackagePath })).not.toThrow();
+  });
+
+  test('should fail when there is an error', () => {
+    expect(() =>
+      packageManagerCreate({
+        script: '@ama-sdk',
+        args: ['typescript', sdkPackageName, '--package-manager', packageManager, '--spec-path','./missing-file.yml']
+      }, execAppOptions)
+    ).toThrow('missing-file.yml does not exist');
   });
 });

--- a/packages/@ama-sdk/create/src/index.ts
+++ b/packages/@ama-sdk/create/src/index.ts
@@ -91,12 +91,15 @@ const run = () => {
   ];
 
   const errors = steps
-    .map((step) => spawnSync(step.runner || process.execPath, step.args, { stdio: 'pipe', cwd: step.cwd || process.cwd() }))
-    .map(({error}) => error)
-    .filter((err) => !!err);
+    .map((step) => spawnSync(step.runner || process.execPath, step.args, { stdio: 'inherit', cwd: step.cwd || process.cwd() }))
+    .filter(({error, status}) => (error || status !== 0));
 
   if (errors.length > 0) {
-    errors.forEach((err) => console.error(err));
+    errors.forEach(({error}) => {
+      if (error) {
+        console.error(error);
+      }
+    });
     process.exit(1);
   }
 };

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/index.ts
@@ -83,7 +83,7 @@ function ngGenerateTypescriptSDKFn(options: NgGenerateTypescriptSDKCoreSchematic
    */
   const generateSource = async () => {
     if (!existsSync(specPath)) {
-      throw new Error(`${specPath} does not exists`);
+      throw new Error(`${specPath} does not exist`);
     }
 
     const pathObjects = await generateOperationFinder();


### PR DESCRIPTION
## Proposed change

This PR fixes the following problem: in case a sub process started by `npm create @ama-sdk` or `npm create @o3r` fails (i.e. exiting with a non-zero code, for example, if the spec file given to the sdk generator does not exist, or if there is a dependency conflict when doing `npm install` as it was the case recently), the `npm create` command itself was hiding the error and exiting with 0.
