### PR TITLE
chore: enhance testing on sdk generation with or without reviver

### DIFF
--- a/packages/@ama-sdk/create/src/index.it.spec.ts
+++ b/packages/@ama-sdk/create/src/index.it.spec.ts
@@ -10,7 +10,7 @@ import {
   setupLocalRegistry
 } from '@o3r/test-helpers';
 import * as fs from 'node:fs';
-import { cpSync, mkdirSync, renameSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, renameSync } from 'node:fs';
 import * as path from 'node:path';
 
 const projectName = 'test-sdk';
@@ -48,9 +48,10 @@ describe('Create new sdk command', () => {
 
   beforeEach(() => {
     cpSync(path.join(__dirname, '..', 'testing', 'mocks', 'MOCK_swagger_updated.yaml'), path.join(sdkFolderPath, 'swagger-spec.yml'));
+    cpSync(path.join(__dirname, '..', 'testing', 'mocks', 'MOCK_DATE_UTILS_swagger.yaml'), path.join(sdkFolderPath, 'swagger-spec-with-date.yml'));
   });
 
-  test('should generate a full SDK when the specification is provided', () => {
+  test('should generate a light SDK when the specification is provided', () => {
     expect(() =>
       packageManagerCreate({
         script: '@ama-sdk',
@@ -58,6 +59,18 @@ describe('Create new sdk command', () => {
       }, execAppOptions)
     ).not.toThrow();
     expect(() => packageManagerRun({script: 'build'}, { ...execAppOptions, cwd: sdkPackagePath })).not.toThrow();
+    expect(existsSync(path.join(sdkPackagePath, 'src', 'models', 'base', 'pet', 'pet.reviver.ts'))).toBeFalsy();
+  });
+
+  test('should generate a full SDK when the specification is provided', () => {
+    expect(() =>
+      packageManagerCreate({
+        script: '@ama-sdk',
+        args: ['typescript', sdkPackageName, '--package-manager', packageManager, '--spec-path', path.join(sdkFolderPath, 'swagger-spec-with-date.yml')]
+      }, execAppOptions)
+    ).not.toThrow();
+    expect(() => packageManagerRun({script: 'build'}, { ...execAppOptions, cwd: sdkPackagePath })).not.toThrow();
+    expect(existsSync(path.join(sdkPackagePath, 'src', 'models', 'base', 'pet', 'pet.reviver.ts'))).toBeTruthy();
   });
 
   test('should generate an SDK with no package scope', () => {

--- a/packages/@ama-sdk/create/testing/mocks/MOCK_DATE_UTILS_swagger.yaml
+++ b/packages/@ama-sdk/create/testing/mocks/MOCK_DATE_UTILS_swagger.yaml
@@ -1,0 +1,111 @@
+swagger: "2.0"
+info:
+  version: 1.0.1
+  title: Swagger Petstore
+  license:
+    name: MIT
+host: petstore.swagger.io
+basePath: /v1
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: A paged array of pets
+          headers:
+            x-next:
+              type: string
+              description: A link to the next page of responses
+          schema:
+            $ref: '#/definitions/Pets'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          type: string
+      responses:
+        "200":
+          description: Expected response to a valid request
+          schema:
+            $ref: '#/definitions/Pets'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  Pet:
+    type: "object"
+    required:
+      - id
+      - name
+      - tag
+    properties:
+      nextMeetingAtTheVet:
+        type: string
+        format: date
+      friends:
+        type: object
+        allOf:
+          - $ref: '#/definitions/Pets'
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string
+  Pets:
+    type: array
+    items:
+      $ref: '#/definitions/Pet'
+  Error:
+    type: "object"
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string


### PR DESCRIPTION
## Proposed change

Add a new use case to make sure non light sdk will not throw errors after generation

## Related issues

- :bug: Add test cases for https://github.com/AmadeusITGroup/otter/pull/1537 
