### PR TITLE
fix: duplicates of operators in rules-engine

### DIFF
--- a/packages/@o3r/rules-engine/builders/rules-engine-extractor/helpers/rules-engine.extractor.ts
+++ b/packages/@o3r/rules-engine/builders/rules-engine-extractor/helpers/rules-engine.extractor.ts
@@ -316,7 +316,7 @@ export class RulesEngineExtractor {
         });
       }
     });
-    return operators;
+    return Array.from((new Map(operators.map((operator) => [operator.id, operator]))).values());
   }
 
   /**


### PR DESCRIPTION
## Proposed change

An issue was raised regarding duplicated operators in the rules.operators.metadata.json file, so the proposed fix is to filter the operators before adding them in the file

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
