### PR TITLE
fix(telemetry): do not wait for tasks

### DIFF
--- a/packages/@o3r/telemetry/src/schematics/index.spec.ts
+++ b/packages/@o3r/telemetry/src/schematics/index.spec.ts
@@ -18,17 +18,15 @@ jest.mock('node:perf_hooks', () => {
 });
 
 import { callRule, Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
-import { lastValueFrom, of } from 'rxjs';
+import { lastValueFrom } from 'rxjs';
 import { createSchematicWithMetrics, SchematicWrapper } from './index';
 
 let context: SchematicContext;
 let debug: jest.Mock;
-let executePostTasks: jest.Mock;
 
 describe('createSchematicWithMetricsIfInstalled', () => {
   beforeEach(() => {
     debug = jest.fn();
-    executePostTasks = jest.fn().mockReturnValue(of(''));
     context = {
       schematic: {
         description: {
@@ -37,9 +35,6 @@ describe('createSchematicWithMetricsIfInstalled', () => {
           },
           name: 'MySchematic'
         }
-      },
-      engine: {
-        executePostTasks
       },
       interactive: false,
       logger: {
@@ -60,7 +55,6 @@ describe('createSchematicWithMetricsIfInstalled', () => {
     expect(originalSchematic).toHaveBeenCalled();
     expect(originalSchematic).toHaveBeenCalledWith(options);
     expect(rule).toHaveBeenCalled();
-    expect(executePostTasks).toHaveBeenCalled();
     expect(debug).toHaveBeenCalled();
     expect(debug).toHaveBeenCalledWith(JSON.stringify({
       environment: { env: 'env' },
@@ -82,7 +76,6 @@ describe('createSchematicWithMetricsIfInstalled', () => {
     expect(originalSchematic).toHaveBeenCalled();
     expect(originalSchematic).toHaveBeenCalledWith(options);
     expect(rule).toHaveBeenCalled();
-    expect(executePostTasks).toHaveBeenCalled();
     expect(debug).toHaveBeenCalled();
     expect(debug).toHaveBeenCalledWith(JSON.stringify({
       environment: { env: 'env' },
@@ -104,7 +97,6 @@ describe('createSchematicWithMetricsIfInstalled', () => {
     expect(originalSchematic).toHaveBeenCalled();
     expect(originalSchematic).toHaveBeenCalledWith(options);
     expect(rule).toHaveBeenCalled();
-    expect(executePostTasks).not.toHaveBeenCalled();
     expect(debug).toHaveBeenCalled();
     expect(debug).toHaveBeenCalledWith(expect.stringContaining('error example'));
   });

--- a/packages/@o3r/telemetry/src/schematics/index.ts
+++ b/packages/@o3r/telemetry/src/schematics/index.ts
@@ -27,7 +27,6 @@ export const createSchematicWithMetrics: SchematicWrapper =
     try {
       const rule = schematicFn(options);
       await lastValueFrom(callRule(rule, tree, context));
-      await lastValueFrom(context.engine.executePostTasks());
     }
     catch (e: any) {
       const err = e instanceof Error ? e : new Error(error);
@@ -57,7 +56,7 @@ export const createSchematicWithMetrics: SchematicWrapper =
         ?? (packageJson.config as JsonObject)?.o3rMetrics
       );
       if (shouldSendData) {
-        if (typeof ((options as any).o3rMetrics ?? typeof process.env.O3R_METRICS) === 'undefined') {
+        if (typeof ((options as any).o3rMetrics ?? process.env.O3R_METRICS) === 'undefined') {
           context.logger.info(
             'Telemetry is globally activated for the project (`config.o3rMetrics` in package.json). '
             + 'If you personally don\'t want to send telemetry, you can deactivate it by setting `O3R_METRICS` to false in your environment variables, '


### PR DESCRIPTION
## Proposed change
We should not wait for tasks to complete because if there are none the schematics will fail.
maybe we can open an issue to ask [executePostTasks](https://github.com/angular/angular-cli/blob/main/packages/angular_devkit/schematics/src/engine/engine.ts#L380) to not throw an error when we do `lastValueFrom` if there are no tasks pending
