### PR TITLE
fix: timeout plugin should not break on null messages

### DIFF
--- a/packages/@ama-sdk/core/src/plugins/timeout/timeout.fetch.ts
+++ b/packages/@ama-sdk/core/src/plugins/timeout/timeout.fetch.ts
@@ -27,7 +27,7 @@ export type TimeoutStatus = 'timeoutStopped' | 'timeoutStarted';
  * @param message
  */
 function isImpervaCaptchaMessage(message: any): message is ImpervaCaptchaMessageData {
-  return Object.prototype.hasOwnProperty.call(message, 'impervaChallenge') &&
+  return !!message && Object.prototype.hasOwnProperty.call(message, 'impervaChallenge') &&
     Object.prototype.hasOwnProperty.call(message.impervaChallenge, 'status') &&
     Object.prototype.hasOwnProperty.call(message.impervaChallenge, 'type') && message.impervaChallenge.type === 'captcha';
 }

--- a/packages/@ama-sdk/core/src/plugins/timeout/timeout.spec.ts
+++ b/packages/@ama-sdk/core/src/plugins/timeout/timeout.spec.ts
@@ -128,6 +128,13 @@ describe('impervaCaptchaEventHandlerFactory', () => {
     expect(callback).not.toHaveBeenCalled();
   });
 
+  it('should not throw on null messages', () => {
+    const callback = jest.fn();
+    impervaCaptchaEventHandlerFactory({whiteListedHostNames: []})(callback, this);
+    postMessageTemp(null);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
   it('should trigger a timeoutStopped if the captcha challenge has been started', () => {
     const callback = jest.fn();
     impervaCaptchaEventHandlerFactory({whiteListedHostNames: []})(callback, this);


### PR DESCRIPTION
## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
