### PR TITLE
feat: ng-update script for migration to openapitools 7.4

### DIFF
--- a/packages/@ama-sdk/schematics/migration.json
+++ b/packages/@ama-sdk/schematics/migration.json
@@ -5,6 +5,11 @@
       "version": "10.0.0-alpha.0",
       "description": "Updates of @ama-sdk/schematics to v10.0.*",
       "factory": "./schematics/ng-update/index#updateV10_0"
+    },
+    "migration-v10_3": {
+      "version": "10.3.0-alpha.0",
+      "description": "Updates of @ama-sdk/schematics to v10.3.*",
+      "factory": "./schematics/ng-update/index#updateV10_3"
     }
   }
 }

--- a/packages/@ama-sdk/schematics/schematics/migrate/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/migrate/index.ts
@@ -4,17 +4,21 @@ import { getMigrationRuleRunner, getWorkspaceConfig, type MigrationRulesMap } fr
 import { resolve } from 'node:path';
 import { gt, minVersion } from 'semver';
 import { isTypescriptSdk } from '../helpers/is-typescript-project';
+import {updateOpenApiVersionInProject} from '../ng-update/typescript/v10.3/update-openapiversion';
 
+/* eslint-disable @typescript-eslint/naming-convention */
 const tsMigrationMap: MigrationRulesMap = {
-
+  '~10.3.2': updateOpenApiVersionInProject()
 };
