### PR TITLE
fix(ama-sdk-core): removing useless abort controller in angular client

### DIFF
--- a/packages/@ama-sdk/core/src/clients/api-angular-client.ts
+++ b/packages/@ama-sdk/core/src/clients/api-angular-client.ts
@@ -102,10 +102,6 @@ export class ApiAngularClient implements ApiClient {
     try {
       const headers = Object.fromEntries(options.headers.entries());
 
-      const controller = typeof AbortController !== 'undefined' ? new AbortController() : undefined;
-      if (controller) {
-        options.signal = controller.signal;
-      }
       const asyncResponse = new Promise<HttpResponse<any>>((resolve, reject) => {
         let data: HttpResponse<any>;
         this.options.httpClient.request(options.method, url, {


### PR DESCRIPTION
## Proposed change

The angular client in `@ama-sdk/core` creates an abort controller, but there is no way to abort the request, so that part of the code is useless and should be removed. Also the correct way to abort a request with [httpClient.request](https://angular.io/api/common/http/HttpClient#request) is to unsubscribe from the observable (and not to pass a signal to the request method).