### PR TITLE
fix(renovate): remove schedule rule from base preset

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -5,6 +5,7 @@
     "github>AmadeusITGroup/otter//tools/renovate/design-factory",
     ":labels(dependencies)"
   ],
+  "timezone": "Europe/Paris",
   "ignorePaths": [
     "**/node_modules/**",
     "**/templates/**"

--- a/tools/renovate/base.json
+++ b/tools/renovate/base.json
@@ -8,8 +8,7 @@
     "group:recommended",
     "group:test",
     "group:linters",
-    "helpers:pinGitHubActionDigestsToSemver",
-    "schedule:nonOfficeHours"
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "hostRules": [
     {
@@ -21,7 +20,6 @@
     "master",
     "/^release\\/.*-next$/"
   ],
-  "timezone": "Europe/Paris",
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
   "enabledManagers": [


### PR DESCRIPTION
## Proposed change

- No need to override the default timezone on base preset
- The `schedule` rule should be opt-in to prevent people from thinking the renovate config doesn't work because it doesn't create pull-requests

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
