### PR TITLE
feat: parameters for localization vars in placeholders

### DIFF
--- a/packages/@o3r/components/schemas/placeholder-template.schema.json
+++ b/packages/@o3r/components/schemas/placeholder-template.schema.json
@@ -41,9 +41,17 @@
               "type": "string"
             },
             "vars": {
+              "deprecated": true,
+              "description": "Deprecated: will be removed in V12. List of variables that can be used in the localization string",
               "type": "array",
               "items": {
                 "type": "string"
+              }
+            },
+            "parameters": {
+              "type": "object",
+              "additionalProperties": {
+                "type":  "string"
               }
             }
           }

--- a/packages/@o3r/components/src/rules-engine/placeholder.rules-engine.effect.ts
+++ b/packages/@o3r/components/src/rules-engine/placeholder.rules-engine.effect.ts
@@ -33,11 +33,12 @@ export class PlaceholderTemplateResponseEffect {
       ofType(setPlaceholderRequestEntityFromUrl),
       fromApiEffectSwitchMapById(
         (templateResponse, action) => {
-          const facts = templateResponse.vars ? Object.values(templateResponse.vars).filter((variable: PlaceholderVariable) => variable.type === 'fact') : [];
-          const factsStreamsList = this.rulesEngineService ? facts.map((fact) =>
+          const facts = templateResponse.vars ? Object.entries(templateResponse.vars).filter(([, variable]) => variable.type === 'fact') : [];
+          const factsStreamsList = this.rulesEngineService ? facts.map(([varName, fact]) =>
             this.rulesEngineService!.engine.retrieveOrCreateFactStream(fact.value).pipe(
               map((factValue) => ({
-                name: fact.value,
+                varName,
+                factName: fact.value,
                 // eslint-disable-next-line new-cap
                 factValue: (fact.path && factValue) ? JSONPath({ wrap: false, json: factValue, path: fact.path }) : factValue
               })),
@@ -87,11 +88,15 @@ export class PlaceholderTemplateResponseEffect {
    * @param vars
    * @param facts
    */
-  private getRenderedHTML$(template?: string, vars?: Record<string, PlaceholderVariable>, facts?: { name: string; factValue: any }[]) {
+  private getRenderedHTML$(template?: string, vars?: Record<string, PlaceholderVariable>, facts?: { varName: string; factName: string; factValue: any }[]) {
     let unknownTypeFound = false;
-    const factset = (facts || []).reduce((set: { [key: string]: any }, fact) => {
-      set[fact.name] = fact.factValue;
-      return set;
+    const factMap = (facts || []).reduce((mapping: { [key: string]: any }, fact) => {
+      mapping[fact.factName] = fact.factValue;
+      return mapping;
+    }, {});
+    const factMapFromVars = (facts || []).reduce((mapping: { [key: string]: any }, fact) => {
+      mapping[fact.varName] = fact.factValue;
+      return mapping;
     }, {});
     const replacements$: Observable<{ ejsVar: RegExp; value: string } | null>[] = [];
     if (vars && template) {
@@ -113,15 +118,19 @@ export class PlaceholderTemplateResponseEffect {
               break;
             }
             case 'fact': {
-              template = template.replace(ejsVar, factset[vars[varName].value] ?? '');
+              template = template.replace(ejsVar, factMap[vars[varName].value] ?? '');
               break;
             }
             case 'localisation': {
-              const linkedParams = (vars[varName].vars || []).reduce((acc: { [key: string]: any }, parameter) => {
+              const linkedVars = (vars[varName].vars || []).reduce((acc: { [key: string]: any }, parameter) => {
                 const paramName = vars[parameter].value;
-                acc[paramName] = factset[paramName];
+                acc[paramName] = factMap[paramName];
                 return acc;
               }, {});
+              const linkedParams = (Object.entries(vars[varName].parameters || {})).reduce((acc: { [key: string]: any }, [paramKey, paramValue]) => {
+                acc[paramKey] = factMapFromVars[paramValue];
+                return acc;
+              }, linkedVars);
               replacements$.push(
                 this.translationService ?
                   this.translationService.translate(vars[varName].value, linkedParams).pipe(

--- a/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.state.ts
+++ b/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.state.ts
@@ -8,6 +8,7 @@ export interface PlaceholderVariable {
   type: 'fact' | 'fullUrl' | 'relativeUrl' | 'localisation';
   value: string;
   vars?: string[];
+  parameters?: Record<string, string>;
   path?: string;
 }
 


### PR DESCRIPTION
## Proposed change

Currently, localization strings used in placeholders support variables. However there are some limitations for some use cases like usage of JSONPath in fact variables. This can be solved thanks to a `parameters` mapping for localization variables. 

``en-GB.json``

```json
{
  "o3r-greet-key": "Welcome back, { firstName } { lastName }!"
}
```

``ruleset.json``

```json
{
  "vars": {
    "greetKey": {
      "type": "localisation",
      "value": "o3r-greet-key",
      "parameters": {
        "firstName": "firstNameVar",
        "lastName": "lastNameVar"
      }
    },
    "firstNameVar": {
      "type": "fact",
      "value": "user",
      "path": "$.firstName"
    },
    "lastNameVar": {
      "type": "fact",
      "value": "user",
      "path": "$.lastName"
    }
  },
  "template": "<div><%= greetKey %></div>"
}
```
