### PR TITLE
fix(chrome-ext): display a specific message when component selection is not available

### DIFF
--- a/apps/chrome-devtools/src/app-devtools/component-panel/component-panel-pres.template.html
+++ b/apps/chrome-devtools/src/app-devtools/component-panel/component-panel-pres.template.html
@@ -1,18 +1,23 @@
-<div class="d-flex p-2 border-bottom align-items-center gap-2">
-  <i (click)="toggleInspector()" class="icon-external-link-square" [class.text-primary]="inspectorRunning"></i>
-  <button *ngIf="(isLookingToContainer$ | async) || (selectedComponentInfo$ | async)?.container" class="btn btn-primary" (click)="toggleContainerPresenter()">
-    Switch to {{(isLookingToContainer$ | async) ? 'Presenter' : 'Container'}}
-  </button>
-</div>
-<ng-container *ngIf="selectedComponentInfo$ | async as selectedComponentInfo; else noSelectedComponent">
-  <app-otter-component
-    [config]="config$ | async"
-    [rulesetExecutions]="rulesetExecutions$ | async"
-    [componentName]="selectedComponentInfo.componentName"
-    [translations]="selectedComponentInfo.translations"
-    [analytics]="selectedComponentInfo.analytics">
-  </app-otter-component>
-</ng-container>
-<ng-template #noSelectedComponent>
-  <h3>No selected component</h3>
-</ng-template>
+@if (isComponentSelectionAvailable$ | async) {
+  <div class="d-flex p-2 border-bottom align-items-center gap-2">
+    <i (click)="toggleInspector()" class="icon-external-link-square" [class.text-primary]="inspectorRunning"></i>
+    @if ((isLookingToContainer$ | async) || (selectedComponentInfo$ | async)?.container) {
+      <button class="btn btn-primary" (click)="toggleContainerPresenter()">
+        Switch to {{(isLookingToContainer$ | async) ? 'Presenter' : 'Container'}}
+      </button>
+    }
+  </div>
+  @if (selectedComponentInfo$ | async; as selectedComponentInfo) {
+    <app-otter-component
+      [config]="config$ | async"
+      [rulesetExecutions]="rulesetExecutions$ | async"
+      [componentName]="selectedComponentInfo.componentName"
+      [translations]="selectedComponentInfo.translations"
+      [analytics]="selectedComponentInfo.analytics">
+    </app-otter-component>
+  } @else {
+    <h3>No selected component</h3>
+  }
+} @else {
+  <h3>Component selection not available in production mode</h3>
+}

--- a/packages/@o3r/components/src/devkit/components-devkit.interface.ts
+++ b/packages/@o3r/components/src/devkit/components-devkit.interface.ts
@@ -1,18 +1,35 @@
 import type { ConnectContentMessage, DevtoolsCommonOptions, MessageDataTypes, OtterMessageContent, RequestMessagesContentMessage } from '@o3r/core';
 import { OtterLikeComponentInfo } from './inspector';
 
+/**
+ * Component Devtools options
+ */
 export interface ComponentsDevtoolsServiceOptions extends DevtoolsCommonOptions {
 }
 
+/**
+ * Message to give the selected component information
+ */
 export interface SelectedComponentInfoMessage extends OtterLikeComponentInfo, OtterMessageContent<'selectedComponentInfo'> {
 }
 
+/**
+ * Message to toggle the inspector
+ */
 export interface ToggleInspectorMessage extends OtterMessageContent<'toggleInspector'> {
   /** Is the inspector running */
   isRunning: boolean;
 }
 
+/**
+ * Message to know the component selection availability
+ */
+export interface IsComponentSelectionAvailableMessage extends OtterMessageContent<'isComponentSelectionAvailable'> {
+  available: boolean;
+}
+
 type ComponentsMessageContents =
+  | IsComponentSelectionAvailableMessage
   | SelectedComponentInfoMessage
   | ToggleInspectorMessage;
 
@@ -34,5 +51,6 @@ export const isComponentsMessage = (message: any): message is AvailableComponent
     message.dataType === 'requestMessages' ||
     message.dataType === 'connect' ||
     message.dataType === 'selectedComponentInfo' ||
+    message.dataType === 'isComponentSelectionAvailable' ||
     message.dataType === 'toggleInspector');
 };

--- a/packages/@o3r/components/src/devkit/components-devtools.message.service.ts
+++ b/packages/@o3r/components/src/devkit/components-devtools.message.service.ts
@@ -50,13 +50,25 @@ export class ComponentsDevtoolsMessageService implements OnDestroy, DevtoolsServ
     }
   }
 
+  private sendIsComponentSelectionAvailable() {
+    this.sendMessage('isComponentSelectionAvailable', { available: !!(window as any).ng });
+  }
+
   /**
    * Function to trigger a re-send a requested messages to the Otter Chrome DevTools extension
    * @param only restricted list of messages to re-send
    */
   private handleReEmitRequest(only?: ComponentsMessageDataTypes[]) {
-    if (!only || only.includes('selectedComponentInfo')) {
+    if (!only) {
       void this.sendCurrentSelectedComponent();
+      this.sendIsComponentSelectionAvailable();
+      return;
+    }
+    if (only.includes('selectedComponentInfo')) {
+      void this.sendCurrentSelectedComponent();
+    }
+    if (only.includes('isComponentSelectionAvailable')) {
+      this.sendIsComponentSelectionAvailable();
     }
   }
 


### PR DESCRIPTION
## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
