### PR TITLE
test: fix it-tests not running in local

### DIFF
--- a/packages/@o3r/test-helpers/src/prepare-test-env.ts
+++ b/packages/@o3r/test-helpers/src/prepare-test-env.ts
@@ -69,7 +69,7 @@ export async function prepareTestEnv(folderName: string, options?: PrepareTestEn
     logger.debug?.(`Creating it-tests folder`);
     await createWithLock(() => {
       mkdirSync(itTestsFolderPath);
-      setPackagerManagerConfig(packageManagerConfig, {...execAppOptions, cwd: itTestsFolderPath});
+      setPackagerManagerConfig(packageManagerConfig, {...execAppOptions, cwd: itTestsFolderPath}, 'npm');
       return Promise.resolve();
     }, {lockFilePath: `${itTestsFolderPath}.lock`, cwd: path.join(rootFolderPath, '..'), appDirectory: 'it-tests'});
   }
@@ -89,7 +89,13 @@ export async function prepareTestEnv(folderName: string, options?: PrepareTestEn
   const prepareFinalApp = (baseApp: string) => {
     logger.debug?.(`Copying ${baseApp} to ${workspacePath}`);
     const baseProjectPath = path.join(itTestsFolderPath, baseApp);
-    cpSync(baseProjectPath, workspacePath, { recursive: true, dereference: true, filter: (source) => !/node_modules/.test(source) });
+    cpSync(baseProjectPath, workspacePath, {
+      recursive: true,
+      dereference: true,
+      filter: (source) =>
+        !/(?:^|[\\/])node_modules(?:[\\/]|$)/.test(source) &&
+        !/(?:^|[\\/])\.git(?:[\\/]|$)/.test(source)
+    });
     if (existsSync(path.join(workspacePath, 'package.json'))) {
       packageManagerInstall(execAppOptions);
     }

--- a/packages/@o3r/test-helpers/src/test-environments/create-test-environment-otter-project.ts
+++ b/packages/@o3r/test-helpers/src/test-environments/create-test-environment-otter-project.ts
@@ -76,7 +76,7 @@ export async function createTestEnvironmentOtterProjectWithAppAndLib(inputOption
     }
 
     // prepare package manager config
-    setPackagerManagerConfig(options, { ...execAppOptions, cwd: options.cwd });
+    setPackagerManagerConfig(options, { ...execAppOptions, cwd: options.cwd }, 'npm');
     try { mkdirSync(appFolderPath, { recursive: true }); } catch { }
     setPackagerManagerConfig(options, execAppOptions);
 

--- a/packages/@o3r/test-helpers/src/utilities/package-manager.ts
+++ b/packages/@o3r/test-helpers/src/utilities/package-manager.ts
@@ -198,9 +198,11 @@ export interface PackageManagerConfig {
  * Set configuration for package manager
  * @param options
  * @param execAppOptions
+ * @param packageManagerOverride
  */
-export function setPackagerManagerConfig(options: PackageManagerConfig, execAppOptions: ExecSyncOptions) {
+export function setPackagerManagerConfig(options: PackageManagerConfig, execAppOptions: ExecSyncOptions, packageManagerOverride?: keyof typeof PACKAGE_MANAGERS_CMD) {
   const execOptions = {...execAppOptions, shell: process.platform === 'win32'};
+  const packageManager = packageManagerOverride || getPackageManager();
 
   // Need to add this even for yarn because `ng add` only reads registry from .npmrc
   execFileSync('npm', ['config', 'set', `@ama-sdk:registry=${options.registry}`, '-L=project'], execOptions);
@@ -209,7 +211,7 @@ export function setPackagerManagerConfig(options: PackageManagerConfig, execAppO
 
   const packageJsonPath = join(execOptions.cwd as string, 'package.json');
   const shouldCleanPackageJson = !existsSync(packageJsonPath);
-  switch (getPackageManager()) {
+  switch (packageManager) {
     case 'yarn': {
       // Set yarn version
       if (options.yarnVersion) {


### PR DESCRIPTION
## Proposed change

- No need to create yarn config when doing the create since we always use npm, this prevent some race condition issues 
- No need to copy the `.git` folder of the base app, this prevent some files being incorrectly versioned if committed before the setup of `.gitignore`

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
