### PR TITLE
ci: upload chrome extension artifact even if vscode fails

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -140,7 +140,7 @@ jobs:
           CHROME_EXT_ID: ${{ secrets.CHROME_EXT_ID }}
           CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
       - name: Expose Chrome extension artifact
-        if: '!inputs.prerelease'
+        if: (success() || failure()) && !inputs.prerelease
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: chrome-extension


### PR DESCRIPTION
## Proposed change

Today, if one of the tasks in `publish:extension` fails, the upload of chrome-extension is skipped

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
