### PR TITLE
fix: missing package name for gh actions

### DIFF
--- a/.yarn/sdks/eslint/package.json
+++ b/.yarn/sdks/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint",
-  "version": "8.56.0-sdk",
+  "version": "8.57.0-sdk",
   "main": "./lib/api.js",
   "type": "commonjs",
   "bin": {

--- a/tools/github-actions/audit/package.json
+++ b/tools/github-actions/audit/package.json
@@ -1,6 +1,7 @@
 {
   "version": "0.0.0-placeholder",
   "private": true,
+  "name": "audit-gh-action",
   "description": "Yarn audit GitHub action provided by Otter",
   "main": "tmp/main.js",
   "scripts": {

--- a/tools/github-actions/cascading/package.json
+++ b/tools/github-actions/cascading/package.json
@@ -1,6 +1,7 @@
 {
   "version": "0.0.0-placeholder",
   "private": true,
+  "name": "cascading-gh-action",
   "description": "Cascading GitHub action provided by Otter",
   "main": "tmp/main.js",
   "scripts": {

--- a/tools/github-actions/get-npm-tag/package.json
+++ b/tools/github-actions/get-npm-tag/package.json
@@ -1,6 +1,7 @@
 {
   "version": "0.0.0-placeholder",
   "private": true,
+  "name": "get-npm-tag-gh-action",
   "description": "Get npm tag GitHub action provided by Otter",
   "main": "tmp/main.js",
   "scripts": {

--- a/tools/github-actions/new-version/package.json
+++ b/tools/github-actions/new-version/package.json
@@ -1,6 +1,7 @@
 {
   "version": "0.0.0-placeholder",
   "private": true,
+  "name": "new-version-gh-action",
   "description": "New version GitHub action provided by Otter",
   "main": "tmp/main.js",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13464,9 +13464,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"audit-67f6b4@workspace:tools/github-actions/audit":
+"audit-gh-action@workspace:tools/github-actions/audit":
   version: 0.0.0-use.local
-  resolution: "audit-67f6b4@workspace:tools/github-actions/audit"
+  resolution: "audit-gh-action@workspace:tools/github-actions/audit"
   dependencies:
     "@actions/core": "npm:^1.10.0"
     "@actions/exec": "npm:^1.1.1"
@@ -14374,9 +14374,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cascading-920ed5@workspace:tools/github-actions/cascading":
+"cascading-gh-action@workspace:tools/github-actions/cascading":
   version: 0.0.0-use.local
-  resolution: "cascading-920ed5@workspace:tools/github-actions/cascading"
+  resolution: "cascading-gh-action@workspace:tools/github-actions/cascading"
   dependencies:
     "@actions/core": "npm:^1.10.0"
     "@actions/exec": "npm:^1.1.1"
@@ -18963,9 +18963,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-npm-tag-5d7ac2@workspace:tools/github-actions/get-npm-tag":
+"get-npm-tag-gh-action@workspace:tools/github-actions/get-npm-tag":
   version: 0.0.0-use.local
-  resolution: "get-npm-tag-5d7ac2@workspace:tools/github-actions/get-npm-tag"
+  resolution: "get-npm-tag-gh-action@workspace:tools/github-actions/get-npm-tag"
   dependencies:
     "@actions/core": "npm:^1.10.0"
     "@actions/exec": "npm:^1.1.1"
@@ -23297,9 +23297,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"new-version-c91c90@workspace:tools/github-actions/new-version":
+"new-version-gh-action@workspace:tools/github-actions/new-version":
   version: 0.0.0-use.local
-  resolution: "new-version-c91c90@workspace:tools/github-actions/new-version"
+  resolution: "new-version-gh-action@workspace:tools/github-actions/new-version"
   dependencies:
     "@actions/core": "npm:^1.10.0"
     "@actions/exec": "npm:^1.1.1"


### PR DESCRIPTION
Follow up on #1424


The name is missing for Github Action packages.
According to the NPM doc, the [name is required](https://docs.npmjs.com/creating-a-package-json-file#required-name-and-version-fields).
