### PR TITLE
feat(create): allow pinning the version with --exact-o3r-version

### DIFF
--- a/packages/@ama-sdk/create/README.md
+++ b/packages/@ama-sdk/create/README.md
@@ -33,6 +33,7 @@ npm create @ama-sdk typescript <project-name> -- --package-manager=yarn [...opti
 - `--spec-path`: Path to the swagger/open-api specification used to generate the SDK
 - `--package-manager`: Node package manager to be used (`npm` and `yarn` are available).
 - `--debug`: Enable schematics debug mode (including dry run).
+- `--exact-o3r-version` : use a pinned version for [otter packages](https://github.com/AmadeusITGroup/otter/blob/main/docs/README.md).
 
 > [!NOTE]
 > If the `--spec-path` is specified, the SDK will be generated based on this specification at the creation time.

--- a/packages/@ama-sdk/create/package.json
+++ b/packages/@ama-sdk/create/package.json
@@ -17,13 +17,13 @@
     "prepare:publish": "prepare-publish ./dist"
   },
   "dependencies": {
-    "@ama-sdk/core": "workspace:^",
-    "@ama-sdk/schematics": "workspace:^",
+    "@ama-sdk/core": "workspace:*",
+    "@ama-sdk/schematics": "workspace:*",
     "@angular-devkit/core": "~17.2.0",
     "@angular-devkit/schematics": "~17.2.0",
     "@angular-devkit/schematics-cli": "~17.2.0",
     "@angular/cli": "~17.2.0",
-    "@o3r/schematics": "workspace:^",
+    "@o3r/schematics": "workspace:*",
     "@openapitools/openapi-generator-cli": "~2.10.0",
     "@schematics/angular": "~17.2.0",
     "minimist": "^1.2.6",

--- a/packages/@ama-sdk/create/src/index.ts
+++ b/packages/@ama-sdk/create/src/index.ts
@@ -66,6 +66,7 @@ const schematicArgs = [
   '--name', name,
   '--package', pck,
   '--package-manager', packageManager,
+  ...(argv['exact-o3r-version'] ? ['--exact-o3r-version'] : []),
   ...(typeof argv['o3r-metrics'] !== 'undefined' ? [`--${!argv['o3r-metrics'] ? 'no-' : ''}o3r-metrics`] : [])
 ];
 

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/index.ts
@@ -68,6 +68,8 @@ function ngGenerateTypescriptSDKFn(options: NgGenerateTypescriptSDKShellSchemati
       projectDescription: options.description,
       packageManager: getPackageManagerName(options.packageManager),
       projectHosting: options.hosting,
+      exactO3rVersion: options.exactO3rVersion,
+      sdkCoreRange: `${options.exactO3rVersion ? '' : '~'}${amaSdkSchematicsPackageJson.version}`,
       sdkCoreVersion: amaSdkSchematicsPackageJson.version,
       angularVersion: amaSdkSchematicsPackageJson.dependencies!['@angular-devkit/core'],
       angularEslintVersion: amaSdkSchematicsPackageJson.devDependencies!['@angular-eslint/eslint-plugin'],

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/schema.json
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/schema.json
@@ -35,6 +35,11 @@
         "yarn"
       ],
       "description": "Package manager to be used in the generated SDK"
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/schema.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/schema.ts
@@ -18,4 +18,7 @@ export interface NgGenerateTypescriptSDKShellSchematicsSchema extends SchematicO
 
   /** Skip NPM install */
   skipInstall: boolean;
+
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/package.json.template
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/package.json.template
@@ -74,12 +74,12 @@
     "@commitlint/cli": "^17.0.0",
     "@schematics/angular": "<%= angularVersion %>",
     "@commitlint/config-conventional": "^17.0.0",
-    "@ama-sdk/schematics": "~<%= sdkCoreVersion %>",
-    "@ama-sdk/core": "~<%= sdkCoreVersion %>",
-    "@o3r/eslint-config-otter": "^<%= sdkCoreVersion %>",
-    "@o3r/eslint-plugin": "^<%= sdkCoreVersion %>",
-    "@o3r/schematics": "^<%= sdkCoreVersion %>",
-    "@o3r/workspace": "^<%= sdkCoreVersion %>",
+    "@ama-sdk/schematics": "<%= sdkCoreRange %>",
+    "@ama-sdk/core": "<%= sdkCoreRange %>",
+    "@o3r/eslint-config-otter": "<%= sdkCoreRange %>",
+    "@o3r/eslint-plugin": "<%= sdkCoreRange %>",
+    "@o3r/schematics": "<%= sdkCoreRange %>",
+    "@o3r/workspace": "<%= sdkCoreRange %>",
     "@openapitools/openapi-generator-cli": "<%= versions['@openapitools/openapi-generator-cli'] %>",
     "@swc/cli": "^0.1.57",
     "@swc/core": "^1.3.85",
@@ -106,7 +106,10 @@
     "typedoc": "~0.25.0",
     "tsc-watch": "^6.0.0",
     "typescript": "<%= versions['typescript'] %>"
-  },
+  },<% if (exactO3rVersion) { %>
+  "<%= packageManager == 'yarn' ? 'resolutions' : 'overrides' %>": {
+    "@o3r/schematics": "<%= sdkCoreRange %>"
+  },<% } %>
   "peerDependencies": {
     "@ama-sdk/core": "~<%= sdkCoreVersion %>",
     "isomorphic-fetch": "<%= versions['isomorphic-fetch'] %>"

--- a/packages/@o3r/analytics/schematics/ng-add/index.ts
+++ b/packages/@o3r/analytics/schematics/ng-add/index.ts
@@ -14,7 +14,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
   return (tree) => {
     return setupDependencies({
       projectName: options.projectName,
-      dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName)
+      dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion)
     });
   };
 }

