### PR TITLE
feat(ama-sdk-core): abort requests by passing an abort signal in metadata

### DIFF
--- a/packages/@ama-sdk/core/src/clients/api-fetch-client.ts
+++ b/packages/@ama-sdk/core/src/clients/api-fetch-client.ts
@@ -114,10 +114,13 @@ export class ApiFetchClient implements ApiClient {
     // Execute call
     try {
 
+      const metadataSignal = options.metadata?.signal;
+      metadataSignal?.throwIfAborted();
+
       const controller = new AbortController();
-      if (controller) {
-        options.signal = controller.signal;
-      }
+      options.signal = controller.signal;
+      metadataSignal?.addEventListener('abort', () => controller.abort());
+
       const loadedPlugins: (PluginAsyncRunner<Response, FetchCall> & PluginAsyncStarter)[] = [];
       if (this.options.fetchPlugins) {
         loadedPlugins.push(...this.options.fetchPlugins.map((plugin) => plugin.load({url, options, fetchPlugins: loadedPlugins, controller, apiClient: this, logger: this.options.logger})));

--- a/packages/@ama-sdk/core/src/plugins/core/request-plugin.ts
+++ b/packages/@ama-sdk/core/src/plugins/core/request-plugin.ts
@@ -33,6 +33,8 @@ export interface RequestMetadata<C extends string = string, A extends string = s
   headerContentType?: C;
   /** Force a MIME type to be used as Accept header */
   headerAccept?: A;
+  /** Signal to abort the request */
+  signal?: AbortSignal;
 }
 
 export interface RequestOptions extends RequestInit {


### PR DESCRIPTION
## Proposed change

Adds the ability to abort requests in `@ama-sdk/core` (and any request of an SDK generated by the Otter SDK generator) by passing an [abort signal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) in metadata. It is implemented both for the fetch and the angular client.
