### PR TITLE
docs(compodoc): prevent broken fallback on 404

### DIFF
--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,8 +1,4 @@
 {
-  "navigationFallback": {
-    "rewrite": "index.html",
-    "exclude": ["/assets/*.{png,jpg,gif,css,js}"]
-  },
   "globalHeaders": {
     "content-security-policy": "default-src https: 'unsafe-eval' 'unsafe-inline'; object-src 'none'"
   },


### PR DESCRIPTION
## Proposed change

Currently on the compodoc, if we target a page that does not exist, we land on a broken page
https://docs.otter.digitalforairlines.com/THIS/LINK/IS/BROKEN.html

We should land on a 404 page

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