+/* eslint-enable @typescript-eslint/naming-convention */
+
 /**
  * Facilitate the migration of a version to another by the run of migration rules
  * @param options
  */
 function migrateFn(options: MigrateSchematicsSchemaOptions): Rule {
 
-  const currentVersion = JSON.parse(require(resolve(__dirname, '..', '..', 'package.json'))).version;
+  const currentVersion = require(resolve(__dirname, '..', '..', 'package.json')).version;
   const to: string = options.to || currentVersion;
   const minimumVersion = minVersion(to);
 

--- a/packages/@ama-sdk/schematics/schematics/ng-update/typescript/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/ng-update/typescript/index.ts
@@ -4,6 +4,7 @@
 import { chain, Rule } from '@angular-devkit/schematics';
 import { addCpyDependencies, deprecateScriptsFolder, updateScriptPackageJson } from './v10.0/script-removal';
 import { addPresetsRenovate } from './v10.1/add-presets-renovate';
+import {updateOpenApiVersionInProject} from './v10.3/update-openapiversion';
 
 /**
  * update of Otter library V10.0
@@ -24,6 +25,17 @@ export function updateV10_0(): Rule {
 export function updateV10_1(): Rule {
   const updateRules: Rule[] = [
     addPresetsRenovate()
+  ];
+
+  return chain(updateRules);
+}
+
+/**
+ * Update of Ama-sdk library V10.3
+ */
+export function updateV10_3(): Rule {
+  const updateRules: Rule[] = [
+    updateOpenApiVersionInProject()
   ];
 
   return chain(updateRules);

--- a/packages/@ama-sdk/schematics/schematics/ng-update/typescript/v10.3/update-openapiversion.ts
+++ b/packages/@ama-sdk/schematics/schematics/ng-update/typescript/v10.3/update-openapiversion.ts
@@ -1,0 +1,74 @@
+import type {Rule} from '@angular-devkit/schematics';
+import * as semver from 'semver';
+import {getWorkspaceConfig, globInTree} from '@o3r/schematics';
+import {chain} from '@angular-devkit/schematics';
+
+/**
+ * Update open api version used in the project to match with the one used in @ama-sdk/schematics:typescript-core
+ */
+export const updateOpenApiVersionInProject = (): Rule => {
+  const overwriteOpenApiVersion = (pathOfWorkspace: string): Rule => {
+    return (tree, context) => {
+      const packageJson = tree.readText(`${pathOfWorkspace}/package.json`);
+      const amaSdkTypescriptUsage = packageJson.match(/@ama-sdk\/schematics:typescript-core.*",?$/mg);
+      if (!amaSdkTypescriptUsage) {
+        context.logger.info(`Skipping ng-update for ${pathOfWorkspace} as it does not use @ama-sdk/schematics:typescript-core`);
+        return tree;
+      }
+      const openapitoolsPaths: string[] = [];
+      amaSdkTypescriptUsage.forEach((script) => {
+        const openapiToolsPath = new RegExp(/@ama-sdk\/schematics:typescript-core.* --spec-config-path(?:=|\s+)["']?(?:\.\/)?([a-zA-Z-/.0-9_]*\.json)/).exec(script);
+        if (openapiToolsPath?.length === 2) {
+          openapitoolsPaths.push(`${pathOfWorkspace}/${openapiToolsPath[1]}`);
+        }
+      });
+      if (amaSdkTypescriptUsage.length > openapitoolsPaths.length) {
+        openapitoolsPaths.push(`${pathOfWorkspace}/openapitools.json`);
+      }
+      (openapitoolsPaths || []).forEach((path) => {
+        if (!tree.exists(path)) {
+          context.logger.warn(`Missing ${path} file described in the package json.`);
+          return;
+        }
+        const openApiToolsConfig = tree.readJson(path) as any;
+        openApiToolsConfig['generator-cli'] ||= {};
+        if (!openApiToolsConfig['generator-cli'].version || !semver.satisfies(openApiToolsConfig['generator-cli'].version, '~7.4.0')) {
+          context.logger.info(`The following file will be updated to target open api tools version 7.4: ${path}`);
+          openApiToolsConfig['generator-cli'].version = '7.4.0';
+          tree.overwrite(path, JSON.stringify(openApiToolsConfig, null, 2));
+        }
+      }
+      );
+      return tree;
+    };
+  };
+
+  return (tree, context) => {
+    const pathsPackageJson = ['.'];
+    if (!tree.exists('package.json')) {
+      context.logger.error('Could not find a package.json file, make sure to run the ng-update at the root of typescript project');
+    }
+    const cwdPackageJson = tree.readJson('package.json') as any;
+    if (tree.exists('angular.json')) {
+      const workspaceConfig = getWorkspaceConfig(tree);
+      pathsPackageJson.push(...Object.values(workspaceConfig?.projects || {}).map((project) => project.root));
+    } else if (cwdPackageJson.workspaces) {
+      context.logger.info('Workspaces detected outside an angular project, running the update on the workspaces');
+      pathsPackageJson.push(...cwdPackageJson.workspaces.reduce((paths: string[], workspace: string) => {
+        if (workspace.includes('*')) {
+          paths.push(
+            ...globInTree(tree, [`**/${workspace}/package.json`]).map((path) => path.replace('/package.json', ''))
+          );
+        } else {
+          paths.push(workspace);
+        }
+        return paths;
+      }, []));
+    }
+    return chain(
+      pathsPackageJson.map((pathPackageJson) =>
+        overwriteOpenApiVersion(pathPackageJson.at(pathPackageJson.length - 1) === '/' ? pathPackageJson.trim() : pathPackageJson)
+      )
+    );
+  };
+};

--- a/packages/@o3r/schematics/src/utility/monorepo.ts
+++ b/packages/@o3r/schematics/src/utility/monorepo.ts
@@ -44,7 +44,7 @@ export function isStandaloneRepository(tree: Tree) {
  * @param tree
  */
 export function isMultipackagesContext(tree: Tree) {
-  return !!(tree.readJson('/package.json') as PackageJson).wokspaces;
+  return !!(tree.readJson('/package.json') as PackageJson).workspaces;
 }
 
 /** Default name of the folder where libraries will be generated inside monorepo */


### PR DESCRIPTION
## Proposed change

Ng update script to help the migration to @ama-sdk/schematics 10.3
As projects generated via the @ama-sdk/create command, the update is exposed as a schematics.
Unfortunately, it will not allow the update of several version in one command and needs the 10.3 version of ama-sdk/schematics to already be installed to be run.