### PR TITLE
fix: ignore bundlephobia from md link check

### DIFF
--- a/.github/markdown-external-links.config.json
+++ b/.github/markdown-external-links.config.json
@@ -5,6 +5,9 @@
     },
     {
       "pattern": "https://pkgs.dev.azure.com/AmadeusDigitalAirline/Otter/_packaging/otter-pr/npm/registry/"
+    },
+    {
+      "pattern": "https://img.shields.io/bundlephobia/*"
     }
   ],
   "replacementPatterns": [


### PR DESCRIPTION
## Proposed change

Bundlephobia links are seen as broken (false positive). https://github.com/AmadeusITGroup/otter/issues/1510

https://github.com/AmadeusITGroup/otter/actions/runs/8683478379/job/23809543790

The proposal is to ignore them from the MD check.
