### PR TITLE
fix: schematic generating library

### DIFF
--- a/packages/@o3r/workspace/schematics/library/index.spec.ts
+++ b/packages/@o3r/workspace/schematics/library/index.spec.ts
@@ -51,8 +51,6 @@ describe('New module generator', () => {
     }, initialTree);
 
     expect(spy).toHaveBeenNthCalledWith(1, '@schematics/angular', 'library', expect.anything());
-    expect(spy).toHaveBeenNthCalledWith(2, '@o3r/core', 'ng-add', expect.anything());
-    expect(spy).toHaveBeenNthCalledWith(3, '@o3r/core', 'ng-add-create', expect.anything());
     expect(tree.exists('/packages-test/my-new-module/tsconfig.json')).toBe(true);
     expect(tree.exists('/packages-test/my-new-module/project.json')).toBe(false);
     expect(JSON.parse(tree.readContent('/tsconfig.base.json')).compilerOptions.paths['@my/new-module']).toContain('packages-test/my-new-module/src/public-api');

--- a/packages/@o3r/workspace/schematics/library/index.ts
+++ b/packages/@o3r/workspace/schematics/library/index.ts
@@ -1,4 +1,5 @@
-import { chain, externalSchematic, noop, Rule, strings } from '@angular-devkit/schematics';
+import { chain, noop, Rule, strings } from '@angular-devkit/schematics';
+import { RunSchematicTask } from '@angular-devkit/schematics/tasks';
 import * as path from 'node:path';
 import {
   applyEsLintFix,
@@ -57,10 +58,11 @@ function generateModuleFn(options: NgGenerateModuleSchema): Rule {
         dependencies,
         skipInstall: options.skipInstall,
         ngAddToRun: Object.keys(dependencies),
-        projectName: options.name
+        projectName: options.name,
+        scheduleTaskCallback: (ids) => {
+          context.addTask(new RunSchematicTask('@o3r/core', 'ng-add-create', { name: extendedOptions.name, projectName: extendedOptions.name, path: targetPath }), ids);
+        }
       }),
-      (t, c) => externalSchematic('@o3r/core', 'ng-add', { ...options, projectName: extendedOptions.name })(t, c),
-      (t, c) => externalSchematic('@o3r/core', 'ng-add-create', { name: extendedOptions.name, projectName: extendedOptions.name, path: targetPath })(t, c),
       options.skipLinter ? noop() : applyEsLintFix()
     ])(tree, context);
   };


### PR DESCRIPTION
## Proposed change

Fix the generation of `library` by avoiding call twice the `ng-add` schematics from `@o3r/core`
