### PR TITLE
fix: remove deprecated prepareRuleset method

### DIFF
--- a/packages/@o3r/core/package.json
+++ b/packages/@o3r/core/package.json
@@ -160,7 +160,7 @@
     "@nx/eslint-plugin": "~18.0.2",
     "jsonc-eslint-parser": "~2.4.0",
     "eslint-import-resolver-node": "^0.3.4",
-    "eslint-plugin-jest": "~27.8.0",
+    "eslint-plugin-jest": "~27.9.0",
     "eslint-plugin-jsdoc": "~48.1.0",
     "eslint-plugin-prefer-arrow": "~1.2.3",
     "eslint-plugin-unicorn": "^51.0.0",

--- a/packages/@o3r/rules-engine/src/engine/ruleset-executor.ts
+++ b/packages/@o3r/rules-engine/src/engine/ruleset-executor.ts
@@ -320,12 +320,4 @@ export class RulesetExecutor {
       rulesResultsSubject$: result$
     } as EngineRuleset;
   }
-
-  /**
-   * Plug ruleset to fact streams and trigger a first evaluation
-   * @deprecated This function is not made to be accessible from Outside of the class, will be removed in v10
-   */
-  public prepareRuleset() {
-    return this.plugRuleset();
-  }
 }


### PR DESCRIPTION
## Proposed change

Follow up on #1044 

The comment mentions that it should be removed in v10. 

If it's too early we can do it in v12. 

