### PR TITLE
chore: deprecate isStandaloneRepository

### DIFF
--- a/packages/@o3r/schematics/src/utility/monorepo.ts
+++ b/packages/@o3r/schematics/src/utility/monorepo.ts
@@ -31,6 +31,7 @@ export function isNxContext(tree: Tree) {
 
 /**
  * Determine if a repository is standalone (not part of a monorepo)
+ * @deprecated no longer in use. Will be removed in V12
  * @param tree
  */
 export function isStandaloneRepository(tree: Tree) {


### PR DESCRIPTION
## Proposed change

The `isStandaloneRepository` is no longer used. Since it's an exported method, deprecating it for now and removing in next major.