--- a/packages/@o3r/analytics/schematics/ng-add/schema.json
+++ b/packages/@o3r/analytics/schematics/ng-add/schema.json
@@ -10,6 +10,11 @@
       "$default": {
         "$source": "projectName"
       }
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/analytics/schematics/ng-add/schema.ts
+++ b/packages/@o3r/analytics/schematics/ng-add/schema.ts
@@ -3,4 +3,7 @@ import type { SchematicOptionObject } from '@o3r/schematics';
 export interface NgAddSchematicsSchema extends SchematicOptionObject {
   /** Project name */
   projectName?: string | undefined;
+
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/apis-manager/schematics/ng-add/index.ts
+++ b/packages/@o3r/apis-manager/schematics/ng-add/index.ts
@@ -24,12 +24,13 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       const dependencies = depsInfo.o3rPeerDeps.reduce((acc, dep) => {
         acc[dep] = {
           inManifest: [{
-            range: `~${depsInfo.packageVersion}`,
+            range: `${options.exactO3rVersion ? '' : '~'}${depsInfo.packageVersion}`,
             types: getProjectNewDependenciesTypes(workspaceProject)
-          }]
+          }],
+          ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
         };
         return acc;
-      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName));
+      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion));
 
       return () => chain([
         ...rulesToExecute,

--- a/packages/@o3r/apis-manager/schematics/ng-add/schema.json
+++ b/packages/@o3r/apis-manager/schematics/ng-add/schema.json
@@ -20,6 +20,11 @@
       "type": "boolean",
       "description": "Skip the install process",
       "default": true
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "required": [

--- a/packages/@o3r/apis-manager/schematics/ng-add/schema.ts
+++ b/packages/@o3r/apis-manager/schematics/ng-add/schema.ts
@@ -9,4 +9,7 @@ export interface NgAddSchematicsSchema extends SchematicOptionObject {
 
   /** Skip the install process */
   skipInstall: boolean;
+
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/application/schematics/ng-add/index.ts
+++ b/packages/@o3r/application/schematics/ng-add/index.ts
@@ -72,12 +72,13 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       const dependencies = depsInfo.o3rPeerDeps.reduce((acc, dep) => {
         acc[dep] = {
           inManifest: [{
-            range: `^${depsInfo.packageVersion}`,
+            range: `${options.exactO3rVersion ? '' : '~'}${depsInfo.packageVersion}`,
             types: getProjectNewDependenciesTypes(workspaceProject)
-          }]
+          }],
+          ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
         };
         return acc;
-      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName));
+      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion));
 
       const registerDevtoolRule = await registerDevtools(options);
       return () => chain([

--- a/packages/@o3r/application/schematics/ng-add/schema.json
+++ b/packages/@o3r/application/schematics/ng-add/schema.json
@@ -10,6 +10,11 @@
       "$default": {
         "$source": "projectName"
       }
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/application/schematics/ng-add/schema.ts
+++ b/packages/@o3r/application/schematics/ng-add/schema.ts
@@ -3,4 +3,7 @@ import type { SchematicOptionObject } from '@o3r/schematics';
 export interface NgAddSchematicsSchema extends SchematicOptionObject {
   /** Project name */
   projectName?: string | undefined;
+
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/components/schematics/ng-add/index.ts
+++ b/packages/@o3r/components/schematics/ng-add/index.ts
@@ -38,12 +38,13 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       const dependencies = depsInfo.o3rPeerDeps.reduce((acc, dep) => {
         acc[dep] = {
           inManifest: [{
-            range: `~${depsInfo.packageVersion}`,
+            range: `${options.exactO3rVersion ? '' : '~'}${depsInfo.packageVersion}`,
             types: getProjectNewDependenciesTypes(workspaceProject)
-          }]
+          }],
+          ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
         };
         return acc;
-      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName));
+      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion));
       const devDependencies: Record<string, DependencyToAdd> = {
         chokidar: {
           inManifest: [{

--- a/packages/@o3r/components/schematics/ng-add/schema.json
+++ b/packages/@o3r/components/schematics/ng-add/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false,
       "description": "Activate metadata extraction"
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/components/schematics/ng-add/schema.ts
+++ b/packages/@o3r/components/schematics/ng-add/schema.ts
@@ -6,4 +6,7 @@ export interface NgAddSchematicsSchema extends SchematicOptionObject {
 
   /** Activate metadata extraction */
   enableMetadataExtract: boolean;
+
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/configuration/schematics/ng-add/index.ts
+++ b/packages/@o3r/configuration/schematics/ng-add/index.ts
@@ -29,12 +29,13 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       const dependencies = depsInfo.o3rPeerDeps.reduce((acc, dep) => {
         acc[dep] = {
           inManifest: [{
-            range: `~${depsInfo.packageVersion}`,
+            range: `${options.exactO3rVersion ? '' : '~'}${depsInfo.packageVersion}`,
             types: getProjectNewDependenciesTypes(workspaceProject)
-          }]
+          }],
+          ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
         };
         return acc;
-      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName));
+      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion));
       context.logger.info(`The package ${depsInfo.packageName as string} comes with a debug mechanism`);
       context.logger.info('Get more information on the following page: https://github.com/AmadeusITGroup/otter/tree/main/docs/configuration/OVERVIEW.md#Runtime-debugging');
       return () => chain([

--- a/packages/@o3r/configuration/schematics/ng-add/schema.json
+++ b/packages/@o3r/configuration/schematics/ng-add/schema.json
@@ -10,6 +10,11 @@
       "$default": {
         "$source": "projectName"
       }
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/configuration/schematics/ng-add/schema.ts
+++ b/packages/@o3r/configuration/schematics/ng-add/schema.ts
@@ -3,4 +3,7 @@ import type { SchematicOptionObject } from '@o3r/schematics';
 export interface NgAddSchematicsSchema extends SchematicOptionObject {
   /** Project name */
   projectName?: string | undefined;
+
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/core/schematics/ng-add/index.ts
+++ b/packages/@o3r/core/schematics/ng-add/index.ts
@@ -26,6 +26,7 @@ const o3rDevDependencies = [
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   const corePackageJsonContent = JSON.parse(fs.readFileSync(path.resolve(__dirname, '..', '..', 'package.json'), {encoding: 'utf-8'})) as PackageJson;
   const o3rCoreVersion = corePackageJsonContent.version!;
+  const o3rVersionRange = options.exactO3rVersion ? o3rCoreVersion : `~${o3rCoreVersion}`;
 
   return (): Rule => {
     const dependenciesSetupConfig: SetupDependenciesOptions = {
@@ -33,9 +34,10 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       dependencies: o3rDevDependencies.reduce((acc, dep) => {
         acc[dep] = {
           inManifest: [{
-            range: `~${o3rCoreVersion}`,
+            range: o3rVersionRange,
             types: [NodeDependencyType.Dev]
-          }]
+          }],
+          ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
         };
         return acc;
       }, {} as Record<string, DependencyToAdd>),
@@ -46,9 +48,10 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       dependenciesSetupConfig.dependencies[workspacePackageName] = {
         toWorkspaceOnly: true,
         inManifest: [{
-          range: `~${o3rCoreVersion}`,
+          range: o3rVersionRange,
           types: [NodeDependencyType.Default]
-        }]
+        }],
+        ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
       };
       (dependenciesSetupConfig.ngAddToRun ||= []).push(workspacePackageName);
     }

--- a/packages/@o3r/core/schematics/ng-add/project-setup/index.ts
+++ b/packages/@o3r/core/schematics/ng-add/project-setup/index.ts
@@ -53,9 +53,10 @@ export const prepareProject = (options: NgAddSchematicsSchema, dependenciesSetup
     .forEach((dep) => {
       dependenciesSetupConfig.dependencies[dep] = {
         inManifest: [{
-          range: `~${o3rCoreVersion}`,
+          range: `${options.exactO3rVersion ? '' : '~'}${o3rCoreVersion}`,
           types: getProjectNewDependenciesTypes(workspaceProject)
-        }]
+        }],
+        ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
       };
     });
   (dependenciesSetupConfig.ngAddToRun ||= []).push(...internalPackagesToInstallWithNgAdd);

--- a/packages/@o3r/core/schematics/ng-add/schema.json
+++ b/packages/@o3r/core/schematics/ng-add/schema.json
@@ -53,6 +53,11 @@
       "description": "Force package installation (in case of unmet peer dependencies)",
       "type": "boolean",
       "default": true
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/core/schematics/ng-add/schema.ts
+++ b/packages/@o3r/core/schematics/ng-add/schema.ts
@@ -29,4 +29,7 @@ export interface NgAddSchematicsSchema extends SchematicOptionObject {
 
   /** Force package installation (in case of unmet peer dependencies) */
   forceInstall: boolean;
+
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/core/schematics/rule-factories/store/index.ts
+++ b/packages/@o3r/core/schematics/rule-factories/store/index.ts
@@ -39,7 +39,7 @@ const ngrxRouterStoreDevToolDep = '@ngrx/store-devtools';
  * @param options.workingDirector
  */
 export function updateStore(
-  options: { projectName?: string | undefined; workingDirector?: string | undefined; dependenciesSetupConfig: SetupDependenciesOptions },
+  options: { projectName?: string | undefined; workingDirector?: string | undefined; dependenciesSetupConfig: SetupDependenciesOptions; exactO3rVersion?: boolean },
   projectType?: WorkspaceProject['projectType']): Rule {
 
   const addStoreModules: Rule = (tree) => {
@@ -50,9 +50,10 @@ export function updateStore(
 
     options.dependenciesSetupConfig.dependencies[storeSyncPackageName] = {
       inManifest: [{
-        range: `~${o3rCoreVersion}`,
+        range: `${options.exactO3rVersion ? '' : '~'}${o3rCoreVersion}`,
         types: getProjectNewDependenciesTypes(workspaceProject)
-      }]
+      }],
+      ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
     };
     (options.dependenciesSetupConfig.ngAddToRun ||= []).push(storeSyncPackageName);
   };

--- a/packages/@o3r/core/schematics/shared/presets/helpers.ts
+++ b/packages/@o3r/core/schematics/shared/presets/helpers.ts
@@ -22,9 +22,10 @@ export function defaultPresetRuleFactory(moduleToInstall: string[], options: Pre
     const dependencies = moduleToInstall.reduce((acc, dep) => {
       acc[dep] = {
         inManifest: [{
-          range: `~${corePackageJsonContent.version}`,
+          range: `${options.exactO3rVersion ? '' : '~'}${corePackageJsonContent.version}`,
           types: getProjectNewDependenciesTypes(workspaceProject)
-        }]
+        }],
+        ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
       };
       return acc;
     }, {} as Record<string, DependencyToAdd>);

--- a/packages/@o3r/core/schematics/shared/presets/preset.interface.ts
+++ b/packages/@o3r/core/schematics/shared/presets/preset.interface.ts
@@ -12,6 +12,9 @@ export interface PresetOptions {
 
   /** Option to provide to the dependency setup helper */
   dependenciesSetupConfig?: SetupDependenciesOptions;
+
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }
 
 /** Definition of the modules preset */

--- a/packages/@o3r/create/README.md
+++ b/packages/@o3r/create/README.md
@@ -34,3 +34,4 @@ The generator accepts all the configurations from Angular `ng new` command, find
 On top of them, the following options can be provided to the initializer:
 
 - `--yarn-version` : specify the version of yarn to use (default: `latest`)
+- `--exact-o3r-version` : use a pinned version for [otter packages](https://github.com/AmadeusITGroup/otter/blob/main/docs/README.md).

--- a/packages/@o3r/create/src/index.it.spec.ts
+++ b/packages/@o3r/create/src/index.it.spec.ts
@@ -50,4 +50,37 @@ describe('Create new otter project command', () => {
     expect(existsSync(path.join(inAppPath, 'project'))).toBe(false);
     expect(() => packageManagerRunOnProject(appName, true, { script: 'build' }, execInAppOptions)).not.toThrow();
   });
+
+  test('should generate a project with an application with --exact-o3r-version', async () => {
+    const packageManager = getPackageManager();
+    const createOptions = ['--package-manager', packageManager, '--skip-confirmation', '--exact-o3r-version',
+      ...(packageManagerConfig.yarnVersion ? ['--yarn-version', packageManagerConfig.yarnVersion] : [])];
+    const inAppPath = path.join(workspacePath, workspaceProjectName);
+    const execInAppOptions = {...execWorkspaceOptions, cwd: inAppPath };
+
+    // TODO: remove it when fixing #1356
+    await fs.mkdir(inAppPath, { recursive: true });
+    setPackagerManagerConfig(packageManagerConfig, execInAppOptions);
+
+    expect(() => packageManagerCreate({ script: `@o3r@${o3rVersion}`, args: [workspaceProjectName, ...createOptions] }, execWorkspaceOptions, 'npm')).not.toThrow();
+    expect(existsSync(path.join(inAppPath, 'angular.json'))).toBe(true);
+    expect(existsSync(path.join(inAppPath, 'package.json'))).toBe(true);
+    expect(() => packageManagerInstall(execInAppOptions)).not.toThrow();
+
+    const appName = 'test-application';
+    expect(() => packageManagerExec({ script: 'ng', args: ['g', 'application', appName, '--exact-o3r-version'] }, execInAppOptions)).not.toThrow();
+    expect(existsSync(path.join(inAppPath, 'project'))).toBe(false);
+    expect(() => packageManagerRunOnProject(appName, true, { script: 'build' }, execInAppOptions)).not.toThrow();
+
+    const rootPackageJson = JSON.parse(await fs.readFile(path.join(inAppPath, 'package.json'), 'utf-8'));
+    const resolutions = packageManager === 'yarn' ? rootPackageJson.resolutions : rootPackageJson.overrides;
+    const appPackageJson = JSON.parse(await fs.readFile(path.join(inAppPath, 'apps', appName, 'package.json'), 'utf-8'));
+    // all otter dependencies in both package.json files must be pinned:
+    [
+      ...Object.entries(rootPackageJson.dependencies), ...Object.entries(rootPackageJson.devDependencies), ...Object.entries(resolutions),
+      ...Object.entries(appPackageJson.dependencies), ...Object.entries(appPackageJson.devDependencies)
+    ].filter(([dep]) => dep.startsWith('@o3r/') || dep.startsWith('@ama-sdk/')).forEach(([,version]) => {
+      expect(version).toBe(o3rVersion);
+    });
+  });
 });

