### PR TITLE
feat: split and export renovate presets

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>AmadeusITGroup/otter//tools/renovate/base",
+    "github>AmadeusITGroup/otter//tools/renovate/design-factory",
+    "github>AmadeusITGroup/otter//tools/renovate/otter-project",
+    "github>AmadeusITGroup/otter//tools/renovate/sdk"
+  ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/templates/**"
+  ],
+  "enabledManagers": [
+    "npm",
+    "github-actions",
+    "gradle"
+  ],
+  "labels": [
+    "upgrade"
+  ],
+  "baseBranches": [
+    "main",
+    "/^release\\/.*-next$/"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "typescript",
+        "eslint",
+        "@yarnpkg/sdks"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "yarn install",
+          "yarn sdks"
+        ],
+        "executionMode": "branch",
+        "fileFilters": [
+          ".yarn/sdks/**"
+        ]
+      }
+    },
+    {
+      // Update of bootstrap disabled as it is not supported by design-factory (Can be removed when upgrading design-factory to v17)
+      "matchCurrentVersion": "<=5.2.0",
+      "matchPackageNames": [
+        "bootstrap"
+      ],
+      "enabled": false
+    },
+    {
+      //Major update of chalk disabled as it drops support on CommonJS
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "matchCurrentVersion": "<5",
+      "matchPackageNames": [
+        "chalk"
+      ],
+      "enabled": false
+    },
+    {
+      //Major update of globby disabled as it drops support on CommonJS
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "matchCurrentVersion": "<14",
+      "matchPackageNames": [
+        "globby"
+      ],
+      "enabled": false
+    },
+    {
+      // This rule disable the upgrade of the gaurav-nelson/github-action-markdown-link-check
+      // TODO: re-activate the upgrade when the following issue is fixed: gaurav-nelson/github-action-markdown-link-check#200
+      "matchPackagePatterns": [
+        ".*markdown-link-check"
+      ],
+      "enabled": false
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,9 @@
     "**/.DS_Store": true,
     "**/Thumbs.db": true
   },
+  "files.associations": {
+    "*.json5": "jsonc"
+  },
   "npm.packageManager": "yarn",
   "typescript.tsdk": ".yarn/sdks/typescript/lib",
   "typescript.preferences.importModuleSpecifier": "relative",

