### PR TITLE
fix: missing peer deps in eslint-config-otter

### DIFF
--- a/packages/@o3r/eslint-config-otter/schematics/ng-add/index.ts
+++ b/packages/@o3r/eslint-config-otter/schematics/ng-add/index.ts
@@ -35,11 +35,14 @@ export function ngAdd(options: NgAddSchematicsSchema): Rule {
           [
             'eslint',
             '@angular-eslint/builder',
+            '@angular-eslint/eslint-plugin',
             '@typescript-eslint/parser',
             '@typescript-eslint/eslint-plugin',
+            'eslint-plugin-jest',
             'eslint-plugin-jsdoc',
             'eslint-plugin-prefer-arrow',
             'eslint-plugin-unicorn',
+            'jest',
             'jsonc-eslint-parser'
           ],
           path.resolve(__dirname, '..', '..', 'package.json'),


### PR DESCRIPTION
## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
