### PR TITLE
docs: v10 migration guide for pipe rename

### DIFF
--- a/migration-guides/10.0.md
+++ b/migration-guides/10.0.md
@@ -56,3 +56,19 @@ available in ``@o3r/rules-engine``) and dedicated modules to handle the actions 
 This change allows a better tuning of the stores and packages loaded with your application. This means that from version
 10 onwards, actions need to be explicitly registered in your application.
 You will find more information on the integration of the new rules engine on the [dedicated documentation](../docs/rules-engine/how-to-use/integration.md).
+
+## Otter pipes are now prefixed
+
+In order to avoid name clashes with pipes coming from other libraries, all Otter pipes are now prefixed with `o3r`. Also, Angular started [raising warnings](https://github.com/AmadeusITGroup/otter/issues/1214) about this.
+
+> [!TIP]
+> The migration is handled by the `ng update @o3r/core` script.
+
+| Previous pipe   | Prefixed pipe      |
+|-----------------|--------------------|
+| capitalize      | o3rCapitalize      |
+| duration        | o3rDuration        |
+| keepWhiteSpace  | o3rKeepWhiteSpace  |
+| replaceWithBold | o3rReplaceWithBold |
+| dynamicContent  | o3rDynamicContent  |
+| translate       | o3rTranslate       |


### PR DESCRIPTION
## Proposed change

Add migration details for pipe rename (even if the migration is handled by the `ng update` script).

## Related issues

- :rocket: Feature #1253