--- a/docs/renovate/readme.md
+++ b/docs/renovate/readme.md
@@ -1,0 +1,31 @@
+# Renovate Presets
+
+The Otter library provides a set of custom [Renovate Presets](https://docs.renovatebot.com/config-presets/) to facilitate the configuration of automated dependency updates.
+
+## Usage
+
+To be able to benefit from the Renovate Presets exposed by the Otter Framework, you can add the configurations in the `extends` field in your `.renovaterc.json` file as described in the following example:
+
+```json5
+{
+  "extends": [
+    "config:base"
+    "github>AmadeusITGroup/otter//tools/renovate/base",
+    "github>AmadeusITGroup/otter//tools/renovate/otter-project"
+  ],
+  "packageRules": [
+    // ...
+  ]
+}
+```
+
+> [!NOTE]
+> The Otter Renovate presets are always prefixed with `github>AmadeusITGroup/otter//tools/renovate/` to target the specific configuration files hosted in the Otter repository.
+
+## Available presets
+
+- **base**: Base configuration recommended to an Otter base project.
+- **otter-project**: Configuration to be used in a project to facilitate and regroup the upgrades of Otter dependencies.
+- **sdk**: Configuration to ensure the upgrade of the dependencies of a generated SDK
+- **sdk-spec-upgrade**: Setup an auto-regeneration of the SDK based on a given Swagger/OAS specification dependency (as first [parameter](https://docs.renovatebot.com/config-presets/#preset-parameters)).
+- **design-factory**: Renovate configuration to ensure the dependency upgrade of the Design Factory dependencies are following the Design Factory constraints.

--- a/packages/@ama-sdk/schematics/schematics/ng-update/typescript/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/ng-update/typescript/index.ts
@@ -3,6 +3,7 @@
 
 import { chain, Rule } from '@angular-devkit/schematics';
 import { addCpyDependencies, deprecateScriptsFolder, updateScriptPackageJson } from './v10.0/script-removal';
+import { addPresetsRenovate } from './v10.1/add-presets-renovate';
 
 /**
  * update of Otter library V10.0
@@ -12,6 +13,17 @@ export function updateV10_0(): Rule {
     updateScriptPackageJson(),
     deprecateScriptsFolder(),
     addCpyDependencies()
+  ];
+
+  return chain(updateRules);
+}
+
+/**
+ * Update of Ama-sdk library V10.1
+ */
+export function updateV10_1(): Rule {
+  const updateRules: Rule[] = [
+    addPresetsRenovate()
   ];
 
   return chain(updateRules);

--- a/packages/@ama-sdk/schematics/schematics/ng-update/typescript/v10.1/add-presets-renovate.ts
+++ b/packages/@ama-sdk/schematics/schematics/ng-update/typescript/v10.1/add-presets-renovate.ts
@@ -1,0 +1,23 @@
+import type { Rule } from '@angular-devkit/schematics';
+
+const renovatePresets = [
+  'github>AmadeusITGroup/otter//tools/renovate/base',
+  'github>AmadeusITGroup/otter//tools/renovate/sdk'
+];
+
+export const addPresetsRenovate = (): Rule => {
+  return (tree, context) => {
+    if (tree.exists('.renovaterc.json')) {
+      const renovateConfig = tree.readJson('.renovaterc.json') as any;
+      renovateConfig.extends ||= [];
+      renovatePresets
+        .filter((preset) => !renovateConfig.extends.includes(preset))
+        .forEach((preset) => renovateConfig.extends.push(preset));
+      tree.overwrite('renovate.json', JSON.stringify(renovateConfig, null, 2));
+    } else {
+      context.logger.debug('renovate.json not found, skipping preset addition');
+    }
+    // eslint-disable-next-line max-len
+    context.logger.info('To activate the auto-generation based on a dependency package, replace "my-specification-package", in your Renovate configuration, by your specification dependency package name.');
+  };
+};

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/.renovaterc.json
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/.renovaterc.json
@@ -2,19 +2,16 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
-    "group:allNonMajor",
-    "group:recommended",
-    "group:monorepos",
-    "group:test",
-    "group:linters"
+    "github>AmadeusITGroup/otter//tools/renovate/base",
+    "github>AmadeusITGroup/otter//tools/renovate/sdk",
+    "github>AmadeusITGroup/otter//tools/renovate/sdk-spec-upgrade(my-specification-package)"
   ],
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
   "baseBranches": [
-    "master"
+    "master",
+    "main"
   ],
-  "endpoint": "https://dev.azure.com/AmadeusDigitalAirline",
-  "platform": "azure",
   "enabledManagers": [
     "npm"
   ],
@@ -32,54 +29,6 @@
   "automerge": true,
   "platformAutomerge": true,
   "packageRules": [
-    {
-      "matchPackagePrefixes": [
-        "@my-api-scope",
-        "@ama-sdk/generator"
-      ],
-      "postUpgradeTasks": {
-        "commands": [
-          "<%=packageManager%> install",
-          "<%=packageManager%> run generate"
-        ],
-        "executionMode": "branch"
-      }
-    },
-    {
-      "matchPackagePrefixes": [
-        "@my-api-scope"
-      ],
-      "rangeStrategy": "bump",
-      "groupName": "Swagger Specification upgrade",
-      "groupSlug": "spec-upgrade"
-    },
-    {
-      "matchPackagePrefixes": [
-        "@my-api-scope"
-      ],
-      "matchBaseBranches": [
-        "/^release\/.*/"
-      ],
-      "rangeStrategy": "in-range-only"
-    },
-    {
-      "matchPackageNames": [
-        "@ama-sdk/core",
-        "@ama-sdk/schematics"
-      ],
-      "rangeStrategy": "bump",
-      "groupName": "SDK Core and Generator dependencies",
-      "groupSlug": "sdk-core-dependencies"
-    },
-    {
-      "excludePackagePrefixes": [
-        "@my-api-scope"
-      ],
-      "matchBaseBranches": [
-        "/^release\/.*/"
-      ],
-      "enabled": false
-    },
     {
       "matchDepTypes": [
         "peerDependencies"

--- a/packages/@o3r/workspace/migration.json
+++ b/packages/@o3r/workspace/migration.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular_devkit/schematics/collection-schema.json",
   "schematics": {
-
+    "migration-v10_0": {
+      "version": "10.1.0-alpha.0",
+      "description": "Updates of @o3r/workspace to v10.1.*",
+      "factory": "./schematics/ng-update/index#updateV10_1"
+    }
   }
 }

--- a/packages/@o3r/workspace/schematics/ng-add/helpers/renovate/templates/__dot__renovaterc.json.template
+++ b/packages/@o3r/workspace/schematics/ng-add/helpers/renovate/templates/__dot__renovaterc.json.template
@@ -2,15 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
-    "group:allNonMajor",
-    "group:monorepos",
-    "group:recommended",
-    "group:test"
+    "github>AmadeusITGroup/otter//tools/renovate/base",
+    "github>AmadeusITGroup/otter//tools/renovate/otter-project"
   ],
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
   "baseBranches": [
-    "master"
+    "main"
   ],
   "platform": "azure",
   "enabledManagers": [
@@ -28,34 +26,9 @@
   "packageRules": [
     {
       "matchPackageNames": [
-        "@o3r/core"
+        "@o3r/*"
       ],
-      "postUpgradeTasks": {
-        "commands": [
-          "npm install",
-          "npm run ng update {{{depName}}} --from={{{currentVersion}}} --to={{{newVersion}}} --migrate-only --allow-dirty --force"
-        ],
-        "fileFilters": [
-          "**"
-        ],
-        "executionMode": "branch"
-      }
-    },
-    {
-      "matchPackagePrefixes": [
-        "@otter",
-        "@o3r",
-        "@ama-sdk",
-        "@ama-terasu"
-      ],
-      "groupName": "Otter dependencies",
-      "groupSlug": "otter-dependencies"
-    },
-    {
-      "matchPackagePatterns": [
-        "*"
-      ],
-      "rangeStrategy": "replace"
+      "automergeType": "patch"
     }
   ]
 }

--- a/packages/@o3r/workspace/schematics/ng-update/index.ts
+++ b/packages/@o3r/workspace/schematics/ng-update/index.ts
@@ -1,1 +1,21 @@
-export type {};
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable camelcase */
+
+import { chain, type Rule } from '@angular-devkit/schematics';
+import { createSchematicWithMetricsIfInstalled } from '@o3r/schematics';
+import { addPresetsRenovate } from './v10.1/add-presets-renovate';
+
+/**
+ * Update of Otter Workspace V10.1
+ */
+function updateV10_1Fn(): Rule {
+  const updateRules: Rule[] = [
+    addPresetsRenovate()
+  ];
+  return chain(updateRules);
+}
+
+/**
+ * Update of Otter Workspace V10.1
+ */
+export const updateV10_1 = createSchematicWithMetricsIfInstalled(updateV10_1Fn);

--- a/packages/@o3r/workspace/schematics/ng-update/v10.1/add-presets-renovate.ts
+++ b/packages/@o3r/workspace/schematics/ng-update/v10.1/add-presets-renovate.ts
@@ -1,0 +1,21 @@
+import type { Rule } from '@angular-devkit/schematics';
+
+const renovatePresets = [
+  'github>AmadeusITGroup/otter//tools/renovate/base',
+  'github>AmadeusITGroup/otter//tools/renovate/otter-project'
+];
+
+export const addPresetsRenovate = (): Rule => {
+  return (tree, context) => {
+    if (tree.exists('.renovaterc.json')) {
+      const renovateConfig = tree.readJson('.renovaterc.json') as any;
+      renovateConfig.extends ||= [];
+      renovatePresets
+        .filter((preset) => !renovateConfig.extends.includes(preset))
+        .forEach((preset) => renovateConfig.extends.push(preset));
+      tree.overwrite('renovate.json', JSON.stringify(renovateConfig, null, 2));
+    } else {
+      context.logger.info('renovate.json not found, skipping preset addition');
+    }
+  };
+};

--- a/tools/renovate/base.json
+++ b/tools/renovate/base.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
+    "config:recommended",
     ":dependencyDashboard",
     "group:allNonMajor",
     "group:monorepos",
@@ -11,26 +12,22 @@
     "helpers:pinGitHubActionDigestsToSemver",
     "schedule:nonOfficeHours"
   ],
-  "ignorePaths": [
-    "**/node_modules/**",
-    "**/templates/**"
-  ],
   "hostRules": [
     {
       "timeout": 240000
     }
   ],
+  "baseBranches": [
+    "main",
+    "master",
+    "/^release\\/.*-next$/"
+  ],
   "timezone": "Europe/Paris",
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
-  "baseBranches": [
-    "main",
-    "/^release\\/.*-next$/"
-  ],
   "enabledManagers": [
     "npm",
-    "github-actions",
-    "gradle"
+    "github-actions"
   ],
   "npm": {
     "stabilityDays": 0
@@ -40,7 +37,7 @@
     "yarnDedupeHighest"
   ],
   "labels": [
-    "dependencies"
+    "upgrade"
   ],
   "automerge": true,
   "platformAutomerge": true,
@@ -52,30 +49,6 @@
   },
   "packageRules": [
     {
-      "matchPackageNames": [
-        "@angular/core",
-        "@o3r/*"
-      ],
-      "postUpgradeTasks": {
-        "commands": [
-          "yarn install",
-          "yarn ng update {{{depName}}} --from={{{currentVersion}}} --to={{{newVersion}}} --migrate-only --allow-dirty --force",
-          "yarn dlx browserslist@latest --update-db"
-        ],
-        "executionMode": "branch",
-        "fileFilters": [
-          "**"
-        ]
-      }
-    },
-    {
-      "matchPackagePrefixes": [
-        "@o3r"
-      ],
-      "groupName": "Otter dependencies",
-      "groupSlug": "otter-dependencies"
-    },
-    {
       "matchPackagePatterns": [
         "*"
       ],
@@ -83,19 +56,34 @@
       "rangeStrategy": "replace"
     },
     {
-      "matchPackagePrefixes": [
-        "@o3r"
+      "matchManagers":[
+        "yarn"
       ],
-      "rangeStrategy": "bump"
-    },
-    {
       "matchDepTypes": [
         "packageManager"
       ],
       "postUpgradeTasks": {
         "commands": [
-          "yarn install",
-          "yarn harmonize:version"
+          "yarn install"
+        ],
+        "executionMode": "branch",
+        "fileFilters": [
+          "packages/**/package.json",
+          "packages/**/package.json.template",
+          "package.json"
+        ]
+      }
+    },
+    {
+      "matchManagers": [
+        "npm"
+      ],
+      "matchDepTypes": [
+        "packageManager"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "npm install"
         ],
         "executionMode": "branch",
         "fileFilters": [
@@ -137,13 +125,13 @@
       ],
       "rangeStrategy": "in-range-only"
     },
-
     {
       "matchUpdateTypes": [
         "major"
       ],
       "matchBaseBranches": [
         "main",
+        "master",
         "/^release/"
       ],
       "enabled": false
@@ -168,15 +156,6 @@
       "rangeStrategy": "replace"
     },
     {
-      "matchPackagePatterns": [
-        "bootstrap",
-        "^ag-grid-",
-        "^@design-factory"
-      ],
-      "groupName": "Application dependencies",
-      "groupSlug": "application-dependencies"
-    },
-    {
       "matchUpdateTypes": [
         "major"
       ],
@@ -188,51 +167,22 @@
       "enabled": true
     },
     {
+      "matchManagers": [
+        "yarn"
+      ],
       "matchPackageNames": [
         "typescript",
-        "eslint",
-        "@yarnpkg/sdks"
+        "eslint"
       ],
       "postUpgradeTasks": {
         "commands": [
-          "yarn install",
-          "yarn sdks"
+          "yarn dlx @yarnpkg/sdks"
         ],
         "executionMode": "branch",
         "fileFilters": [
           ".yarn/sdks/**"
         ]
       }
-    },
-    {
-      "groupName": "Update of bootstrap disabled as it is not supported by design-factory (Can be removed when upgrading design-factory to v17)",
-      "matchCurrentVersion": "<=5.2.0",
-      "matchPackageNames": [
-        "bootstrap"
-      ],
-      "enabled": false
-    },
-    {
-      "groupName": "Major update of chalk disabled as it drops support on CommonJS",
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "matchCurrentVersion": "<5",
-      "matchPackageNames": [
-        "chalk"
-      ],
-      "enabled": false
-    },
-    {
-      "groupName": "Major update of globby disabled as it drops support on CommonJS",
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "matchCurrentVersion": "<14",
-      "matchPackageNames": [
-        "globby"
-      ],
-      "enabled": false
     }
   ]
 }

--- a/tools/renovate/design-factory.json
+++ b/tools/renovate/design-factory.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": [
+        "bootstrap",
+        "^ag-grid-",
+        "^@design-factory"
+      ],
+      "groupName": "Design Factory dependencies",
+      "groupSlug": "design-factory-dependencies"
+    }
+  ]
+}
+

