### PR TITLE
feat(ama-sdk-create): allow creation without a scope

### DIFF
--- a/packages/@ama-sdk/create/src/index.it.spec.ts
+++ b/packages/@ama-sdk/create/src/index.it.spec.ts
@@ -10,7 +10,7 @@ import {
   setupLocalRegistry
 } from '@o3r/test-helpers';
 import * as fs from 'node:fs';
-import { cpSync, mkdirSync } from 'node:fs';
+import { cpSync, mkdirSync, renameSync } from 'node:fs';
 import * as path from 'node:path';
 
 const projectName = 'test-sdk';
@@ -58,6 +58,19 @@ describe('Create new sdk command', () => {
       }, execAppOptions)
     ).not.toThrow();
     expect(() => packageManagerRun({script: 'build'}, { ...execAppOptions, cwd: sdkPackagePath })).not.toThrow();
+  });
+
+  test('should generate an SDK with no package scope', () => {
+    const packageName = sdkPackageName.replace('@', '').split('/')[1];
+    const newSdkPackagePath = path.join(sdkFolderPath, packageName);
+    renameSync(sdkPackagePath, newSdkPackagePath);
+    expect(() =>
+      packageManagerCreate({
+        script: '@ama-sdk',
+        args: ['typescript', packageName, '--package-manager', packageManager, '--spec-path', path.join(sdkFolderPath, 'swagger-spec.yml')]
+      }, execAppOptions)
+    ).not.toThrow();
+    expect(() => packageManagerRun({script: 'build'}, { ...execAppOptions, cwd: newSdkPackagePath })).not.toThrow();
   });
 
   test('should generate an empty SDK ready to be used', () => {

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/index.spec.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/index.spec.ts
@@ -101,4 +101,15 @@ describe('Typescript Shell Generator', () => {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     expect(openApiTools['generator-cli'].generators).toEqual(expect.objectContaining({'test-scope-test-sdk': expect.anything()}));
   });
+
+  it('should work with no package scope', async () => {
+    const runner = new SchematicTestRunner('@ama-sdk/schematics', collectionPath);
+    const tree = await runner.runSchematic('typescript-shell', {
+      package: 'test-sdk',
+      skipInstall: true,
+      packageManager: 'npm'
+    }, Tree.empty());
+    const {name} = JSON.parse(tree.readContent('/package.json'));
+    expect(name).toEqual('test-sdk');
+  });
 });

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/schema.json
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/schema.json
@@ -44,7 +44,6 @@
   },
   "additionalProperties": true,
   "required": [
-    "name",
     "package"
   ]
 }

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/schema.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/schema.ts
@@ -2,7 +2,7 @@ import type { SchematicOptionObject } from '@o3r/schematics';
 
 export interface NgGenerateTypescriptSDKShellSchematicsSchema extends SchematicOptionObject {
   /** Project name (NPM package scope, package.json name will be @{projectName}/{packageName}) */
-  name: string;
+  name?: string;
 
   /** Package name (package.json name will be @{projectName}/{packageName}) */
   package: string;


### PR DESCRIPTION
## Proposed change

When running `npm create @ama-sdk typescript my-package`, I would intuitively expect a `my-package` package to be created in `my-package` folder.
What currently happens is the creation of the `@sdk/my-package` package inside the `sdk/my-package` folder. Why is this `sdk` scope added? I suggest in this PR to remove the `sdk` default scope.