### PR TITLE
fix(telemetry): ask only once to install telemetry when creating an sdk

### DIFF
--- a/packages/@ama-sdk/create/src/index.ts
+++ b/packages/@ama-sdk/create/src/index.ts
@@ -2,7 +2,8 @@
 /* eslint-disable no-console */
 
 import { execSync, spawnSync } from 'node:child_process';
-import { dirname, join, resolve } from 'node:path';
+import * as url from 'node:url';
+import { dirname, join, relative, resolve } from 'node:path';
 import * as minimist from 'minimist';
 
 const packageManagerEnv = process.env.npm_config_user_agent?.split('/')[0];
@@ -40,10 +41,6 @@ if (!pck) {
 
 const targetDirectory = join('.', name, pck);
 const schematicsPackage = dirname(require.resolve('@ama-sdk/schematics/package.json'));
-const schematicsToRun = [
-  `${schematicsPackage}:typescript-shell`,
-  ...(argv['spec-path'] ? [`${schematicsPackage}:typescript-core`] : [])
-];
 
 const getYarnVersion = () => {
   try {
@@ -69,26 +66,31 @@ const schematicArgs = [
   '--name', name,
   '--package', pck,
   '--package-manager', packageManager,
-  '--directory', targetDirectory,
-  ...(argv['spec-path'] ? ['--spec-path', argv['spec-path']] : []),
   ...(typeof argv['o3r-metrics'] !== 'undefined' ? [`--${!argv['o3r-metrics'] ? 'no-' : ''}o3r-metrics`] : [])
 ];
 
-const getSchematicStepInfo = (schematic: string) => ({
-  args: [binPath, schematic, ...schematicArgs]
-});
+const resolveTargetDirectory = resolve(process.cwd(), targetDirectory);
 
 const run = () => {
+  const isSpecPathUrl = url.URL.canParse(argv['spec-path']);
 
   const runner = process.platform === 'win32' ? `${packageManager}.cmd` : packageManager;
   const steps: { args: string[]; cwd?: string; runner?: string }[] = [
-    getSchematicStepInfo(schematicsToRun[0]),
+    { args: [binPath, `${schematicsPackage}:typescript-shell`, ...schematicArgs, '--directory', targetDirectory] },
     ...(
       packageManager === 'yarn'
-        ? [{ runner, args: ['set', 'version', getYarnVersion()], cwd: resolve(process.cwd(), targetDirectory)}]
+        ? [{ runner, args: ['set', 'version', getYarnVersion()], cwd: resolveTargetDirectory }]
         : []
     ),
-    ...schematicsToRun.slice(1).map(getSchematicStepInfo)
+    ...(argv['spec-path'] ? [{
+      args: [
+        binPath,
+        `${schematicsPackage}:typescript-core`,
+        ...schematicArgs,
+        '--spec-path', isSpecPathUrl ? argv['spec-path'] : relative(resolveTargetDirectory, resolve(process.cwd(), argv['spec-path']))
+      ],
+      cwd: resolveTargetDirectory
+    }] : [])
   ];
 
   const errors = steps

--- a/packages/@o3r/schematics/src/rule-factories/ng-add/dependencies.ts
+++ b/packages/@o3r/schematics/src/rule-factories/ng-add/dependencies.ts
@@ -71,6 +71,8 @@ export interface SetupDependenciesOptions {
   runAfterTasks?: TaskId[];
   /** Callback to run after the task ID is calculated */
   scheduleTaskCallback?: (taskIds?: TaskId[]) => void;
+  /** Working directory for the installation process only */
+  workingDirectory?: string;
 }
 
 /** Result of the Setup Dependencies task scheduling process */
@@ -200,7 +202,9 @@ export const setupDependencies = (options: SetupDependenciesOptions): Rule => {
 
     const runNgAddSchematics: Rule = (_, context) => {
       const packageManager = options.packageManager || getPackageManager();
-      const installId = isInstallNeeded() ? [context.addTask(new NodePackageInstallTask({ packageManager, quiet: true }), options.runAfterTasks)] : undefined;
+      const installId = isInstallNeeded() ? [
+        context.addTask(new NodePackageInstallTask({ packageManager, quiet: true, workingDirectory: options.workingDirectory }), options.runAfterTasks)
+      ] : undefined;
 
       if (installId !== undefined) {
         context.logger.debug(`Schedule the installation of the workspace (${ngAddToRun.size > 0 ? 'for: ' + [...ngAddToRun].join(', ') : options.skipInstall ? 'skipped' : 'forced'})`);

--- a/packages/@o3r/schematics/src/utility/wrapper.ts
+++ b/packages/@o3r/schematics/src/utility/wrapper.ts
@@ -1,5 +1,5 @@
 import type { JsonObject } from '@angular-devkit/core';
-import { chain, noop, type Rule } from '@angular-devkit/schematics';
+import { applyToSubtree, chain, noop, type Rule } from '@angular-devkit/schematics';
 import type { SchematicWrapper } from '@o3r/telemetry';
 import { NodeDependencyType } from '@schematics/angular/utility/dependencies';
 import { prompt, Question } from 'inquirer';
@@ -11,10 +11,7 @@ const noopSchematicWrapper: SchematicWrapper = (fn) => fn;
 
 const PACKAGE_JSON_PATH = 'package.json';
 
-const setupO3rMetricsInPackageJson: (activated: boolean) => Rule = (activated) => (tree, context) => {
-  if (!activated) {
-    context.logger.info('You can activate it at any time by running `ng add @o3r/telemetry`.');
-  }
+const setupO3rMetricsInPackageJson: (activated: boolean) => Rule = (activated) => (tree) => {
   if (tree.exists(PACKAGE_JSON_PATH)) {
     const packageJson = tree.readJson(PACKAGE_JSON_PATH) as JsonObject;
 
@@ -25,7 +22,7 @@ const setupO3rMetricsInPackageJson: (activated: boolean) => Rule = (activated) =
   }
 };
 
-const setupTelemetry: Rule = (_, context) => {
+const setupTelemetry: (opts: {workingDirectory?: string; runNgAdd?: boolean}) => Rule = ({ workingDirectory, runNgAdd }) => (_, context) => {
   const taskIdsFromContext = hasSetupInformation(context) ? context.setupDependencies.taskIds : undefined;
   const version = JSON.parse(readFileSync(path.join(__dirname, '..', '..', 'package.json'), 'utf-8')).version;
   return setupDependencies({
@@ -38,8 +35,9 @@ const setupTelemetry: Rule = (_, context) => {
         }]
       }
     },
-    ngAddToRun: ['@o3r/telemetry'],
-    runAfterTasks: taskIdsFromContext
+    ngAddToRun: runNgAdd ? ['@o3r/telemetry'] : [],
+    runAfterTasks: taskIdsFromContext,
+    workingDirectory
   });
 };
 
@@ -50,7 +48,7 @@ const setupTelemetry: Rule = (_, context) => {
  */
 export const createSchematicWithMetricsIfInstalled: SchematicWrapper = (schematicFn) => (opts) => async (tree, context) => {
   let wrapper: SchematicWrapper = noopSchematicWrapper;
-  let shouldInstallTelemetry = false;
+  let shouldInstallTelemetry: boolean | undefined;
   const packageJson = tree.exists(PACKAGE_JSON_PATH) ? tree.readJson(PACKAGE_JSON_PATH) as JsonObject : {};
   try {
     const { createSchematicWithMetrics } = await import('@o3r/telemetry');
@@ -81,10 +79,13 @@ For more details and instructions on how to change these settings, see https://g
       shouldInstallTelemetry = isReplyPositive;
     }
   }
+  const subtreeDirectory = context.schematic.description.name === 'typescript-shell' ? (opts as any).directory.split(path.posix.sep).join(path.sep) ?? '' : '';
+
   const rule = chain([
-    setupO3rMetricsInPackageJson(shouldInstallTelemetry),
+    typeof shouldInstallTelemetry !== 'undefined' ? applyToSubtree(subtreeDirectory, [setupO3rMetricsInPackageJson(!!shouldInstallTelemetry)]) : noop(),
     schematicFn(opts),
-    shouldInstallTelemetry ? setupTelemetry : noop()
+    shouldInstallTelemetry ? applyToSubtree(subtreeDirectory, [setupTelemetry({ workingDirectory: subtreeDirectory || undefined, runNgAdd: !subtreeDirectory })]) : noop(),
+    typeof shouldInstallTelemetry !== 'undefined' && subtreeDirectory ? applyToSubtree(subtreeDirectory, [setupO3rMetricsInPackageJson(shouldInstallTelemetry)]) : noop()
   ]);
   return wrapper(() => rule)(opts);
 };


### PR DESCRIPTION
## Proposed change
Ask only once to install telemetry when creating an sdk

## Related issues

- :bug: Fixes #1408
