### PR TITLE
fix(renovate): error while migrating ama-sdk version for an sdk

### DIFF
--- a/tools/renovate/tasks/sdk-regenerate.json
+++ b/tools/renovate/tasks/sdk-regenerate.json
@@ -9,7 +9,7 @@
       "postUpgradeTasks": {
         "commands": [
           "{{arg0}} install",
-          "{{arg0}} run schematics @ama-sdk/schematics:migrate -- --from={{{currentVersion}}} --to={{{newVersion}}}",
+          "{{#if (equals arg0 'npm')}}npm exec --{{else}}{{arg0}} exec{{/if}} schematics @ama-sdk/schematics:migrate --from={{{currentVersion}}} --to={{{newVersion}}}",
           "{{arg0}} run spec:upgrade"
         ],
         "fileFilters": [


### PR DESCRIPTION
## Proposed change

Fix following error:
```
Command failed: yarn run schematics @ama-sdk/schematics:migrate -- --from=10.4.0-rc.1 --to=10.4.0-rc.9
[1m[31mError: Schematic input does not validate against the Schema: {}[39m[22m
[1m[31mErrors:[39m[22m
[1m[31m[39m[22m
[1m[31m  Data path "" must have required property 'from'.[39m[22m
```

The double dashes `--` should only be used for npm

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
