### PR TITLE
fix: remove unused ngAddPeerDependencyPackages

### DIFF
--- a/packages/@o3r/schematics/src/rule-factories/ng-add/ng-add.helpers.ts
+++ b/packages/@o3r/schematics/src/rule-factories/ng-add/ng-add.helpers.ts
@@ -1,13 +1,12 @@
 import { chain, externalSchematic, noop, Rule, Schematic, SchematicContext } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
-import type { NodeDependency } from '@schematics/angular/utility/dependencies';
 import { NodeDependencyType } from '@schematics/angular/utility/dependencies';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { lastValueFrom } from 'rxjs';
 import type { PackageJson } from 'type-fest';
 import type { NgAddPackageOptions } from '../../tasks/index';
-import { getExternalDependenciesVersionRange, getNodeDependencyList, getPackageManager } from '../../utility/index';
+import { getPackageManager } from '../../utility/index';
 
 /**
  * Install via `ng add` a list of npm packages.
@@ -137,32 +136,4 @@ export function ngAddPackages(packages: string[], options?: Omit<NgAddPackageOpt
       return chain(ngAddsToApply);
     }
   ]);
-}
-
-/**
- * Look for the peer dependencies and run ng add on the package requested version
- * TODO: Remove this method in v11. No longer used
- * @param packages list of the name of the packages needed
- * @param packageJsonPath path to package json that needs the peer to be resolved
- * @param type how to install the dependency (dev, peer for a library or default for an application)
- * @param options
- * @param parentPackageInfo for logging purposes
- */
-export function ngAddPeerDependencyPackages(packages: string[], packageJsonPath: string, type: NodeDependencyType = NodeDependencyType.Default,
-  options: NgAddPackageOptions, parentPackageInfo?: string) {
-  if (!packages.length) {
-    return noop;
-  }
-  const dependencies: NodeDependency[] = getNodeDependencyList(
-    getExternalDependenciesVersionRange(packages, packageJsonPath),
-    type
-  );
-  return ngAddPackages(dependencies.map(({ name }) => name), {
-    ...options,
-    skipConfirmation: true,
-    version: dependencies.map(({ version }) => version),
-    parentPackageInfo,
-    dependencyType: type,
-    workingDirectory: options.workingDirectory
-  });
 }

--- a/packages/@o3r/schematics/src/utility/dependencies.ts
+++ b/packages/@o3r/schematics/src/utility/dependencies.ts
@@ -4,14 +4,13 @@ import { logging } from '@angular-devkit/core';
 import type { PackageJson } from 'type-fest';
 
 /**
- * TODO make logger parameter mandatory in v11 and remove the console fallback.
  * Method to extract the provided package version range from a package.json file
  * @param packageNames list of package we want to retrieve the version
  * @param packageJsonPath Path to the package.json to refer to
  * @param logger logger
  * @returns The version range value retrieved from the provided package.json file
  */
-export function getExternalDependenciesVersionRange<T extends string>(packageNames: T[], packageJsonPath: string, logger?: logging.LoggerApi): Record<T, string> {
+export function getExternalDependenciesVersionRange<T extends string>(packageNames: T[], packageJsonPath: string, logger: logging.LoggerApi): Record<T, string> {
   const packageJsonContent = JSON.parse(fs.readFileSync(packageJsonPath, {encoding: 'utf-8'})) as PackageJson & { generatorDependencies: Record<string, string> };
   return packageNames.reduce((acc: Partial<Record<T, string>>, packageName) => {
     acc[packageName] =
@@ -20,7 +19,7 @@ export function getExternalDependenciesVersionRange<T extends string>(packageNam
       packageJsonContent.dependencies?.[packageName] ||
       packageJsonContent.devDependencies?.[packageName];
     if (!acc[packageName]) {
-      (logger || console).warn(`Unable to retrieve version for ${packageName} in ${packageJsonPath}. Version set to "latest".`);
+      logger.warn(`Unable to retrieve version for ${packageName} in ${packageJsonPath}. Version set to "latest".`);
       acc[packageName] = 'latest';
     }
     return acc;


### PR DESCRIPTION
## Proposed change

Follow up on https://github.com/AmadeusITGroup/otter/pull/1903

In v11 `ngAddPeerDependencyPackages` is removed as unused. 

