### PR TITLE
feat(eslint-plugin): add resolutions field support to version harmonize

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/nrwl/nx/master/packages/nx/schemas/nx-schema.json",
-  "affected": {
-    "defaultBase": "remotes/origin/main"
-  },
+  "defaultBase": "remotes/origin/main",
   "cli": {
     "schematicCollections": [
       "@schematics/angular",

--- a/packages/@o3r/eslint-plugin/src/rules/json/json-dependency-versions-harmonize/json-dependency-versions-harmonize.spec.ts
+++ b/packages/@o3r/eslint-plugin/src/rules/json/json-dependency-versions-harmonize/json-dependency-versions-harmonize.spec.ts
@@ -57,7 +57,12 @@ ruleTester.run('json-dependency-versions-harmonize', jsonDependencyVersionsHarmo
     { code: JSON.stringify({ dependencies: { myDep: '1.0.0' } }), filename: packageToLint, options: [{ ignoredDependencies: ['myDep'] }] },
     { code: JSON.stringify({ dependencies: { myDep: '1.0.0' } }), filename: packageToLint, options: [{ ignoredDependencies: ['my*'] }] },
     { code: JSON.stringify({ dependencies: { myOtherDep: '1.0.0' } }), filename: packageToLint, options: [{ ignoredPackages: ['testPackage'] }] },
-    { code: JSON.stringify({ peerDependencies: { myOtherDep: '^2.0.0' } }), filename: packageToLint, options: [{ alignPeerDependencies: false }] }
+    { code: JSON.stringify({ peerDependencies: { myOtherDep: '^2.0.0' } }), filename: packageToLint, options: [{ alignPeerDependencies: false }] },
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    { code: JSON.stringify({ resolutions: { 'test/sub/myDep': '1.0.0' } }), filename: packageToLint, options: [{ alignResolutions: false }] },
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    { code: JSON.stringify({ overrides: { test: { myDep: '1.0.0' } } }), filename: packageToLint, options: [{ alignResolutions: false }] },
+    { code: JSON.stringify({ overrides: { myDep: '1.0.0' } }), filename: packageToLint, options: [{ alignResolutions: false }] }
   ],
   invalid: [
     {
@@ -127,6 +132,60 @@ ruleTester.run('json-dependency-versions-harmonize', jsonDependencyVersionsHarmo
             depName: 'myOtherDep',
             packageJsonFile: path.join(fakeFolder, 'local', 'packages', 'my-package-2', 'package.json'),
             version: '~2.0.0'
+          }
+        }
+      ]
+    },
+    {
+      filename: packageToLint,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      output: JSON.stringify({ resolutions: { 'test/sub/myDep': '^2.0.0' } }),
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      code: JSON.stringify({ resolutions: { 'test/sub/myDep': '1.0.0' } }),
+      options: [{ alignResolutions: true }],
+      errors: [
+        {
+          messageId: 'error',
+          data: {
+            depName: 'test/sub/myDep',
+            packageJsonFile: path.join(fakeFolder, 'local', 'package.json'),
+            version: '^2.0.0'
+          }
+        }
+      ]
+    },
+    {
+      filename: packageToLint,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      output: JSON.stringify({ overrides: { test: { myDep: '^2.0.0' } } }),
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      code: JSON.stringify({ overrides: { test: { myDep: '1.0.0' } } }),
+      options: [{ alignResolutions: true }],
+      errors: [
+        {
+          messageId: 'error',
+          data: {
+            depName: 'myDep',
+            packageJsonFile: path.join(fakeFolder, 'local', 'package.json'),
+            version: '^2.0.0'
+          }
+        }
+      ]
+    },
+    {
+      filename: packageToLint,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      output: JSON.stringify({ overrides: { myDep: '^2.0.0' } }),
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      code: JSON.stringify({ overrides: { myDep: '1.0.0' } }),
+      options: [{ alignResolutions: true }],
+      errors: [
+        {
+          messageId: 'error',
+          data: {
+            depName: 'myDep',
+            packageJsonFile: path.join(fakeFolder, 'local', 'package.json'),
+            version: '^2.0.0'
           }
         }
       ]

--- a/packages/@o3r/eslint-plugin/src/rules/json/json-dependency-versions-harmonize/json-dependency-versions-harmonize.ts
+++ b/packages/@o3r/eslint-plugin/src/rules/json/json-dependency-versions-harmonize/json-dependency-versions-harmonize.ts
@@ -17,12 +17,15 @@ interface Options {
    * If not set, the version will be aligned with the latest range if the latest range is not intersected with the current range.
    */
   alignPeerDependencies: boolean;
+  /** Align the resolutions/overrides dependency rules with the latest determined range */
+  alignResolutions: boolean;
 }
 
 const defaultOptions: [Options] = [{
   ignoredDependencies: [],
   dependencyTypes: ['optionalDependencies', 'dependencies', 'devDependencies', 'peerDependencies', 'generatorDependencies'],
   alignPeerDependencies: false,
+  alignResolutions: true,
   ignoredPackages: []
 }];
 
@@ -64,6 +67,10 @@ export default createRule<[Options, ...any], 'versionUpdate' | 'error', any>({
             items: {
               type: 'string'
             }
+          },
+          alignResolutions: {
+            type: 'boolean',
+            description: 'Align the resolutions dependencies with the latest determined range.'
           }
         },
         additionalProperties: false
@@ -77,11 +84,13 @@ export default createRule<[Options, ...any], 'versionUpdate' | 'error', any>({
   },
   defaultOptions,
   create: (context, [options]: [Options]) => {
+    const resolutionsFields = ['resolutions', 'overrides'];
     const parserServices = getJsoncParserServices(context);
     const dirname = path.dirname(context.getFilename());
     const workspace = findWorkspacePackageJsons(dirname);
     const bestRanges = workspace && getBestRanges(options.dependencyTypes, workspace.packages.filter(({ content }) => !content.name || !options.ignoredPackages.includes(content.name)));
     const ignoredDependencies = options.ignoredDependencies.map((dep) => new RegExp(dep.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*')));
+    const dependencyTypes = [...options.dependencyTypes, ...(options.alignResolutions ? resolutionsFields : [])];
 
     if (parserServices.isJSON) {
       return {
@@ -89,19 +98,13 @@ export default createRule<[Options, ...any], 'versionUpdate' | 'error', any>({
         'JSONExpressionStatement': (node: AST.JSONExpressionStatement) => {
           if (node.expression.type === 'JSONObjectExpression') {
             const deps = node.expression.properties
-              .filter(({ key }) => options.dependencyTypes.includes(key.type === 'JSONLiteral' ? key.value.toString() : key.name));
+              .filter(({ key }) => dependencyTypes.includes(key.type === 'JSONLiteral' ? key.value.toString() : key.name));
             if (deps.length > 0 && bestRanges) {
               deps
                 .map((depGroup) => depGroup.value)
                 .filter((depGroup): depGroup is AST.JSONObjectExpression => depGroup.type === 'JSONObjectExpression')
                 .forEach((depGroup) => {
-                  depGroup.properties.forEach((dep) => {
-                    const name = dep.key.type === 'JSONLiteral' ? dep.key.value.toString() : dep.key.name;
-                    if (ignoredDependencies.some((ignore) => ignore.test(name))) {
-                      return;
-                    }
-                    const range = dep.value.type === 'JSONLiteral' ? dep.value.value as string : (dep.value.type === 'JSONIdentifier' ? dep.value.name : undefined);
-                    const bestRange = getBestRange(range, bestRanges[name]?.range);
+                  const report = (name: string, resolvedName: string, dep: AST.JSONProperty, range: string | undefined, bestRange: string | undefined) => {
                     if (bestRange && bestRange !== range) {
                       if (!options.alignPeerDependencies && depGroup.parent.type === 'JSONProperty' && range &&
                         (depGroup.parent.key.type === 'JSONLiteral' ? depGroup.parent.key.value.toString() : depGroup.parent.key.name) === 'peerDependencies' &&
@@ -114,7 +117,7 @@ export default createRule<[Options, ...any], 'versionUpdate' | 'error', any>({
                         data: {
                           depName: name,
                           version: bestRange,
-                          packageJsonFile: bestRanges[name].path
+                          packageJsonFile: bestRanges[resolvedName].path
                         },
                         fix: (fixer) => fixer.replaceTextRange(dep.value.range, `"${bestRange}"`),
                         suggest: [
@@ -128,6 +131,33 @@ export default createRule<[Options, ...any], 'versionUpdate' | 'error', any>({
                         ]
                       });
                     }
+                  };
+
+                  depGroup.properties.forEach((dependencyNode) => {
+                    const isResolutionsField = options.alignResolutions && depGroup.parent.type === 'JSONProperty' &&
+                      resolutionsFields.includes(depGroup.parent.key.type === 'JSONLiteral' ? depGroup.parent.key.value.toString() : depGroup.parent.key.name);
+
+                    const getNodeDetails = (dep: AST.JSONProperty): void => {
+                      const name = dep.key.type === 'JSONLiteral' ? dep.key.value.toString() : dep.key.name;
+                      const nameParts = name.split('/');
+                      if (ignoredDependencies.some((ignore) => ignore.test(name))) {
+                        return;
+                      }
+
+                      const range = dep.value.type === 'JSONLiteral' ? dep.value.value as string : (dep.value.type === 'JSONIdentifier' ? dep.value.name : undefined);
+                      if (!range && dep.value.type === 'JSONObjectExpression') {
+                        return dep.value.properties
+                          .forEach((prop) => getNodeDetails(prop));
+                      }
+
+                      const resolutionSubNameIndex = isResolutionsField ? nameParts.findIndex((_, i) => !!bestRanges[nameParts.slice(nameParts.length - i).join('/')]) : -1;
+                      const resolvedName = resolutionSubNameIndex > -1 ? nameParts.slice(nameParts.length - resolutionSubNameIndex).join('/') : name;
+                      const bestRange = getBestRange(range, bestRanges[resolvedName]?.range);
+
+                      report(name, resolvedName, dep, range, bestRange);
+                    };
+
+                    getNodeDetails(dependencyNode);
                   });
                 });
             }


### PR DESCRIPTION
## Proposed change

Add `resolutions` field support to version harmonize

## Related issues

- :rocket: Feature resolves #1448 

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
