### PR TITLE
chore: update package.json repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,10 @@
     ]
   },
   "homepage": "https://amadeusitgroup.github.io/otter/",
-  "repository": "https://github.com/AmadeusITGroup/otter",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AmadeusITGroup/otter.git"
+  },
   "bugs": "https://github.com/AmadeusITGroup/otter/issues",
   "license": "BSD-3-Clause",
   "contributors": [
@@ -94,6 +97,7 @@
     },
     {
       "name": "Stephane Dalle",
+      "url": "https://github.com/sdalle-1A",
       "email": "sdalle-1A@users.noreply.github.com"
     },
     {


### PR DESCRIPTION
## Proposed change
Fixing some publish warnings.
```shell
  npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
  npm warn publish errors corrected:
  npm warn publish "repository" was changed from a string to an object
  npm warn publish "repository.url" was normalized to "git+https://github.com/AmadeusITGroup/otter.git"
```
https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository