### PR TITLE
chore: bump stCarolas/setup-maven GH Action

### DIFF
--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -15,7 +15,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v4.5
+      uses: stCarolas/setup-maven@v5
       with:
         maven-version: ${{ inputs.mvn-version }}
     - name: Set up JDK 17


### PR DESCRIPTION
## Proposed change

Bumping to v5 https://github.com/stCarolas/setup-maven/releases/tag/v5 that runs on Node 20.