### PR TITLE
fix: bump swc versions and remove o3r-set-version in sdk generator 

### DIFF
--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/package.json.template
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/package.json.template
@@ -35,10 +35,10 @@
     "lint": "eslint \"**/*[jt]s\" --cache",
     "start": "tsc-watch -b tsconfigs/esm2020 --noClear --onFirstSuccess \"<%=packageManager%> run files:pack --watch\"",
     "build": "<%=packageManager%> run build:cjs && <%=packageManager%> run build:esm2015 && <%=packageManager%> run build:esm2020 && <%=packageManager%> run files:pack",
-    "build:cjs": "swc src -d dist/cjs -C module.type=commonjs -q",
-    "build:esm2015": "swc src -d dist/esm2015 -C module.type=es6 -q",
+    "build:cjs": "swc src -d dist/cjs -C module.type=commonjs -q --strip-leading-paths",
+    "build:esm2015": "swc src -d dist/esm2015 -C module.type=es6 -q --strip-leading-paths",
     "build:esm2020": "tsc -b tsconfigs/esm2020",
-    "set:version": "o3r-set-version --placeholder 0.0.0-placeholder",
+    "set:version": "npm version",
     "resolve": "node -e 'process.stdout.write(require.resolve(process.argv[1]));'",
     "generate": "schematics @ama-sdk/schematics:typescript-core",
     "spec:regen": "<%=packageManager%> run generate <% if (packageManager === 'npm') {%>-- <%}%>--generator-key <%=projectName%>-<%=projectPackageName%> && amasdk-clear-index",
@@ -56,7 +56,7 @@
     ]
   },
   "dependencies": {
-    "@swc/helpers": "^0.5.0",
+    "@swc/helpers": "~0.5.0",
     "tslib": "<%= versions['tslib'] %>"
   },
   "peerDependenciesMeta": {
@@ -83,8 +83,8 @@
     "@o3r/schematics": "<%= sdkCoreRange %>",
     "@openapitools/openapi-generator-cli": "<%= versions['@openapitools/openapi-generator-cli'] %>",
     "@stylistic/eslint-plugin-ts": "<%= versions['@stylistic/eslint-plugin-ts'] %>",
-    "@swc/cli": "^0.1.57",
-    "@swc/core": "1.5.7",
+    "@swc/cli": "~0.3.0",
+    "@swc/core": "~1.5.24",
     "@types/jest": "<%= versions['@types/jest'] %>",
     "@types/node": "<%= versions['@types/node'] %>",
     "@typescript-eslint/eslint-plugin": "<%= versions['@typescript-eslint/eslint-plugin'] %>",


### PR DESCRIPTION
- bump and align swc versions with the ones from main branch
- remove o3r-set-version from a standlone sdk generated as it is meant for workspaces

## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
