### PR TITLE
fix(vscode): add caching to the parsed design token files

### DIFF
--- a/apps/vscode-extension/tsconfig.json
+++ b/apps/vscode-extension/tsconfig.json
@@ -4,6 +4,9 @@
   "references": [
     {
       "path": "./tsconfig.build.composite.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
     }
   ]
 }


### PR DESCRIPTION
## Proposed change

Add caching to the parsed design token files mechanism

## Related issues

- :rocket: Feature resolves #1490 

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
