### PR TITLE
feat: only create schema file for facts of type object

### DIFF
--- a/packages/@o3r/rules-engine/builders/rules-engine-extractor/helpers/rules-engine.extractor.interfaces.ts
+++ b/packages/@o3r/rules-engine/builders/rules-engine-extractor/helpers/rules-engine.extractor.interfaces.ts
@@ -1,18 +1,49 @@
 /** Supported types for a fact */
-export type FactSupportedTypes = 'string' | 'number' | 'date' | 'object' | 'boolean';
+export type FactSupportedTypes = 'string' | 'number' | 'date' | 'object' | 'boolean' | 'array';
 
-/** Fact as description in the metadata file */
-export interface MetadataFact {
+/** Base metadata fact */
+interface BaseMetadataFact {
   /** Name of the Fact */
   name: string;
   /** Fact description */
   description?: string;
   /** Type of the fact */
   type: FactSupportedTypes;
+}
+
+/** Metadata fact of type enum */
+export interface EnumMetadataFact extends BaseMetadataFact {
+  /** @inheritdoc */
+  type: 'string';
+  /** Set of values of enum of type string */
+  enum: string[];
+}
+
+/** Metadata fact of type object */
+export interface ObjectMetadataFact extends BaseMetadataFact {
+  /** @inheritdoc */
+  type: 'object';
   /** Path to schema file describing the complex file */
   schemaFile?: string;
 }
 
+/** Metadata fact of type array */
+export interface ArrayMetadataFact extends BaseMetadataFact {
+  /** @inheritdoc */
+  type: 'array';
+  /** Items in array */
+  // eslint-disable-next-line no-use-before-define
+  items: MetadataFact;
+}
+
+/** Metadata fact of type string, number, date, or boolean */
+export interface OtherMetadataFact extends BaseMetadataFact {
+  /** @inheritdoc */
+  type: 'string' | 'number' | 'date' | 'boolean';
+}
+
+/** Fact as description in the metadata file */
+export type MetadataFact = OtherMetadataFact | ObjectMetadataFact | EnumMetadataFact | ArrayMetadataFact;
 /** Supported types for a operand */
 export type MetadataOperatorSupportedTypes = 'string' | 'number' | 'date' | 'object' | 'boolean';
 

--- a/packages/@o3r/rules-engine/builders/rules-engine-extractor/helpers/rules-engine.extractor.ts
+++ b/packages/@o3r/rules-engine/builders/rules-engine-extractor/helpers/rules-engine.extractor.ts
@@ -4,12 +4,25 @@ import { ConfigDocParser } from '@o3r/extractors';
 import { O3rCliError } from '@o3r/schematics';
 import { promises as fs } from 'node:fs';
 import globby from 'globby';
+import type { JSONSchema7Type } from 'json-schema';
 import * as path from 'node:path';
 import { lastValueFrom, zip } from 'rxjs';
 import { map } from 'rxjs/operators';
 import * as ts from 'typescript';
 import * as tjs from 'typescript-json-schema';
-import { Action, allDefaultSupportedTypes, allSupportedTypes, FactSupportedTypes, MetadataFact, MetadataOperator, MetadataOperatorSupportedTypes } from './rules-engine.extractor.interfaces';
+import {
+  Action,
+  allDefaultSupportedTypes,
+  allSupportedTypes,
+  ArrayMetadataFact,
+  EnumMetadataFact,
+  FactSupportedTypes,
+  MetadataFact,
+  MetadataOperator,
+  MetadataOperatorSupportedTypes,
+  ObjectMetadataFact,
+  OtherMetadataFact
+} from './rules-engine.extractor.interfaces';
 
 /**
  * Extracts rules engine facts and operator from code
@@ -26,12 +39,12 @@ export class RulesEngineExtractor {
   public static readonly RESERVED_FACT_NAMES: Readonly<string[]> = ['portalFacts'];
 
   /** TSConfig to parse the code  */
-  private tsconfig: any;
+  private readonly tsconfig: any;
 
   /** Instance of the comment parser */
   private readonly commentParser = new ConfigDocParser();
 
-  constructor(tsconfigPath: string, private basePath: string, private logger: LoggerApi) {
+  constructor(tsconfigPath: string, private readonly basePath: string, private readonly logger: LoggerApi) {
     const {config} = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
     this.tsconfig = config;
   }
@@ -41,9 +54,8 @@ export class RulesEngineExtractor {
    *
    * @param type Name of the type to extract
    * @param sourceFile path to the code source file
-   * @param outputPath path to the schema file to generate
    */
-  private async extractTypeRef(type: string, sourceFile: string, outputPath: string) {
+  private async extractTypeRef(type: string, sourceFile: string) {
     const internalLibFiles = this.tsconfig.extraOptions?.otterSubModuleRefs?.length > 0 ?
       await lastValueFrom(zip(...(this.tsconfig.extraOptions?.otterSubModuleRefs as string[]).map((value: string) => globby(value))).pipe(
         map((globFiles: string[][]) =>
@@ -67,7 +79,7 @@ export class RulesEngineExtractor {
     if (schema?.definitions?.['utils.DateTime']) {
       schema.definitions['utils.DateTime'] = {type: 'string', format: 'date-time'};
     }
-    return fs.writeFile(outputPath, JSON.stringify(schema, null, 2));
+    return schema;
   }
 
   /**
@@ -210,20 +222,53 @@ export class RulesEngineExtractor {
               const typeName = mainType.getText(source);
               const type = ts.isTypeReferenceNode(mainType) && typeName !== 'Date' ? 'object' : typeName.replace('Date', 'date') as FactSupportedTypes;
 
-              const fact: MetadataFact = {
-                name,
-                description,
-                type
-              };
+              let fact: MetadataFact;
 
               if (type === 'object') {
-                const schemaFile = `${strings.dasherize(typeName)}.schema.json`;
+                fact = {
+                  type: 'object',
+                  name,
+                  description
+                } as ObjectMetadataFact;
                 try {
-                  await this.extractTypeRef(typeName, sourceFile, path.resolve(schemaFolderFullPath, schemaFile));
-                  fact.schemaFile = path.join(schemaFolderRelativePath, schemaFile).replace(/[\\]/g, '/');
+                  const schema = await this.extractTypeRef(typeName, sourceFile);
+                  if (schema === null) {
+                    this.logger.warn(`Schema of ${typeName} is null.`);
+                  } else if (schema.type === 'object') {
+                    const schemaFile = `${strings.dasherize(typeName)}.schema.json`;
+                    await fs.writeFile(path.resolve(schemaFolderFullPath, schemaFile), JSON.stringify(schema, null, 2));
+                    fact = {
+                      ...fact,
+                      schemaFile: path.join(schemaFolderRelativePath, schemaFile).replace(/[\\]/g, '/')
+                    } as ObjectMetadataFact;
+                  } else if (schema.type === 'array') {
+                    fact = {
+                      ...fact,
+                      type: 'array',
+                      items: schema.items as MetadataFact
+                    } as ArrayMetadataFact;
+                  } else if (schema.enum) {
+                    fact = {
+                      ...fact,
+                      type: 'string',
+                      // eslint-disable-next-line @typescript-eslint/no-base-to-string
+                      enum: schema.enum?.filter((value): value is JSONSchema7Type => !!value).map((v) => v!.toString())
+                    } as EnumMetadataFact;
+                  } else {
+                    fact = {
+                      ...fact,
+                      type: schema.type as FactSupportedTypes
+                    } as OtherMetadataFact;
+                  }
                 } catch {
                   this.logger.warn(`Error when parsing ${type} in ${sourceFile}`);
                 }
+              } else {
+                fact = {
+                  type: type as unknown,
+                  name,
+                  description
+                } as OtherMetadataFact;
               }
               return fact;
             })

--- a/packages/@o3r/rules-engine/builders/rules-engine-extractor/index.ts
+++ b/packages/@o3r/rules-engine/builders/rules-engine-extractor/index.ts
@@ -3,7 +3,7 @@ import { CmsMetadataData, createBuilderWithMetricsIfInstalled, getLibraryCmsMeta
 import { existsSync, promises as fs } from 'node:fs';
 import globby from 'globby';
 import { dirname, resolve } from 'node:path';
-import { MetadataFact, MetadataOperator, RulesEngineExtractor } from './helpers';
+import { MetadataFact, MetadataOperator, ObjectMetadataFact, RulesEngineExtractor } from './helpers';
 import { RulesEngineExtractorBuilderSchema } from './schema';
 
 export * from './schema';
@@ -65,7 +65,7 @@ export default createBuilder(createBuilderWithMetricsIfInstalled<RulesEngineExtr
     Object.entries(rulesEngineFactsMetadataFileWithContent)
       .reduce((acc, [metadataFilePath, factsFile]) => acc.concat([
         ...(factsFile.facts || [])
-          .filter(({schemaFile}) => !!schemaFile)
+          .filter((fact: MetadataFact): fact is ObjectMetadataFact => fact.type === 'object' && !!fact.schemaFile)
           .map(({schemaFile}) => ({fullPath: resolve(dirname(metadataFilePath), schemaFile!), relativePath: schemaFile!}))
       ]), [] as { fullPath: string; relativePath: string }[])
       .map(({fullPath, relativePath}) => fs.copyFile(fullPath, resolve(basePath, relativePath)))

--- a/packages/@o3r/rules-engine/package.json
+++ b/packages/@o3r/rules-engine/package.json
@@ -123,6 +123,7 @@
     "@stylistic/eslint-plugin-ts": "^1.5.4",
     "@types/jasmine": "~5.1.0",
     "@types/jest": "~29.5.2",
+    "@types/json-schema": "^7.0.9",
     "@types/node": "^20.0.0",
     "@types/semver": "^7.3.13",
     "@typescript-eslint/eslint-plugin": "^7.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8277,6 +8277,7 @@ __metadata:
     "@stylistic/eslint-plugin-ts": "npm:^1.5.4"
     "@types/jasmine": "npm:~5.1.0"
     "@types/jest": "npm:~29.5.2"
+    "@types/json-schema": "npm:^7.0.9"
     "@types/node": "npm:^20.0.0"
     "@types/semver": "npm:^7.3.13"
     "@typescript-eslint/eslint-plugin": "npm:^7.2.0"


### PR DESCRIPTION
## Proposed change

Currently schema files are being created for all facts that have non-standard types or are of type enum. The goal is to only create schema files for facts of type object.

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
