### PR TITLE
feat: configure light SDK with openapitools.json and options

### DIFF
--- a/packages/@ama-sdk/create/src/index.it.spec.ts
+++ b/packages/@ama-sdk/create/src/index.it.spec.ts
@@ -51,7 +51,11 @@ describe('Create new sdk command', () => {
 
   test('should generate a full SDK when the specification is provided', () => {
     expect(() =>
-      packageManagerCreate({script: '@ama-sdk', args: ['typescript', sdkPackageName, '--package-manager', packageManager, '--spec-path', './swagger-spec.yml']}, execAppOptions)).not.toThrow();
+      packageManagerCreate({
+        script: '@ama-sdk',
+        args: ['typescript', sdkPackageName, '--package-manager', packageManager, '--spec-path', path.join(sdkFolderPath, 'swagger-spec.yml')]
+      }, execAppOptions)
+    ).not.toThrow();
     expect(() => packageManagerRun({script: 'build'}, { ...execAppOptions, cwd: sdkPackagePath })).not.toThrow();
   });
 
@@ -74,6 +78,6 @@ describe('Create new sdk command', () => {
         script: '@ama-sdk',
         args: ['typescript', sdkPackageName, '--package-manager', packageManager, '--spec-path','./missing-file.yml']
       }, execAppOptions)
-    ).toThrow('missing-file.yml does not exist');
+    ).toThrow();
   });
 });

--- a/packages/@ama-sdk/schematics/README.md
+++ b/packages/@ama-sdk/schematics/README.md
@@ -119,6 +119,90 @@ Example:
 yarn schematics @ama-sdk/schematics:typescript-core --spec-path ./swagger-spec.yaml --global-property allowModelExtension
 ```
 
+#### Generator Configuration
+
+##### Parameters
+
+It is possible to configure the SDK code generation by passing parameters to the generator command line to override the default configuration values.
+The available parameters are:
+* `--spec-path`: Path to the swagger specification used to generate the SDK
+* `--spec-config-path`: Path to the spec generation configuration
+* `--global-property`: Comma separated string of options to give to the openapi-generator-cli
+* `--output-path`: Output path for the generated SDK
+* `--generator-custom-path`: Path to a custom generator
+
+#### openapitools.json
+
+There is also a possibility to configure the SDK code generation in `openapitools.json`. The structure for this file looks something like this:
+
+```json5
+{
+  "$schema": "https://raw.githubusercontent.com/OpenAPITools/openapi-generator-cli/master/apps/generator-cli/src/config.schema.json",
+  "generator-cli": {
+    "version": "0.0.0",
+    "storageDir": ".openapi-generator",
+    "generators": { // optional
+      "example-sdk": { // any name you like (can be referenced using --generator-key)
+        "generatorName": "typescriptFetch",
+        "output": ".",
+        "inputSpec": "./swagger-spec.yaml"
+      }
+    }
+  }
+}
+```
+
+`example-sdk` corresponds to the key of the generator which can be referenced in the generator command as a parameter, for example:
+
+```shell
+yarn schematics @ama-sdk/schematics:typescript-core --generator-key example-sdk
+```
+
+The properties `generatorName`, `output`, and `inputSpec` are required and additional properties can be added (available properties described in the schema 
+[here](https://github.com/OpenAPITools/openapi-generator-cli/blob/master/apps/generator-cli/src/config.schema.json)). For example, we can add the previously 
+described global properties `stringifyDate` and  `allowModelExtension`:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/OpenAPITools/openapi-generator-cli/master/apps/generator-cli/src/config.schema.json",
+  "generator-cli": {
+    "version": "0.0.0",
+    "storageDir": ".openapi-generator",
+    "generators": { 
+      "example-sdk": {
+        "generatorName": "typescriptFetch",
+        "output": ".",
+        "inputSpec": "./swagger-spec.yaml",
+        "globalProperty": {
+          "stringifyDate": true,
+          "allowModelExtension": true
+        }
+      }
+    }
+  }
+}
+```
+
+We have added the possibility in the generator command to both specify the generator key and override specific properties of said key.
+For example, if we want to use the properties of `example-sdk` from `openapitools.json` but override the global properties we can do so like this:
+
+```shell
+yarn schematics @ama-sdk/schematics:typescript-core --generator-key example-sdk --global-property stringifyDate=false
+```
+
+> [!CAUTION]
+> If the parameter `--generator-key` is provided in combination with other parameters to be overridden, the limitation is that not all
+> properties from `openapitools.json` will be taken into account (contrary to the case when there is only the `--generator-key` parameter). 
+> As of now, the only properties that will be taken into account are `output`, `inputSpec`, `config`, `globalProperty` which can be
+> overridden with the parameters `--output-path`, `--spec-path`, `--spec-config-path`, and `--global-property`.
+
+> [!NOTE]
+> The parameter `--generator-custom-path` is not impacted and will always be taken into account if provided.
+
+> [!NOTE]
+> The values provided by the parameter `--global-property` will actually be merged with the values of `globalProperty` from
+> `openapitools.json` (rather than override them like the other properties).
+
 ### Debug
 
 The OpenApi generator extracts an enhanced JSON data model from the specification YAML and uses this data model to feed the templates to generate the code.

