### PR TITLE
fix: schematics params should be added only for one project

### DIFF
--- a/packages/@o3r/configuration/schematics/ng-add/index.ts
+++ b/packages/@o3r/configuration/schematics/ng-add/index.ts
@@ -24,7 +24,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       getWorkspaceConfig,
       getO3rPeerDeps,
       registerPackageCollectionSchematics,
-      setupSchematicsDefaultParams,
+      setupSchematicsParamsForProject,
       getPackageInstallConfig
     } = await import('@o3r/schematics');
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
@@ -45,7 +45,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
     context.logger.info('Get more information on the following page: https://github.com/AmadeusITGroup/otter/tree/main/docs/configuration/OVERVIEW.md#Runtime-debugging');
     return () => chain([
       registerPackageCollectionSchematics(packageJson),
-      setupSchematicsDefaultParams({
+      setupSchematicsParamsForProject({
         // eslint-disable-next-line @typescript-eslint/naming-convention
         '@o3r/core:component': {
           useOtterConfig: undefined
@@ -58,7 +58,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
         '@o3r/core:component-presenter': {
           useOtterConfig: undefined
         }
-      }),
+      }, options.projectName),
       setupDependencies({
         projectName: options.projectName,
         dependencies,

--- a/packages/@o3r/core/schematics/ng-add/index.ts
+++ b/packages/@o3r/core/schematics/ng-add/index.ts
@@ -5,7 +5,7 @@ import type { PackageJson } from 'type-fest';
 import { getExternalPreset, presets } from '../shared/presets';
 import { NgAddSchematicsSchema } from './schema';
 import { askConfirmation } from '@angular/cli/src/utilities/prompt';
-import { createSchematicWithMetricsIfInstalled, displayModuleListRule, registerPackageCollectionSchematics, setupSchematicsDefaultParams } from '@o3r/schematics';
+import { createSchematicWithMetricsIfInstalled, displayModuleListRule, registerPackageCollectionSchematics, setupSchematicsParamsForProject } from '@o3r/schematics';
 import { prepareProject } from './project-setup/index';
 import {
   type DependencyToAdd,
@@ -58,7 +58,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
 
     return chain([
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      setupSchematicsDefaultParams({ '*:ng-add': { registerDevtool: options.withDevtool } }),
+      setupSchematicsParamsForProject({ '*:ng-add': { registerDevtool: options.withDevtool } }, options.projectName),
       options.projectName ? prepareProject(options, dependenciesSetupConfig) : noop(),
       registerPackageCollectionSchematics(corePackageJsonContent),
       async (t, c) => {

--- a/packages/@o3r/core/schematics/rule-factories/component/common.ts
+++ b/packages/@o3r/core/schematics/rule-factories/component/common.ts
@@ -1,6 +1,6 @@
 import { chain, externalSchematic, noop, Rule, schematic, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { askConfirmation, askQuestion } from '@angular/cli/src/utilities/prompt';
-import { O3rCliError, SchematicOptionObject, setupSchematicsDefaultParams } from '@o3r/schematics';
+import { O3rCliError, SchematicOptionObject, setupSchematicsParamsForProject } from '@o3r/schematics';
 import type { PackageJson } from 'type-fest';
 
 /**
@@ -77,13 +77,14 @@ export const askQuestionsToGetRulesOrThrowIfPackageNotAvailable = (
         ? externalSchematic(packageName, schematicName, options)
         : schematic(schematicName, options),
       ...(alwaysApplyRule !== 'ask-again' ? [
-        setupSchematicsDefaultParams(
+        setupSchematicsParamsForProject(
           schematicsNameToUpdate.reduce((acc: Record<string, SchematicOptionObject>, schematicToUpdateName) => {
             acc[schematicToUpdateName] = {
               [optionName]: alwaysApplyRule === 'yes'
             };
             return acc;
-          }, {})
+          }, {}),
+          options.projectName
         )
       ] : [])
     ]) : noop;

--- a/packages/@o3r/core/schematics/shared/presets/all.preset.ts
+++ b/packages/@o3r/core/schematics/shared/presets/all.preset.ts
@@ -1,7 +1,7 @@
 import { chain } from '@angular-devkit/schematics';
 import { defaultPresetRuleFactory } from './helpers';
 import type { PresetOptions } from './preset.interface';
-import { setupSchematicsDefaultParams, WorkspaceSchematics } from '@o3r/schematics';
+import { setupSchematicsParamsForProject, WorkspaceSchematics } from '@o3r/schematics';
 
 /**
  * Preset Installing all the Otter modules
@@ -33,7 +33,7 @@ export function allPreset(options: PresetOptions) {
     modules,
     rule: chain([
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      setupSchematicsDefaultParams({ '*:ng-add': { enableMetadataExtract: true } } as WorkspaceSchematics),
+      setupSchematicsParamsForProject({ '*:ng-add': { enableMetadataExtract: true } } as WorkspaceSchematics, options.projectName),
       rule
     ])
   };

--- a/packages/@o3r/core/schematics/shared/presets/cms.preset.ts
+++ b/packages/@o3r/core/schematics/shared/presets/cms.preset.ts
@@ -1,7 +1,7 @@
 import { chain } from '@angular-devkit/schematics';
 import { defaultPresetRuleFactory } from './helpers';
 import type { PresetOptions } from './preset.interface';
-import { setupSchematicsDefaultParams, WorkspaceSchematics } from '@o3r/schematics';
+import { setupSchematicsParamsForProject, WorkspaceSchematics } from '@o3r/schematics';
 
 /**
  * Preset Installing the minimum modules to fully administrated the application via CMS
@@ -24,7 +24,7 @@ export function cmsPreset(options: PresetOptions) {
     modules,
     rule: chain([
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      setupSchematicsDefaultParams({ '*:ng-add': { enableMetadataExtract: true } } as WorkspaceSchematics),
+      setupSchematicsParamsForProject({ '*:ng-add': { enableMetadataExtract: true } } as WorkspaceSchematics, options.projectName),
       rule
     ])
   };

--- a/packages/@o3r/design/schematics/ng-add/index.ts
+++ b/packages/@o3r/design/schematics/ng-add/index.ts
@@ -19,10 +19,10 @@ You need to install '@o3r/schematics' to be able to use the o3r apis-manager pac
 export function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
   return async (tree) => {
-    const { getPackageInstallConfig, setupDependencies, setupSchematicsDefaultParams } = await import('@o3r/schematics');
+    const { getPackageInstallConfig, setupDependencies, setupSchematicsParamsForProject } = await import('@o3r/schematics');
     return chain([
       registerGenerateCssBuilder(),
-      setupSchematicsDefaultParams({
+      setupSchematicsParamsForProject({
         // eslint-disable-next-line @typescript-eslint/naming-convention
         '@o3r/core:component': {
           useOtterDesignToken: true
@@ -35,7 +35,7 @@ export function ngAddFn(options: NgAddSchematicsSchema): Rule {
         '*:*': {
           useOtterDesignToken: true
         }
-      }),
+      }, options.projectName),
       setupDependencies({
         projectName: options.projectName,
         dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion)

--- a/packages/@o3r/localization/schematics/ng-add/index.ts
+++ b/packages/@o3r/localization/schematics/ng-add/index.ts
@@ -32,7 +32,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       getO3rPeerDeps,
       getExternalDependenciesVersionRange,
       registerPackageCollectionSchematics,
-      setupSchematicsDefaultParams
+      setupSchematicsParamsForProject
     } = await import('@o3r/schematics');
     const {updateI18n, updateLocalization} = await import('../localization-base');
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
@@ -73,12 +73,12 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       }),
       updateCmsAdapter(options),
       registerPackageCollectionSchematics(packageJson),
-      setupSchematicsDefaultParams({
+      setupSchematicsParamsForProject({
         // eslint-disable-next-line @typescript-eslint/naming-convention
         '@o3r/core:component*': {
           useLocalization: true
         }
-      }),
+      }, options.projectName),
       registerDevtoolRule
     ]);
   };

--- a/packages/@o3r/rules-engine/schematics/ng-add/index.ts
+++ b/packages/@o3r/rules-engine/schematics/ng-add/index.ts
@@ -32,7 +32,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       getWorkspaceConfig,
       getExternalDependenciesVersionRange,
       removePackages,
-      setupSchematicsDefaultParams,
+      setupSchematicsParamsForProject,
       registerPackageCollectionSchematics
     } = await import('@o3r/schematics');
     options = {...getDefaultOptionsForSchematic(getWorkspaceConfig(tree), '@o3r/rules-engine', 'ng-add', options), ...options};
@@ -64,7 +64,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       });
     const rule = chain([
       registerPackageCollectionSchematics(packageJson),
-      setupSchematicsDefaultParams({
+      setupSchematicsParamsForProject({
         // eslint-disable-next-line @typescript-eslint/naming-convention
         '@o3r/core:component': {
           useRulesEngine: undefined
@@ -73,7 +73,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
         '@o3r/core:component-container': {
           useRulesEngine: undefined
         }
-      }),
+      }, options.projectName),
       removePackages(['@otter/rules-engine', '@otter/rules-engine-core']),
       setupDependencies({
         projectName: options.projectName,

--- a/packages/@o3r/schematics/src/rule-factories/ng-add/schematics-register.ts
+++ b/packages/@o3r/schematics/src/rule-factories/ng-add/schematics-register.ts
@@ -24,7 +24,51 @@ export function registerPackageCollectionSchematics(packageJson: PackageJson, an
 }
 
 /**
+ * Setup schematics default params in angular.json and per project
+ * @param schematicsDefaultParams default params to setup by schematic
+ * @param projectName The name of the project on which to add the schematics
+ * @param overrideValue Define if the given value should override the one already defined in the workspace
+ */
+export function setupSchematicsParamsForProject(schematicsDefaultParams: Record<string, SchematicOptionObject>, projectName?: string, overrideValue = false): Rule {
+  return (tree, context) => {
+    const workspace = getWorkspaceConfig(tree);
+    if (!workspace) {
+      context.logger.error('No workspace found');
+      return tree;
+    }
+    Object.entries(schematicsDefaultParams).forEach(([schematicName, defaultParams]) => {
+      workspace.schematics ||= {};
+      workspace.schematics[schematicName] = overrideValue ? {
+        ...workspace.schematics[schematicName],
+        ...defaultParams
+      } : {
+        ...defaultParams,
+        ...workspace.schematics[schematicName]
+      };
+    });
+
+    if (projectName && workspace.projects[projectName]) {
+      const project = workspace.projects[projectName];
+      Object.entries(schematicsDefaultParams).forEach(([schematicName, defaultParams]) => {
+        project.schematics ||= {};
+        if (project.schematics[schematicName]) {
+          project.schematics[schematicName] = overrideValue ? {
+            ...project.schematics[schematicName],
+            ...defaultParams
+          } : {
+            ...defaultParams,
+            ...project.schematics[schematicName]
+          };
+        }
+      });
+    }
+    return writeAngularJson(tree, workspace);
+  };
+}
+
+/**
  * Setup schematics default params in angular.json
+ * @deprecated will be removed in v12. Use {@link setupSchematicsParamsForProject}
  * @param schematicsDefaultParams default params to setup by schematic
  * @param overrideValue Define if the given value should override the one already defined in the workspace
  * @param angularJsonFile Path to the Angular.json file. Will use the workspace root's angular.json if not specified

--- a/packages/@o3r/styling/schematics/ng-add/index.ts
+++ b/packages/@o3r/styling/schematics/ng-add/index.ts
@@ -39,7 +39,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       setupDependencies,
       removePackages,
       registerPackageCollectionSchematics,
-      setupSchematicsDefaultParams,
+      setupSchematicsParamsForProject,
       updateSassImports,
       getExternalDependenciesVersionRange
     } = await import('@o3r/schematics');
@@ -91,7 +91,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
         ngAddToRun: depsInfo.o3rPeerDeps
       }),
       registerPackageCollectionSchematics(JSON.parse(fs.readFileSync(packageJsonPath).toString())),
-      setupSchematicsDefaultParams({
+      setupSchematicsParamsForProject({
         // eslint-disable-next-line @typescript-eslint/naming-convention
         '@o3r/core:component': {
           useOtterTheming: undefined
@@ -100,7 +100,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
         '@o3r/core:component-presenter': {
           useOtterTheming: undefined
         }
-      }),
+      }, options.projectName),
       ...(options.enableMetadataExtract ? [updateCmsAdapter(options)] : [])
     ]);
   };

--- a/packages/@o3r/testing/schematics/ng-add/index.ts
+++ b/packages/@o3r/testing/schematics/ng-add/index.ts
@@ -11,7 +11,7 @@ import {
   O3rCliError,
   registerPackageCollectionSchematics,
   removePackages, setupDependencies,
-  setupSchematicsDefaultParams
+  setupSchematicsParamsForProject
 } from '@o3r/schematics';
 import { askConfirmation } from '@angular/cli/src/utilities/prompt';
 import { NodeDependencyType } from '@schematics/angular/utility/dependencies';
@@ -103,7 +103,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
           ngAddToRun: depsInfo.o3rPeerDeps
         }),
         registerPackageCollectionSchematics(packageJson),
-        setupSchematicsDefaultParams({
+        setupSchematicsParamsForProject({
           // eslint-disable-next-line @typescript-eslint/naming-convention
           '@o3r/core:component': {
             useComponentFixtures: undefined
@@ -116,7 +116,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
           '@o3r/core:component-presenter': {
             useComponentFixtures: undefined
           }
-        })
+        }, options.projectName)
       ];
 
       if (installJest) {

--- a/packages/@o3r/workspace/schematics/ng-add/helpers/npm-workspace.ts
+++ b/packages/@o3r/workspace/schematics/ng-add/helpers/npm-workspace.ts
@@ -2,7 +2,7 @@ import { chain } from '@angular-devkit/schematics';
 import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { SchematicsException } from '@angular-devkit/schematics';
 import type { PackageJson } from 'type-fest';
-import { DEFAULT_ROOT_FOLDERS, isNxContext, setupSchematicsDefaultParams, WorkspaceLayout, WorkspaceSchematics } from '@o3r/schematics';
+import { DEFAULT_ROOT_FOLDERS, isNxContext, setupSchematicsParamsForProject, WorkspaceLayout, WorkspaceSchematics } from '@o3r/schematics';
 
 /**
  * Update root package.json to include workspaces
@@ -29,7 +29,7 @@ export function addWorkspacesToProject(directories: WorkspaceLayout = DEFAULT_RO
   };
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  const updateAngularJson = setupSchematicsDefaultParams({ '*:*': directories } as WorkspaceSchematics);
+  const updateAngularJson = setupSchematicsParamsForProject({ '*:*': directories } as WorkspaceSchematics);
 
   const updateNxWorkspaceLayout = (tree: Tree, _context: SchematicContext) => {
     const nxJson = tree.readJson('/nx.json') as any;


### PR DESCRIPTION
## Proposed change

Today, during the `ng add`, schematic parameters are added on all projects present in the workspace. 
It should be added only for one given project.