--- a/tools/renovate/otter-project.json
+++ b/tools/renovate/otter-project.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "labels": [
+    "upgrade",
+    "otter"
+  ],
+  "updateInternalDeps": true,
+  "automerge": true,
+  "platformAutomerge": true,
+  "enabledManagers": [
+    "npm"
+  ],
+  "npm": {
+    "stabilityDays": 0
+  },
+  "packageRules": [
+    {
+      "matchManagers": [
+        "yarn"
+      ],
+      "matchPackageNames": [
+        "@o3r/core",
+        "@ama-sdk/core",
+        "@otter/core"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "yarn install",
+          "yarn run ng update {{{depName}}} --from={{{currentVersion}}} --to={{{newVersion}}} --migrate-only --allow-dirty --force"
+        ],
+        "fileFilters": [
+          "!**/.{npmrc,yarnrc*}"
+        ],
+        "executionMode": "branch"
+      }
+    },
+    {
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "@o3r/core",
+        "@ama-sdk/core",
+        "@otter/core"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "npm install",
+          "npm run ng update {{{depName}}} --from={{{currentVersion}}} --to={{{newVersion}}} --migrate-only --allow-dirty --force"
+        ],
+        "fileFilters": [
+          "!**/.{npmrc,yarnrc*}"
+        ],
+        "executionMode": "branch"
+      }
+    },
+    {
+      "matchBaseBranches": [
+        "main",
+        "master"
+      ],
+      "matchPackagePrefixes": [
+        "@otter",
+        "@o3r",
+        "@ama-sdk",
+        "@ama-terasu"
+      ],
+      "rangeStrategy": "bump"
+    },
+    {
+      "matchBaseBranches": [
+        "/^release/.*/"
+      ],
+      "matchPackagePrefixes": [
+        "@otter",
+        "@o3r",
+        "@ama-sdk",
+        "@ama-terasu"
+      ],
+      "rangeStrategy": "patch"
+    }
+  ]
+}