--- a/packages/@ama-sdk/schematics/schematics/code-generator/open-api-cli-generator/open-api-cli.generator.ts
+++ b/packages/@ama-sdk/schematics/schematics/code-generator/open-api-cli-generator/open-api-cli.generator.ts
@@ -52,11 +52,14 @@ export class OpenApiCliGenerator extends CodeGenerator<OpenApiCliOptions> {
       'openapi-generator-cli',
       'generate',
       generatorOptions.generatorCustomPath ? `--custom-generator=${generatorOptions.generatorCustomPath}` : '',
-      '-g', generatorOptions.generatorName,
-      '-i', generatorOptions.specPath,
-      ...generatorOptions.specConfigPath ? ['-c', generatorOptions.specConfigPath] : [],
-      '-o', generatorOptions.outputPath,
-      ...generatorOptions.globalProperty ? ['--global-property', generatorOptions.globalProperty] : []
+      ...generatorOptions.generatorKey ? ['--generator-key', generatorOptions.generatorKey] :
+        [
+          '-g', generatorOptions.generatorName,
+          '-i', generatorOptions.specPath,
+          ...generatorOptions.specConfigPath ? ['-c', generatorOptions.specConfigPath] : [],
+          '-o', generatorOptions.outputPath,
+          ...generatorOptions.globalProperty ? ['--global-property', generatorOptions.globalProperty] : []
+        ]
     ];
     return new Promise<void>((resolve, reject) => {
       spawn(this.packageManagerRunner, args, spawnOptions)

--- a/packages/@ama-sdk/schematics/schematics/code-generator/open-api-cli-generator/open-api-cli.options.ts
+++ b/packages/@ama-sdk/schematics/schematics/code-generator/open-api-cli-generator/open-api-cli.options.ts
@@ -34,9 +34,22 @@ export type OpenApiCliOptions = CodegenTaskOptions & {
    * ```typescript
    * 'debugOperations'
    * ```
+   * @example To generate the dates as string types
+   * ```typescript
+   * 'stringifyDate'
+   * ```
+   * @example To be able to extend the SDK models and ensure that revivers are generated
+   * ```typescript
+   * 'allowModelExtension'
+   * ```
    * @default ''
    */
   globalProperty: string;
+  /**
+   * Run generator by key (from openapitools.json)
+   * @default ''
+   */
+  generatorKey: string;
 };
 
 /**
@@ -49,5 +62,6 @@ export const defaultTypescriptGeneratorOptions: OpenApiCliOptions = {
   specPath: 'swagger-spec.yaml',
   outputPath: '.',
   specConfigPath: '',
-  globalProperty: ''
+  globalProperty: '',
+  generatorKey: ''
 };

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/index.ts
@@ -13,7 +13,7 @@ import {
 } from '@angular-devkit/schematics';
 import type { Operation, PathObject } from '@ama-sdk/core';
 import { createSchematicWithMetricsIfInstalled } from '@o3r/schematics';
-import {existsSync, readFileSync} from 'node:fs';
+import { readFileSync } from 'node:fs';
 import * as path from 'node:path';
 import * as semver from 'semver';
 import * as sway from 'sway';
@@ -22,6 +22,36 @@ import { OpenApiCliOptions } from '../../code-generator/open-api-cli-generator/o
 import { treeGlob } from '../../helpers/tree-glob';
 import { NgGenerateTypescriptSDKCoreSchematicsSchema } from './schema';
 import { OpenApiCliGenerator } from '../../code-generator/open-api-cli-generator/open-api-cli.generator';
+
+const JAVA_OPTIONS = ['specPath', 'specConfigPath', 'globalProperty', 'outputPath'];
+const OPEN_API_TOOLS_OPTIONS = ['generatorName', 'output', 'inputSpec', 'config', 'globalProperty'];
+
+interface OpenApiToolsGenerator {
+  /** Location of the OpenAPI spec, as URL or file */
+  inputSpec: string;
+  /** Output path for the generated SDK */
+  output: string;
+  /** Generator to use */
+  generatorName: string;
+  /** Path to configuration file. It can be JSON or YAML */
+  config?: string;
+  /** Sets specified global properties */
+  globalProperty?: string | Record<string, any>;
+}
+
+interface OpenApiToolsGeneratorObject {
+  [generatorName: string]: OpenApiToolsGenerator;
+}
+
+interface OpenApiToolsGeneratorCli {
+  version: string;
+  generators: OpenApiToolsGeneratorObject;
+}
+
+interface OpenApiToolsConfiguration {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  'generator-cli': OpenApiToolsGeneratorCli;
+}
 
 const getRegexpTemplate = (regexp: RegExp) => `new RegExp('${regexp.toString().replace(/\/(.*)\//, '$1').replace(/\\\//g, '/')}')`;
 
@@ -36,119 +66,181 @@ const getPathObjectTemplate = (pathObj: PathObject) => {
     }`;
 };
 
+const getGlobalProperties = (globalPropertyMap: Map<string, any>, globalProperties: string) => {
+  const globalPropertiesArray = globalProperties.split(',');
+  globalPropertiesArray.forEach((property) => {
+    const [propName, propValue] = property.split('=');
+    globalPropertyMap.set(propName, propValue ?? true);
+  });
+  return globalPropertyMap;
+};
+
+const getGeneratorOptions = (tree: Tree, context: SchematicContext, options: NgGenerateTypescriptSDKCoreSchematicsSchema) => {
+  let openApiToolsJson: OpenApiToolsConfiguration | undefined;
+  let openApiToolsJsonGenerator: OpenApiToolsGenerator | undefined;
+  const openApiToolsPath = path.posix.join(options.directory || '', 'openapitools.json');
+
+  // read openapitools.json
+  if (tree.exists(openApiToolsPath)) {
+    try {
+      openApiToolsJson = (tree.readJson(openApiToolsPath) as any as OpenApiToolsConfiguration);
+    } catch (e: any) {
+      context.logger.warn(`File ${openApiToolsPath} could not be parsed. Error message:\n${e}`);
+    }
+  } else {
+    context.logger.warn(`File not found at ${openApiToolsPath}`);
+  }
+  const openApiVersion = openApiToolsJson?.['generator-cli'].version;
+
+  // get generator config if generator key is provided
+  if (openApiToolsJson && options.generatorKey) {
+    openApiToolsJsonGenerator = openApiToolsJson['generator-cli'].generators?.[options.generatorKey];
+    if (!openApiToolsJsonGenerator) {
+      context.logger.warn(`Generator ${options.generatorKey} not found in ${openApiToolsPath} file`);
+    } else if (openApiToolsJsonGenerator.generatorName !== 'typescriptFetch') {
+      context.logger.warn(`Generator ${openApiToolsJsonGenerator.generatorName} is not supported. By default, the generator name is set to typescriptFetch (the only supported generator).`);
+    }
+  }
+
+  const specPath = options.specPath || openApiToolsJsonGenerator?.inputSpec;
+  if (!specPath) {
+    throw new Error('Path to the swagger/open-api specification is undefined');
+  }
+
+  const generatorOptions: Partial<OpenApiCliOptions> = {specPath};
+
+  const packageJsonFile: { openApiSupportedVersion?: string } = JSON.parse((readFileSync(path.join(__dirname, '..', '..', '..', 'package.json'))).toString());
+  const packageOpenApiSupportedVersionRange = packageJsonFile.openApiSupportedVersion;
+  const packageOpenApiSupportedVersion = packageOpenApiSupportedVersionRange && semver.minVersion(packageOpenApiSupportedVersionRange)?.version;
+  if (!!packageOpenApiSupportedVersionRange && !!packageOpenApiSupportedVersion
+    && semver.valid(packageOpenApiSupportedVersion) && (!openApiVersion || !semver.satisfies(openApiVersion, packageOpenApiSupportedVersionRange))
+  ) {
+    generatorOptions.generatorVersion = packageOpenApiSupportedVersion;
+    context.logger.warn((openApiVersion ? `Version ${openApiVersion} is not supported` : `Version not provided`) + `, fallback to ${packageOpenApiSupportedVersion}`);
+  } else if (!!openApiVersion && semver.valid(openApiVersion)) {
+    generatorOptions.generatorVersion = openApiVersion;
+  }
+
+  const specConfigPath = options.specConfigPath || openApiToolsJsonGenerator?.config;
+  const outputPath = options.outputPath || openApiToolsJsonGenerator?.output;
+
+  // combine global properties from openapitools.json and options
+  let globalPropertyMap: Map<string, any> = new Map();
+  if (openApiToolsJsonGenerator?.globalProperty) {
+    if (typeof openApiToolsJsonGenerator.globalProperty === 'object') {
+      Object.entries(openApiToolsJsonGenerator.globalProperty).forEach(([key, value]) => globalPropertyMap.set(key, value));
+    } else {
+      globalPropertyMap = getGlobalProperties(globalPropertyMap, openApiToolsJsonGenerator.globalProperty);
+    }
+  }
+  if (options.globalProperty) {
+    globalPropertyMap = getGlobalProperties(globalPropertyMap, options.globalProperty);
+  }
+  const globalProperty = Array.from(globalPropertyMap).map(([key, value]) => `${key}=${value}`).join(',');
+
+  // log warning of options that won't be taken into account if generator key and other options are provided in the command
+  if (options.generatorKey && openApiToolsJsonGenerator && JAVA_OPTIONS.some((optionName) => typeof options[optionName] !== undefined)) {
+    Object.keys(openApiToolsJsonGenerator).filter((option) => !OPEN_API_TOOLS_OPTIONS.includes(option))
+      .forEach((ignoredOption) => context.logger.warn(`Option ${ignoredOption} from ${openApiToolsPath} will not be taken into account`));
+  }
+
+  return {
+    ...generatorOptions,
+    ...(outputPath ? {outputPath} : {}),
+    ...(specConfigPath ? {specConfigPath} : {}),
+    ...(globalProperty ? {globalProperty} : {}),
+    ...(options.generatorCustomPath ? {generatorCustomPath: options.generatorCustomPath} : {})
+  };
+};
+
 /**
  * Generate a typescript SDK source code base on swagger specification
  * @param options
  */
 function ngGenerateTypescriptSDKFn(options: NgGenerateTypescriptSDKCoreSchematicsSchema): Rule {
 
-  const specPath = path.resolve(process.cwd(), options.specPath);
-  const targetPath = options.directory || '';
-  const globalProperty = options.globalProperty;
+  return (tree, context) => {
+    const targetPath = options.directory || '';
+    const generatorOptions = getGeneratorOptions(tree, context, options);
 
-  const generateOperationFinder = async (): Promise<PathObject[]> => {
-    const swayOptions = {
-      definition: path.resolve(options.specPath)
+    /**
+     * rule to clear previous SDK generation
+     */
+    const clearGeneratedCode = () => {
+      treeGlob(tree, path.posix.join(targetPath, 'src', 'api', '**', '*.ts')).forEach((file) => tree.delete(file));
+      treeGlob(tree, path.posix.join(targetPath, 'src', 'models', 'base', '**', '!(index).ts')).forEach((file) => tree.delete(file));
+      treeGlob(tree, path.posix.join(targetPath, 'src', 'spec', '!(operation-adapter|index).ts')).forEach((file) => tree.delete(file));
+      return tree;
     };
-    const swayApi = await sway.create(swayOptions);
-    const extraction = swayApi.getPaths().map((obj) => ({
-      path: `${obj.path as string}`,
-      regexp: obj.regexp as RegExp,
-      operations: obj.getOperations().map((op: any) => {
-        const operation: Operation = {
-          method: `${op.method as string}`,
-          operationId: `${op.operationId as string}`
-        };
-        return operation;
-      }) as Operation[]
-    }));
-    return extraction || [];
-  };
 
-  /**
-   * rule to clear previous SDK generation
-   * @param tree
-   * @param _context
-   */
-  const clearGeneratedCode = (tree: Tree, _context: SchematicContext) => {
-    treeGlob(tree, path.posix.join(targetPath, 'src', 'api', '**', '*.ts')).forEach((file) => tree.delete(file));
-    treeGlob(tree, path.posix.join(targetPath, 'src', 'models', 'base', '**', '!(index).ts')).forEach((file) => tree.delete(file));
-    treeGlob(tree, path.posix.join(targetPath, 'src', 'spec', '!(operation-adapter|index).ts')).forEach((file) => tree.delete(file));
-    return tree;
-  };
+    const generateOperationFinder = async (): Promise<PathObject[]> => {
+      const swayOptions = {
+        definition: path.resolve(generatorOptions.specPath!)
+      };
+      const swayApi = await sway.create(swayOptions);
+      const extraction = swayApi.getPaths().map((obj) => ({
+        path: obj.path,
+        regexp: obj.regexp as RegExp,
+        operations: obj.getOperations().map((op: any) => ({method: op.method, operationId: op.operationId} as Operation))
+      }));
+      return extraction || [];
+    };
 
-  /**
-   * rule to update readme and generate mandatory code source
-   */
-  const generateSource = async () => {
-    if (!existsSync(specPath)) {
-      throw new Error(`${specPath} does not exist`);
-    }
+    /**
+     * rule to update readme and generate mandatory code source
+     */
+    const generateSource = async () => {
+      const pathObjects = await generateOperationFinder();
+      const swayOperationAdapter = `[${pathObjects.map((pathObj) => getPathObjectTemplate(pathObj)).join(',')}]`;
 
-    const pathObjects = await generateOperationFinder();
-    const swayOperationAdapter = `[${pathObjects.map((pathObj) => getPathObjectTemplate(pathObj)).join(',')}]`;
+      return mergeWith(apply(url('./templates'), [
+        template({
+          ...options,
+          swayOperationAdapter,
+          empty: ''
+        }),
+        move(targetPath),
+        renameTemplateFiles()
+      ]), MergeStrategy.Overwrite);
+    };
 
-    return mergeWith(apply(url('./templates'), [
-      template({
-        ...options,
-        swayOperationAdapter,
-        empty: ''
-      }),
-      move(targetPath),
-      renameTemplateFiles()
-    ]), MergeStrategy.Overwrite);
-  };
+    /**
+     * Update local swagger spec file
+     */
+    const updateSpec = () => {
+      const readmeFile = path.posix.join(targetPath, 'readme.md');
+      const specContent = readFileSync(generatorOptions.specPath!).toString();
+      if (tree.exists(readmeFile)) {
+        const specVersion = /version: *([0-9]+\.[0-9]+\.[0-9]+(?:-[^ ]+)?)/.exec(specContent);
 
-  /**
-   * Update local swagger spec file
-   * @param tree
-   * @param _context
-   */
-  const updateSpec = (tree: Tree, _context: SchematicContext) => {
-    const readmeFile = path.posix.join(targetPath, 'readme.md');
-    const specContent = readFileSync(specPath).toString();
-    if (tree.exists(readmeFile)) {
-      const swaggerVersion = /version: ([0-9]+\.[0-9]+\.[0-9]+)/.exec(specContent);
-
-      if (swaggerVersion) {
-        const readmeContent = tree.read(readmeFile)!.toString('utf8');
-        tree.overwrite(readmeFile, readmeContent.replace(/Based on Swagger spec .*/i, `Based on Swagger spec ${swaggerVersion[1]}`));
+        if (specVersion) {
+          const readmeContent = tree.read(readmeFile)!.toString('utf8');
+          tree.overwrite(readmeFile, readmeContent.replace(/Based on Swagger spec .*/i, `Based on Swagger spec ${specVersion[1]}`));
+        }
       }
-    }
 
-    if (tree.exists(path.posix.join(targetPath, 'swagger-spec.yaml'))) {
-      tree.overwrite(path.posix.join(targetPath, 'swagger-spec.yaml'), specContent);
-    } else {
-      tree.create(path.posix.join(targetPath, 'swagger-spec.yaml'), specContent);
-    }
-    return () => tree;
+      if (tree.exists(path.posix.join(targetPath, 'swagger-spec.yaml'))) {
+        tree.overwrite(path.posix.join(targetPath, 'swagger-spec.yaml'), specContent);
+      } else {
+        tree.create(path.posix.join(targetPath, 'swagger-spec.yaml'), specContent);
+      }
+      return () => tree;
+    };
+
+    const runGeneratorRule = () => {
+      return () => (new OpenApiCliGenerator(options)).getGeneratorRunSchematic(
+        (options.generatorKey && JAVA_OPTIONS.every((optionName) => options[optionName] === undefined)) ? {generatorKey: options.generatorKey} : generatorOptions,
+        {rootDirectory: options.directory || undefined}
+      );
+    };
+
+    return chain([
+      clearGeneratedCode,
+      generateSource,
+      updateSpec,
+      runGeneratorRule
+    ]);
   };
-
-  const runGeneratorRule = (tree: Tree, context: SchematicContext) => {
-    const generatorOptions: Partial<OpenApiCliOptions> = {specPath, globalProperty};
-    const packageJsonFile: {openApiSupportedVersion?: string} = JSON.parse((readFileSync(path.join(__dirname, '..', '..', '..', 'package.json'))).toString());
-    const packageOpenApiSupportedVersion: string | undefined = packageJsonFile.openApiSupportedVersion?.replace(/\^|~/, '');
-    let openApiVersion = '';
-    try {
-      openApiVersion = (tree.readJson(path.posix.join(targetPath, 'openapitools.json')) as any)?.['generator-cli']?.version;
-    } catch {
-      context.logger.warn('No openapitools.json file found in the project');
-    }
-    if (!!packageOpenApiSupportedVersion && semver.valid(packageOpenApiSupportedVersion) && (!packageOpenApiSupportedVersion || !semver.satisfies(openApiVersion, packageOpenApiSupportedVersion))) {
-      generatorOptions.generatorVersion = packageOpenApiSupportedVersion;
-    }
-    if (options.specConfigPath) {
-      generatorOptions.specConfigPath = options.specConfigPath;
-    }
-    return () => (new OpenApiCliGenerator(options)).getGeneratorRunSchematic(generatorOptions, {rootDirectory: options.directory || undefined});
-  };
-
-  return chain([
-    clearGeneratedCode,
-    generateSource,
-    updateSpec,
-    runGeneratorRule
-  ]);
 }
 
 /**

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/schema.json
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/schema.json
@@ -7,7 +7,6 @@
     "specPath": {
       "type": "string",
       "description": "Path to the swagger/open-api specification used to generate the SDK",
-      "x-prompt": "Path to the swagger / open-api spec",
       "$default": {
         "$source": "argv",
         "index": 0
@@ -32,10 +31,19 @@
     "globalProperty": {
       "type": "string",
       "description": "Comma separated string of options to give to the openapi-generator-cli"
+    },
+    "generatorKey": {
+      "type": "string",
+      "description": "Run generator by key (from openapitools.json)"
+    },
+    "outputPath": {
+      "type": "string",
+      "description": "Output path for the generated SDK"
+    },
+    "generatorCustomPath": {
+      "type": "string",
+      "description": "Path to a custom generator"
     }
   },
-  "additionalProperties": true,
-  "required": [
-    "specPath"
-  ]
+  "additionalProperties": true
 }

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/schema.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/schema.ts
@@ -2,7 +2,7 @@ import type { SchematicOptionObject } from '@o3r/schematics';
 
 export interface NgGenerateTypescriptSDKCoreSchematicsSchema extends SchematicOptionObject {
   /** Path to the swagger specification used to generate the SDK */
-  specPath: string;
+  specPath?: string;
 
   /** Directory where to generate the SDK */
   directory?: string | undefined;
@@ -17,13 +17,29 @@ export interface NgGenerateTypescriptSDKCoreSchematicsSchema extends SchematicOp
    * Comma separated string of options to give to the openapi-generator-cli
    * @example To log the full json structure used to generate models
    * ```typescript
-   * 'debugModule'
+   * 'debugModels'
    * ```
    * @example To log the full json structure used to generate operations
    * ```typescript
    * 'debugOperations'
    * ```
-   * @default ''
+   * @example To generate the dates as string types
+   * ```typescript
+   * 'stringifyDate'
+   * ```
+   * @example To be able to extend the SDK models and ensure that revivers are generated
+   * ```typescript
+   * 'allowModelExtension'
+   * ```
    */
   globalProperty: string | undefined;
+
+  /** Run generator by key (from openapitools.json) */
+  generatorKey: string | undefined;
+
+  /** Output path for the generated SDK */
+  outputPath: string | undefined;
+
+  /** Path to a custom generator */
+  generatorCustomPath: string | undefined;
 }

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/index.spec.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/index.spec.ts
@@ -95,4 +95,10 @@ describe('Typescript Shell Generator', () => {
     expect(npmTree.readContent('/package.json')).toContain('npm exec');
     expect(npmTree.readContent('/package.json')).not.toContain('yarn exec');
   });
+
+  it('should generate correct openapitools.json', () => {
+    const openApiTools = JSON.parse(yarnTree.readContent('/openapitools.json'));
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    expect(openApiTools['generator-cli'].generators).toEqual(expect.objectContaining({'test-scope-test-sdk': expect.anything()}));
+  });
 });

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/openapitools.json
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/openapitools.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "https://raw.githubusercontent.com/OpenAPITools/openapi-generator-cli/master/apps/generator-cli/src/config.schema.json",
-  "spaces": 2,
-  "generator-cli": {
-    "version": "<%= openApiSupportedVersion %>",
-    "storageDir": ".openapi-generator"
-  }
-}

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/openapitools.json.template
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/openapitools.json.template
@@ -2,16 +2,13 @@
   "$schema": "https://raw.githubusercontent.com/OpenAPITools/openapi-generator-cli/master/apps/generator-cli/src/config.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "6.6.0",
+    "version": "<%= openApiSupportedVersion %>",
     "storageDir": ".openapi-generator",
     "generators": {
-      "ama-sdk-showcase-sdk": {
+      "<%=projectName%>-<%=projectPackageName%>": {
         "generatorName": "typescriptFetch",
         "output": ".",
-        "inputSpec": "./swagger-spec.yaml",
-        "globalProperty": {
-          "stringifyDate": true
-        }
+        "inputSpec": "./swagger-spec.yaml"
       }
     }
   }

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/package.json.template
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/package.json.template
@@ -40,7 +40,7 @@
     "set:version": "o3r-set-version --placeholder 0.0.0-placeholder",
     "resolve": "node -e 'process.stdout.write(require.resolve(process.argv[1]));'",
     "generate": "schematics @ama-sdk/schematics:typescript-core",
-    "spec:regen": "<%=packageManager%> run generate <% if (packageManager === 'npm') {%>-- <%}%>--spec-path ./swagger-spec.yaml && amasdk-clear-index",
+    "spec:regen": "<%=packageManager%> run generate <% if (packageManager === 'npm') {%>-- <%}%>--generator-key <%=projectName%>-<%=projectPackageName%> && amasdk-clear-index",
     "files:pack": "amasdk-files-pack",
     "test": "jest --passWithNoTests",
     "publish:package": "npm publish ./dist",

--- a/packages/@ama-sdk/showcase-sdk/package.json
+++ b/packages/@ama-sdk/showcase-sdk/package.json
@@ -39,7 +39,7 @@
     "build:esm2015": "swc src -d dist/esm2015 -C module.type=es6 -q",
     "build:esm2020": "tsc -b tsconfigs/esm2020",
     "resolve": "node -e 'process.stdout.write(require.resolve(process.argv[1]));'",
-    "generate": "schematics ../schematics:typescript-core --spec-path ./swagger-spec.yaml --global-property stringifyDate",
+    "generate": "schematics ../schematics:typescript-core --generator-key ama-sdk-showcase-sdk",
     "spec:regen": "yarn run generate --no-dry-run && amasdk-clear-index",
     "files:pack": "yarn amasdk-files-pack",
     "test": "jest --passWithNoTests",


### PR DESCRIPTION
## Proposed change

Possibility of generating typescript SDK without revivers when they are not necessary.
Configuration in `openapitools.json` and combination of provided options.

## Related issues

- :rocket: Feature [#(1337)](https://github.com/AmadeusITGroup/otter/issues/1337)
