### PR TITLE
ci(renovate): add grouping for otter dependencies in presets

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -2,8 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>AmadeusITGroup/otter//tools/renovate/base",
-    "github>AmadeusITGroup/otter//tools/renovate/otter-project",
-    "github>AmadeusITGroup/otter//tools/renovate/sdk",
     "github>AmadeusITGroup/otter//tools/renovate/design-factory",
     ":labels(dependencies)"
   ],

--- a/tools/renovate/otter-project.json
+++ b/tools/renovate/otter-project.json
@@ -1,6 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Group all otter dependencies and trigger ng update scripts",
   "packageRules": [
+    {
+      "groupName": "Otter dependencies",
+      "groupSlug": "otter-dependencies",
+      "matchPackagePrefixes": [
+        "@otter",
+        "@o3r",
+        "@ama-sdk",
+        "@ama-terasu"
+      ]
+    },
     {
       "matchManagers": [
         "yarn"

--- a/tools/renovate/sdk-spec-upgrade.json
+++ b/tools/renovate/sdk-spec-upgrade.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Trigger SDK regeneration for a specific package name",
   "packageRules": [
     {
       "matchPackageNames": [

--- a/tools/renovate/sdk.json
+++ b/tools/renovate/sdk.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Group all otter dependencies and trigger SDK regeneration",
   "labels": [
     "dependencies"
   ],
@@ -7,6 +8,16 @@
   "automerge": true,
   "platformAutomerge": true,
   "packageRules": [
+    {
+      "groupName": "Otter dependencies",
+      "groupSlug": "otter-dependencies",
+      "matchPackagePrefixes": [
+        "@otter",
+        "@o3r",
+        "@ama-sdk",
+        "@ama-terasu"
+      ]
+    },
     {
       "matchBaseBranches": [
         "master",
@@ -25,18 +36,6 @@
         "@ama-sdk"
       ],
       "rangeStrategy": "patch"
-    },
-    {
-      "groupName": "Otter SDK dependencies",
-      "groupSlug": "otter-sdk-dependencies",
-      "matchBaseBranches": [
-        "master",
-        "main",
-        "/^release/.*/"
-      ],
-      "matchPackagePrefixes": [
-        "@ama-sdk"
-      ]
     },
     {
       "matchBaseBranches": [


### PR DESCRIPTION
## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