--- a/tools/renovate/sdk-spec-upgrade.json
+++ b/tools/renovate/sdk-spec-upgrade.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": [
+    "upgrade",
+    "specification"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "{{arg0}}"
+      ],
+      "matchBaseBranches": [
+        "master",
+        "main"
+      ],
+      "rangeStrategy": "bump",
+      "groupName": "Swagger Specification upgrade",
+      "groupSlug": "spec-upgrade"
+    },
+    {
+      "matchManagers": [
+        "npm"
+      ],
+      "matchBaseBranches": [
+        "master",
+        "main"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "npm install",
+          "npm run swagger:generate"
+        ],
+        "executionMode": "branch",
+        "fileFilters": [
+          "!**/.{npmrc,yarnrc*}"
+        ]
+      }
+    },
+    {
+      "matchPackageNames": [
+        "{{arg0}}"
+      ],
+      "matchManagers": [
+        "yarn"
+      ],
+      "matchBaseBranches": [
+        "master",
+        "main"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "yarn install",
+          "yarn run swagger:generate"
+        ],
+        "executionMode": "branch",
+        "fileFilters": [
+          "!**/.{npmrc,yarnrc*}"
+        ]
+      }
+    },
+    {
+      "matchPackageNames": [
+        "{{arg0}}"
+      ],
+      "matchBaseBranches": [
+        "/^release/.*/"
+      ],
+      "rangeStrategy": "patch"
+    },
+    {
+      "matchPackageNames": [
+        "{{arg0}}"
+      ],
+      "matchManagers": [
+        "npm"
+      ],
+      "matchBaseBranches": [
+        "/^release/.*/"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "npm install",
+          "npm run swagger:generate"
+        ],
+        "executionMode": "branch",
+        "fileFilters": [
+          "!**/.{npmrc,yarnrc*}"
+        ]
+      }
+    },
+    {
+      "matchPackageNames": [
+        "{{arg0}}"
+      ],
+      "matchManagers": [
+        "yarn"
+      ],
+      "matchBaseBranches": [
+        "/^release/.*/"
+      ],
+      "rangeStrategy": "patch",
+      "postUpgradeTasks": {
+        "commands": [
+          "yarn install",
+          "yarn run swagger:generate"
+        ],
+        "executionMode": "branch",
+        "fileFilters": [
+          "!**/.{npmrc,yarnrc*}"
+        ]
+      }
+    }
+  ]
+}