--- a/packages/@o3r/design/schematics/ng-add/index.ts
+++ b/packages/@o3r/design/schematics/ng-add/index.ts
@@ -31,7 +31,7 @@ export function ngAdd(options: NgAddSchematicsSchema): Rule {
     }),
     setupDependencies({
       projectName: options.projectName,
-      dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName)
+      dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion)
     }),
     options.extractDesignToken ? extractToken({ componentFilePatterns: ['**/*.scss'], includeTags: true }) : noop
   ]);

--- a/packages/@o3r/design/schematics/ng-add/schema.json
+++ b/packages/@o3r/design/schematics/ng-add/schema.json
@@ -14,6 +14,11 @@
     "extractDesignToken": {
       "type": "boolean",
       "description": "Extract the design token from Sass file in the project"
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/design/schematics/ng-add/schema.ts
+++ b/packages/@o3r/design/schematics/ng-add/schema.ts
@@ -5,4 +5,6 @@ export interface NgAddSchematicsSchema extends SchematicOptionObject {
   projectName?: string | undefined;
   /** Extract the design token from Sass file in the project */
   extractDesignToken?: boolean;
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/dynamic-content/schematics/ng-add/index.ts
+++ b/packages/@o3r/dynamic-content/schematics/ng-add/index.ts
@@ -14,7 +14,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
   return (tree) => {
     return setupDependencies({
       projectName: options.projectName,
-      dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName)
+      dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion)
     });
   };
 }

