### PR TITLE
fix(sdk-create): cannot create an sdk with debug mode

### DIFF
--- a/packages/@ama-sdk/create/README.md
+++ b/packages/@ama-sdk/create/README.md
@@ -32,7 +32,8 @@ npm create @ama-sdk typescript <project-name> -- --package-manager=yarn [...opti
 
 - `--spec-path`: Path to the swagger/open-api specification used to generate the SDK
 - `--package-manager`: Node package manager to be used (`npm` and `yarn` are available).
-- `--debug`: Enable schematics debug mode (including dry run).
+- `--debug --no-dry-run`: Enable schematics debug mode (dry-run is not currently supported).
+- `--o3r-metrics`: Enable or disable the collection of anonymous data for Otter
 
 > [!NOTE]
 > If the `--spec-path` is specified, the SDK will be generated based on this specification at the creation time.

--- a/packages/@ama-sdk/create/src/index.ts
+++ b/packages/@ama-sdk/create/src/index.ts
@@ -66,7 +66,8 @@ const schematicArgs = [
   '--name', name,
   '--package', pck,
   '--package-manager', packageManager,
-  ...(typeof argv['o3r-metrics'] !== 'undefined' ? [`--${!argv['o3r-metrics'] ? 'no-' : ''}o3r-metrics`] : [])
+  ...(typeof argv['dry-run'] !== 'undefined' ? [`--${!argv['dry-run'] || argv['dry-run'] === 'false' ? 'no-' : ''}dry-run`] : []),
+  ...(typeof argv['o3r-metrics'] !== 'undefined' ? [`--${!argv['o3r-metrics'] || argv['o3r-metrics'] === 'false' ? 'no-' : ''}o3r-metrics`] : [])
 ];
 
 const resolveTargetDirectory = resolve(process.cwd(), targetDirectory);


### PR DESCRIPTION
## Proposed change

Currently running `npm create @ama-sdk typescript test --debug` triggers an exception on spawnSync ENOENT
This is because --debug enables --dry-run by default on angular schematics
We are not currently supporting dry-run mode for generators because we are running shell commands during generation so the files need to be present on disk

To use debug mode, we need to be able to override the `--dry-run` parameter

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
