### PR TITLE
test: use timestamp in the version used for verdaccio

### DIFF
--- a/.github/workflows/it-tests.yml
+++ b/.github/workflows/it-tests.yml
@@ -84,13 +84,6 @@ jobs:
             !.cache/test-app/cache/@ama-terasu*
             !.cache/test-app/cache/@o3r*
           key: ${{ runner.os }}-test-app-${{ matrix.packageManager }}-${{ env.currentMonth }}
-      - name: Make sure that internal packages are not cached for whatever reason - yarn
-        run: npx --yes rimraf -g ".cache/test-app/cache/@{o3r,ama-sdk,ama-terasu}-*"
-      - name: Make sure that internal packages are not cached for whatever reason - npm
-        run: |
-          npm cache --cache=.cache/test-app/npm-cache ls | grep 127.0.0.1:4873 | xargs -d'\n' -r -n 1 npm cache --cache=.cache/test-app/npm-cache clean || true
-          npx --yes -p replace-in-files-cli replace-in-files --regex=".*127.0.0.1:4873.*" --replacement="" ".cache/test-app/npm-cache/_cacache/index-v5/**/*"
-        shell: bash
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         name: Download verdaccio storage prepared in the previous job
         with:

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "verdaccio:start-persistent": "docker run -d -it --rm --name verdaccio -p 4873:4873 -v \"$(yarn get:current-dir)/.verdaccio/conf\":/verdaccio/conf -v \"$(yarn get:current-dir)/.verdaccio/storage\":/verdaccio/storage:z verdaccio/verdaccio",
     "verdaccio:clean": "rimraf -g \".verdaccio/storage/@{o3r,ama-sdk,ama-terasu}\"",
     "verdaccio:login": "yarn cpy --cwd=./.verdaccio/conf .npmrc . --rename=.npmrc-logged && npx --yes npm-cli-login -u verdaccio -p verdaccio -e test@test.com -r http://127.0.0.1:4873 --config-path \".verdaccio/conf/.npmrc-logged\"",
-    "verdaccio:publish": "yarn verdaccio:clean && yarn set:version 999.0.0 --include \"!**/!(dist)/package.json\" --include !package.json && yarn verdaccio:login && yarn run publish --userconfig \".verdaccio/conf/.npmrc-logged\" --tag=latest --@o3r:registry=http://127.0.0.1:4873 --@ama-sdk:registry=http://127.0.0.1:4873 --@ama-terasu:registry=http://127.0.0.1:4873",
+    "verdaccio:publish": "yarn verdaccio:clean && yarn set:version 999.0.$(node -e 'process.stdout.write(String(Date.now()))') --include \"!**/!(dist)/package.json\" --include !package.json && yarn verdaccio:login && yarn run publish --userconfig \".verdaccio/conf/.npmrc-logged\" --tag=latest --@o3r:registry=http://127.0.0.1:4873 --@ama-sdk:registry=http://127.0.0.1:4873 --@ama-terasu:registry=http://127.0.0.1:4873",
     "verdaccio:stop": "docker container stop $(docker ps -a -q --filter=\"name=verdaccio\")",
     "verdaccio:all": "yarn verdaccio:stop && yarn verdaccio:start && yarn verdaccio:publish",
     "watch:vscode-extension": "yarn nx run vscode-extension:compile:watch",

--- a/packages/@ama-sdk/create/src/index.it.spec.ts
+++ b/packages/@ama-sdk/create/src/index.it.spec.ts
@@ -114,7 +114,7 @@ describe('Create new sdk command', () => {
   test('should use pinned versions when --exact-o3r-version is used', () => {
     expect(() =>
       packageManagerCreate({
-        script: `@ama-sdk@${o3rEnvironment.testEnvironment.o3rVersion}`,
+        script: `@ama-sdk@${o3rEnvironment.testEnvironment.o3rExactVersion}`,
         args: ['typescript', sdkPackageName, '--exact-o3r-version', '--package-manager', packageManager, '--spec-path', path.join(sdkFolderPath, 'swagger-spec.yml')]
       }, execAppOptions)
     ).not.toThrow();
@@ -125,7 +125,7 @@ describe('Create new sdk command', () => {
     [
       ...Object.entries(packageJson.dependencies), ...Object.entries(packageJson.devDependencies), ...Object.entries(resolutions)
     ].filter(([dep]) => dep.startsWith('@o3r/') || dep.startsWith('@ama-sdk/')).forEach(([,version]) => {
-      expect(version).toBe(o3rEnvironment.testEnvironment.o3rVersion);
+      expect(version).toBe(o3rEnvironment.testEnvironment.o3rExactVersion);
     });
   });
 });

--- a/packages/@o3r/create/src/index.it.spec.ts
+++ b/packages/@o3r/create/src/index.it.spec.ts
@@ -45,7 +45,7 @@ describe('Create new otter project command', () => {
   });
 
   test('should generate a project with an application with --exact-o3r-version', async () => {
-    const { workspacePath, packageManagerConfig, o3rVersion } = o3rEnvironment.testEnvironment;
+    const { workspacePath, packageManagerConfig, o3rExactVersion } = o3rEnvironment.testEnvironment;
     const inAppPath = path.join(workspacePath, workspaceProjectName);
     const execWorkspaceOptions = {...defaultExecOptions, cwd: workspacePath };
     const execInAppOptions = {...defaultExecOptions, cwd: inAppPath };
@@ -57,7 +57,7 @@ describe('Create new otter project command', () => {
     await fs.mkdir(inAppPath, { recursive: true });
     setPackagerManagerConfig(packageManagerConfig, execInAppOptions);
 
-    expect(() => packageManagerCreate({ script: `@o3r@${o3rVersion}`, args: [workspaceProjectName, ...createOptions] }, execWorkspaceOptions, 'npm')).not.toThrow();
+    expect(() => packageManagerCreate({ script: `@o3r@${o3rExactVersion}`, args: [workspaceProjectName, ...createOptions] }, execWorkspaceOptions, 'npm')).not.toThrow();
     expect(existsSync(path.join(inAppPath, 'angular.json'))).toBe(true);
     expect(existsSync(path.join(inAppPath, 'package.json'))).toBe(true);
     expect(() => packageManagerInstall(execInAppOptions)).not.toThrow();
@@ -75,7 +75,7 @@ describe('Create new otter project command', () => {
       ...Object.entries(rootPackageJson.dependencies), ...Object.entries(rootPackageJson.devDependencies), ...Object.entries(resolutions),
       ...Object.entries(appPackageJson.dependencies), ...Object.entries(appPackageJson.devDependencies)
     ].filter(([dep]) => dep.startsWith('@o3r/') || dep.startsWith('@ama-sdk/')).forEach(([,version]) => {
-      expect(version).toBe(o3rVersion);
+      expect(version).toBe(o3rExactVersion);
     });
   });
 });

--- a/packages/@o3r/test-helpers/src/test-environments/create-test-environment-otter-project.ts
+++ b/packages/@o3r/test-helpers/src/test-environments/create-test-environment-otter-project.ts
@@ -34,7 +34,7 @@ export interface CreateTestEnvironmentOtterProjectWithAppOptions extends CreateW
   logger?: Logger;
 }
 
-const o3rVersion = '999.0.0';
+const o3rVersion = '~999';
 
 /**
  * Generate a base angular app with minimal necessary dependencies


### PR DESCRIPTION
## Proposed change

Using a timestamp in the version that we use to publish on Verdaccio ensures that we always target the latest published version with no cache

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