--- a/packages/@o3r/dynamic-content/schematics/ng-add/schema.json
+++ b/packages/@o3r/dynamic-content/schematics/ng-add/schema.json
@@ -10,6 +10,11 @@
       "$default": {
         "$source": "projectName"
       }
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/dynamic-content/schematics/ng-add/schema.ts
+++ b/packages/@o3r/dynamic-content/schematics/ng-add/schema.ts
@@ -3,4 +3,6 @@ import type { SchematicOptionObject } from '@o3r/schematics';
 export interface NgAddSchematicsSchema extends SchematicOptionObject {
   /** Project name */
   projectName?: string | undefined;
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/eslint-config-otter/schematics/ng-add/index.ts
+++ b/packages/@o3r/eslint-config-otter/schematics/ng-add/index.ts
@@ -45,12 +45,13 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       const dependencies = depsInfo.o3rPeerDeps.reduce((acc, dep) => {
         acc[dep] = {
           inManifest: [{
-            range: `~${depsInfo.packageVersion}`,
+            range: `${options.exactO3rVersion ? '' : '~'}${depsInfo.packageVersion}`,
             types: getProjectNewDependenciesTypes(workspaceProject)
-          }]
+          }],
+          ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
         };
         return acc;
-      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName, true));
+      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName, true, !!options.exactO3rVersion));
       Object.entries(getExternalDependenciesVersionRange(devDependenciesToInstall, packageJsonPath))
         .forEach(([dep, range]) => {
           dependencies[dep] = {

--- a/packages/@o3r/eslint-config-otter/schematics/ng-add/schema.json
+++ b/packages/@o3r/eslint-config-otter/schematics/ng-add/schema.json
@@ -10,6 +10,11 @@
       "$default": {
         "$source": "projectName"
       }
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/eslint-config-otter/schematics/ng-add/schema.ts
+++ b/packages/@o3r/eslint-config-otter/schematics/ng-add/schema.ts
@@ -3,4 +3,6 @@ import type { SchematicOptionObject } from '@o3r/schematics';
 export interface NgAddSchematicsSchema extends SchematicOptionObject {
   /** Project name */
   projectName?: string | undefined;
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/extractors/schematics/ng-add/index.ts
+++ b/packages/@o3r/extractors/schematics/ng-add/index.ts
@@ -19,12 +19,13 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       const dependencies = depsInfo.o3rPeerDeps.reduce((acc, dep) => {
         acc[dep] = {
           inManifest: [{
-            range: `~${depsInfo.packageVersion}`,
+            range: `${options.exactO3rVersion ? '' : '~'}${depsInfo.packageVersion}`,
             types: getProjectNewDependenciesTypes(workspaceProject)
-          }]
+          }],
+          ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
         };
         return acc;
-      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName, true));
+      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName, true, !!options.exactO3rVersion));
       return chain([
         setupDependencies({
           projectName: options.projectName,

--- a/packages/@o3r/extractors/schematics/ng-add/schema.json
+++ b/packages/@o3r/extractors/schematics/ng-add/schema.json
@@ -10,6 +10,11 @@
       "$default": {
         "$source": "projectName"
       }
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/extractors/schematics/ng-add/schema.ts
+++ b/packages/@o3r/extractors/schematics/ng-add/schema.ts
@@ -3,4 +3,6 @@ import type { SchematicOptionObject } from '@o3r/schematics';
 export interface NgAddSchematicsSchema extends SchematicOptionObject {
   /** Project name */
   projectName?: string | undefined;
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/forms/schematics/ng-add/index.ts
+++ b/packages/@o3r/forms/schematics/ng-add/index.ts
@@ -14,7 +14,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
   return (tree) => {
     return setupDependencies({
       projectName: options.projectName,
-      dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName)
+      dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion)
     });
   };
 }

--- a/packages/@o3r/forms/schematics/ng-add/schema.json
+++ b/packages/@o3r/forms/schematics/ng-add/schema.json
@@ -10,6 +10,11 @@
       "$default": {
         "$source": "projectName"
       }
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/forms/schematics/ng-add/schema.ts
+++ b/packages/@o3r/forms/schematics/ng-add/schema.ts
@@ -3,4 +3,6 @@ import type { SchematicOptionObject } from '@o3r/schematics';
 export interface NgAddSchematicsSchema extends SchematicOptionObject {
   /** Project name */
   projectName?: string | undefined;
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/localization/schematics/ng-add/index.ts
+++ b/packages/@o3r/localization/schematics/ng-add/index.ts
@@ -39,12 +39,13 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       const dependencies = depsInfo.o3rPeerDeps.reduce((acc, dep) => {
         acc[dep] = {
           inManifest: [{
-            range: `~${depsInfo.packageVersion}`,
+            range: `${options.exactO3rVersion ? '' : '~'}${depsInfo.packageVersion}`,
             types: getProjectNewDependenciesTypes(workspaceProject)
-          }]
+          }],
+          ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
         };
         return acc;
-      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName));
+      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion));
       Object.entries(getExternalDependenciesVersionRange(dependenciesToInstall, packageJsonPath)).forEach(([dep, range]) => {
         dependencies[dep] = {
           inManifest: [{

--- a/packages/@o3r/localization/schematics/ng-add/schema.json
+++ b/packages/@o3r/localization/schematics/ng-add/schema.json
@@ -20,6 +20,11 @@
       "type": "boolean",
       "description": "Skip the install process",
       "default": true
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/localization/schematics/ng-add/schema.ts
+++ b/packages/@o3r/localization/schematics/ng-add/schema.ts
@@ -7,4 +7,6 @@ export interface NgAddSchematicsSchema extends SchematicOptionObject {
   skipLinter: boolean;
   /** Skip the install process */
   skipInstall: boolean;
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/logger/schematics/ng-add/index.ts
+++ b/packages/@o3r/logger/schematics/ng-add/index.ts
@@ -14,7 +14,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
   return (tree) => {
     return setupDependencies({
       projectName: options.projectName,
-      dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName)
+      dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion)
     });
   };
 }

--- a/packages/@o3r/logger/schematics/ng-add/schema.json
+++ b/packages/@o3r/logger/schematics/ng-add/schema.json
@@ -10,6 +10,11 @@
       "$default": {
         "$source": "projectName"
       }
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/logger/schematics/ng-add/schema.ts
+++ b/packages/@o3r/logger/schematics/ng-add/schema.ts
@@ -3,4 +3,6 @@ import type { SchematicOptionObject } from '@o3r/schematics';
 export interface NgAddSchematicsSchema extends SchematicOptionObject {
   /** Project name */
   projectName?: string | undefined;
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/mobile/schematics/ng-add/index.ts
+++ b/packages/@o3r/mobile/schematics/ng-add/index.ts
@@ -19,12 +19,13 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       const dependencies = depsInfo.o3rPeerDeps.reduce((acc, dep) => {
         acc[dep] = {
           inManifest: [{
-            range: `~${depsInfo.packageVersion}`,
+            range: `${options.exactO3rVersion ? '' : '~'}${depsInfo.packageVersion}`,
             types: getProjectNewDependenciesTypes(workspaceProject)
-          }]
+          }],
+          ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
         };
         return acc;
-      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName));
+      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion));
       return () => chain([
         removePackages(['@otter/mobile']),
         setupDependencies({

--- a/packages/@o3r/mobile/schematics/ng-add/schema.json
+++ b/packages/@o3r/mobile/schematics/ng-add/schema.json
@@ -10,6 +10,11 @@
       "$default": {
         "$source": "projectName"
       }
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/mobile/schematics/ng-add/schema.ts
+++ b/packages/@o3r/mobile/schematics/ng-add/schema.ts
@@ -3,4 +3,6 @@ import type { SchematicOptionObject } from '@o3r/schematics';
 export interface NgAddSchematicsSchema extends SchematicOptionObject {
   /** Project name */
   projectName?: string | undefined;
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/routing/schematics/ng-add/index.ts
+++ b/packages/@o3r/routing/schematics/ng-add/index.ts
@@ -14,7 +14,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
   return (tree) => {
     return setupDependencies({
       projectName: options.projectName,
-      dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName)
+      dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion)
     });
   };
 }

--- a/packages/@o3r/routing/schematics/ng-add/schema.json
+++ b/packages/@o3r/routing/schematics/ng-add/schema.json
@@ -10,6 +10,11 @@
       "$default": {
         "$source": "projectName"
       }
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/routing/schematics/ng-add/schema.ts
+++ b/packages/@o3r/routing/schematics/ng-add/schema.ts
@@ -3,4 +3,6 @@ import type { SchematicOptionObject } from '@o3r/schematics';
 export interface NgAddSchematicsSchema extends SchematicOptionObject {
   /** Project name */
   projectName?: string | undefined;
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/rules-engine/schematics/ng-add/index.ts
+++ b/packages/@o3r/rules-engine/schematics/ng-add/index.ts
@@ -40,12 +40,13 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       const dependencies = depsInfo.o3rPeerDeps.reduce((acc, dep) => {
         acc[dep] = {
           inManifest: [{
-            range: `~${depsInfo.packageVersion}`,
+            range: `${options.exactO3rVersion ? '' : '~'}${depsInfo.packageVersion}`,
             types: getProjectNewDependenciesTypes(workspaceProject)
-          }]
+          }],
+          ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
         };
         return acc;
-      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName));
+      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion));
       Object.entries(getExternalDependenciesVersionRange(devDependenciesToInstall, packageJsonPath))
         .forEach(([dep, range]) => {
           dependencies[dep] = {

--- a/packages/@o3r/rules-engine/schematics/ng-add/schema.json
+++ b/packages/@o3r/rules-engine/schematics/ng-add/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false,
       "description": "Activate metadata extraction"
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/rules-engine/schematics/ng-add/schema.ts
+++ b/packages/@o3r/rules-engine/schematics/ng-add/schema.ts
@@ -6,4 +6,7 @@ export interface NgAddSchematicsSchema extends SchematicOptionObject {
 
   /** Activate metadata extraction */
   enableMetadataExtract: boolean;
+
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/schematics/src/rule-factories/ng-add/dependencies.ts
+++ b/packages/@o3r/schematics/src/rule-factories/ng-add/dependencies.ts
@@ -96,8 +96,9 @@ export const hasSetupInformation = (context: SchematicContext): context is Schem
  * @param tree Tree to read the file
  * @param projectName Name of the project
  * @param devDependencyOnly If true, the dependency will be added as devDependency
+ * @param exactO3rVersion Use a pinned version of the o3r package
  */
-export const getPackageInstallConfig = (packageJsonPath: string, tree: Tree, projectName?: string, devDependencyOnly?: boolean): Record<string, DependencyToAdd> => {
+export const getPackageInstallConfig = (packageJsonPath: string, tree: Tree, projectName?: string, devDependencyOnly?: boolean, exactO3rVersion?: boolean): Record<string, DependencyToAdd> => {
   if (!projectName) {
     return {};
   }
@@ -107,10 +108,11 @@ export const getPackageInstallConfig = (packageJsonPath: string, tree: Tree, pro
   return {
     [packageJson.name!]: {
       inManifest: [{
-        range: `~${packageJson.version}`,
+        range: `${exactO3rVersion ? '' : '~'}${packageJson.version}`,
         types: devDependencyOnly ? [NodeDependencyType.Dev] : getProjectNewDependenciesTypes(workspaceProject)
       }],
-      requireInstall: true
+      requireInstall: true,
+      ngAddOptions: { exactO3rVersion: exactO3rVersion }
     }
   };
 };

--- a/packages/@o3r/store-sync/schematics/ng-add/index.ts
+++ b/packages/@o3r/store-sync/schematics/ng-add/index.ts
@@ -33,12 +33,13 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       const dependencies = depsInfo.o3rPeerDeps.reduce((acc, dep) => {
         acc[dep] = {
           inManifest: [{
-            range: `~${depsInfo.packageVersion}`,
+            range: `${options.exactO3rVersion ? '' : '~'}${depsInfo.packageVersion}`,
             types: getProjectNewDependenciesTypes(workspaceProject)
-          }]
+          }],
+          ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
         };
         return acc;
-      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName));
+      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion));
       Object.entries(getExternalDependenciesVersionRange(devDependenciesToInstall, packageJsonPath))
         .forEach(([dep, range]) => {
           dependencies[dep] = {

--- a/packages/@o3r/store-sync/schematics/ng-add/schema.json
+++ b/packages/@o3r/store-sync/schematics/ng-add/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "description": "Skip the linter process",
       "default": true
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/store-sync/schematics/ng-add/schema.ts
+++ b/packages/@o3r/store-sync/schematics/ng-add/schema.ts
@@ -9,4 +9,7 @@ export interface NgAddSchematicsSchema extends SchematicOptionObject {
 
   /** Skip the install process */
   skipInstall: boolean;
+
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/storybook/schematics/ng-add/index.ts
+++ b/packages/@o3r/storybook/schematics/ng-add/index.ts
@@ -19,12 +19,13 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       const dependencies = depsInfo.o3rPeerDeps.reduce((acc, dep) => {
         acc[dep] = {
           inManifest: [{
-            range: `~${depsInfo.packageVersion}`,
+            range: `${options.exactO3rVersion ? '' : '~'}${depsInfo.packageVersion}`,
             types: getProjectNewDependenciesTypes(workspaceProject)
-          }]
+          }],
+          ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
         };
         return acc;
-      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName));
+      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion));
       return () => chain([
         removePackages(['@otter/storybook']),
         updateStorybook(options, __dirname),

--- a/packages/@o3r/storybook/schematics/ng-add/schema.json
+++ b/packages/@o3r/storybook/schematics/ng-add/schema.json
@@ -20,6 +20,11 @@
       "type": "boolean",
       "description": "Skip the install process",
       "default": true
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/storybook/schematics/ng-add/schema.ts
+++ b/packages/@o3r/storybook/schematics/ng-add/schema.ts
@@ -7,4 +7,6 @@ export interface NgAddSchematicsSchema extends SchematicOptionObject {
   skipLinter: boolean;
   /** Skip the install process */
   skipInstall: boolean;
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/stylelint-plugin/schematics/ng-add/index.ts
+++ b/packages/@o3r/stylelint-plugin/schematics/ng-add/index.ts
@@ -14,7 +14,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
   return (tree) => {
     return setupDependencies({
       projectName: options.projectName,
-      dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, true)
+      dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, true, !!options.exactO3rVersion)
     });
   };
 }

--- a/packages/@o3r/stylelint-plugin/schematics/ng-add/schema.json
+++ b/packages/@o3r/stylelint-plugin/schematics/ng-add/schema.json
@@ -10,6 +10,11 @@
       "$default": {
         "$source": "projectName"
       }
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/stylelint-plugin/schematics/ng-add/schema.ts
+++ b/packages/@o3r/stylelint-plugin/schematics/ng-add/schema.ts
@@ -1,4 +1,8 @@
-export interface NgAddSchematicsSchema {
+import type { SchematicOptionObject } from '@o3r/schematics';
+
+export interface NgAddSchematicsSchema extends SchematicOptionObject {
   /** Project name */
   projectName?: string | undefined;
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/styling/schematics/ng-add/index.ts
+++ b/packages/@o3r/styling/schematics/ng-add/index.ts
@@ -49,12 +49,13 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       const dependencies = depsInfo.o3rPeerDeps.reduce((acc, dep) => {
         acc[dep] = {
           inManifest: [{
-            range: `~${depsInfo.packageVersion}`,
+            range: `${options.exactO3rVersion ? '' : '~'}${depsInfo.packageVersion}`,
             types: getProjectNewDependenciesTypes(workspaceProject)
-          }]
+          }],
+          ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
         };
         return acc;
-      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName));
+      }, getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion));
       Object.entries(getExternalDependenciesVersionRange(devDependenciesToInstall, packageJsonPath))
         .forEach(([dep, range]) => {
           dependencies[dep] = {

--- a/packages/@o3r/styling/schematics/ng-add/schema.json
+++ b/packages/@o3r/styling/schematics/ng-add/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "default": false,
       "description": "Activate metadata extraction"
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/styling/schematics/ng-add/schema.ts
+++ b/packages/@o3r/styling/schematics/ng-add/schema.ts
@@ -6,4 +6,7 @@ export interface NgAddSchematicsSchema extends SchematicOptionObject {
 
   /** Activate metadata extraction */
   enableMetadataExtract: boolean;
+
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/test-helpers/schematics/ng-add/index.ts
+++ b/packages/@o3r/test-helpers/schematics/ng-add/index.ts
@@ -24,9 +24,10 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       const dependencies = depsInfo.o3rPeerDeps.reduce((acc, dep) => {
         acc[dep] = {
           inManifest: [{
-            range: `~${depsInfo.packageVersion}`,
+            range: `${options.exactO3rVersion ? '' : '~'}${depsInfo.packageVersion}`,
             types: getProjectNewDependenciesTypes(workspaceProject)
-          }]
+          }],
+          ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
         };
         return acc;
       }, {} as Record<string, DependencyToAdd>);

--- a/packages/@o3r/test-helpers/schematics/ng-add/schema.json
+++ b/packages/@o3r/test-helpers/schematics/ng-add/schema.json
@@ -20,6 +20,11 @@
       "type": "boolean",
       "description": "Skip the install process",
       "default": true
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/test-helpers/schematics/ng-add/schema.ts
+++ b/packages/@o3r/test-helpers/schematics/ng-add/schema.ts
@@ -9,4 +9,7 @@ export interface NgAddSchematicsSchema extends SchematicOptionObject {
 
   /** Skip the install process */
   skipInstall: boolean;
+
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/testing/schematics/ng-add/index.ts
+++ b/packages/@o3r/testing/schematics/ng-add/index.ts
@@ -45,12 +45,13 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       const dependencies = depsInfo.o3rPeerDeps.reduce((acc, dep) => {
         acc[dep] = {
           inManifest: [{
-            range: `~${depsInfo.packageVersion}`,
+            range: `${options.exactO3rVersion ? '' : '~'}${depsInfo.packageVersion}`,
             types: getProjectNewDependenciesTypes(workspaceProject)
-          }]
+          }],
+          ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
         };
         return acc;
-      }, getPackageInstallConfig(testPackageJsonPath, tree, options.projectName, true));
+      }, getPackageInstallConfig(testPackageJsonPath, tree, options.projectName, true, !!options.exactO3rVersion));
       Object.entries(getExternalDependenciesVersionRange(devDependenciesToInstall, testPackageJsonPath))
         .forEach(([dep, range]) => {
           dependencies[dep] = {

--- a/packages/@o3r/testing/schematics/ng-add/schema.json
+++ b/packages/@o3r/testing/schematics/ng-add/schema.json
@@ -22,6 +22,11 @@
     "enablePlaywright": {
       "type": "boolean",
       "description": "Install playwright"
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/testing/schematics/ng-add/schema.ts
+++ b/packages/@o3r/testing/schematics/ng-add/schema.ts
@@ -9,4 +9,7 @@ export interface NgAddSchematicsSchema extends SchematicOptionObject {
 
   /** Enable playwright */
   enablePlaywright: boolean;
+
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/third-party/schematics/ng-add/index.ts
+++ b/packages/@o3r/third-party/schematics/ng-add/index.ts
@@ -18,7 +18,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
         registerPackageCollectionSchematics(packageJson),
         setupDependencies({
           projectName: options.projectName,
-          dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName)
+          dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion)
         })
       ]);
     } catch (e) {

--- a/packages/@o3r/third-party/schematics/ng-add/schema.json
+++ b/packages/@o3r/third-party/schematics/ng-add/schema.json
@@ -10,6 +10,11 @@
       "$default": {
         "$source": "projectName"
       }
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/third-party/schematics/ng-add/schema.ts
+++ b/packages/@o3r/third-party/schematics/ng-add/schema.ts
@@ -3,4 +3,7 @@ import type { SchematicOptionObject } from '@o3r/schematics';
 export interface NgAddSchematicsSchema extends SchematicOptionObject {
   /** Project name */
   projectName?: string | undefined;
+
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/workspace/schematics/application/index.ts
+++ b/packages/@o3r/workspace/schematics/application/index.ts
@@ -70,10 +70,11 @@ function generateApplicationFn(options: NgGenerateApplicationSchema): Rule {
       '@o3r/core': {
         inManifest: [
           {
-            range: `~${ownPackageJsonContent.version!}`,
+            range: `${options.exactO3rVersion ? '' : '~'}${ownPackageJsonContent.version!}`,
             types: [NodeDependencyType.Default]
           }
-        ]
+        ],
+        ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
       }
     };
 

--- a/packages/@o3r/workspace/schematics/application/schema.json
+++ b/packages/@o3r/workspace/schematics/application/schema.json
@@ -46,6 +46,11 @@
       "description": "Creates an application with Server-Side Rendering (SSR) and Static Site Generation (SSG/Prerendering) enabled.",
       "type": "boolean",
       "default": false
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "required": ["name"],

--- a/packages/@o3r/workspace/schematics/application/schema.ts
+++ b/packages/@o3r/workspace/schematics/application/schema.ts
@@ -15,4 +15,7 @@ export interface NgGenerateApplicationSchema extends SchematicOptionObject {
 
   /** Do not install dependency packages. */
   skipInstall: boolean;
+
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/workspace/schematics/library/index.ts
+++ b/packages/@o3r/workspace/schematics/library/index.ts
@@ -45,10 +45,11 @@ function generateModuleFn(options: NgGenerateModuleSchema): Rule {
       '@o3r/core': {
         inManifest: [
           {
-            range: `~${ownPackageJsonContent.version!}`,
+            range: `${options.exactO3rVersion ? '' : '~'}${ownPackageJsonContent.version!}`,
             types: [NodeDependencyType.Default]
           }
-        ]
+        ],
+        ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
       }
     };
 

--- a/packages/@o3r/workspace/schematics/library/schema.json
+++ b/packages/@o3r/workspace/schematics/library/schema.json
@@ -35,6 +35,11 @@
       "description": "Do not install dependency packages.",
       "type": "boolean",
       "default": false
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "required": ["name"],

--- a/packages/@o3r/workspace/schematics/library/schema.ts
+++ b/packages/@o3r/workspace/schematics/library/schema.ts
@@ -21,4 +21,7 @@ export interface NgGenerateModuleSchema extends SchematicOptionObject {
 
   /** Do not install dependency packages. */
   skipInstall: boolean;
+
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/workspace/schematics/ng-add/project-setup.ts
+++ b/packages/@o3r/workspace/schematics/ng-add/project-setup.ts
@@ -48,9 +48,10 @@ export const prepareProject = (options: NgAddSchematicsSchema): Rule => {
     const dependencies = [...internalPackagesToInstallWithNgAdd, ...dependenciesToInstall].reduce((acc, dep) => {
       acc[dep] = {
         inManifest: [{
-          range: `~${depsInfo.packageVersion}`,
+          range: `${options.exactO3rVersion ? '' : '~'}${depsInfo.packageVersion}`,
           types: [NodeDependencyType.Default]
-        }]
+        }],
+        ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
       };
       return acc;
     }, {} as Record<string, DependencyToAdd>);

--- a/packages/@o3r/workspace/schematics/ng-add/schema.json
+++ b/packages/@o3r/workspace/schematics/ng-add/schema.json
@@ -45,6 +45,11 @@
       "type": "boolean",
       "default": false,
       "alias": "g"
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/workspace/schematics/ng-add/schema.ts
+++ b/packages/@o3r/workspace/schematics/ng-add/schema.ts
@@ -14,4 +14,7 @@ export interface NgAddSchematicsSchema extends SchematicOptionObject {
 
   /** Do not initialize a git repository. */
   skipGit: boolean;
+
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,7 +74,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ama-sdk/core@workspace:^, @ama-sdk/core@workspace:packages/@ama-sdk/core":
+"@ama-sdk/core@workspace:*, @ama-sdk/core@workspace:^, @ama-sdk/core@workspace:packages/@ama-sdk/core":
   version: 0.0.0-use.local
   resolution: "@ama-sdk/core@workspace:packages/@ama-sdk/core"
   dependencies:
@@ -162,8 +162,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@ama-sdk/create@workspace:packages/@ama-sdk/create"
   dependencies:
-    "@ama-sdk/core": "workspace:^"
-    "@ama-sdk/schematics": "workspace:^"
+    "@ama-sdk/core": "workspace:*"
+    "@ama-sdk/schematics": "workspace:*"
     "@angular-devkit/core": "npm:~17.2.0"
     "@angular-devkit/schematics": "npm:~17.2.0"
     "@angular-devkit/schematics-cli": "npm:~17.2.0"
@@ -177,7 +177,7 @@ __metadata:
     "@o3r/build-helpers": "workspace:^"
     "@o3r/eslint-config-otter": "workspace:^"
     "@o3r/eslint-plugin": "workspace:^"
-    "@o3r/schematics": "workspace:^"
+    "@o3r/schematics": "workspace:*"
     "@o3r/test-helpers": "workspace:^"
     "@openapitools/openapi-generator-cli": "npm:~2.10.0"
     "@schematics/angular": "npm:~17.2.0"
@@ -214,7 +214,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ama-sdk/schematics@workspace:^, @ama-sdk/schematics@workspace:packages/@ama-sdk/schematics":
+"@ama-sdk/schematics@workspace:*, @ama-sdk/schematics@workspace:^, @ama-sdk/schematics@workspace:packages/@ama-sdk/schematics":
   version: 0.0.0-use.local
   resolution: "@ama-sdk/schematics@workspace:packages/@ama-sdk/schematics"
   dependencies:
@@ -8320,7 +8320,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@o3r/schematics@workspace:^, @o3r/schematics@workspace:packages/@o3r/schematics":
+"@o3r/schematics@workspace:*, @o3r/schematics@workspace:^, @o3r/schematics@workspace:packages/@o3r/schematics":
   version: 0.0.0-use.local
   resolution: "@o3r/schematics@workspace:packages/@o3r/schematics"
   dependencies:


### PR DESCRIPTION
## Proposed change

This PR implements the `--exact-o3r-version` parameter for `npm create @o3r` and `npm create @ama-sdk`, allowing to force the exact version of otter to use.
This way, when using `npm create @o3r@x.y.z -- --exact-o3r-version` or `npm create @ama-sdk@x.y.z -- --exact-o3r-version`, I will get the exact `x.y.z` version I requested, and not a newer version. This is especially important if a new version breaks something and I want to use an earlier version.
This PR is an alternative to #1381.
