### PR TITLE
fix: remove deprecated prepareOptions

### DIFF
--- a/migration-guides/11.0.md
+++ b/migration-guides/11.0.md
@@ -1,0 +1,8 @@
+# Major 11.0 Migration guide
+
+> [!IMPORTANT]
+> Please make sure to first follow the ["Upgrade new version guide"](https://github.com/AmadeusITGroup/otter/blob/main/docs/core/UPGRADE_NEW_VERSION.md) before going through these steps.
+
+## @ama-sdk/core
+
+- `prepareOptions` method has been removed from `ApiClient`. `getRequestOptions` should be used instead.

--- a/packages/@ama-sdk/core/src/clients/api-angular-client.ts
+++ b/packages/@ama-sdk/core/src/clients/api-angular-client.ts
@@ -1,10 +1,10 @@
 import type { HttpClient, HttpResponse } from '@angular/common/http';
-import { RequestBody, RequestMetadata, RequestOptions, TokenizedOptions } from '../plugins/core/index';
+import type { RequestOptions, TokenizedOptions } from '../plugins/core/index';
 import { ExceptionReply } from '../plugins/exception';
 import { ReviverReply } from '../plugins/reviver';
 import { ApiTypes } from '../fwk/api';
 import { extractQueryParams, filterUndefinedValues, getResponseReviver, prepareUrl, processFormData, tokenizeRequestOptions } from '../fwk/api.helpers';
-import type { Api, PartialExcept } from '../fwk/api.interface';
+import type { PartialExcept } from '../fwk/api.interface';
 import type { ApiClient,RequestOptionsParameters } from '../fwk/core/api-client';
 import { BaseApiClientOptions } from '../fwk/core/base-api-constructor';
 import { EmptyResponseError } from '../fwk/errors';
@@ -66,21 +66,6 @@ export class ApiAngularClient implements ApiClient {
     }
 
     return opts;
-  }
-
-  /** @inheritdoc */
-  public async prepareOptions(url: string, method: string, queryParams: { [key: string]: string | undefined }, headers: { [key: string]: string | undefined }, body?: RequestBody,
-    tokenizedOptions?: TokenizedOptions, metadata?: RequestMetadata, api?: Api) {
-    return this.getRequestOptions({
-      headers,
-      method,
-      basePath: url,
-      queryParams,
-      body,
-      metadata,
-      tokenizedOptions,
-      api
-    });
   }
 
   /** @inheritdoc */

--- a/packages/@ama-sdk/core/src/clients/api-beacon-client.ts
+++ b/packages/@ama-sdk/core/src/clients/api-beacon-client.ts
@@ -1,7 +1,7 @@
-import type { RequestBody, RequestMetadata, RequestOptions, TokenizedOptions } from '../plugins';
+import type { RequestBody, RequestOptions, TokenizedOptions } from '../plugins';
 import type { ApiTypes } from '../fwk/api';
 import { extractQueryParams, filterUndefinedValues, prepareUrl, processFormData, tokenizeRequestOptions } from '../fwk/api.helpers';
-import type { Api, PartialExcept } from '../fwk/api.interface';
+import type { PartialExcept } from '../fwk/api.interface';
 import type { ApiClient, RequestOptionsParameters } from '../fwk/core/api-client';
 import type { BaseApiClientOptions } from '../fwk/core/base-api-constructor';
 
@@ -83,21 +83,6 @@ export class ApiBeaconClient implements ApiClient {
     }
 
     return Promise.resolve(opts);
-  }
-
-  /** @inheritdoc */
-  public prepareOptions(url: string, method: string, queryParams: { [key: string]: string | undefined }, headers: { [key: string]: string | undefined }, body?: RequestBody,
-    tokenizedOptions?: TokenizedOptions, metadata?: RequestMetadata, api?: Api) {
-    return this.getRequestOptions({
-      headers,
-      method,
-      basePath: url,
-      queryParams,
-      body,
-      metadata,
-      tokenizedOptions,
-      api
-    });
   }
 
   /** @inheritdoc */

