### PR TITLE
fix(eslint-config): use jest rule only if jest dependency is found

### DIFF
--- a/packages/@o3r/eslint-config-otter/schematics/ng-add/index.ts
+++ b/packages/@o3r/eslint-config-otter/schematics/ng-add/index.ts
@@ -23,7 +23,8 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       'eslint-plugin-prefer-arrow',
       'eslint-plugin-unicorn',
       'jest',
-      'jsonc-eslint-parser'
+      'jsonc-eslint-parser',
+      'yaml-eslint-parser'
     ];
 
     try {

--- a/packages/@o3r/eslint-config-otter/typescript.cjs
+++ b/packages/@o3r/eslint-config-otter/typescript.cjs
@@ -1,3 +1,8 @@
+const hasJestDependency = (() => {
+  try { return !!require.resolve('jest'); }
+  catch { return false; }
+})();
+
 module.exports = {
   overrides: [
     {
@@ -11,7 +16,7 @@ module.exports = {
         './rules/typescript/prefer-arrow.cjs',
         './rules/typescript/stylistic.cjs',
         './rules/typescript/unicorn.cjs',
-        './rules/typescript/jest.cjs',
+        ...hasJestDependency ? ['./rules/typescript/jest.cjs'] : [],
         './rules/typescript/stylistic.cjs'
       ],
       parserOptions: {


### PR DESCRIPTION
## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
