### PR TITLE
chore: remove stability-days from renovate config

### DIFF
--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/.renovaterc.json.template
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/.renovaterc.json.template
@@ -19,9 +19,6 @@
   "enabledManagers": [
     "npm"
   ],
-  "npm": {
-    "stabilityDays": 0
-  },
   "labels": [
     "dependencies"
   ],

--- a/packages/@o3r/workspace/schematics/ng-add/helpers/renovate/templates/__dot__renovaterc.json.template
+++ b/packages/@o3r/workspace/schematics/ng-add/helpers/renovate/templates/__dot__renovaterc.json.template
@@ -14,9 +14,6 @@
   "enabledManagers": [
     "npm"
   ],
-  "npm": {
-    "stabilityDays": 0
-  },
   "labels": [
     "upgrade"
   ],

--- a/tools/renovate/base.json
+++ b/tools/renovate/base.json
@@ -26,9 +26,6 @@
     "npm",
     "github-actions"
   ],
-  "npm": {
-    "stabilityDays": 0
-  },
   "updateInternalDeps": true,
   "postUpdateOptions": [
     "yarnDedupeHighest"


### PR DESCRIPTION
## Proposed change

`stabilityDays` is now named `minimumReleaseAge`
I propose to remove it entirely from our config since it was set to the default value anyway

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
