### PR TITLE
chore: components not present in gh issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-O3R-ISSUE-FORM.yaml
+++ b/.github/ISSUE_TEMPLATE/1-O3R-ISSUE-FORM.yaml
@@ -20,7 +20,7 @@ body:
         apis-manager,
         application,
         build-helpers,
-        chrome-devtools
+        chrome-devtools,
         components,
         configuration,
         core,


### PR DESCRIPTION
## Proposed change

`components` option is missing from the Github issue creation template.
