### PR TITLE
fix(devkit): improve localization override performances

### DIFF
--- a/packages/@o3r/localization/src/devkit/localization-devtools.console.service.ts
+++ b/packages/@o3r/localization/src/devkit/localization-devtools.console.service.ts
@@ -84,9 +84,11 @@ export class LocalizationDevtoolsConsoleService implements DevtoolsServiceInterf
    * @inheritdoc
    */
   public updateLocalizationKeys(keyValues: { [key: string]: string }, language?: string): void | Promise<void> {
-    Object.entries(keyValues).map(([key, value]) => {
-      this.localizationService.getTranslateService().set(key, value, language || this.localizationDevtools.getCurrentLanguage());
-    });
+    this.localizationService.getTranslateService().setTranslation(
+      language || this.localizationDevtools.getCurrentLanguage(),
+      keyValues,
+      true
+    );
     this.appRef.tick();
   }
 


### PR DESCRIPTION
## Proposed change

When we had too many localization keys to update the application was freezing.
If we use `setTranslation` once instead of `set` for every keys it's much more faster.
(improvement from ~20ms per key to less than 100ms for all keys)