### PR TITLE
fix: paths for tsconfig doc files

### DIFF
--- a/packages/@o3r/apis-manager/tsconfig.doc.json
+++ b/packages/@o3r/apis-manager/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/application/tsconfig.doc.json
+++ b/packages/@o3r/application/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/artifactory-tools/tsconfig.doc.json
+++ b/packages/@o3r/artifactory-tools/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/azure-tools/tsconfig.doc.json
+++ b/packages/@o3r/azure-tools/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/components/tsconfig.doc.json
+++ b/packages/@o3r/components/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/configuration/tsconfig.doc.json
+++ b/packages/@o3r/configuration/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/core/tsconfig.doc.json
+++ b/packages/@o3r/core/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/design/tsconfig.doc.json
+++ b/packages/@o3r/design/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*.spec.ts",
     "**/*reducer.ts",

--- a/packages/@o3r/dev-tools/tsconfig.doc.json
+++ b/packages/@o3r/dev-tools/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/dynamic-content/tsconfig.doc.json
+++ b/packages/@o3r/dynamic-content/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/eslint-plugin/tsconfig.doc.json
+++ b/packages/@o3r/eslint-plugin/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/extractors/tsconfig.doc.json
+++ b/packages/@o3r/extractors/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/forms/tsconfig.doc.json
+++ b/packages/@o3r/forms/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/localization/tsconfig.doc.json
+++ b/packages/@o3r/localization/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/logger/tsconfig.doc.json
+++ b/packages/@o3r/logger/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/mobile/tsconfig.doc.json
+++ b/packages/@o3r/mobile/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/routing/tsconfig.doc.json
+++ b/packages/@o3r/routing/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/rules-engine/tsconfig.doc.json
+++ b/packages/@o3r/rules-engine/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/schematics/tsconfig.doc.json
+++ b/packages/@o3r/schematics/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/storybook/tsconfig.doc.json
+++ b/packages/@o3r/storybook/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/stylelint-plugin/tsconfig.doc.json
+++ b/packages/@o3r/stylelint-plugin/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/styling/tsconfig.doc.json
+++ b/packages/@o3r/styling/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/testing/tsconfig.doc.json
+++ b/packages/@o3r/testing/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"

--- a/packages/@o3r/third-party/tsconfig.doc.json
+++ b/packages/@o3r/third-party/tsconfig.doc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.doc",
+  "extends": "../../../tsconfig.doc",
   "exclude": [
     "**/*reducer.ts",
     "**/*.fixture.ts"


### PR DESCRIPTION
## Proposed change

The `tsconfig.doc` paths were extending from an unexisting file. 
