### PR TITLE
fix: sdk-generator - support basepath in operation adapter regexp

### DIFF
--- a/packages/@ama-sdk/schematics/schematics/typescript/core/helpers/path-extractor.spec.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/helpers/path-extractor.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import type { OpenAPIV3 } from 'openapi-types';
+import type { OpenAPIV2, OpenAPIV3 } from 'openapi-types';
 import { generateOperationFinderFromSingleFile } from './path-extractor';
 
 describe('generateOperationFinderFromSingleFile', () => {
@@ -103,6 +103,70 @@ describe('generateOperationFinderFromSingleFile', () => {
         path: '/pet', regexp: new RegExp('^/pet(?:/(?=$))?$'), operations: [{ 'method': 'post', 'operationId': 'addPet' }]
       }
     ]);
+  });
+
+  it('should add the basepath in the returned regexp', () => {
+    const spec1: OpenAPIV2.Document = {
+      swagger: '2.0',
+      basePath: '/v2',
+      info: {
+        title: 'test',
+        version: '0.0.0'
+      },
+      paths: {
+        '/pet': {
+          $ref: '#/definitions/schemas'
+        }
+      },
+      definitions: {
+        schemas: {
+          post: {
+            description: 'Add a new pet to the store',
+            operationId: 'addPet',
+            responses: {
+              200: {
+                $ref: ''
+              },
+              405: {
+                $ref: ''
+              }
+            }
+          } as any
+        }
+      }
+    };
+
+    const result1 = generateOperationFinderFromSingleFile(spec1);
+    expect(result1).toEqual([
+      {
+        path: '/pet', regexp: new RegExp('^/v2/pet(?:/(?=$))?$'), operations: [{ 'method': 'post', 'operationId': 'addPet' }]
+      }
+    ]);
+
+    const spec2: OpenAPIV2.Document = {
+      ...spec1,
+      basePath: '/v3/'
+    };
+
+    const result2 = generateOperationFinderFromSingleFile(spec2);
+    expect(result2).toEqual([
+      {
+        path: '/pet', regexp: new RegExp('^/v3/pet(?:/(?=$))?$'), operations: [{ 'method': 'post', 'operationId': 'addPet' }]
+      }
+    ]);
+
+    const spec3: OpenAPIV2.Document = {
+      ...spec1,
+      basePath: undefined
+    };
+
+    const result3 = generateOperationFinderFromSingleFile(spec3);
+    expect(result3).toEqual([
+      {
+        path: '/pet', regexp: new RegExp('^/pet(?:/(?=$))?$'), operations: [{ 'method': 'post', 'operationId': 'addPet' }]
+      }
+    ]);
+
   });
 
 });

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/helpers/path-extractor.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/helpers/path-extractor.ts
@@ -12,6 +12,11 @@ export const generateOperationFinderFromSingleFile = (specification: OpenAPIV2.D
   if (!specification.paths) {
     return [];
   }
+  let basePath = '/';
+  if ('basePath' in specification && specification.basePath) {
+    basePath = specification.basePath.replace(/\/$/, '');
+
+  }
 
   return Object.entries(specification.paths)
     .filter(([, pathObject]) => !!pathObject)
@@ -22,7 +27,7 @@ export const generateOperationFinderFromSingleFile = (specification: OpenAPIV2.D
         : pathObjectOrRef;
       return {
         path,
-        regexp: new RegExp(`^${path.replace(/\{[^}]+}/g, '((?:[^/]+?))')}(?:/(?=$))?$`),
+        regexp: new RegExp(`^${(basePath + path).replace(/^\/{2,}/, '/').replace(/\{[^}]+}/g, '((?:[^/]+?))')}(?:/(?=$))?$`),
         operations: Object.entries(pathObject)
           .map(([method, reqObject]) => ({
             method,


### PR DESCRIPTION
## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