--- a/packages/@ama-sdk/core/src/clients/api-fetch-client.ts
+++ b/packages/@ama-sdk/core/src/clients/api-fetch-client.ts
@@ -1,10 +1,8 @@
-import {
+import type {
   FetchCall,
   FetchPlugin,
   PluginAsyncRunner,
   PluginAsyncStarter,
-  RequestBody,
-  RequestMetadata,
   RequestOptions,
   TokenizedOptions
 } from '../plugins/core/index';
@@ -12,7 +10,7 @@ import {ExceptionReply} from '../plugins/exception';
 import {ReviverReply} from '../plugins/reviver';
 import {ApiTypes} from '../fwk/api';
 import {extractQueryParams, filterUndefinedValues, getResponseReviver, prepareUrl, processFormData, tokenizeRequestOptions} from '../fwk/api.helpers';
-import type {Api, PartialExcept} from '../fwk/api.interface';
+import type {PartialExcept} from '../fwk/api.interface';
 import type {ApiClient, RequestOptionsParameters} from '../fwk/core/api-client';
 import {BaseApiClientOptions} from '../fwk/core/base-api-constructor';
 import {CanceledCallError, EmptyResponseError, ResponseJSONParseError} from '../fwk/errors';
@@ -80,21 +78,6 @@ export class ApiFetchClient implements ApiClient {
     }
 
     return opts;
-  }
-
-  /** @inheritdoc */
-  public async prepareOptions(url: string, method: string, queryParams: { [key: string]: string | undefined }, headers: { [key: string]: string | undefined }, body?: RequestBody,
-    tokenizedOptions?: TokenizedOptions, metadata?: RequestMetadata, api?: Api) {
-    return this.getRequestOptions({
-      headers,
-      method,
-      basePath: url,
-      queryParams,
-      body,
-      metadata,
-      tokenizedOptions,
-      api
-    });
   }
 
   /** @inheritdoc */

--- a/packages/@ama-sdk/core/src/fwk/core/api-client.ts
+++ b/packages/@ama-sdk/core/src/fwk/core/api-client.ts
@@ -1,8 +1,8 @@
-import {RequestBody, RequestMetadata, RequestOptions, TokenizedOptions} from '../../plugins/index';
-import {ApiTypes} from '../api';
+import type { RequestBody, RequestMetadata, RequestOptions, TokenizedOptions } from '../../plugins/index';
+import type { ApiTypes } from '../api';
 import type { Api } from '../api.interface';
