### PR TITLE
test: library integration tests

### DIFF
--- a/packages/@ama-sdk/create/src/index.it.spec.ts
+++ b/packages/@ama-sdk/create/src/index.it.spec.ts
@@ -27,7 +27,7 @@ const packageManager = getPackageManager();
 
 describe('Create new sdk command', () => {
   beforeEach(() => {
-    const isYarnTest = packageManager.startsWith('yarn');
+    const isYarnTest = o3rEnvironment.testEnvironment.isYarnTest;
     const yarnVersion = isYarnTest ? getYarnVersionFromRoot(process.cwd()) || 'latest' : undefined;
     sdkFolderPath = o3rEnvironment.testEnvironment.workspacePath;
     sdkPackagePath = path.join(sdkFolderPath, sdkPackageName.replace(/^@/, ''));

--- a/packages/@o3r/apis-manager/schematics/index.it.spec.ts
+++ b/packages/@o3r/apis-manager/schematics/index.it.spec.ts
@@ -16,18 +16,24 @@ import * as path from 'node:path';
 
 describe('new otter application with apis-manager', () => {
   test('should add apis-manager to existing application', () => {
-    const { workspacePath, projectName, isInWorkspace, untouchedProjectPath, o3rVersion } = o3rEnvironment.testEnvironment;
+    const { workspacePath, appName, isInWorkspace, isYarnTest, untouchedProjectsPaths, libraryPath, o3rVersion } = o3rEnvironment.testEnvironment;
     const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
-    packageManagerExec({script: 'ng', args: ['add', `@o3r/apis-manager@${o3rVersion}`, '--skip-confirmation', '--project-name', projectName]}, execAppOptions);
+    packageManagerExec({script: 'ng', args: ['add', `@o3r/apis-manager@${o3rVersion}`, '--skip-confirmation', '--project-name', appName]}, execAppOptions);
 
     expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
-    expect(() => packageManagerRunOnProject(projectName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(appName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
 
     const diff = getGitDiff(workspacePath);
-    expect(diff.modified).toContain('package.json');
-    if (untouchedProjectPath) {
-      const relativeUntouchedProjectPath = path.relative(workspacePath, untouchedProjectPath);
-      expect(diff.all.filter((file) => new RegExp(relativeUntouchedProjectPath.replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBe(0);
-    }
+    expect(diff.modified.sort()).toEqual([
+      'apps/test-app/package.json',
+      'apps/test-app/src/app/app.config.ts',
+      'apps/test-app/tsconfig.app.json',
+      'package.json',
+      isYarnTest ? 'yarn.lock' : 'package-lock.json'
+    ].sort());
+
+    [libraryPath, ...untouchedProjectsPaths].forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
   });
 });

--- a/packages/@o3r/application/package.json
+++ b/packages/@o3r/application/package.json
@@ -75,6 +75,7 @@
     "@o3r/logger": "workspace:^",
     "@o3r/routing": "workspace:^",
     "@o3r/schematics": "workspace:^",
+    "@o3r/test-helpers": "workspace:^",
     "@o3r/testing": "workspace:^",
     "@schematics/angular": "~17.3.0",
     "@stylistic/eslint-plugin-ts": "^1.5.4",

--- a/packages/@o3r/application/project.json
+++ b/packages/@o3r/application/project.json
@@ -16,6 +16,12 @@
         "tsConfig": "packages/@o3r/application/tsconfig.build.json"
       }
     },
+    "test-int": {
+      "executor": "@nx/jest:jest",
+      "options": {
+        "jestConfig": "packages/@o3r/application/testing/jest.config.it.js"
+      }
+    },
     "lint": {
       "options": {
         "eslintConfig": "packages/@o3r/application/.eslintrc.js",

--- a/packages/@o3r/application/schematics/index.it.spec.ts
+++ b/packages/@o3r/application/schematics/index.it.spec.ts
@@ -1,0 +1,24 @@
+/**
+ * Test environment exported by O3rEnvironment, must be first line of the file
+ * @jest-environment @o3r/test-helpers/jest-environment
+ * @jest-environment-o3r-app-folder test-app-application
+ */
+const o3rEnvironment = globalThis.o3rEnvironment;
+
+import {
+  getDefaultExecSyncOptions,
+  packageManagerExec,
+  packageManagerInstall,
+  packageManagerRunOnProject
+} from '@o3r/test-helpers';
+
+describe('new Angular application', () => {
+  test('should add Otter Application to existing Angular app', () => {
+    const { workspacePath, isInWorkspace, appName, o3rVersion } = o3rEnvironment.testEnvironment;
+    const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
+    packageManagerExec({script: 'ng', args: ['add', `@o3r/application@${o3rVersion}`,'--project-name', appName, '--skip-confirmation']}, execAppOptions);
+    expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
+
+    expect(() => packageManagerRunOnProject(appName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+  });
+});

--- a/packages/@o3r/application/testing/jest.config.it.js
+++ b/packages/@o3r/application/testing/jest.config.it.js
@@ -1,0 +1,8 @@
+const { join } = require('node:path');
+const getJestConfig = require('../../../../jest.config.it').getJestConfig;
+
+/** @type {import('ts-jest/dist/types').JestConfigWithTsJest} */
+module.exports = {
+  ...getJestConfig(join(__dirname, '..')),
+  displayName: require('../package.json').name
+};

--- a/packages/@o3r/application/tsconfig.spec.json
+++ b/packages/@o3r/application/tsconfig.spec.json
@@ -6,7 +6,7 @@
     "rootDir": ".",
   },
   "include": [
-    "./src/**/*.spec.ts"
+    "./**/*.spec.ts"
   ],
   "exclude": [],
   "references": [

--- a/packages/@o3r/components/schematics/index.it.spec.ts
+++ b/packages/@o3r/components/schematics/index.it.spec.ts
@@ -14,21 +14,52 @@ import {
 } from '@o3r/test-helpers';
 import * as path from 'node:path';
 
-describe('new otter application with components', () => {
-  test('should add components to existing application', () => {
-    const { workspacePath, projectName, isInWorkspace, untouchedProjectPath, o3rVersion } = o3rEnvironment.testEnvironment;
+describe('ng add components', () => {
+  test('should add components to an application', () => {
+    const { workspacePath, appName, isInWorkspace, o3rVersion, libraryPath, untouchedProjectsPaths } = o3rEnvironment.testEnvironment;
     const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
-    packageManagerExec({script: 'ng', args: ['add', `@o3r/components@${o3rVersion}`, '--skip-confirmation', '--enable-metadata-extract', '--project-name', projectName]}, execAppOptions);
-
-    expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
-    expect(() => packageManagerRunOnProject(projectName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+    expect(() => packageManagerExec({script: 'ng',args: ['add', `@o3r/components@${o3rVersion}`,
+      '--skip-confirmation', '--enable-metadata-extract', '--project-name', appName]}, execAppOptions)).not.toThrow();
 
     const diff = getGitDiff(workspacePath);
     expect(diff.modified).toContain('package.json');
+    expect(diff.modified).toContain('angular.json');
+    expect(diff.modified).toContain('apps/test-app/package.json');
+    expect(diff.modified.length).toBe(5);
+    expect(diff.added).toContain('apps/test-app/cms.json');
+    expect(diff.added).toContain('apps/test-app/placeholders.metadata.json');
+    expect(diff.added).toContain('apps/test-app/tsconfig.cms.json');
+    expect(diff.added.length).toBe(3);
 
-    if (untouchedProjectPath) {
-      const relativeUntouchedProjectPath = path.relative(workspacePath, untouchedProjectPath);
-      expect(diff.all.filter((file) => new RegExp(relativeUntouchedProjectPath.replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBe(0);
-    }
+    [libraryPath, ...untouchedProjectsPaths].forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
+
+    expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(appName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+  });
+
+  test('should add components to a library', () => {
+    const { workspacePath, libName, isInWorkspace, o3rVersion, applicationPath, untouchedProjectsPaths } = o3rEnvironment.testEnvironment;
+    const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
+    expect(() => packageManagerExec({script: 'ng',args: ['add', `@o3r/components@${o3rVersion}`,
+      '--skip-confirmation', '--enable-metadata-extract', '--project-name', libName]}, execAppOptions)).not.toThrow();
+
+    const diff = getGitDiff(workspacePath);
+    expect(diff.modified).toContain('package.json');
+    expect(diff.modified).toContain('angular.json');
+    expect(diff.modified).toContain('libs/test-lib/package.json');
+    expect(diff.modified.length).toBe(7);
+    expect(diff.added).toContain('libs/test-lib/cms.json');
+    expect(diff.added).toContain('libs/test-lib/placeholders.metadata.json');
+    expect(diff.added).toContain('libs/test-lib/tsconfig.cms.json');
+    expect(diff.added.length).toBe(3);
+
+    [applicationPath, ...untouchedProjectsPaths].forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
+
+    expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(libName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
   });
 });

--- a/packages/@o3r/configuration/schematics/index.it.spec.ts
+++ b/packages/@o3r/configuration/schematics/index.it.spec.ts
@@ -16,35 +16,66 @@ import {
 import * as path from 'node:path';
 
 describe('new otter application with configuration', () => {
-  test('should add configuration to existing application', async () => {
-    const { projectPath, workspacePath, projectName, isInWorkspace, untouchedProjectPath, o3rVersion } = o3rEnvironment.testEnvironment;
+  test('should add configuration to an application', async () => {
+    const { applicationPath, workspacePath, appName, libraryPath, isInWorkspace, untouchedProjectsPaths, o3rVersion } = o3rEnvironment.testEnvironment;
     const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
-    const relativeProjectPath = path.relative(workspacePath, projectPath);
-    packageManagerExec({script: 'ng', args: ['add', `@o3r/configuration@${o3rVersion}`, '--skip-confirmation', '--project-name', projectName]}, execAppOptions);
+    const relativeApplicationPath = path.relative(workspacePath, applicationPath);
+    packageManagerExec({script: 'ng', args: ['add', `@o3r/configuration@${o3rVersion}`, '--skip-confirmation', '--project-name', appName]}, execAppOptions);
 
-    const componentPath = path.normalize(path.join(relativeProjectPath, 'src/components/test-component/test-component.component.ts'));
-    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', 'test-component', '--project-name', projectName, '--use-otter-config', 'false']}, execAppOptions);
+    const componentPath = path.normalize(path.posix.join(relativeApplicationPath, 'src/components/test-component/test-component.component.ts'));
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', 'test-component', '--project-name', appName, '--use-otter-config', 'false']}, execAppOptions);
     packageManagerExec({script: 'ng', args: ['g', '@o3r/configuration:add-config', '--path', componentPath]}, execAppOptions);
-    await addImportToAppModule(projectPath, 'TestComponentModule', 'src/components/test-component');
+    await addImportToAppModule(applicationPath, 'TestComponentModule', 'src/components/test-component');
 
-    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', 'test-signal', '--project-name', projectName, '--use-otter-config', 'false']}, execAppOptions);
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', 'test-signal', '--project-name', appName, '--use-otter-config', 'false']}, execAppOptions);
     packageManagerExec({
       script: 'ng',
-      args: ['g', '@o3r/configuration:add-config', '--path', path.join(relativeProjectPath, 'src/components/test-signal/test-signal.component.ts'), '--use-signal']
+      args: ['g', '@o3r/configuration:add-config', '--path', path.join(relativeApplicationPath, 'src/components/test-signal/test-signal.component.ts'), '--use-signal']
     }, execAppOptions);
-    await addImportToAppModule(projectPath, 'TestSignalModule', 'src/components/test-signal');
+    await addImportToAppModule(applicationPath, 'TestSignalModule', 'src/components/test-signal');
 
     const diff = getGitDiff(workspacePath);
+    expect(diff.added.length).toEqual(20);
+    expect(diff.modified.length).toEqual(6);
     expect(diff.modified).toContain('package.json');
-    expect(diff.added).toContain(path.join(relativeProjectPath, 'src/components/test-component/test-component.config.ts').replace(/[\\/]+/g, '/'));
-    expect(diff.added).toContain(path.join(relativeProjectPath, 'src/components/test-signal/test-signal.config.ts').replace(/[\\/]+/g, '/'));
+    expect(diff.added).toContain(path.posix.join(relativeApplicationPath, 'src/components/test-component/test-component.config.ts').replace(/[\\/]+/g, '/'));
+    expect(diff.added).toContain(path.posix.join(relativeApplicationPath, 'src/components/test-signal/test-signal.config.ts').replace(/[\\/]+/g, '/'));
 
-    if (untouchedProjectPath) {
-      const relativeUntouchedProjectPath = path.relative(workspacePath, untouchedProjectPath);
-      expect(diff.all.filter((file) => new RegExp(relativeUntouchedProjectPath.replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBe(0);
-    }
+    [libraryPath, ...untouchedProjectsPaths].forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
 
     expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
-    expect(() => packageManagerRunOnProject(projectName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(appName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+  });
+  test('should add configuration to a library', () => {
+    const { applicationPath, workspacePath, libName, libraryPath, isInWorkspace, untouchedProjectsPaths, o3rVersion } = o3rEnvironment.testEnvironment;
+    const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
+    const relativeLibraryPath = path.relative(workspacePath, libraryPath);
+    packageManagerExec({script: 'ng', args: ['add', `@o3r/configuration@${o3rVersion}`, '--skip-confirmation', '--project-name', libName]}, execAppOptions);
+
+    const componentPath = path.normalize(path.posix.join(relativeLibraryPath, 'src/components/test-component/test-component.component.ts'));
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', 'test-component', '--project-name', libName, '--use-otter-config', 'false']}, execAppOptions);
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/configuration:add-config', '--path', componentPath]}, execAppOptions);
+
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', 'test-signal', '--project-name', libName, '--use-otter-config', 'false']}, execAppOptions);
+    packageManagerExec({
+      script: 'ng',
+      args: ['g', '@o3r/configuration:add-config', '--path', path.join(relativeLibraryPath, 'src/components/test-signal/test-signal.component.ts'), '--use-signal']
+    }, execAppOptions);
+
+    const diff = getGitDiff(workspacePath);
+    expect(diff.added.length).toEqual(20);
+    expect(diff.modified.length).toEqual(7);
+    expect(diff.modified).toContain('package.json');
+    expect(diff.added).toContain(path.posix.join(relativeLibraryPath, 'src/components/test-component/test-component.config.ts').replace(/[\\/]+/g, '/'));
+    expect(diff.added).toContain(path.posix.join(relativeLibraryPath, 'src/components/test-signal/test-signal.config.ts').replace(/[\\/]+/g, '/'));
+
+    [applicationPath, ...untouchedProjectsPaths].forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
+
+    expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(libName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
   });
 });

--- a/packages/@o3r/core/schematics/index.it.spec.ts
+++ b/packages/@o3r/core/schematics/index.it.spec.ts
@@ -21,39 +21,39 @@ import getPidFromPort from 'pid-from-port';
 const devServerPort = 4200;
 describe('new otter application', () => {
   test('should build empty app', async () => {
-    const { projectPath, workspacePath, projectName, isInWorkspace, untouchedProjectPath, o3rVersion } = o3rEnvironment.testEnvironment;
+    const { applicationPath, workspacePath, appName, isInWorkspace, o3rVersion, untouchedProjectsPaths } = o3rEnvironment.testEnvironment;
     const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
-    const relativeProjectPath = path.relative(workspacePath, projectPath);
-    const projectNameOptions = ['--project-name', projectName];
-    expect(() => packageManagerExec({ script: 'ng', args: ['add', `@o3r/core@${o3rVersion}`, '--preset', 'all', ...projectNameOptions, '--skip-confirmation'] }, execAppOptions)).not.toThrow();
+    const relativeApplicationPath = path.relative(workspacePath, applicationPath);
+    const appNameOptions = ['--project-name', appName];
+    expect(() => packageManagerExec({script: 'ng', args: ['add', `@o3r/core@${o3rVersion}`, '--preset', 'all', ...appNameOptions, '--skip-confirmation']}, execAppOptions)).not.toThrow();
     expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
 
-    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:store-entity-async', '--store-name', 'test-entity-async', '--model-name', 'Bound', '--model-id-prop-name', 'id', ...projectNameOptions]},
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:store-entity-async', '--store-name', 'test-entity-async', '--model-name', 'Bound', '--model-id-prop-name', 'id', ...appNameOptions]},
       execAppOptions
     );
-    await addImportToAppModule(projectPath, 'TestEntityAsyncStoreModule', 'src/store/test-entity-async');
+    await addImportToAppModule(applicationPath, 'TestEntityAsyncStoreModule', 'src/store/test-entity-async');
 
-    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:store-entity-sync', '--store-name', 'test-entity-sync', '--model-name', 'Bound', '--model-id-prop-name', 'id', ...projectNameOptions]},
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:store-entity-sync', '--store-name', 'test-entity-sync', '--model-name', 'Bound', '--model-id-prop-name', 'id', ...appNameOptions]},
       execAppOptions
     );
-    await addImportToAppModule(projectPath, 'TestEntitySyncStoreModule', 'src/store/test-entity-sync');
+    await addImportToAppModule(applicationPath, 'TestEntitySyncStoreModule', 'src/store/test-entity-sync');
 
-    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:store-simple-async', '--store-name', 'test-simple-async', '--model-name', 'Bound', ...projectNameOptions]},
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:store-simple-async', '--store-name', 'test-simple-async', '--model-name', 'Bound', ...appNameOptions]},
       execAppOptions
     );
-    await addImportToAppModule(projectPath, 'TestSimpleAsyncStoreModule', 'src/store/test-simple-async');
+    await addImportToAppModule(applicationPath, 'TestSimpleAsyncStoreModule', 'src/store/test-simple-async');
 
-    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:store-simple-sync', '--store-name', 'test-simple-sync', ...projectNameOptions]},
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:store-simple-sync', '--store-name', 'test-simple-sync', ...appNameOptions]},
       execAppOptions
     );
-    await addImportToAppModule(projectPath, 'TestSimpleSyncStoreModule', 'src/store/test-simple-sync');
+    await addImportToAppModule(applicationPath, 'TestSimpleSyncStoreModule', 'src/store/test-simple-sync');
 
-    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:service', 'test-service', '--feature-name', 'base', ...projectNameOptions]},
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:service', 'test-service', '--feature-name', 'base', ...appNameOptions]},
       execAppOptions
     );
-    await addImportToAppModule(projectPath, 'TestServiceBaseModule', 'src/services/test-service');
+    await addImportToAppModule(applicationPath, 'TestServiceBaseModule', 'src/services/test-service');
 
-    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:page', 'test-page', '--app-routing-module-path', 'apps/test-app/src/app/app-routing.module.ts', ...projectNameOptions]},
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:page', 'test-page', '--app-routing-module-path', 'apps/test-app/src/app/app-routing.module.ts', ...appNameOptions]},
       execAppOptions
     );
 
@@ -66,10 +66,10 @@ describe('new otter application', () => {
       '--use-context', 'false',
       '--use-rules-engine', 'false'
     ];
-    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', 'test-component', ...defaultOptions, ...projectNameOptions]},
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', 'test-component', ...defaultOptions, ...appNameOptions]},
       execAppOptions
     );
-    await addImportToAppModule(projectPath, 'TestComponentModule', 'src/components/test-component');
+    await addImportToAppModule(applicationPath, 'TestComponentModule', 'src/components/test-component');
 
     const advancedOptions = [
       '--activate-dummy',
@@ -80,58 +80,57 @@ describe('new otter application', () => {
       '--use-context', 'true',
       '--use-rules-engine', 'true'
     ];
-    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', 'test-component-advanced', ...advancedOptions, ...projectNameOptions]},
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', 'test-component-advanced', ...advancedOptions, ...appNameOptions]},
       execAppOptions
     );
-    await addImportToAppModule(projectPath, 'TestComponentAdvancedModule', 'src/components/test-component-advanced');
+    await addImportToAppModule(applicationPath, 'TestComponentAdvancedModule', 'src/components/test-component-advanced');
 
-    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', 'test-add-context-component', ...defaultOptions, ...projectNameOptions]},
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', 'test-add-context-component', ...defaultOptions, ...appNameOptions]},
       execAppOptions
     );
     packageManagerExec({script: 'ng', args: ['g', '@o3r/core:add-context', '--path', 'apps/test-app/src/components/test-add-context-component/test-add-context-component.component.ts']},
       execAppOptions
     );
-    await addImportToAppModule(projectPath, 'TestAddContextComponentModule', 'src/components/test-add-context-component');
+    await addImportToAppModule(applicationPath, 'TestAddContextComponentModule', 'src/components/test-add-context-component');
 
-    packageManagerExec({script: 'ng', args: ['g', '@schematics/angular:component', 'test-ng-component', '--project', projectName]},
+    packageManagerExec({script: 'ng', args: ['g', '@schematics/angular:component', 'test-ng-component', '--project', appName]},
       execAppOptions
     );
     packageManagerExec({script: 'ng', args: ['g', '@o3r/core:convert-component', '--path', 'apps/test-app/src/app/test-ng-component/test-ng-component.component.ts']},
       execAppOptions
     );
 
-    packageManagerExec({script: 'ng', args: ['g', '@o3r/testing:playwright-scenario', '--name', 'test-scenario', ...projectNameOptions]}, execAppOptions);
-    packageManagerExec({script: 'ng', args: ['g', '@o3r/testing:playwright-sanity', '--name', 'test-sanity', ...projectNameOptions]}, execAppOptions);
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/testing:playwright-scenario', '--name', 'test-scenario', ...appNameOptions]}, execAppOptions);
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/testing:playwright-sanity', '--name', 'test-sanity', ...appNameOptions]}, execAppOptions);
 
     const diff = getGitDiff(execAppOptions.cwd);
 
-    if (untouchedProjectPath) {
-      const relativeUntouchedProjectPath = path.relative(workspacePath, untouchedProjectPath);
-      expect(diff.all.filter((file) => new RegExp(relativeUntouchedProjectPath.replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBe(0);
-    }
+    untouchedProjectsPaths.forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
 
     // Expect created files inside `test-app` project
-    expect(diff.added.filter((file) => new RegExp(path.join(relativeProjectPath, 'e2e-playwright').replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBeGreaterThan(0);
-    expect(diff.added.filter((file) => new RegExp(path.join(relativeProjectPath, 'src/app').replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBeGreaterThan(0);
-    expect(diff.added.filter((file) => new RegExp(path.join(relativeProjectPath, 'src/components').replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBeGreaterThan(0);
+    expect(diff.added.filter((file) => new RegExp(path.posix.join(relativeApplicationPath, 'e2e-playwright').replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBeGreaterThan(0);
+    expect(diff.added.filter((file) => new RegExp(path.posix.join(relativeApplicationPath, 'src/app').replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBeGreaterThan(0);
+    expect(diff.added.filter((file) => new RegExp(path.posix.join(relativeApplicationPath, 'src/components').replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBeGreaterThan(0);
 
-    expect(diff.added.filter((file) => new RegExp(path.join(relativeProjectPath, 'src/services').replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBeGreaterThan(0);
-    expect(diff.added.filter((file) => new RegExp(path.join(relativeProjectPath, 'src/store').replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBeGreaterThan(0);
-    expect(diff.added.filter((file) => new RegExp(path.join(relativeProjectPath, 'src/styling').replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBeGreaterThan(0);
+    expect(diff.added.filter((file) => new RegExp(path.posix.join(relativeApplicationPath, 'src/services').replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBeGreaterThan(0);
+    expect(diff.added.filter((file) => new RegExp(path.posix.join(relativeApplicationPath, 'src/store').replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBeGreaterThan(0);
+    expect(diff.added.filter((file) => new RegExp(path.posix.join(relativeApplicationPath, 'src/styling').replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBeGreaterThan(0);
 
-    expect(() => packageManagerRunOnProject(projectName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(appName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
 
     // should pass the e2e tests
-    spawn(`npx http-server -p ${devServerPort} ${path.join(relativeProjectPath, 'dist/browser')}`, [], {
+    spawn(`npx http-server -p ${devServerPort} ${path.posix.join(relativeApplicationPath, 'dist/browser')}`, [], {
       ...execAppOptions,
       shell: true,
       stdio: ['ignore', 'ignore', 'inherit']
     });
     execSync(`npx --yes wait-on http://127.0.0.1:${devServerPort} -t 20000`, execAppOptions);
 
-    packageManagerExecOnProject(projectName, isInWorkspace, {script: 'playwright', args: ['install', '--with-deps']}, execAppOptions);
-    expect(() => packageManagerRunOnProject(projectName, isInWorkspace, {script: 'test:playwright'}, execAppOptions)).not.toThrow();
-    expect(() => packageManagerRunOnProject(projectName, isInWorkspace, {script: 'test:playwright:sanity'}, execAppOptions)).not.toThrow();
+    packageManagerExecOnProject(appName, isInWorkspace, {script: 'playwright', args: ['install', '--with-deps']}, execAppOptions);
+    expect(() => packageManagerRunOnProject(appName, isInWorkspace, {script: 'test:playwright'}, execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(appName, isInWorkspace, {script: 'test:playwright:sanity'}, execAppOptions)).not.toThrow();
   });
 
   afterAll(async () => {

--- a/packages/@o3r/core/schematics/rule-factories/otter-environment/index.ts
+++ b/packages/@o3r/core/schematics/rule-factories/otter-environment/index.ts
@@ -2,7 +2,7 @@ import { chain, Rule, SchematicContext, Tree } from '@angular-devkit/schematics'
 import type { PackageManager } from '@angular/cli/lib/config/workspace-schema';
 import generateEnvironments from '@schematics/angular/environments/index';
 import * as ts from 'typescript';
-import { getPackageManager, getWorkspaceConfig, OTTER_ITEM_TYPES, readPackageJson, registerCollectionSchematics, TYPES_DEFAULT_FOLDER } from '@o3r/schematics';
+import { getPackageManager, getWorkspaceConfig, OTTER_ITEM_TYPES, registerCollectionSchematics, TYPES_DEFAULT_FOLDER } from '@o3r/schematics';
 import { join, posix } from 'node:path';
 
 /**
@@ -11,7 +11,6 @@ import { join, posix } from 'node:path';
  * @param rootPath @see RuleFactory.rootPath
  * @param options.projectName
  * @param options.enableStorybook
- * @param options.enablePlaywright
  * @param options.enableStyling
  * @param options.enableAnalytics
  * @param options.workingDirectory
@@ -42,15 +41,10 @@ export function updateOtterEnvironmentAdapter(
       return tree;
     }
 
-    const packageJson = readPackageJson(tree, workspaceProject);
-    const scope = packageJson.name!.split('/')[0];
-
     workspace.cli = workspace.cli || {};
+    workspaceProject.schematics ||= {};
 
     if (workspaceProject.projectType === 'application') {
-      if (!workspaceProject.schematics) {
-        workspaceProject.schematics = {};
-      }
 
       OTTER_ITEM_TYPES.forEach((item) => {
         const path = TYPES_DEFAULT_FOLDER[item].app;
@@ -81,11 +75,11 @@ export function updateOtterEnvironmentAdapter(
       workspace.cli.packageManager ||= getPackageManager() as PackageManager;
 
       OTTER_ITEM_TYPES.forEach((item) => {
-        const path = TYPES_DEFAULT_FOLDER[item].lib ? `modules/${scope}/${TYPES_DEFAULT_FOLDER[item].lib!}` : null;
+        const path = TYPES_DEFAULT_FOLDER[item].lib;
         if (path) {
-          workspace.schematics![`${item}*`] = {
-            path,
-            ...(workspace.schematics![item] || {})
+          workspaceProject.schematics![item] = {
+            path: posix.join(workspaceProject.root, path),
+            ...(workspaceProject.schematics![item] || {})
           };
         }
       });

--- a/packages/@o3r/create/src/index.it.spec.ts
+++ b/packages/@o3r/create/src/index.it.spec.ts
@@ -24,52 +24,76 @@ const workspaceProjectName = 'my-project';
 describe('Create new otter project command', () => {
   test('should generate a project with an application', async () => {
     const { workspacePath, packageManagerConfig, o3rVersion } = o3rEnvironment.testEnvironment;
-    const inAppPath = path.join(workspacePath, workspaceProjectName);
+    const inProjectPath = path.join(workspacePath, workspaceProjectName);
     const execWorkspaceOptions = {...defaultExecOptions, cwd: workspacePath };
-    const execInAppOptions = {...defaultExecOptions, cwd: inAppPath };
+    const execInAppOptions = {...defaultExecOptions, cwd: inProjectPath };
     const createOptions = ['--package-manager', getPackageManager(), '--skip-confirmation', ...(packageManagerConfig.yarnVersion ? ['--yarn-version', packageManagerConfig.yarnVersion] : [])];
 
     // TODO: remove it when fixing #1356
-    await fs.mkdir(inAppPath, { recursive: true });
+    await fs.mkdir(inProjectPath, { recursive: true });
     setPackagerManagerConfig(packageManagerConfig, execInAppOptions);
 
     expect(() => packageManagerCreate({ script: `@o3r@${o3rVersion}`, args: [workspaceProjectName, ...createOptions] }, execWorkspaceOptions, 'npm')).not.toThrow();
-    expect(existsSync(path.join(inAppPath, 'angular.json'))).toBe(true);
-    expect(existsSync(path.join(inAppPath, 'package.json'))).toBe(true);
+    expect(existsSync(path.join(inProjectPath, 'angular.json'))).toBe(true);
+    expect(existsSync(path.join(inProjectPath, 'package.json'))).toBe(true);
     expect(() => packageManagerInstall(execInAppOptions)).not.toThrow();
 
     const appName = 'test-application';
+    const inApplicationPath = path.join(inProjectPath, 'apps', appName);
     expect(() => packageManagerExec({ script: 'ng', args: ['g', 'application', appName] }, execInAppOptions)).not.toThrow();
-    expect(existsSync(path.join(inAppPath, 'project'))).toBe(false);
+    expect(existsSync(path.join(inProjectPath, 'project'))).toBe(false);
+    expect(existsSync(path.join(inApplicationPath, 'package.json'))).toBe(true);
     expect(() => packageManagerRunOnProject(appName, true, { script: 'build' }, execInAppOptions)).not.toThrow();
+  });
+
+  test('should generate a project with a library', async () => {
+    const { workspacePath, packageManagerConfig, o3rVersion } = o3rEnvironment.testEnvironment;
+    const inProjectPath = path.join(workspacePath, workspaceProjectName);
+    const execWorkspaceOptions = {...defaultExecOptions, cwd: workspacePath };
+    const execInAppOptions = {...defaultExecOptions, cwd: inProjectPath };
+    const createOptions = ['--package-manager', getPackageManager(), '--skip-confirmation', ...(packageManagerConfig.yarnVersion ? ['--yarn-version', packageManagerConfig.yarnVersion] : [])];
+
+    // TODO: remove it when fixing #1356
+    await fs.mkdir(inProjectPath, { recursive: true });
+    setPackagerManagerConfig(packageManagerConfig, execInAppOptions);
+
+    expect(() => packageManagerCreate({ script: `@o3r@${o3rVersion}`, args: [workspaceProjectName, ...createOptions] }, execWorkspaceOptions, 'npm')).not.toThrow();
+    expect(existsSync(path.join(inProjectPath, 'angular.json'))).toBe(true);
+    expect(existsSync(path.join(inProjectPath, 'package.json'))).toBe(true);
+    expect(() => packageManagerInstall(execInAppOptions)).not.toThrow();
+
+    const libName = 'test-library';
+    expect(() => packageManagerExec({ script: 'ng', args: ['g', 'library', libName] }, execInAppOptions)).not.toThrow();
+    expect(existsSync(path.join(inProjectPath, 'project'))).toBe(false);
+    expect(() => packageManagerRunOnProject(libName, true, { script: 'build' }, execInAppOptions)).not.toThrow();
   });
 
   test('should generate a project with an application with --exact-o3r-version', async () => {
     const { workspacePath, packageManagerConfig, o3rExactVersion } = o3rEnvironment.testEnvironment;
-    const inAppPath = path.join(workspacePath, workspaceProjectName);
+    const inProjectPath = path.join(workspacePath, workspaceProjectName);
     const execWorkspaceOptions = {...defaultExecOptions, cwd: workspacePath };
-    const execInAppOptions = {...defaultExecOptions, cwd: inAppPath };
+    const execInAppOptions = {...defaultExecOptions, cwd: inProjectPath };
     const packageManager = getPackageManager();
     const createOptions = ['--package-manager', packageManager, '--skip-confirmation', '--exact-o3r-version',
       ...(packageManagerConfig.yarnVersion ? ['--yarn-version', packageManagerConfig.yarnVersion] : [])];
 
     // TODO: remove it when fixing #1356
-    await fs.mkdir(inAppPath, { recursive: true });
+    await fs.mkdir(inProjectPath, { recursive: true });
     setPackagerManagerConfig(packageManagerConfig, execInAppOptions);
 
     expect(() => packageManagerCreate({ script: `@o3r@${o3rExactVersion}`, args: [workspaceProjectName, ...createOptions] }, execWorkspaceOptions, 'npm')).not.toThrow();
-    expect(existsSync(path.join(inAppPath, 'angular.json'))).toBe(true);
-    expect(existsSync(path.join(inAppPath, 'package.json'))).toBe(true);
+    expect(existsSync(path.join(inProjectPath, 'angular.json'))).toBe(true);
+    expect(existsSync(path.join(inProjectPath, 'package.json'))).toBe(true);
     expect(() => packageManagerInstall(execInAppOptions)).not.toThrow();
 
     const appName = 'test-application';
     expect(() => packageManagerExec({ script: 'ng', args: ['g', 'application', appName, '--exact-o3r-version'] }, execInAppOptions)).not.toThrow();
-    expect(existsSync(path.join(inAppPath, 'project'))).toBe(false);
+    expect(existsSync(path.join(inProjectPath, 'project'))).toBe(false);
     expect(() => packageManagerRunOnProject(appName, true, { script: 'build' }, execInAppOptions)).not.toThrow();
 
-    const rootPackageJson = JSON.parse(await fs.readFile(path.join(inAppPath, 'package.json'), 'utf-8'));
+    const rootPackageJson = JSON.parse(await fs.readFile(path.join(inProjectPath, 'package.json'), 'utf-8'));
     const resolutions = packageManager === 'yarn' ? rootPackageJson.resolutions : rootPackageJson.overrides;
-    const appPackageJson = JSON.parse(await fs.readFile(path.join(inAppPath, 'apps', appName, 'package.json'), 'utf-8'));
+    const appPackageJson = JSON.parse(await fs.readFile(path.join(inProjectPath, 'apps', appName, 'package.json'), 'utf-8'));
     // all otter dependencies in both package.json files must be pinned:
     [
       ...Object.entries(rootPackageJson.dependencies), ...Object.entries(rootPackageJson.devDependencies), ...Object.entries(resolutions),

--- a/packages/@o3r/design/schematics/index.it.spec.ts
+++ b/packages/@o3r/design/schematics/index.it.spec.ts
@@ -14,20 +14,22 @@ import {
 } from '@o3r/test-helpers';
 import * as path from 'node:path';
 
+// TODO: enhance tests after fixing https://github.com/AmadeusITGroup/otter/issues/1771
 describe('new otter application with Design', () => {
   test('should add design to existing application', () => {
-    const { workspacePath, projectName, isInWorkspace, untouchedProjectPath, o3rVersion } = o3rEnvironment.testEnvironment;
+    const { workspacePath, appName, isInWorkspace, untouchedProjectsPaths, o3rVersion } = o3rEnvironment.testEnvironment;
     const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
-    packageManagerExec({script: 'ng', args: ['add', `@o3r/design@${o3rVersion}`, '--skip-confirmation', '--project-name', projectName]}, execAppOptions);
+    packageManagerExec({script: 'ng', args: ['add', `@o3r/design@${o3rVersion}`, '--skip-confirmation', '--project-name', appName]}, execAppOptions);
 
     expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
-    expect(() => packageManagerRunOnProject(projectName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(appName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
 
     const diff = getGitDiff(workspacePath);
     expect(diff.modified).toContain('package.json');
-    if (untouchedProjectPath) {
-      const relativeUntouchedProjectPath = path.relative(workspacePath, untouchedProjectPath);
-      expect(diff.all.filter((file) => new RegExp(relativeUntouchedProjectPath.replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBe(0);
-    }
+    expect(diff.modified).toContain('angular.json');
+
+    untouchedProjectsPaths.forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
   });
 });

--- a/packages/@o3r/design/schematics/ng-add/index.ts
+++ b/packages/@o3r/design/schematics/ng-add/index.ts
@@ -21,7 +21,7 @@ export function ngAddFn(options: NgAddSchematicsSchema): Rule {
   return async (tree) => {
     const { getPackageInstallConfig, setupDependencies, setupSchematicsParamsForProject } = await import('@o3r/schematics');
     return chain([
-      registerGenerateCssBuilder(),
+      registerGenerateCssBuilder(options.projectName),
       setupSchematicsParamsForProject({
         // eslint-disable-next-line @typescript-eslint/naming-convention
         '@o3r/core:component': {

--- a/packages/@o3r/eslint-config-otter/project.json
+++ b/packages/@o3r/eslint-config-otter/project.json
@@ -21,7 +21,7 @@
     "test-int": {
       "executor": "@nx/jest:jest",
       "options": {
-        "jestConfig": "packages/@o3r//eslint-config-otter/testing/jest.config.it.js"
+        "jestConfig": "packages/@o3r/eslint-config-otter/testing/jest.config.it.js"
       }
     },
     "lint": {

--- a/packages/@o3r/eslint-config-otter/schematics/index.it.spec.ts
+++ b/packages/@o3r/eslint-config-otter/schematics/index.it.spec.ts
@@ -7,28 +7,67 @@ const o3rEnvironment = globalThis.o3rEnvironment;
 
 import {
   getDefaultExecSyncOptions,
+  getGitDiff,
   packageManagerExec,
   packageManagerInstall,
   packageManagerRunOnProject
 } from '@o3r/test-helpers';
+import path from 'node:path';
 
-describe('new otter application with eslint-config', () => {
-  test('should add eslint-config to existing application', () => {
-    const { workspacePath, projectName, isInWorkspace, o3rVersion } = o3rEnvironment.testEnvironment;
+describe('ng add eslint-config', () => {
+
+  test('should add eslint-config to an application', () => {
+    const { workspacePath, appName, libraryPath, untouchedProjectsPaths, isInWorkspace, isYarnTest, o3rVersion } = o3rEnvironment.testEnvironment;
     const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
-    packageManagerExec({script: 'ng', args: ['add', `@o3r/eslint-config-otter@${o3rVersion}`, '--skip-confirmation', '--project-name', projectName]}, execAppOptions);
+    packageManagerExec({script: 'ng', args: ['add', `@o3r/eslint-config-otter@${o3rVersion}`, '--skip-confirmation', '--project-name', appName]}, execAppOptions);
+    const diff = getGitDiff(workspacePath);
+    expect(diff.modified.sort()).toEqual([
+      '.vscode/extensions.json',
+      'angular.json',
+      'apps/test-app/package.json',
+      'apps/test-app/src/main.ts',
+      'package.json',
+      isYarnTest ? 'yarn.lock' : 'package-lock.json'
+    ].sort());
+    expect(diff.added.sort()).toEqual([
+      '.eslintignore',
+      '.eslintrc.js',
+      'apps/test-app/.eslintrc.js',
+      'apps/test-app/tsconfig.eslint.json'
+    ]);
+
+    [libraryPath, ...untouchedProjectsPaths].forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
 
     expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
-    expect(() => packageManagerRunOnProject(projectName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
-    expect(() => packageManagerExec({script: 'ng', args: ['lint', projectName, '--fix']}, execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(appName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+    expect(() => packageManagerExec({script: 'ng', args: ['lint', appName, '--fix']}, execAppOptions)).not.toThrow();
   });
 
-  test('should add eslint-config to new library', () => {
-    const libName = 'mylib';
-    const { workspacePath, isInWorkspace, o3rVersion } = o3rEnvironment.testEnvironment;
+  test('should add eslint-config to a library', () => {
+    const { workspacePath, libName, applicationPath, untouchedProjectsPaths, isInWorkspace, isYarnTest, o3rVersion } = o3rEnvironment.testEnvironment;
     const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
-    packageManagerExec({script: 'ng', args: ['g', 'library', libName]}, execAppOptions);
     packageManagerExec({script: 'ng', args: ['add', `@o3r/eslint-config-otter@${o3rVersion}`, '--skip-confirmation', '--project-name', libName]}, execAppOptions);
+    const diff = getGitDiff(workspacePath);
+
+    expect(diff.modified.sort()).toEqual([
+      '.vscode/extensions.json',
+      'angular.json',
+      'libs/test-lib/package.json',
+      'package.json',
+      isYarnTest ? 'yarn.lock' : 'package-lock.json'
+    ].sort());
+    expect(diff.added.sort()).toEqual([
+      '.eslintignore',
+      '.eslintrc.js',
+      'libs/test-lib/.eslintrc.js',
+      'libs/test-lib/tsconfig.eslint.json'
+    ].sort());
+
+    [applicationPath, ...untouchedProjectsPaths].forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
 
     expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
     expect(() => packageManagerRunOnProject(libName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();

--- a/packages/@o3r/extractors/schematics/index.it.spec.ts
+++ b/packages/@o3r/extractors/schematics/index.it.spec.ts
@@ -14,21 +14,58 @@ import {
 } from '@o3r/test-helpers';
 import * as path from 'node:path';
 
-describe('new otter application with extractors', () => {
-  test('should add extractors to existing application', () => {
-    const { workspacePath, projectName, isInWorkspace, untouchedProjectPath, o3rVersion } = o3rEnvironment.testEnvironment;
+describe('ng add extractors', () => {
+  test('should add extractors to an application', () => {
+    const { workspacePath, appName, isInWorkspace, isYarnTest, o3rVersion, libraryPath, untouchedProjectsPaths } = o3rEnvironment.testEnvironment;
     const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
-    packageManagerExec({script: 'ng', args: ['add', `@o3r/extractors@${o3rVersion}`, '--skip-confirmation', '--project-name', projectName]}, execAppOptions);
+    expect(() => packageManagerExec({script: 'ng', args: ['add', `@o3r/extractors@${o3rVersion}`, '--skip-confirmation', '--project-name', appName]}, execAppOptions)).not.toThrow();
+
 
     const diff = getGitDiff(workspacePath);
-    expect(diff.modified).toContain('package.json');
+    expect(diff.modified.sort()).toEqual([
+      'package.json',
+      'apps/test-app/package.json',
+      isYarnTest ? 'yarn.lock' : 'package-lock.json'
+    ].sort());
+    expect(diff.added.sort()).toEqual([
+      'apps/test-app/cms.json',
+      'apps/test-app/placeholders.metadata.json',
+      'apps/test-app/tsconfig.cms.json'
+    ].sort());
 
-    if (untouchedProjectPath) {
-      const relativeUntouchedProjectPath = path.relative(workspacePath, untouchedProjectPath);
-      expect(diff.all.filter((file) => new RegExp(relativeUntouchedProjectPath.replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBe(0);
-    }
+    [libraryPath, ...untouchedProjectsPaths].forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
+
 
     expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
-    expect(() => packageManagerRunOnProject(projectName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(appName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+  });
+
+  test('should add extractors to a library', () => {
+    const { workspacePath, libName, isInWorkspace, isYarnTest, o3rVersion, applicationPath, untouchedProjectsPaths } = o3rEnvironment.testEnvironment;
+    const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
+    expect(() => packageManagerExec({script: 'ng', args: ['add', `@o3r/extractors@${o3rVersion}`, '--skip-confirmation', '--project-name', libName]}, execAppOptions)).not.toThrow();
+
+
+    const diff = getGitDiff(workspacePath);
+    expect(diff.modified.sort()).toEqual([
+      'package.json',
+      'libs/test-lib/package.json',
+      isYarnTest ? 'yarn.lock' : 'package-lock.json'
+    ].sort());
+    expect(diff.added.sort()).toEqual([
+      'libs/test-lib/cms.json',
+      'libs/test-lib/placeholders.metadata.json',
+      'libs/test-lib/tsconfig.cms.json'
+    ].sort());
+
+    [applicationPath, ...untouchedProjectsPaths].forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
+
+
+    expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(libName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
   });
 });

--- a/packages/@o3r/localization/schematics/index.it.spec.ts
+++ b/packages/@o3r/localization/schematics/index.it.spec.ts
@@ -15,29 +15,54 @@ import {
 } from '@o3r/test-helpers';
 import * as path from 'node:path';
 
-describe('new otter application with localization', () => {
-  test('should add localization to existing application', async () => {
-    const { projectPath, workspacePath, projectName, isInWorkspace, untouchedProjectPath, o3rVersion } = o3rEnvironment.testEnvironment;
+describe('ng add otter localization', () => {
+  test('should add localization to an application', async () => {
+    const { applicationPath, workspacePath, appName, isInWorkspace, o3rVersion, libraryPath, untouchedProjectsPaths } = o3rEnvironment.testEnvironment;
     const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
-    const relativeProjectPath = path.relative(workspacePath, projectPath);
-    packageManagerExec({script: 'ng', args: ['add', `@o3r/localization@${o3rVersion}`, '--skip-confirmation', '--project-name', projectName]}, execAppOptions);
+    const relativeApplicationPath = path.relative(workspacePath, applicationPath);
+    expect(() => packageManagerExec({script: 'ng', args: ['add', `@o3r/localization@${o3rVersion}`, '--skip-confirmation', '--project-name', appName]}, execAppOptions)).not.toThrow();
 
-    const componentPath = path.normalize(path.join(relativeProjectPath, 'src/components/test-component/test-component.component.ts'));
-    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', 'test-component', '--project-name', projectName, '--use-localization', 'false']}, execAppOptions);
+    const componentPath = path.normalize(path.posix.join(relativeApplicationPath, 'src/components/test-component/test-component.component.ts'));
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', 'test-component', '--project-name', appName, '--use-localization', 'false']}, execAppOptions);
     packageManagerExec({script: 'ng', args: ['g', '@o3r/localization:add-localization', '--activate-dummy', '--path', componentPath]}, execAppOptions);
-    await addImportToAppModule(projectPath, 'TestComponentModule', 'src/components/test-component');
+    await addImportToAppModule(applicationPath, 'TestComponentModule', 'src/components/test-component');
 
     const diff = getGitDiff(workspacePath);
-    expect(diff.modified).toContain('package.json');
-    expect(diff.added).toContain(path.join(relativeProjectPath, 'src/components/test-component/test-component.localization.json').replace(/[\\/]+/g, '/'));
-    expect(diff.added).toContain(path.join(relativeProjectPath, 'src/components/test-component/test-component.translation.ts').replace(/[\\/]+/g, '/'));
+    expect(diff.modified.length).toBe(8);
+    expect(diff.added.length).toBe(15);
+    expect(diff.added).toContain(path.join(relativeApplicationPath, 'src/components/test-component/test-component.localization.json').replace(/[\\/]+/g, '/'));
+    expect(diff.added).toContain(path.join(relativeApplicationPath, 'src/components/test-component/test-component.translation.ts').replace(/[\\/]+/g, '/'));
 
-    if (untouchedProjectPath) {
-      const relativeUntouchedProjectPath = path.relative(workspacePath, untouchedProjectPath);
-      expect(diff.all.filter((file) => new RegExp(relativeUntouchedProjectPath.replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBe(0);
-    }
+    [libraryPath, ...untouchedProjectsPaths].forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
 
     expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
-    expect(() => packageManagerRunOnProject(projectName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(appName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+  });
+
+  // TODO add after fixing https://github.com/AmadeusITGroup/otter/issues/1758
+  test.skip('should add localization to a library', () => {
+    const { workspacePath, isInWorkspace, untouchedProjectsPaths, o3rVersion, libraryPath, libName, applicationPath } = o3rEnvironment.testEnvironment;
+    const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
+    const relativeLibraryPath = path.relative(workspacePath, libraryPath);
+    expect(() => packageManagerExec({script: 'ng', args: ['add', `@o3r/localization@${o3rVersion}`, '--skip-confirmation', '--project-name', libName]}, execAppOptions)).not.toThrow();
+
+    const componentPath = path.normalize(path.posix.join(relativeLibraryPath, 'src/components/test-component/test-component.component.ts'));
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', 'test-component', '--project-name', libName, '--use-localization', 'false']}, execAppOptions);
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/localization:add-localization', '--activate-dummy', '--path', componentPath]}, execAppOptions);
+
+    const diff = getGitDiff(workspacePath);
+    expect(diff.modified.length).toBe(8);
+    expect(diff.added.length).toBe(15);
+    expect(diff.added).toContain(path.join(relativeLibraryPath, 'src/components/test-component/test-component.localization.json').replace(/[\\/]+/g, '/'));
+    expect(diff.added).toContain(path.join(relativeLibraryPath, 'src/components/test-component/test-component.translation.ts').replace(/[\\/]+/g, '/'));
+
+    [applicationPath, ...untouchedProjectsPaths].forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
+
+    expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(libName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
   });
 });

--- a/packages/@o3r/localization/schematics/localization-base/index.ts
+++ b/packages/@o3r/localization/schematics/localization-base/index.ts
@@ -133,17 +133,19 @@ export function updateLocalization(options: { projectName?: string | null | unde
         libraries: []
       }
     };
-
+    const localizationAssetsConfig = {
+      glob: '**/*.json',
+      input: `${devResourcesFolder}/localizations`,
+      output: '/localizations'
+    };
     if (workspaceProject.architect.build) {
       const alreadyExistingBuildOption =
         workspaceProject.architect.build.options?.assets?.map((a: { glob: string; input: string; output: string }) => a.output).find((output: string) => output === '/localizations');
 
       if (!alreadyExistingBuildOption) {
-        workspaceProject.architect.build.options.assets.push({
-          glob: '**/*.json',
-          input: `${devResourcesFolder}/localizations`,
-          output: '/localizations'
-        });
+        workspaceProject.architect.build.options ||= {};
+        workspaceProject.architect.build ||= [];
+        workspaceProject.architect.build.options.assets.push(localizationAssetsConfig);
       }
     }
 
@@ -151,11 +153,9 @@ export function updateLocalization(options: { projectName?: string | null | unde
       const alreadyExistingTestOption =
         workspaceProject.architect.test.options?.assets?.map((a: { glob: string; input: string; output: string }) => a.output).find((output: string) => output === '/localizations');
       if (!alreadyExistingTestOption) {
-        workspaceProject.architect.test.options.assets.push({
-          glob: '**/*.json',
-          input: `${devResourcesFolder}/localizations`,
-          output: '/localizations'
-        });
+        workspaceProject.architect.test.options ||= {};
+        workspaceProject.architect.test.options.assets ||= [];
+        workspaceProject.architect.test.options.assets.push(localizationAssetsConfig);
       }
     }
 
@@ -222,7 +222,10 @@ export function updateLocalization(options: { projectName?: string | null | unde
   const registerModules: Rule = (tree: Tree, context: SchematicContext) => {
     const additionalRules: Rule[] = [];
     const moduleFilePath = getAppModuleFilePath(tree, context, options.projectName);
-    if (!moduleFilePath) {
+    if (!moduleFilePath || !tree.exists(moduleFilePath)) {
+      context.logger.warn(!moduleFilePath ?
+        'No module file found. Localization modules not registered.' :
+        `Module file not found under '${moduleFilePath}'. Localization modules not registered.`);
       return tree;
     }
 

--- a/packages/@o3r/rules-engine/schematics/index.it.spec.ts
+++ b/packages/@o3r/rules-engine/schematics/index.it.spec.ts
@@ -15,27 +15,57 @@ import {
 } from '@o3r/test-helpers';
 import * as path from 'node:path';
 
-describe('new otter application with rules-engine', () => {
-  test('should add rules engine to existing application', async () => {
-    const { projectPath, workspacePath, projectName, isInWorkspace, untouchedProjectPath, o3rVersion } = o3rEnvironment.testEnvironment;
+describe('ng add rules-engine', () => {
+  test('should add rules engine to an application', async () => {
+    const { applicationPath, workspacePath, appName, isInWorkspace, untouchedProjectsPaths, o3rVersion, libraryPath } = o3rEnvironment.testEnvironment;
     const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
-    const relativeProjectPath = path.relative(workspacePath, projectPath);
-    packageManagerExec({script: 'ng', args: ['add', `@o3r/rules-engine@${o3rVersion}`, '--enable-metadata-extract', '--project-name', projectName, '--skip-confirmation']}, execAppOptions);
-
-    const componentPath = path.normalize(path.join(relativeProjectPath, 'src/components/test-component/test-component.component.ts'));
-    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', 'test-component', '--activate-dummy', '--use-rules-engine', 'false', '--project-name', projectName]}, execAppOptions);
+    const relativeApplicationPath = path.relative(workspacePath, applicationPath);
+    expect(() => packageManagerExec({script: 'ng', args: ['add', `@o3r/rules-engine@${o3rVersion}`,
+      '--enable-metadata-extract', '--project-name', appName, '--skip-confirmation']}, execAppOptions)).not.toThrow();
+    const componentPath = path.normalize(path.posix.join(relativeApplicationPath, 'src/components/test-component/test-component.component.ts'));
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', 'test-component', '--activate-dummy', '--use-rules-engine', 'false', '--project-name', appName]}, execAppOptions);
     packageManagerExec({script: 'ng', args: ['g', '@o3r/rules-engine:rules-engine-to-component', '--path', componentPath]}, execAppOptions);
-    await addImportToAppModule(projectPath, 'TestComponentModule', 'src/components/test-component');
+    await addImportToAppModule(applicationPath, 'TestComponentModule', 'src/components/test-component');
 
     const diff = getGitDiff(workspacePath);
-    expect(diff.modified).toContain('package.json');
+    expect(diff.added).toContain('apps/test-app/cms.json');
+    expect(diff.added).toContain('apps/test-app/placeholders.metadata.json');
+    expect(diff.added).toContain('apps/test-app/tsconfig.cms.json');
+    expect(diff.added.length).toBe(12);
+    expect(diff.modified.length).toBe(6);
 
-    if (untouchedProjectPath) {
-      const relativeUntouchedProjectPath = path.relative(workspacePath, untouchedProjectPath);
-      expect(diff.all.filter((file) => new RegExp(relativeUntouchedProjectPath.replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBe(0);
-    }
+    [libraryPath, ...untouchedProjectsPaths].forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
 
     expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
-    expect(() => packageManagerRunOnProject(projectName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(appName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+  });
+  test('should add rules engine to a library', () => {
+    const { applicationPath, workspacePath, isInWorkspace, o3rVersion, libraryPath, libName, untouchedProjectsPaths } = o3rEnvironment.testEnvironment;
+    const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
+    const relativeLibraryPath = path.relative(workspacePath, libraryPath);
+    expect(() => packageManagerExec({script: 'ng', args: ['add', `@o3r/rules-engine@${o3rVersion}`,
+      '--enable-metadata-extract', '--project-name', libName, '--skip-confirmation']}, execAppOptions)).not.toThrow();
+    const componentPath = path.normalize(path.posix.join(relativeLibraryPath, 'src/components/test-component/test-component.component.ts'));
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', 'test-component', '--activate-dummy', '--use-rules-engine', 'false', '--project-name', libName]}, execAppOptions);
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/rules-engine:rules-engine-to-component', '--path', componentPath]}, execAppOptions);
+
+    const diff = getGitDiff(workspacePath);
+    expect(diff.added).toContain('libs/test-lib/cms.json');
+    expect(diff.added).toContain('libs/test-lib/placeholders.metadata.json');
+    expect(diff.added).toContain('libs/test-lib/tsconfig.cms.json');
+    expect(diff.added.length).toBe(12);
+    expect(diff.modified).toContain('angular.json');
+    expect(diff.modified).toContain('package.json');
+    expect(diff.modified).toContain('libs/test-lib/package.json');
+    expect(diff.modified.length).toBe(4);
+
+    [applicationPath, ...untouchedProjectsPaths].forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
+
+    expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(libName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
   });
 });

--- a/packages/@o3r/schematics/src/utility/generation.ts
+++ b/packages/@o3r/schematics/src/utility/generation.ts
@@ -28,15 +28,15 @@ export const OTTER_ITEM_TYPES: GeneratedItemType[] = [
 /** List of the default destination paths for each generated entity */
 export const TYPES_DEFAULT_FOLDER: { [key in GeneratedItemType] : {app?: string; lib?: string} } = {
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  '@o3r/core:component': {app: 'src/components', lib: 'components/src'},
+  '@o3r/core:component': {app: 'src/components', lib: 'src/components'},
   // eslint-disable-next-line @typescript-eslint/naming-convention
   '@o3r/core:page': {app: 'src/app'},
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  '@o3r/core:service': {app: 'src/services', lib: 'services/src'},
+  '@o3r/core:service': {app: 'src/services', lib: 'src/services'},
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  '@o3r/core:store': {app: 'src/store', lib: 'store/src'},
+  '@o3r/core:store': {app: 'src/store', lib: 'src/store'},
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  '@o3r/core:schematics-update': {app: 'src/schematics', lib: 'schematics/src'},
+  '@o3r/core:schematics-update': {app: 'src/schematics', lib: 'src/schematics'},
   // eslint-disable-next-line @typescript-eslint/naming-convention
   '@o3r/testing:playwright-scenario': { app: 'e2e-playwright/scenarios' },
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/@o3r/schematics/src/utility/modules.ts
+++ b/packages/@o3r/schematics/src/utility/modules.ts
@@ -24,7 +24,7 @@ import { getWorkspaceConfig } from './loaders';
 export function getAppModuleFilePath(tree: Tree, context: SchematicContext, projectName?: string | null) {
   const workspaceProject = projectName ? getWorkspaceConfig(tree)?.projects[projectName] : undefined;
   // exit if not an application
-  if (!workspaceProject) {
+  if (!workspaceProject || workspaceProject.projectType !== 'application') {
     context.logger.debug('Aborted. App module file path will be searched only in application project.');
     return undefined;
   }

--- a/packages/@o3r/stylelint-plugin/schematics/index.it.spec.ts
+++ b/packages/@o3r/stylelint-plugin/schematics/index.it.spec.ts
@@ -17,16 +17,28 @@ import {
 import { writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
-describe('new otter application with stylelint-plugin', () => {
-  test('should add stylelint-plugin to existing application', async () => {
-    const { projectPath, workspacePath, projectName, isInWorkspace, untouchedProjectPath, o3rVersion } = o3rEnvironment.testEnvironment;
+describe('ng add stylelint-plugin', () => {
+
+  test('should add stylelint-plugin to an application', async () => {
+    const { applicationPath, workspacePath, appName, isInWorkspace, isYarnTest, libraryPath, untouchedProjectsPaths, o3rVersion } = o3rEnvironment.testEnvironment;
     const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
-    packageManagerExec({script: 'ng', args: ['add', `@o3r/stylelint-plugin@${o3rVersion}`, '--enable-metadata-extract', '--skip-confirmation', '--project-name', projectName]}, execAppOptions);
+    packageManagerExec({script: 'ng', args: ['add', `@o3r/stylelint-plugin@${o3rVersion}`, '--enable-metadata-extract', '--skip-confirmation', '--project-name', appName]}, execAppOptions);
+    const diff = getGitDiff(workspacePath);
 
-    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', '--defaults', 'true', 'test-component', '--use-otter-theming', 'false', '--project-name', projectName]}, execAppOptions);
+    expect(diff.modified.sort()).toEqual([
+      'apps/test-app/package.json',
+      'package.json',
+      isYarnTest ? 'yarn.lock' : 'package-lock.json'
+    ].sort());
+    expect(diff.added.length).toBe(0);
 
-    await addImportToAppModule(projectPath, 'TestComponentModule', 'src/components/test-component');
-    await writeFile(path.join(projectPath, '.stylelintrc.json'), JSON.stringify({
+    [libraryPath, ...untouchedProjectsPaths].forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', '--defaults', 'true', 'test-component', '--use-otter-theming', 'false', '--project-name', appName]}, execAppOptions);
+
+    await addImportToAppModule(applicationPath, 'TestComponentModule', 'src/components/test-component');
+    await writeFile(path.join(applicationPath, '.stylelintrc.json'), JSON.stringify({
       plugins: [
         '@o3r/stylelint-plugin'
       ],
@@ -37,19 +49,48 @@ describe('new otter application with stylelint-plugin', () => {
       }
     }, null, 2));
 
-    const diff = getGitDiff(execAppOptions.cwd);
-    expect(diff.modified).toContain('package.json');
+    expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(appName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+    expect(() => packageManagerExecOnProject(appName, isInWorkspace, {
+      script: 'stylelint',
+      args: [path.join(applicationPath, 'src', 'components', 'test-component', 'test-component.style.scss')]
+    }, execAppOptions)).not.toThrow();
+  });
 
-    if (untouchedProjectPath) {
-      const relativeUntouchedProjectPath = path.relative(workspacePath, untouchedProjectPath);
-      expect(diff.all.filter((file) => new RegExp(relativeUntouchedProjectPath.replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBe(0);
-    }
+  test('should add stylelint-plugin to a library', async () => {
+    const { applicationPath, workspacePath, libName, libraryPath, isInWorkspace, isYarnTest, untouchedProjectsPaths, o3rVersion } = o3rEnvironment.testEnvironment;
+    const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
+    packageManagerExec({script: 'ng', args: ['add', `@o3r/stylelint-plugin@${o3rVersion}`, '--enable-metadata-extract', '--skip-confirmation', '--project-name', libName]}, execAppOptions);
+    const diff = getGitDiff(workspacePath);
+
+    expect(diff.modified.sort()).toEqual([
+      'libs/test-lib/package.json',
+      'package.json',
+      isYarnTest ? 'yarn.lock' : 'package-lock.json'
+    ].sort());
+    expect(diff.added.length).toBe(0);
+
+    [applicationPath, ...untouchedProjectsPaths].forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', '--defaults', 'true', 'test-component', '--use-otter-theming', 'false', '--project-name', libName]}, execAppOptions);
+
+    await writeFile(path.join(libraryPath, '.stylelintrc.json'), JSON.stringify({
+      plugins: [
+        '@o3r/stylelint-plugin'
+      ],
+      customSyntax: 'postcss-scss',
+      rules: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        '@o3r/o3r-var-parameter-equal-variable': true
+      }
+    }, null, 2));
 
     expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
-    expect(() => packageManagerRunOnProject(projectName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
-    expect(() => packageManagerExecOnProject(projectName, isInWorkspace, {
+    expect(() => packageManagerRunOnProject(libName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+    expect(() => packageManagerExecOnProject(libName, isInWorkspace, {
       script: 'stylelint',
-      args: [path.join(projectPath, 'src', 'components', 'test-component', 'test-component.style.scss')]
+      args: [path.join(libraryPath, 'src', 'components', 'test-component', 'test-component.style.scss')]
     }, execAppOptions)).not.toThrow();
   });
 });

--- a/packages/@o3r/styling/schematics/index.it.spec.ts
+++ b/packages/@o3r/styling/schematics/index.it.spec.ts
@@ -15,28 +15,55 @@ import {
 } from '@o3r/test-helpers';
 import * as path from 'node:path';
 
-describe('new otter application with styling', () => {
-  test('should add styling to existing application', async () => {
-    const { projectPath, workspacePath, projectName, isInWorkspace, untouchedProjectPath, o3rVersion } = o3rEnvironment.testEnvironment;
+describe('ng add styling', () => {
+  test('should add styling to an application', async () => {
+    const { applicationPath, workspacePath, appName, isInWorkspace, o3rVersion, untouchedProjectsPaths, libraryPath } = o3rEnvironment.testEnvironment;
     const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
-    const relativeProjectPath = path.relative(workspacePath, projectPath);
-    packageManagerExec({script: 'ng', args: ['add', `@o3r/styling@${o3rVersion}`, '--enable-metadata-extract', '--skip-confirmation', '--project-name', projectName]}, execAppOptions);
+    const relativeApplicationPath = path.relative(workspacePath, applicationPath);
+    expect(() => packageManagerExec({script: 'ng', args: ['add', `@o3r/styling@${o3rVersion}`,
+      '--enable-metadata-extract', '--skip-confirmation', '--project-name', appName]}, execAppOptions)).not.toThrow();
 
-    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', '--defaults', 'true', 'test-component', '--use-otter-theming', 'false', '--project-name', projectName]}, execAppOptions);
-    const filePath = path.normalize(path.join(relativeProjectPath, 'src/components/test-component/test-component.style.scss'));
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', '--defaults', 'true', 'test-component', '--use-otter-theming', 'false', '--project-name', appName]}, execAppOptions);
+    const filePath = path.normalize(path.posix.join(relativeApplicationPath, 'src/components/test-component/test-component.style.scss'));
     packageManagerExec({script: 'ng', args: ['g', '@o3r/styling:add-theming', '--path', filePath]}, execAppOptions);
-    await addImportToAppModule(projectPath, 'TestComponentModule', 'src/components/test-component');
+    await addImportToAppModule(applicationPath, 'TestComponentModule', 'src/components/test-component');
 
     const diff = getGitDiff(execAppOptions.cwd);
-    expect(diff.modified).toContain('package.json');
-    expect(diff.added).toContain(path.join(relativeProjectPath, 'src/components/test-component/test-component.style.theme.scss').replace(/[\\/]+/g, '/'));
+    expect(diff.added.length).toBe(17);
+    expect(diff.added).toContain(path.join(relativeApplicationPath, 'src/components/test-component/test-component.style.theme.scss').replace(/[\\/]+/g, '/'));
 
-    if (untouchedProjectPath) {
-      const relativeUntouchedProjectPath = path.relative(workspacePath, untouchedProjectPath);
-      expect(diff.all.filter((file) => new RegExp(relativeUntouchedProjectPath.replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBe(0);
-    }
+    expect(diff.modified.length).toBe(6);
+
+    [libraryPath, ...untouchedProjectsPaths].forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
 
     expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
-    expect(() => packageManagerRunOnProject(projectName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(appName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+  });
+
+  test('should add styling to a library', () => {
+    const { applicationPath, workspacePath, libName, isInWorkspace, o3rVersion, libraryPath, untouchedProjectsPaths } = o3rEnvironment.testEnvironment;
+    const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
+    const relativeLibraryPath = path.relative(workspacePath, libraryPath);
+    expect(() => packageManagerExec({script: 'ng', args: ['add', `@o3r/styling@${o3rVersion}`,
+      '--enable-metadata-extract', '--skip-confirmation', '--project-name', libName]}, execAppOptions)).not.toThrow();
+
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/core:component', '--defaults', 'true', 'test-component', '--use-otter-theming', 'false', '--project-name', libName]}, execAppOptions);
+    const filePath = path.normalize(path.posix.join(relativeLibraryPath, 'src/components/test-component/test-component.style.scss'));
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/styling:add-theming', '--path', filePath]}, execAppOptions);
+
+    const diff = getGitDiff(execAppOptions.cwd);
+    expect(diff.added.length).toBe(13);
+    expect(diff.added).toContain(path.join(relativeLibraryPath, 'src/components/test-component/test-component.style.theme.scss').replace(/[\\/]+/g, '/'));
+
+    expect(diff.modified.length).toBe(4);
+
+    [applicationPath, ...untouchedProjectsPaths].forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
+
+    expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(libName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
   });
 });

--- a/packages/@o3r/styling/schematics/ng-add/theme-files/index.ts
+++ b/packages/@o3r/styling/schematics/ng-add/theme-files/index.ts
@@ -12,7 +12,7 @@ export function updateThemeFiles(rootPath: string, options: { projectName?: stri
   return async (tree: Tree, context: SchematicContext) => {
     const { getTemplateFolder, getWorkspaceConfig } = await import('@o3r/schematics');
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
-    if (!workspaceProject) {
+    if (!workspaceProject || workspaceProject.projectType === 'library') {
       return noop;
     }
 

--- a/packages/@o3r/test-helpers/src/test-environments/create-test-environment-otter-project.ts
+++ b/packages/@o3r/test-helpers/src/test-environments/create-test-environment-otter-project.ts
@@ -13,11 +13,16 @@ import {
   setPackagerManagerConfig
 } from '../utilities';
 
-export interface CreateTestEnvironmentOtterProjectWithAppOptions extends CreateWithLockOptions, PackageManagerConfig {
+export interface CreateTestEnvironmentOtterProjectWithAppAndLibOptions extends CreateWithLockOptions, PackageManagerConfig {
   /**
-   * Name of the app to generate
+   * Name of the application to generate
    */
-  projectName: string;
+  appName: string;
+
+  /**
+   * Name of the library to generate
+   */
+  libName: string;
 
   /**
    * Working directory
@@ -42,9 +47,10 @@ const o3rVersion = '~999';
  * The lock will automatically expire after 10 minutes if the creation of the app failed for whatever reason
  * @param inputOptions
  */
-export async function createTestEnvironmentOtterProjectWithApp(inputOptions: Partial<CreateTestEnvironmentOtterProjectWithAppOptions>) {
-  const options: CreateTestEnvironmentOtterProjectWithAppOptions = {
-    projectName: 'test-app',
+export async function createTestEnvironmentOtterProjectWithAppAndLib(inputOptions: Partial<CreateTestEnvironmentOtterProjectWithAppAndLibOptions>) {
+  const options: CreateTestEnvironmentOtterProjectWithAppAndLibOptions = {
+    appName: 'test-app',
+    libName: 'test-lib',
     appDirectory: 'test-app',
     o3rVersion,
     cwd: process.cwd(),
@@ -83,8 +89,10 @@ export async function createTestEnvironmentOtterProjectWithApp(inputOptions: Par
       writeFileSync(gitIgnorePath, gitIgnore.replace(/\/(dist|node_modules)/g, '$1'));
     }
     packageManagerInstall(execAppOptions);
-    packageManagerExec({script: 'ng', args: ['g', 'application', 'dont-modify-me']}, execAppOptions);
-    packageManagerExec({script: 'ng', args: ['g', 'application', options.projectName]}, execAppOptions);
+    packageManagerExec({script: 'ng', args: ['g', 'application', 'untouched-app']}, execAppOptions);
+    packageManagerExec({script: 'ng', args: ['g', 'application', options.appName]}, execAppOptions);
+    packageManagerExec({script: 'ng', args: ['g', 'library', 'untouched-lib']}, execAppOptions);
+    packageManagerExec({script: 'ng', args: ['g', 'library', options.libName]}, execAppOptions);
 
 
     packageManagerExec({script: 'ng', args: ['config', 'cli.cache.environment', 'all']}, execAppOptions);

--- a/packages/@o3r/test-helpers/src/utilities/git.ts
+++ b/packages/@o3r/test-helpers/src/utilities/git.ts
@@ -31,7 +31,7 @@ export function getGitDiff(workingDirectory?: string, baseBranch = 'after-init')
   const trackedFiles = execFileSync('git', ['diff', '--name-status', baseBranch], execOptions).split('\n');
   const indexedFiles = execFileSync('git', ['diff', '--cached', '--name-status', baseBranch], execOptions).split('\n');
   const extractFile = (line: string) => line.replace(/^[ADM]\s*/, '');
-  const cleanList = (list: string[]) => [...new Set(list.filter((file) => !!file))];
+  const cleanList = (list: string[]) => [...new Set(list.filter((file) => !!file).map(filePath => filePath.replace(/[\\/]+/g, '/')))];
   const added = cleanList([...untrackedFiles, ...[...trackedFiles, ...indexedFiles].filter((line) => /^A/.test(line)).map(extractFile)]);
   const modified = cleanList([...trackedFiles, ...indexedFiles].filter((line) => /^M/.test(line)).map(extractFile));
   const deleted = cleanList([...trackedFiles, ...indexedFiles].filter((line) => /^D/.test(line)).map(extractFile));

--- a/packages/@o3r/testing/schematics/index.it.spec.ts
+++ b/packages/@o3r/testing/schematics/index.it.spec.ts
@@ -15,41 +15,96 @@ import {
 } from '@o3r/test-helpers';
 import * as path from 'node:path';
 
-describe('new otter application with testing', () => {
+describe('ng add testing', () => {
 
-  test('should add testing to existing application', () => {
-    const { workspacePath, projectName, isInWorkspace, o3rVersion } = o3rEnvironment.testEnvironment;
+  test('should add testing to an application', () => {
+    const { workspacePath, appName, isInWorkspace, o3rVersion, libraryPath, untouchedProjectsPaths } = o3rEnvironment.testEnvironment;
     const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
-    packageManagerExec({script: 'ng', args: ['add', `@o3r/testing@${o3rVersion}`, '--skip-confirmation', '--project-name', projectName]}, execAppOptions);
-
-    expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
-    expect(() => packageManagerRunOnProject(projectName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
-    expect(() => packageManagerRunOnProject(projectName, isInWorkspace, {script: 'test'}, execAppOptions)).not.toThrow();
-  });
-
-  test('should add testing to existing application and fixture to component', async () => {
-
-    const { projectPath, workspacePath, projectName, isInWorkspace, untouchedProjectPath, o3rVersion } = o3rEnvironment.testEnvironment;
-    const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
-    const relativeProjectPath = path.relative(workspacePath, projectPath);
-    packageManagerExec({script: 'ng', args: ['add', `@o3r/testing@${o3rVersion}`, '--skip-confirmation', '--project-name', projectName]}, execAppOptions);
-
-    const componentPath = path.join(relativeProjectPath, 'src/components/test-component/container/test-component-cont.component.ts');
-    packageManagerExec({script: 'ng',
-      args: ['g', '@o3r/core:component', 'test-component', '--use-component-fixtures', 'false', '--component-structure', 'full', '--project-name', projectName]}, execAppOptions);
-    packageManagerExec({script: 'ng', args: ['g', '@o3r/testing:add-fixture', '--path', componentPath]}, execAppOptions);
-    await addImportToAppModule(projectPath, 'TestComponentContModule', 'src/components/test-component');
+    packageManagerExec({script: 'ng', args: ['add', `@o3r/testing@${o3rVersion}`, '--skip-confirmation', '--project-name', appName]}, execAppOptions);
 
     const diff = getGitDiff(execAppOptions.cwd);
-    expect(diff.added).toContain(path.join(relativeProjectPath, 'src/components/test-component/container/test-component-cont.fixture.ts').replace(/[\\/]+/g, '/'));
+    expect(diff.added.length).toBe(0);
+    expect(diff.modified).toContain('apps/test-app/package.json');
 
-    if (untouchedProjectPath) {
-      const relativeUntouchedProjectPath = path.relative(workspacePath, untouchedProjectPath);
-      expect(diff.all.filter((file) => new RegExp(relativeUntouchedProjectPath.replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBe(0);
-    }
+    [libraryPath, ...untouchedProjectsPaths].forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
+
 
     expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
-    expect(() => packageManagerRunOnProject(projectName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
-    expect(() => packageManagerRunOnProject(projectName, isInWorkspace, {script: 'test'}, execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(appName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(appName, isInWorkspace, {script: 'test'}, execAppOptions)).not.toThrow();
   });
+
+  test('should add testing to an application and fixture to component', async () => {
+
+    const { applicationPath, workspacePath, appName, isInWorkspace, o3rVersion, untouchedProjectsPaths, libraryPath } = o3rEnvironment.testEnvironment;
+    const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
+    const relativeApplicationPath = path.relative(workspacePath, applicationPath);
+    packageManagerExec({script: 'ng', args: ['add', `@o3r/testing@${o3rVersion}`, '--skip-confirmation', '--project-name', appName]}, execAppOptions);
+
+    const componentPath = path.join(relativeApplicationPath, 'src/components/test-component/container/test-component-cont.component.ts');
+    packageManagerExec({script: 'ng',
+      args: ['g', '@o3r/core:component', 'test-component', '--use-component-fixtures', 'false', '--component-structure', 'full', '--project-name', appName]}, execAppOptions);
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/testing:add-fixture', '--path', componentPath]}, execAppOptions);
+    await addImportToAppModule(applicationPath, 'TestComponentContModule', 'src/components/test-component');
+
+    const diff = getGitDiff(execAppOptions.cwd);
+    expect(diff.added).toContain(path.join(relativeApplicationPath, 'src/components/test-component/container/test-component-cont.fixture.ts').replace(/[\\/]+/g, '/'));
+
+    [libraryPath, ...untouchedProjectsPaths].forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
+
+    expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(appName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(appName, isInWorkspace, {script: 'test'}, execAppOptions)).not.toThrow();
+  });
+
+  // TODO: fix https://github.com/AmadeusITGroup/otter/issues/1765 first
+  test.skip('should add testing to a library', () => {
+    const { workspacePath, libName, isInWorkspace, o3rVersion, applicationPath, untouchedProjectsPaths } = o3rEnvironment.testEnvironment;
+    const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
+    packageManagerExec({script: 'ng', args: ['add', `@o3r/testing@${o3rVersion}`, '--skip-confirmation', '--project-name', libName]}, execAppOptions);
+
+    const diff = getGitDiff(execAppOptions.cwd);
+    expect(diff.added.length).toBe(0);
+    expect(diff.modified).toEqual(['libs/test-lib/package.json']);
+
+    [applicationPath, ...untouchedProjectsPaths].forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
+
+    expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(libName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(libName, isInWorkspace, {script: 'test'}, execAppOptions)).not.toThrow();
+  });
+
+  // TODO: fix https://github.com/AmadeusITGroup/otter/issues/1765 first
+  test.skip('should add testing to a library and fixture to component', () => {
+
+    const { applicationPath, workspacePath, libName, isInWorkspace, o3rVersion, untouchedProjectsPaths, libraryPath } = o3rEnvironment.testEnvironment;
+    const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
+    const relativeLibraryPath = path.relative(workspacePath, libraryPath);
+    packageManagerExec({script: 'ng', args: ['add', `@o3r/testing@${o3rVersion}`, '--skip-confirmation', '--project-name', libName]}, execAppOptions);
+
+    const componentPath = path.join(relativeLibraryPath, 'src/components/test-component/container/test-component-cont.component.ts');
+    packageManagerExec({script: 'ng',
+      args: ['g', '@o3r/core:component', 'test-component', '--use-component-fixtures', 'false', '--component-structure', 'full', '--project-name', libName]}, execAppOptions);
+    packageManagerExec({script: 'ng', args: ['g', '@o3r/testing:add-fixture', '--path', componentPath]}, execAppOptions);
+
+    const diff = getGitDiff(execAppOptions.cwd);
+    expect(diff.added).toContain(path.join(relativeLibraryPath, 'src/components/test-component/container/test-component-cont.fixture.ts').replace(/[\\/]+/g, '/'));
+    expect(diff.added.length).toBe(18);
+    expect(diff.modified.length).toBe(6);
+
+    [applicationPath, ...untouchedProjectsPaths].forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
+
+    expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(libName, isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(libName, isInWorkspace, {script: 'test'}, execAppOptions)).not.toThrow();
+  });
+
 });

--- a/packages/@o3r/testing/schematics/ng-add/index.ts
+++ b/packages/@o3r/testing/schematics/ng-add/index.ts
@@ -88,9 +88,12 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
         }
       }
 
-      const installPlaywright = options.enablePlaywright !== undefined && projectType === 'application' ?
-        options.enablePlaywright :
-        await askConfirmation('Do you want to setup Playwright test framework for E2E?', true);
+      let installPlaywright = false;
+      if (projectType === 'application') {
+        installPlaywright = options.enablePlaywright !== undefined ?
+          options.enablePlaywright :
+          await askConfirmation('Do you want to setup Playwright test framework for E2E?', true);
+      }
 
       const rules = [
         updateFixtureConfig(options),

--- a/packages/@o3r/workspace/schematics/index.it.spec.ts
+++ b/packages/@o3r/workspace/schematics/index.it.spec.ts
@@ -11,26 +11,26 @@ import {
   packageManagerInstall,
   packageManagerRunOnProject
 } from '@o3r/test-helpers';
+import { existsSync } from 'node:fs';
 import * as path from 'node:path';
 
 describe('new otter workspace', () => {
   test('should add sdk to an existing workspace', () => {
-    const { workspacePath, isInWorkspace, untouchedProjectPath } = o3rEnvironment.testEnvironment;
+    const { workspacePath, isInWorkspace, untouchedProjectsPaths } = o3rEnvironment.testEnvironment;
     const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
     packageManagerExec({script: 'ng', args: ['g', 'sdk', '@my-sdk/sdk']}, execAppOptions);
 
     const diff = getGitDiff(execAppOptions.cwd);
-    if (untouchedProjectPath) {
-      const relativeUntouchedProjectPath = path.relative(workspacePath, untouchedProjectPath);
-      expect(diff.all.filter((file) => new RegExp(relativeUntouchedProjectPath.replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBe(0);
-    }
+    untouchedProjectsPaths.forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
 
     expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
     expect(() => packageManagerRunOnProject('@my-sdk/sdk', isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
   });
 
   test('should add sdk to an existing workspace with spec package name', () => {
-    const { workspacePath, isInWorkspace, untouchedProjectPath, o3rVersion, registry } = o3rEnvironment.testEnvironment;
+    const { workspacePath, isInWorkspace, untouchedProjectsPaths, o3rVersion, registry } = o3rEnvironment.testEnvironment;
     const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
     packageManagerExec({script: 'ng', args: [
       'g',
@@ -43,13 +43,39 @@ describe('new otter workspace', () => {
     ]}, execAppOptions);
 
     const diff = getGitDiff(execAppOptions.cwd);
-    if (untouchedProjectPath) {
-      const relativeUntouchedProjectPath = path.relative(workspacePath, untouchedProjectPath);
-      expect(diff.all.filter((file) => new RegExp(relativeUntouchedProjectPath.replace(/[\\/]+/g, '[\\\\/]')).test(file)).length).toBe(0);
-    }
+    untouchedProjectsPaths.forEach(untouchedProject => {
+      expect(diff.all.some(file => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
 
     expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
     expect(() => packageManagerRunOnProject('@my-sdk/sdk', isInWorkspace, {script: 'build'}, execAppOptions)).not.toThrow();
     expect(() => packageManagerRunOnProject('@my-sdk/sdk', isInWorkspace, {script: 'spec:upgrade'}, execAppOptions)).not.toThrow();
+  });
+
+  test('should add a library to an existing workspace', () => {
+    const { workspacePath } = o3rEnvironment.testEnvironment;
+    const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
+    const libName = 'test-library';
+    const inLibraryPath = path.resolve(workspacePath, 'libs', libName);
+    expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
+
+    const generatedLibFiles = [
+      'README.md',
+      'ng-package.json',
+      'package.json',
+      'tsconfig.lib.json',
+      'tsconfig.lib.prod.json',
+      'tsconfig.spec.json',
+      'src/public-api.ts',
+      '.gitignore',
+      '.npmignore',
+      'jest.config.js',
+      'tsconfig.builders.json',
+      'tsconfig.json',
+      'testing/setup-jest.ts'];
+    expect(() => packageManagerExec({ script: 'ng', args: ['g', 'library', libName] }, execAppOptions)).not.toThrow();
+    expect(existsSync(path.join(workspacePath, 'project'))).toBe(false);
+    generatedLibFiles.forEach(file => expect(existsSync(path.join(inLibraryPath, file))).toBe(true));
+    expect(() => packageManagerRunOnProject(libName, true, { script: 'build' }, execAppOptions)).not.toThrow();
   });
 });

--- a/packages/@o3r/workspace/schematics/library/rules/shared.ts
+++ b/packages/@o3r/workspace/schematics/library/rules/shared.ts
@@ -45,8 +45,6 @@ export function updatePackageDependenciesFactory(
       '@angular/core': packageJson.peerDependencies['@angular/common'],
       '@angular/platform-browser': packageJson.peerDependencies['@angular/common'],
       '@angular/platform-browser-dynamic': packageJson.peerDependencies['@angular/common'],
-      '@o3r/core': otterVersion,
-      '@o3r/eslint-plugin': otterVersion,
       '@schematics/angular': o3rCorePackageJson.peerDependencies!['@schematics/angular'],
       '@types/jest': o3rCorePackageJson.generatorDependencies!['@types/jest'],
       '@typescript-eslint/eslint-plugin': o3rCorePackageJson.generatorDependencies!['@typescript-eslint/parser'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -7037,6 +7037,7 @@ __metadata:
     "@o3r/logger": "workspace:^"
     "@o3r/routing": "workspace:^"
     "@o3r/schematics": "workspace:^"
+    "@o3r/test-helpers": "workspace:^"
     "@o3r/testing": "workspace:^"
     "@schematics/angular": "npm:~17.3.0"
     "@stylistic/eslint-plugin-ts": "npm:^1.5.4"


### PR DESCRIPTION
## Proposed change

Enhance the integration test campaign with tests for libraries.

- [x] `@o3r/create` should generate a project with a library
- [x] base Otter project should contain a library as well (along with an application)
- [x] check generated files by `@o3r/workspace` schematic for app and lib. Currently in create int tests, to be moved in workspace ones. https://github.com/AmadeusITGroup/otter/pull/1678 should be merged first.


Ensure test coverage for libs (similar to what we have for apps) and add assertions for app tests for:
- [x] eslint-config-otter
- [x] stylelint-plugin
- [x] configuration
- [x] apis-manager
- [x] localization. reactive test for lib after https://github.com/AmadeusITGroup/otter/issues/1758
- [x] rules-engine
- [x] components
- [x] extractors
- [x] analytics
- [x] styling
- [x] testing
- [x] design
- [x] core