### PR TITLE
fix: playwright tests on new otter app

### DIFF
--- a/packages/@o3r/testing/schematics/ng-add/playwright/index.ts
+++ b/packages/@o3r/testing/schematics/ng-add/playwright/index.ts
@@ -44,6 +44,7 @@ export function updatePlaywright(options: NgAddPackageOptions, dependencies: Rec
 # Playwright
 dist-e2e-playwright
 playwright-reports
+test-results
 `;
         tree.overwrite(gitignorePath, gitignore);
       }

--- a/packages/@o3r/testing/schematics/ng-add/playwright/templates/e2e-playwright/scenarios/__name@dasherize__.e2e-playwright-spec.ts
+++ b/packages/@o3r/testing/schematics/ng-add/playwright/templates/e2e-playwright/scenarios/__name@dasherize__.e2e-playwright-spec.ts
@@ -6,7 +6,7 @@ export class <%= classify(scenarioName) %> extends BaseScenario {
     test.describe.serial('Empty <%= classify(scenarioName) %> tests', () => {
       test('Empty test', async ({ page }) => {
         await page.goto(this.targetUrl);
-        await expect(page).toHaveTitle('TestApp');
+        await expect(page.locator('body')).toBeAttached();
       });
     });
   }

--- a/packages/@o3r/testing/schematics/playwright/scenario/templates/__name@dasherize__.e2e-playwright-spec.ts
+++ b/packages/@o3r/testing/schematics/playwright/scenario/templates/__name@dasherize__.e2e-playwright-spec.ts
@@ -6,7 +6,7 @@ export class <%= classify(scenarioName) %> extends BaseScenario {
     test.describe.serial('Empty <%= classify(scenarioName) %> tests', () => {
       test('Empty test', async ({ page }) => {
         await page.goto(this.targetUrl);
-        await expect(page).toHaveTitle('TestApp');
+        await expect(page.locator('body')).toBeAttached();
       });
     });
   }


### PR DESCRIPTION
The test assertions are no longer dependent on the project's name. However a basic assertion is still performed.

Also, adding `test-results` folder to `.gitignore`.
## Related issues

- :bug: Fixes #1632