-import {ReviverType} from '../Reviver';
-import {BaseApiClientOptions} from './base-api-constructor';
+import type { ReviverType } from '../Reviver';
+import type { BaseApiClientOptions } from './base-api-constructor';
 
 /** Parameters to the request the call options */
 export interface RequestOptionsParameters {
@@ -22,9 +22,8 @@ export interface RequestOptionsParameters {
   method: NonNullable<RequestInit['method']>;
   /**
    * API initializing the call
-   * @todo this field will be turned as mandatory in v11
    */
-  api?: Api;
+  api: Api;
 }
 
 /**
@@ -43,17 +42,9 @@ export interface ApiClient {
   extractQueryParams<T extends { [key: string]: any }>(data: T, names: (keyof T)[]): { [p in keyof T]: string; };
 
   /**
-   * Prepare Options
-   * @deprecated use getRequestOptions instead, will be removed in v11
-   */
-  prepareOptions(url: string, method: string, queryParams: { [key: string]: string | undefined }, headers: { [key: string]: string | undefined }, body?: RequestBody,
-    tokenizedOptions?: TokenizedOptions, metadata?: RequestMetadata): Promise<RequestOptions>;
-
-  /**
    * Retrieve the option to process the HTTP Call
-   * @todo turn this function mandatory when `prepareOptions` will be removed
    */
-  getRequestOptions?(requestOptionsParameters: RequestOptionsParameters): Promise<RequestOptions>;
+  getRequestOptions(requestOptionsParameters: RequestOptionsParameters): Promise<RequestOptions>;
 
   /**
    * prepares the url to be called
@@ -93,7 +84,7 @@ export function isApiClient(client: any): client is ApiClient {
   return client &&
     !!client.options &&
     typeof client.extractQueryParams === 'function' &&
-    typeof client.prepareOptions === 'function' &&
+    typeof client.getRequestOptions === 'function' &&
     typeof client.prepareUrl === 'function' &&
     typeof client.processFormData === 'function' &&
     typeof client.processCall === 'function';

--- a/packages/@ama-sdk/core/src/utils/generic-api.ts
+++ b/packages/@ama-sdk/core/src/utils/generic-api.ts
@@ -55,9 +55,7 @@ export class GenericApi implements Api {
       headers,
       ...requestOptions
     };
-    const options = this.client.getRequestOptions ?
-      await this.client.getRequestOptions(requestParameters) :
-      await this.client.prepareOptions(requestParameters.basePath, requestParameters.method, requestParameters.queryParams || {}, requestParameters.headers);
+    const options = await this.client.getRequestOptions(requestParameters);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<T>(url, options, ApiTypes.DEFAULT, requestOptions.api!.apiName, requestOptions.revivers, requestOptions.operationId);

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/api.mustache
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/api.mustache
@@ -118,7 +118,7 @@ export class {{classname}} implements Api {
       api: this
     };
 
-    const options = this.client.getRequestOptions ? await this.client.getRequestOptions(requestOptions) : await this.client.prepareOptions(basePath, '{{httpMethod}}', queryParams, headers, body || undefined, tokenizedOptions, metadata);
+    const options = await this.client.getRequestOptions(requestOptions);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<{{#vendorExtensions}}{{#responses2xxReturnTypes}}{{.}}{{^-last}} | {{/-last}}{{/responses2xxReturnTypes}}{{^responses2xxReturnTypes}}never{{/responses2xxReturnTypes}}{{/vendorExtensions}}>(url, options, {{#tags.0.extensions.x-api-type}}ApiTypes.{{tags.0.extensions.x-api-type}}{{/tags.0.extensions.x-api-type}}{{^tags.0.extensions.x-api-type}}ApiTypes.DEFAULT{{/tags.0.extensions.x-api-type}}, {{classname}}.apiName,{{#keepRevivers}}{{#vendorExtensions}}{{#responses2xx}}{{#-first}} { {{/-first}}{{code}}: {{^primitiveType}}revive{{baseType}}{{/primitiveType}}{{#primitiveType}}undefined{{/primitiveType}}{{^-last}}, {{/-last}}{{#-last}} } {{/-last}}{{/responses2xx}}{{^responses2xx}} undefined{{/responses2xx}}{{/vendorExtensions}}{{/keepRevivers}}{{^keepRevivers}} undefined{{/keepRevivers}}, '{{nickname}}');

--- a/packages/@ama-sdk/showcase-sdk/src/api/pet/pet-api.ts
+++ b/packages/@ama-sdk/showcase-sdk/src/api/pet/pet-api.ts
@@ -143,7 +143,7 @@ export class PetApi implements Api {
       api: this
     };
 
-    const options = this.client.getRequestOptions ? await this.client.getRequestOptions(requestOptions) : await this.client.prepareOptions(basePath, 'POST', queryParams, headers, body || undefined, tokenizedOptions, metadata);
+    const options = await this.client.getRequestOptions(requestOptions);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<Pet>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'addPet');
@@ -181,7 +181,7 @@ export class PetApi implements Api {
       api: this
     };
 
-    const options = this.client.getRequestOptions ? await this.client.getRequestOptions(requestOptions) : await this.client.prepareOptions(basePath, 'DELETE', queryParams, headers, body || undefined, tokenizedOptions, metadata);
+    const options = await this.client.getRequestOptions(requestOptions);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<string>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'deletePet');
@@ -219,7 +219,7 @@ export class PetApi implements Api {
       api: this
     };
 
-    const options = this.client.getRequestOptions ? await this.client.getRequestOptions(requestOptions) : await this.client.prepareOptions(basePath, 'GET', queryParams, headers, body || undefined, tokenizedOptions, metadata);
+    const options = await this.client.getRequestOptions(requestOptions);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<Pet[]>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'findPetsByStatus');
@@ -256,7 +256,7 @@ export class PetApi implements Api {
       api: this
     };
 
-    const options = this.client.getRequestOptions ? await this.client.getRequestOptions(requestOptions) : await this.client.prepareOptions(basePath, 'GET', queryParams, headers, body || undefined, tokenizedOptions, metadata);
+    const options = await this.client.getRequestOptions(requestOptions);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<Pet[]>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'findPetsByTags');
@@ -293,7 +293,7 @@ export class PetApi implements Api {
       api: this
     };
 
-    const options = this.client.getRequestOptions ? await this.client.getRequestOptions(requestOptions) : await this.client.prepareOptions(basePath, 'GET', queryParams, headers, body || undefined, tokenizedOptions, metadata);
+    const options = await this.client.getRequestOptions(requestOptions);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<Pet>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'getPetById');
@@ -335,7 +335,7 @@ export class PetApi implements Api {
       api: this
     };
 
-    const options = this.client.getRequestOptions ? await this.client.getRequestOptions(requestOptions) : await this.client.prepareOptions(basePath, 'PUT', queryParams, headers, body || undefined, tokenizedOptions, metadata);
+    const options = await this.client.getRequestOptions(requestOptions);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<Pet>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'updatePet');
@@ -372,7 +372,7 @@ export class PetApi implements Api {
       api: this
     };
 
-    const options = this.client.getRequestOptions ? await this.client.getRequestOptions(requestOptions) : await this.client.prepareOptions(basePath, 'POST', queryParams, headers, body || undefined, tokenizedOptions, metadata);
+    const options = await this.client.getRequestOptions(requestOptions);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'updatePetWithForm');
@@ -414,7 +414,7 @@ export class PetApi implements Api {
       api: this
     };
 
-    const options = this.client.getRequestOptions ? await this.client.getRequestOptions(requestOptions) : await this.client.prepareOptions(basePath, 'POST', queryParams, headers, body || undefined, tokenizedOptions, metadata);
+    const options = await this.client.getRequestOptions(requestOptions);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<ApiResponse>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'uploadFile');

--- a/packages/@ama-sdk/showcase-sdk/src/api/store/store-api.ts
+++ b/packages/@ama-sdk/showcase-sdk/src/api/store/store-api.ts
@@ -88,7 +88,7 @@ export class StoreApi implements Api {
       api: this
     };
 
-    const options = this.client.getRequestOptions ? await this.client.getRequestOptions(requestOptions) : await this.client.prepareOptions(basePath, 'DELETE', queryParams, headers, body || undefined, tokenizedOptions, metadata);
+    const options = await this.client.getRequestOptions(requestOptions);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, StoreApi.apiName, undefined, 'deleteOrder');
@@ -125,7 +125,7 @@ export class StoreApi implements Api {
       api: this
     };
 
-    const options = this.client.getRequestOptions ? await this.client.getRequestOptions(requestOptions) : await this.client.prepareOptions(basePath, 'GET', queryParams, headers, body || undefined, tokenizedOptions, metadata);
+    const options = await this.client.getRequestOptions(requestOptions);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<{ [key: string]: number }>(url, options, ApiTypes.DEFAULT, StoreApi.apiName, undefined, 'getInventory');
@@ -162,7 +162,7 @@ export class StoreApi implements Api {
       api: this
     };
 
-    const options = this.client.getRequestOptions ? await this.client.getRequestOptions(requestOptions) : await this.client.prepareOptions(basePath, 'GET', queryParams, headers, body || undefined, tokenizedOptions, metadata);
+    const options = await this.client.getRequestOptions(requestOptions);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<Order>(url, options, ApiTypes.DEFAULT, StoreApi.apiName, undefined, 'getOrderById');
@@ -204,7 +204,7 @@ export class StoreApi implements Api {
       api: this
     };
 
-    const options = this.client.getRequestOptions ? await this.client.getRequestOptions(requestOptions) : await this.client.prepareOptions(basePath, 'POST', queryParams, headers, body || undefined, tokenizedOptions, metadata);
+    const options = await this.client.getRequestOptions(requestOptions);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<Order>(url, options, ApiTypes.DEFAULT, StoreApi.apiName, undefined, 'placeOrder');

--- a/packages/@ama-sdk/showcase-sdk/src/api/user/user-api.ts
+++ b/packages/@ama-sdk/showcase-sdk/src/api/user/user-api.ts
@@ -124,7 +124,7 @@ export class UserApi implements Api {
       api: this
     };
 
-    const options = this.client.getRequestOptions ? await this.client.getRequestOptions(requestOptions) : await this.client.prepareOptions(basePath, 'POST', queryParams, headers, body || undefined, tokenizedOptions, metadata);
+    const options = await this.client.getRequestOptions(requestOptions);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'createUser');
@@ -166,7 +166,7 @@ export class UserApi implements Api {
       api: this
     };
 
-    const options = this.client.getRequestOptions ? await this.client.getRequestOptions(requestOptions) : await this.client.prepareOptions(basePath, 'POST', queryParams, headers, body || undefined, tokenizedOptions, metadata);
+    const options = await this.client.getRequestOptions(requestOptions);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<User>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'createUsersWithListInput');
@@ -203,7 +203,7 @@ export class UserApi implements Api {
       api: this
     };
 
-    const options = this.client.getRequestOptions ? await this.client.getRequestOptions(requestOptions) : await this.client.prepareOptions(basePath, 'DELETE', queryParams, headers, body || undefined, tokenizedOptions, metadata);
+    const options = await this.client.getRequestOptions(requestOptions);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'deleteUser');
@@ -240,7 +240,7 @@ export class UserApi implements Api {
       api: this
     };
 
-    const options = this.client.getRequestOptions ? await this.client.getRequestOptions(requestOptions) : await this.client.prepareOptions(basePath, 'GET', queryParams, headers, body || undefined, tokenizedOptions, metadata);
+    const options = await this.client.getRequestOptions(requestOptions);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<User>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'getUserByName');
@@ -277,7 +277,7 @@ export class UserApi implements Api {
       api: this
     };
 
-    const options = this.client.getRequestOptions ? await this.client.getRequestOptions(requestOptions) : await this.client.prepareOptions(basePath, 'GET', queryParams, headers, body || undefined, tokenizedOptions, metadata);
+    const options = await this.client.getRequestOptions(requestOptions);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<string>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'loginUser');
@@ -314,7 +314,7 @@ export class UserApi implements Api {
       api: this
     };
 
-    const options = this.client.getRequestOptions ? await this.client.getRequestOptions(requestOptions) : await this.client.prepareOptions(basePath, 'GET', queryParams, headers, body || undefined, tokenizedOptions, metadata);
+    const options = await this.client.getRequestOptions(requestOptions);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'logoutUser');
@@ -356,7 +356,7 @@ export class UserApi implements Api {
       api: this
     };
 
-    const options = this.client.getRequestOptions ? await this.client.getRequestOptions(requestOptions) : await this.client.prepareOptions(basePath, 'PUT', queryParams, headers, body || undefined, tokenizedOptions, metadata);
+    const options = await this.client.getRequestOptions(requestOptions);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'updateUser');


### PR DESCRIPTION
## Proposed change

Remove the deprecated `prepareOptions` method.

- [x] document in the migration guide
