### PR TITLE
fix: allow override of openapi version

### DIFF
--- a/packages/@ama-sdk/schematics/schematics/typescript/core/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/index.ts
@@ -237,7 +237,11 @@ function ngGenerateTypescriptSDKFn(options: NgGenerateTypescriptSDKCoreSchematic
     const runGeneratorRule = () => {
       return () => (new OpenApiCliGenerator(options)).getGeneratorRunSchematic(
         (options.generatorKey && JAVA_OPTIONS.every((optionName) => options[optionName] === undefined)) ?
-          {generatorKey: options.generatorKey, ...(options.openapiNormalizer ? {openapiNormalizer: options.openapiNormalizer} : {})} : generatorOptions,
+          {
+            generatorKey: options.generatorKey,
+            ...(generatorOptions.generatorVersion ? {generatorVersion: generatorOptions.generatorVersion} : {}),
+            ...(options.openapiNormalizer ? {openapiNormalizer: options.openapiNormalizer} : {})
+          } : generatorOptions,
         {rootDirectory: options.directory || undefined}
       );
     };


### PR DESCRIPTION
## Proposed change

The openapi version is here to make sure the generator will not run with an invalid version.
It should not be ignore in any cases as this is a safegard.
