### PR TITLE
fix(o3r): replaced path.resolve with path.join for better path resolution

### DIFF
--- a/packages/@o3r/core/schematics/service/index.ts
+++ b/packages/@o3r/core/schematics/service/index.ts
@@ -1,6 +1,6 @@
 import { strings } from '@angular-devkit/core';
 import { apply, chain, MergeStrategy, mergeWith, move, noop, renameTemplateFiles, Rule, SchematicContext, template, Tree, url } from '@angular-devkit/schematics';
-import { applyEsLintFix, createSchematicWithMetricsIfInstalled, getDestinationPath, getTestFramework, getWorkspaceConfig, moduleHasSubEntryPoints, writeSubEntryPointPackageJson } from '@o3r/schematics';
+import { applyEsLintFix, createSchematicWithMetricsIfInstalled, getDestinationPath, getTestFramework, getWorkspaceConfig, moduleHasSubEntryPoints, O3rCliError, writeSubEntryPointPackageJson } from '@o3r/schematics';
 import * as path from 'node:path';
 import { NgGenerateServiceSchematicsSchema } from './schema';
 
@@ -9,7 +9,6 @@ import { NgGenerateServiceSchematicsSchema } from './schema';
  * @param options
  */
 function ngGenerateServiceFn(options: NgGenerateServiceSchematicsSchema): Rule {
-
   const generateFiles: Rule = (tree: Tree, context: SchematicContext) => {
     const destination = getDestinationPath('@o3r/core:service', options.path, tree, options.projectName);
 
@@ -45,11 +44,16 @@ function ngGenerateServiceFn(options: NgGenerateServiceSchematicsSchema): Rule {
     const workspaceConfig = getWorkspaceConfig(tree);
     let packageName = destination;
     if (workspaceProject?.projectType !== 'application') {
-      let rec = '..';
-      while (!tree.exists(path.resolve(destination, rec, 'package.json')) && path.resolve(destination, rec) !== '/') {
-        rec = path.join('..', rec);
+      let currentDirectory = path.normalize(destination);
+      const parent = '..';
+      // Find the package.json file in the project directory
+      while (!currentDirectory.includes(parent) && !tree.exists(path.join(currentDirectory, 'package.json'))) {
+        currentDirectory = path.join(currentDirectory, parent);
       }
-      packageName = JSON.parse(tree.read(path.resolve(destination, rec, 'package.json'))!.toString()).name?.split('/')[0] || destination;
+      if (currentDirectory.includes(parent)) {
+        throw new O3rCliError('Could not find package.json in the project directory.');
+      }
+      packageName = JSON.parse(tree.read(path.join(currentDirectory, 'package.json'))!.toString()).name?.split('/')[0] || destination;
     }
 
     const templateData = {


### PR DESCRIPTION
## Proposed change
Change path resolver from path.resolve to path.join  as the tree.exists is unable to resolve the absolute path generated by path.resolve

## Related issues

- :bug: Fixes #1778 


