### PR TITLE
fix: missing linter dep in generated sdk

### DIFF
--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/package.json.template
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/package.json.template
@@ -108,6 +108,7 @@
     "ts-jest": "<%= versions['ts-jest'] %>",
     "typedoc": "~0.25.0",
     "tsc-watch": "^6.0.0",
+    "yaml-eslint-parser": "^1.2.2",
     "typescript": "<%= versions['typescript'] %>"<% if (specPackageName) { %>,
     "<%=specPackageName%>": "<%=specPackageVersion%>"<% } %>
   },<% if (exactO3rVersion) { %>


### PR DESCRIPTION
## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->

- [ ] at cascading in main to add the dep in **generatorDependencies**