### PR TITLE
fix(test-helpers): remove useLocker option in createWithLock

### DIFF
--- a/packages/@o3r/test-helpers/src/test-environments/create-test-environment-blank.ts
+++ b/packages/@o3r/test-helpers/src/test-environments/create-test-environment-blank.ts
@@ -29,7 +29,6 @@ export async function createTestEnvironmentBlank(inputOptions: Partial<CreateTes
     cwd: process.cwd(),
     globalFolderPath: process.cwd(),
     registry: 'http://127.0.0.1:4873',
-    useLocker: true,
     lockTimeout: 10 * 60 * 1000,
     replaceExisting: true,
     ...inputOptions

--- a/packages/@o3r/test-helpers/src/test-environments/create-test-environment-otter-project.ts
+++ b/packages/@o3r/test-helpers/src/test-environments/create-test-environment-otter-project.ts
@@ -50,7 +50,6 @@ export async function createTestEnvironmentOtterProjectWithApp(inputOptions: Par
     cwd: process.cwd(),
     globalFolderPath: process.cwd(),
     registry: 'http://127.0.0.1:4873',
-    useLocker: true,
     lockTimeout: 10 * 60 * 1000,
     replaceExisting: true,
     ...inputOptions


### PR DESCRIPTION
## Proposed change

As shown [here](https://github.com/AmadeusITGroup/otter/actions/runs/8176333422/job/22356066726?pr=1460#step:12:66) it is possible for a race condition to happen while creating the `it-tests` folder. This PR removes the `useLocker` option in `createWithLock` to force the usage of the locker (and hopefully avoid such race conditions).