### PR TITLE
test: remove legacy-peer-deps with npm in it-tests

### DIFF
--- a/packages/@o3r/create/package.json
+++ b/packages/@o3r/create/package.json
@@ -37,6 +37,7 @@
     "@o3r/build-helpers": "workspace:^",
     "@o3r/eslint-config-otter": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
+    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@stylistic/eslint-plugin-ts": "^1.5.4",
     "@types/jest": "~29.5.2",

--- a/packages/@o3r/create/src/index.ts
+++ b/packages/@o3r/create/src/index.ts
@@ -157,7 +157,8 @@ const prepareWorkspace = (relativeDirectory = '.', projectPackageManager = 'npm'
     '@angular-devkit/schematics',
     '@schematics/angular',
     '@angular-devkit/core',
-    '@angular-devkit/architect'
+    '@angular-devkit/architect',
+    '@o3r/schematics'
   ];
 
   const packageJsonPath = resolve(cwd, 'package.json');

--- a/packages/@o3r/design/package.json
+++ b/packages/@o3r/design/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "jsonschema": "~1.4.1",
+    "minimatch": "~9.0.3",
     "minimist": "^1.2.6",
     "tslib": "^2.5.3"
   },
@@ -55,7 +56,6 @@
     "@o3r/styling": "workspace:^",
     "chokidar": "^3.5.2",
     "globby": "^11.1.0",
-    "minimatch": "~9.0.3",
     "sass": "~1.71.0"
   },
   "peerDependenciesMeta": {
@@ -126,7 +126,6 @@
     "jest-junit": "~16.0.0",
     "jsonc-eslint-parser": "~2.4.0",
     "jsonschema": "~1.4.1",
-    "minimatch": "~9.0.3",
     "nx": "~18.0.2",
     "rxjs": "^7.8.1",
     "sass": "~1.71.0",

--- a/packages/@o3r/test-helpers/src/utilities/package-manager.ts
+++ b/packages/@o3r/test-helpers/src/utilities/package-manager.ts
@@ -235,7 +235,6 @@ export function setPackagerManagerConfig(options: PackageManagerConfig, execAppO
 
   execFileSync('npm', ['config', 'set', 'audit=false', '-L=project'], execOptions);
   execFileSync('npm', ['config', 'set', 'fund=false', '-L=project'], execOptions);
-  execFileSync('npm', ['config', 'set', 'legacy-peer-deps=true', '-L=project'], execOptions);
   execFileSync('npm', ['config', 'set', 'prefer-offline=true', '-L=project'], execOptions);
   execFileSync('npm', ['config', 'set', 'ignore-scripts=true', '-L=project'], execOptions);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6809,6 +6809,7 @@ __metadata:
     "@o3r/build-helpers": "workspace:^"
     "@o3r/eslint-config-otter": "workspace:^"
     "@o3r/eslint-plugin": "workspace:^"
+    "@o3r/schematics": "workspace:^"
     "@o3r/test-helpers": "workspace:^"
     "@schematics/angular": "npm:~17.2.0"
     "@stylistic/eslint-plugin-ts": "npm:^1.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6909,7 +6909,6 @@ __metadata:
     "@o3r/styling": "workspace:^"
     chokidar: ^3.5.2
     globby: ^11.1.0
-    minimatch: ~9.0.3
     sass: ~1.71.0
   peerDependenciesMeta:
     "@o3r/core":


### PR DESCRIPTION
## Proposed change

As most npm users do not enable the legacy-peer-deps option (it is not enabled by default), it is important run npm it-tests without it.