### PR TITLE
fix: generate angular app with module

### DIFF
--- a/packages/@o3r/workspace/schematics/application/index.ts
+++ b/packages/@o3r/workspace/schematics/application/index.ts
@@ -83,6 +83,7 @@ function generateApplicationFn(options: NgGenerateApplicationSchema): Rule {
         ...Object.entries(extendedOptions).reduce((acc, [key, value]) => (angularOptions.includes(key) ? {...acc, [key]: value} : acc), {}),
         name: cleanName,
         projectRoot,
+        standalone: false,
         style: Style.Scss}),
       addProjectSpecificFiles(targetPath, rootDependencies),
       updateProjectTsConfig(targetPath, 'tsconfig.app.json'),


### PR DESCRIPTION
## Proposed change

Our schematics do not currently support standalone Angular apps.

## Related issues

- :bug: Fixes #1676 
