### PR TITLE
fix: ids type in entity store

### DIFF
--- a/packages/@o3r/core/src/store/async/async-entity.adapter.ts
+++ b/packages/@o3r/core/src/store/async/async-entity.adapter.ts
@@ -11,7 +11,7 @@ export interface EntityAsyncRequestAdapter<T extends AsyncStoreItem> extends Ent
    * @param ids          Ids of the entity to be updated with AsyncStoreItem properties
    * @param requestId    Id of request which has failed
    */
-  failRequestMany<V extends EntityState<T> & AsyncStoreItem>(state: V, ids?: string[] | number[], requestId?: string): V;
+  failRequestMany<V extends EntityState<T> & AsyncStoreItem>(state: V, ids?: (string | number)[], requestId?: string): V;
 
   /**
    * Adds AsyncStoreItem property to the global store, or the entity if it already exists, when a request is triggered.
@@ -27,7 +27,7 @@ export interface EntityAsyncRequestAdapter<T extends AsyncStoreItem> extends Ent
    * @param ids          Ids of the entity to be updated with AsyncStoreItem properties
    * @param requestId    Id of request which is triggered
    */
-  addRequestMany<V extends EntityState<T>>(state: V, ids: string[] | number[], requestId: string): V;
+  addRequestMany<V extends EntityState<T>>(state: V, ids: (string | number)[], requestId: string): V;
 
   /**
    * Updates the state with the given entity. Update the global or the current entity's status if it exists.
@@ -79,8 +79,8 @@ export function createEntityAsyncRequestAdapter<T extends AsyncStoreItem>(adapte
     return asyncStoreItemAdapter.addRequest(state, requestId);
   };
 
-  const addRequestMany: <V extends EntityState<T>>(state: V, ids: string[], requestId: string) => V =
-    <V extends EntityState<T>>(state: V, ids: string[], requestId: string): V =>
+  const addRequestMany: <V extends EntityState<T>>(state: V, ids: (string | number)[], requestId: string) => V =
+    <V extends EntityState<T>>(state: V, ids: (string | number)[], requestId: string): V =>
       adapter.updateMany(ids.filter((id) => !!state.entities[id]).map((id) => ({
         id,
         changes: asyncStoreItemAdapter.addRequest(asyncStoreItemAdapter.extractAsyncStoreItem(state.entities[id]!), requestId)
@@ -113,8 +113,8 @@ export function createEntityAsyncRequestAdapter<T extends AsyncStoreItem>(adapte
           }
           ), state);
 
-  const failRequestMany: <V extends EntityState<T> & AsyncStoreItem>(state: V, ids?: string[] | number[], requestId?: string) => V =
-    <V extends EntityState<T> & AsyncStoreItem>(state: V, ids: string[] | number[] = [], requestId?: string): V => {
+  const failRequestMany: <V extends EntityState<T> & AsyncStoreItem>(state: V, ids?: (string | number)[], requestId?: string) => V =
+    <V extends EntityState<T> & AsyncStoreItem>(state: V, ids: (string | number)[] = [], requestId?: string): V => {
       if (ids.length && !ids.some((id) => state.entities[id] === undefined)) {
         return adapter.updateMany(ids.map((id) => ({
           id,

--- a/packages/@o3r/core/src/store/types.ts
+++ b/packages/@o3r/core/src/store/types.ts
@@ -101,7 +101,7 @@ export interface SetEntityActionPayload<T> {
 
 /** Payload to fail entities actions */
 export interface FailEntitiesActionPayload<T> extends FailActionPayload<T> {
-  ids?: string[] | number[];
+  ids?: (string | number)[];
 }
 
 /**


### PR DESCRIPTION
## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->

- the list of **ids** in the entities store was restricted to: **string[] | number[]**
- the pb is that when passing an array of strings, tsc is complaining about the fact that a _string_ is not assignable to a _number_, because it cannot fulfill both conditions (the opposite is the same). That's why I changed the type to (string | number)[] to be restrictive only to the element and not to the entire array.
