### PR TITLE
fix: remove jasmine from tsconfig types when adding jest

### DIFF
--- a/packages/@o3r/testing/schematics/ng-add/fixture/index.ts
+++ b/packages/@o3r/testing/schematics/ng-add/fixture/index.ts
@@ -51,6 +51,7 @@ export function updateFixtureConfig(options: { projectName?: string | null | und
         if (tsconfigCompilerOptions.types.indexOf('jest') === -1) {
           tsconfigCompilerOptions.types.push('jest');
         }
+        tsconfigCompilerOptions.types = tsconfigCompilerOptions.types.filter((tsType: string) => tsType !== 'jasmine');
       }
       tsconfigCompilerOptions.esModuleInterop = true;
       tsconfigCompilerOptions.outDir = 'test';


### PR DESCRIPTION
## Related issues

- :bug: Fixes #1683 

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
