### PR TITLE
ci(renovate): fix config-recommended overriding o3r rules

### DIFF
--- a/tools/renovate/base.json
+++ b/tools/renovate/base.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
     "config:recommended",
     ":dependencyDashboard",
     "group:allNonMajor",

--- a/tools/renovate/design-factory.json
+++ b/tools/renovate/design-factory.json
@@ -1,8 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
   "packageRules": [
     {
       "matchPackagePatterns": [

--- a/tools/renovate/otter-project.json
+++ b/tools/renovate/otter-project.json
@@ -1,8 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
   "packageRules": [
     {
       "matchManagers": [

--- a/tools/renovate/sdk-spec-upgrade.json
+++ b/tools/renovate/sdk-spec-upgrade.json
@@ -1,8 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
   "packageRules": [
     {
       "matchPackageNames": [

--- a/tools/renovate/sdk.json
+++ b/tools/renovate/sdk.json
@@ -1,8 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
## Proposed change

The ` extends: ["config:recommended"]` includes ` group:monorepos` which override our rules for Angular and Nx
We need to include it only once in the base preset

Also ` config:base` seems to be an old name for `config:recommended` and should no longer be needed

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
