### PR TITLE
fix(devkit): remove call to appRef.tick because refresh is already handled by setTranslation

### DIFF
--- a/packages/@o3r/localization/src/devkit/localization-devtools.console.service.ts
+++ b/packages/@o3r/localization/src/devkit/localization-devtools.console.service.ts
@@ -89,7 +89,6 @@ export class LocalizationDevtoolsConsoleService implements DevtoolsServiceInterf
       keyValues,
       true
     );
-    this.appRef.tick();
   }
 
   /**


### PR DESCRIPTION
## Proposed change

![image](https://github.com/AmadeusITGroup/otter/assets/52541061/d730ccd4-fdda-4cde-a3de-8191b2cfa09f)

Issue happens only when switching back to a language already loaded.