### PR TITLE
fix: baseUrl under compilerOptions for sdks

### DIFF
--- a/packages/@o3r/workspace/schematics/sdk/rules/update-ts-paths.rule.ts
+++ b/packages/@o3r/workspace/schematics/sdk/rules/update-ts-paths.rule.ts
@@ -28,8 +28,8 @@ export function updateTsConfig(targetPath: string, projectName: string, scope: s
       return tree;
     }
 
-    configWithPath.content.baseUrl ||= '.';
     configWithPath.content.compilerOptions ||= {};
+    configWithPath.content.compilerOptions.baseUrl ||= '.';
     configWithPath.content.compilerOptions.paths ||= {};
     configWithPath.content.compilerOptions.paths[`${scope ? `@${scope}/` : ''}${projectName}`] = [
       `${relativeTargetPath}/dist`,


### PR DESCRIPTION
## Proposed change

Building an sdk inside a monorepo does not work today because the `baseUrl` was in an invalid path.
