### PR TITLE
feat: github issues created from template have triage tag

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-O3R-ISSUE-FORM.yaml
+++ b/.github/ISSUE_TEMPLATE/1-O3R-ISSUE-FORM.yaml
@@ -1,7 +1,7 @@
 name: Bug Report on @o3r
 description: File a bug report on @o3r scope
 title: "[Bug]: "
-labels: ["bug", "o3r"]
+labels: ["bug", "o3r", "triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/2-AMA-SDK-ISSUE-FORM.yaml
+++ b/.github/ISSUE_TEMPLATE/2-AMA-SDK-ISSUE-FORM.yaml
@@ -1,7 +1,7 @@
 name: Bug Report on @ama-sdk
 description: File a bug report on @ama-sdk scope
 title: "[Bug]: "
-labels: ["bug", "ama-sdk"]
+labels: ["bug", "ama-sdk", "triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/3-AMA-TERASU-ISSUE-FORM.yaml
+++ b/.github/ISSUE_TEMPLATE/3-AMA-TERASU-ISSUE-FORM.yaml
@@ -1,7 +1,7 @@
 name: Bug Report on @ama-terasu
 description: File a bug report on @ama-terasu scope
 title: "[Bug]: "
-labels: ["bug", "ama-terasu"]
+labels: ["bug", "ama-terasu", "triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/4-APPLICATION-ISSUE-FORM.yaml
+++ b/.github/ISSUE_TEMPLATE/4-APPLICATION-ISSUE-FORM.yaml
@@ -1,7 +1,7 @@
 name: Bug Report to an Application from the Otter project
 description: File a bug report on an Application from the Otter project
 title: "[Bug]: "
-labels: ["bug"]
+labels: ["bug", "triage"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Proposed change

When a new issue is created using the template, the `triage` tag should be added so that it helps us filtering in order to set a priority. 
