### PR TITLE
test(ama-sdk): format it spec

### DIFF
--- a/packages/@ama-sdk/create/src/index.it.spec.ts
+++ b/packages/@ama-sdk/create/src/index.it.spec.ts
@@ -25,7 +25,7 @@ describe('Create new sdk command', () => {
   beforeEach(async () => {
     const isYarnTest = packageManager.startsWith('yarn');
     const yarnVersion = isYarnTest ? getYarnVersionFromRoot(process.cwd()) || 'latest' : undefined;
-    sdkFolderPath = (await prepareTestEnv(projectName, {type: 'blank', yarnVersion })).workspacePath;
+    sdkFolderPath = (await prepareTestEnv(projectName, { type: 'blank', yarnVersion })).workspacePath;
     sdkPackagePath = path.join(sdkFolderPath, sdkPackageName.replace(/^@/, ''));
     execAppOptions.cwd = sdkFolderPath;
 
@@ -34,9 +34,9 @@ describe('Create new sdk command', () => {
       packageManagerInstall(execAppOptions);
 
       // copy yarnrc config to generated SDK
-      mkdirSync(sdkPackagePath, {recursive: true});
+      mkdirSync(sdkPackagePath, { recursive: true });
       cpSync(path.join(sdkFolderPath, '.yarnrc.yml'), path.join(sdkPackagePath, '.yarnrc.yml'));
-      cpSync(path.join(sdkFolderPath, '.yarn'), path.join(sdkPackagePath, '.yarn'), {recursive: true});
+      cpSync(path.join(sdkFolderPath, '.yarn'), path.join(sdkPackagePath, '.yarn'), { recursive: true });
       fs.writeFileSync(path.join(sdkPackagePath, 'yarn.lock'), '');
     } else {
       // copy npmrc config to generated SDK
@@ -56,27 +56,27 @@ describe('Create new sdk command', () => {
         args: ['typescript', sdkPackageName, '--package-manager', packageManager, '--spec-path', path.join(sdkFolderPath, 'swagger-spec.yml')]
       }, execAppOptions)
     ).not.toThrow();
-    expect(() => packageManagerRun({script: 'build'}, { ...execAppOptions, cwd: sdkPackagePath })).not.toThrow();
+    expect(() => packageManagerRun({ script: 'build' }, { ...execAppOptions, cwd: sdkPackagePath })).not.toThrow();
   });
 
   test('should generate an empty SDK ready to be used', () => {
-    expect(() => packageManagerCreate({script: '@ama-sdk', args: ['typescript', sdkPackageName]}, execAppOptions)).not.toThrow();
-    expect(() => packageManagerRun({script: 'build'}, { ...execAppOptions, cwd: sdkPackagePath })).not.toThrow();
+    expect(() => packageManagerCreate({ script: '@ama-sdk', args: ['typescript', sdkPackageName] }, execAppOptions)).not.toThrow();
+    expect(() => packageManagerRun({ script: 'build' }, { ...execAppOptions, cwd: sdkPackagePath })).not.toThrow();
     expect(() =>
       packageManagerExec({
         script: 'schematics',
         args: ['@ama-sdk/schematics:typescript-core', '--spec-path', path.join(path.relative(sdkPackagePath, sdkFolderPath), 'swagger-spec.yml')]
       }, { ...execAppOptions, cwd: sdkPackagePath })
     ).not.toThrow();
-    expect(() => packageManagerRun({script: 'build'}, { ...execAppOptions, cwd: sdkPackagePath })).not.toThrow();
-    expect(() => packageManagerRun({script: 'doc:generate'}, { ...execAppOptions, cwd: sdkPackagePath })).not.toThrow();
+    expect(() => packageManagerRun({ script: 'build' }, { ...execAppOptions, cwd: sdkPackagePath })).not.toThrow();
+    expect(() => packageManagerRun({ script: 'doc:generate' }, { ...execAppOptions, cwd: sdkPackagePath })).not.toThrow();
   });
 
   test('should fail when there is an error', () => {
     expect(() =>
       packageManagerCreate({
         script: '@ama-sdk',
-        args: ['typescript', sdkPackageName, '--package-manager', packageManager, '--spec-path','./missing-file.yml']
+        args: ['typescript', sdkPackageName, '--package-manager', packageManager, '--spec-path', './missing-file.yml']
       }, execAppOptions)
     ).toThrow();
   });


### PR DESCRIPTION
## Proposed change

The goal is to have a cache miss on the CI for the int test for ama-sdk create.

https://github.com/AmadeusITGroup/otter/pull/1437 [did not run](https://cloud.nx.app/runs/P4Wm9S2wNy) the test for `ama-sdk/create` even if the `package.json` was touched. 
