### PR TITLE
fix(sdk): generate the correct renovate config for sdk

### DIFF
--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/index.spec.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/index.spec.ts
@@ -114,4 +114,63 @@ describe('Typescript Shell Generator', () => {
     const {name} = tree.readJson('/package.json') as PackageJson;
     expect(name).toEqual('test-sdk');
   });
+
+  it('should generate renovate config with otter presets for npm', () => {
+    const renovateConfig = npmTree.readJson('/.renovaterc.json') as PackageJson;
+    const renovatePresets = renovateConfig.extends;
+    expect(renovatePresets).toEqual([
+      'github>AmadeusITGroup/otter//tools/renovate/base',
+      'github>AmadeusITGroup/otter//tools/renovate/group/otter',
+      'github>AmadeusITGroup/otter//tools/renovate/tasks/base',
+      'github>AmadeusITGroup/otter//tools/renovate/tasks/sdk-regenerate(npm)'
+    ]);
+  });
+
+  it('should generate renovate config with otter presets for npm with packageName', async () => {
+    const runner = new SchematicTestRunner('@ama-sdk/schematics', collectionPath);
+    const tree = await runner.runSchematic('typescript-shell', {
+      name: 'test-scope',
+      package: 'test-sdk',
+      skipInstall: true,
+      packageManager: 'npm',
+      specPackageName: '@my-spec-scope/my-spec'
+    }, Tree.empty());
+    const renovateConfig = tree.readJson('/.renovaterc.json') as PackageJson;
+    const renovatePresets = renovateConfig.extends;
+    expect(renovatePresets).toEqual([
+      'github>AmadeusITGroup/otter//tools/renovate/base',
+      'github>AmadeusITGroup/otter//tools/renovate/group/otter',
+      'github>AmadeusITGroup/otter//tools/renovate/tasks/base',
+      'github>AmadeusITGroup/otter//tools/renovate/tasks/sdk-regenerate(npm)',
+      'github>AmadeusITGroup/otter//tools/renovate/group/sdk-spec(@my-spec-scope/my-spec)',
+      'github>AmadeusITGroup/otter//tools/renovate/tasks/sdk-spec-regenerate(npm, @my-spec-scope/my-spec)'
+    ]);
+  });
+
+  it('should generate renovate config with otter presets for yarn', () => {
+    const renovateConfig = yarnTree.readJson('/.renovaterc.json') as PackageJson;
+    const renovatePresets = renovateConfig.extends;
+    expect(renovatePresets).toEqual([
+      'github>AmadeusITGroup/otter//tools/renovate/base',
+      'github>AmadeusITGroup/otter//tools/renovate/sdk'
+    ]);
+  });
+
+  it('should generate renovate config with otter presets for yarn with packageName', async () => {
+    const runner = new SchematicTestRunner('@ama-sdk/schematics', collectionPath);
+    const tree = await runner.runSchematic('typescript-shell', {
+      name: 'test-scope',
+      package: 'test-sdk',
+      skipInstall: true,
+      packageManager: 'yarn',
+      specPackageName: '@my-spec-scope/my-spec'
+    }, Tree.empty());
+    const renovateConfig = tree.readJson('/.renovaterc.json') as PackageJson;
+    const renovatePresets = renovateConfig.extends;
+    expect(renovatePresets).toEqual([
+      'github>AmadeusITGroup/otter//tools/renovate/base',
+      'github>AmadeusITGroup/otter//tools/renovate/sdk',
+      'github>AmadeusITGroup/otter//tools/renovate/sdk-spec-upgrade(@my-spec-scope/my-spec)'
+    ]);
+  });
 });

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/.renovaterc.json.template
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/.renovaterc.json.template
@@ -1,9 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>AmadeusITGroup/otter//tools/renovate/base",
-    "github>AmadeusITGroup/otter//tools/renovate/sdk",
-    "github>AmadeusITGroup/otter//tools/renovate/sdk-spec-upgrade(my-specification-package)"
+    "github>AmadeusITGroup/otter//tools/renovate/base",<% if (packageManager === 'yarn') { %>
+    "github>AmadeusITGroup/otter//tools/renovate/sdk"<% if (specPackageName) { %>,
+    "github>AmadeusITGroup/otter//tools/renovate/sdk-spec-upgrade(<%= specPackageName %>)"<% } %><% } else { %>
+    "github>AmadeusITGroup/otter//tools/renovate/group/otter",
+    "github>AmadeusITGroup/otter//tools/renovate/tasks/base",
+    "github>AmadeusITGroup/otter//tools/renovate/tasks/sdk-regenerate(npm)"<% if (specPackageName) { %>,
+    "github>AmadeusITGroup/otter//tools/renovate/group/sdk-spec(<%= specPackageName %>)",
+    "github>AmadeusITGroup/otter//tools/renovate/tasks/sdk-spec-regenerate(npm, <%= specPackageName %>)"<% } %><% } %>
   ],
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,


### PR DESCRIPTION
## Proposed change

In generated SDK, ` .renovaterc.json` file should match the recommendation defined here: https://github.com/AmadeusITGroup/otter/blob/main/tools/renovate/README.md#otter-sdk

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