--- a/tools/renovate/sdk.json
+++ b/tools/renovate/sdk.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": [
+    "upgrade"
+  ],
+  "updateInternalDeps": true,
+  "automerge": true,
+  "platformAutomerge": true,
+  "packageRules": [
+    {
+      "matchBaseBranches": [
+        "master",
+        "main"
+      ],
+      "matchPackagePrefixes": [
+        "@ama-sdk"
+      ],
+      "rangeStrategy": "bump"
+    },
+    {
+      "matchBaseBranches": [
+        "/^release/.*/"
+      ],
+      "matchPackagePrefixes": [
+        "@ama-sdk"
+      ],
+      "rangeStrategy": "patch"
+    },
+    {
+      "groupName": "Otter SDK dependencies",
+      "groupSlug": "otter-sdk-dependencies",
+      "matchBaseBranches": [
+        "master",
+        "main",
+        "/^release/.*/"
+      ],
+      "matchPackagePrefixes": [
+        "@ama-sdk"
+      ]
+    },
+    {
+      "matchBaseBranches": [
+        "master",
+        "main",
+        "/^release/.*/"
+      ],
+      "matchPackagePrefixes": [
+        "@ama-sdk"
+      ],
+      "matchPackageNames": [
+        "npm"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "npm install",
+          "npm run swagger:generate"
+        ],
+        "fileFilters": [
+          "!**/.{npmrc,yarnrc*}"
+        ],
+        "executionMode": "branch"
+      }
+    },
+    {
+      "matchBaseBranches": [
+        "master",
+        "main",
+        "/^release/.*/"
+      ],
+      "matchPackagePrefixes": [
+        "@ama-sdk"
+      ],
+      "matchPackageNames": [
+        "yarn"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "yarn install",
+          "yarn run swagger:generate"
+        ],
+        "fileFilters": [
+          "!**/.{npmrc,yarnrc*}"
+        ],
+        "executionMode": "branch"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Proposed change

Split and export renovate presets

## Related issues

- :rocket: Feature resolves #1483 

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
