### PR TITLE
fix: do not log error for undefined reviver for string response

### DIFF
--- a/packages/@ama-sdk/core/src/fwk/api.helpers.ts
+++ b/packages/@ama-sdk/core/src/fwk/api.helpers.ts
@@ -132,7 +132,7 @@ export function getResponseReviver<T>(revivers: { [statusCode: number]: ReviverT
   if (typeof revivers === 'function' || typeof revivers === 'undefined') {
     return revivers;
   }
-  if (response.status && revivers[response.status]) {
+  if (response.status && Object.keys(revivers).indexOf(`${response.status}`) > -1) {
     return revivers[response.status];
   }
   if (options?.disableFallback) {


### PR DESCRIPTION
## Proposed change

In the case of simple response for a valid status code (for example number or string), the reviver is undefined.
We should not log this scenario
