### PR TITLE
fix: avoid deleting property if category defined locally

### DIFF
--- a/packages/@o3r/components/builders/component-extractor/helpers/component/component.parser.ts
+++ b/packages/@o3r/components/builders/component-extractor/helpers/component/component.parser.ts
@@ -63,6 +63,7 @@ export interface ParserOutput {
  * Component extractor parser.
  */
 export class ComponentParser {
+  private globalConfigCategoriesMap: Map<string, string>;
 
   /**
    * @param libraryName
@@ -79,7 +80,9 @@ export class ComponentParser {
     private strictMode: boolean = false,
     private libraries: string[] = [],
     private globalConfigCategories: CategoryDescription[] = []
-  ) {}
+  ) {
+    this.globalConfigCategoriesMap = new Map(this.globalConfigCategories.map((category) => [category.name, category.label]));
+  }
 
   /** Get the list of patterns from tsconfig.json */
   private getPatternsFromTsConfig() {
@@ -125,22 +128,23 @@ export class ComponentParser {
     const configurationFileExtractor = new ComponentConfigExtractor(this.libraryName, this.strictMode, source, this.logger, file, checker, this.libraries);
     const configuration = configurationFileExtractor.extract();
     if (configuration.configurationInformation) {
-      const globalConfigCategoriesMap = new Map(this.globalConfigCategories.map((category) => [category.name, category.label]));
       (configuration.configurationInformation.categories || []).forEach((category) => {
-        if (globalConfigCategoriesMap.has(category.name)) {
+        if (this.globalConfigCategoriesMap.has(category.name)) {
           this.logger.warn(`The category ${category.name} is already defined in the global ones.`);
         }
       });
       const categoriesMap = new Map((configuration.configurationInformation.categories || []).map((category) => [category.name, category.label]));
       configuration.configurationInformation.properties.forEach((prop) => {
         if (prop.category) {
-          if (!categoriesMap.has(prop.category) && globalConfigCategoriesMap.has(prop.category)) {
-            categoriesMap.set(prop.category, globalConfigCategoriesMap.get(prop.category)!);
-          } else {
-            this.logger.warn(
-              `The property ${prop.name} from ${configuration.configurationInformation!.name} has an unknown category ${prop.category}. The category will not be set for this property.`
-            );
-            delete prop.category;
+          if (!categoriesMap.has(prop.category)) {
+            if (this.globalConfigCategoriesMap.has(prop.category)) {
+              categoriesMap.set(prop.category, this.globalConfigCategoriesMap.get(prop.category)!);
+            } else {
+              this.logger.warn(
+                `The property ${prop.name} from ${configuration.configurationInformation!.name} has an unknown category ${prop.category}. The category will not be set for this property.`
+              );
+              delete prop.category;
+            }
           }
         }
       });


### PR DESCRIPTION
## Proposed change

It's a small bugfix to avoid deleting @o3rCategory property.
The else clause was used whenever the category was defined locally.

| Local category | Global category | Before fix | After fix |
|---|---|---|---|
| FALSE | FALSE | category deleted | category deleted |
| FALSE | TRUE | category kept | category kept |
| TRUE | TRUE | category deleted | **category kept** |
| TRUE | FALSE | category deleted | **category kept** |


