### PR TITLE
feat: increase renovate minimum day before PR creation

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -22,6 +22,8 @@
     "main",
     "/^release\\/.*-next$/"
   ],
+  "minimumReleaseAge": "5 days",
+  "internalChecksFilter": "strict",
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
## Proposed change

Set minimumReleaseAge to ensure npm packages are a bit mature before considering them
Set internalChecksFilter to prevent renovate from opening PR if they don't match the minimum age


