### PR TITLE
fix(create): issue when nodejs path contains spaces

### DIFF
--- a/packages/@ama-sdk/create/src/index.ts
+++ b/packages/@ama-sdk/create/src/index.ts
@@ -96,7 +96,7 @@ const run = () => {
   ];
 
   const errors = steps
-    .map((step) => spawnSync(step.runner || process.execPath, step.args, { stdio: 'inherit', cwd: step.cwd || process.cwd(), shell: true }))
+    .map((step) => spawnSync(step.runner || `"${process.execPath}"`, step.args, { stdio: 'inherit', cwd: step.cwd || process.cwd(), shell: true }))
     .filter(({error, status}) => (error || status !== 0));
 
   if (errors.length > 0) {

--- a/packages/@o3r/create/src/index.ts
+++ b/packages/@o3r/create/src/index.ts
@@ -146,7 +146,7 @@ const createNgProject = () => {
   const options = schematicsCliOptions
     .filter(([key]) => isNgNewOptions(key))
     .flat();
-  exitProcessIfErrorInSpawnSync(1, spawnSync(process.execPath, [binPath, 'new', ...argv._, ...options], {
+  exitProcessIfErrorInSpawnSync(1, spawnSync(`"${process.execPath}"`, [binPath, 'new', ...argv._, ...options], {
     stdio: 'inherit',
     shell: true
   }));


### PR DESCRIPTION
## Proposed change

Fix the following issue on Windows when path contains spaces (e.g. 'C:\Program Files')
```
npm create -yes @ama-sdk typescript @sdk/buggggg
'C:\Program' is not recognized as an internal or external command,
operable program or batch file.
```

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
