### PR TITLE
fix(schematic-sdk): support the multi tag in SDK's APIs

### DIFF
--- a/migration-guides/11.0.md
+++ b/migration-guides/11.0.md
@@ -7,6 +7,8 @@
 
 - `prepareOptions` method has been removed from `ApiClient`. `getRequestOptions` should be used instead.
 - To support `JSON` specification format and to remove the reference to the outdated `Swagger` format name, the file containing the current specification used to generate the SDK will be stored in a file `open-api.yaml` or `open-api.json` instead of `swagger-api.yaml`.
+- To avoid interface name conflicts in case of an API with multiple tags (See issue [#855](https://github.com/AmadeusITGroup/otter/issues/855)), the API parameter object interface named with the pattern `<api-function-name>RequestData` will now be named with the pattern `<api-function-name><api-name>RequestData`.
+  - The same renaming is applied to `enum` types in request parameters. It changes from `<api-function-name><parameter-name>Enum` to `<api-name><api-function-name><parameter-name>Enum`.
 
 ## @o3r/schematics
 

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/api.mustache
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/api.mustache
@@ -11,24 +11,20 @@ import { Api, ApiClient, ApiTypes, computePiiParameterTokens, isJsonMimeType, Re
   {{#operation}}
     {{#allParams}}
       {{#isEnum}}
-export type {{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}{{#uppercaseFirst}}{{paramName}}{{/uppercaseFirst}}Enum = {{#trimPipe}}{{#allowableValues}}{{#values}}'{{.}}' | {{/values}}{{/allowableValues}}{{/trimPipe}};
+/** Enum {{paramName}} used in the {{classname}}'s {{nickname}} function parameter */
+export type {{classname}}{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}{{#uppercaseFirst}}{{paramName}}{{/uppercaseFirst}}Enum = {{#trimPipe}}{{#allowableValues}}{{#values}}'{{.}}' | {{/values}}{{/allowableValues}}{{/trimPipe}};
+
       {{/isEnum}}
     {{/allParams}}
   {{/operation}}
   {{#operation}}
-export interface {{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}RequestData {
+/** Parameters object to {{classname}}'s {{nickname}} function */
+export interface {{classname}}{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}RequestData {
     {{#allParams}}
   /** {{#description}}{{{description}}}{{/description}}{{^description}}{{#isArray}}List of {{#plurialize}}{{#noArrayInType}}{{{dataType}}}{{/noArrayInType}}{{/plurialize}}{{/isArray}}{{/description}} */
-  '{{baseName}}'{{^required}}?{{/required}}{{#required}}{{#defaultValue}}?{{/defaultValue}}{{/required}}: {{#isEnum}}{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}{{#uppercaseFirst}}{{paramName}}{{/uppercaseFirst}}Enum{{#isArray}}[]{{/isArray}}{{/isEnum}}{{^isEnum}}{{#isBodyParam}}{{{baseType}}}{{#isArray}}[]{{/isArray}}{{/isBodyParam}}{{^isBodyParam}}{{{dataType}}}{{/isBodyParam}}{{/isEnum}};
+  '{{baseName}}'{{^required}}?{{/required}}{{#required}}{{#defaultValue}}?{{/defaultValue}}{{/required}}: {{#isEnum}}{{classname}}{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}{{#uppercaseFirst}}{{paramName}}{{/uppercaseFirst}}Enum{{#isArray}}[]{{/isArray}}{{/isEnum}}{{^isEnum}}{{#isBodyParam}}{{{baseType}}}{{#isArray}}[]{{/isArray}}{{/isBodyParam}}{{^isBodyParam}}{{{dataType}}}{{/isBodyParam}}{{/isEnum}};
     {{/allParams}}
 }
-  {{/operation}}
-  {{#operation}}
-/**
- * @Deprecated, please use {{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}RequestData
- */
-export interface {{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}} extends {{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}RequestData {}
-
   {{/operation}}
   {{#description}}
 /**
@@ -68,13 +64,13 @@ export class {{classname}} implements Api {
    * @param data Data to provide to the API call
    * @param metadata Metadata to pass to the API call
    */
-  public async {{nickname}}(data: {{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}RequestData, metadata?: RequestMetadata<{{#consumes}}'{{mediaType}}'{{^-last}} | {{/-last}}{{/consumes}}{{^consumes}}string{{/consumes}}, {{#produces}}'{{mediaType}}'{{^-last}} | {{/-last}}{{/produces}}{{^produces}}string{{/produces}}>): Promise<{{#vendorExtensions}}{{#responses2xxReturnTypes}}{{.}}{{^-last}} | {{/-last}}{{/responses2xxReturnTypes}}{{^responses2xxReturnTypes}}never{{/responses2xxReturnTypes}}{{/vendorExtensions}}> {
+  public async {{nickname}}(data: {{classname}}{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}RequestData, metadata?: RequestMetadata<{{#consumes}}'{{mediaType}}'{{^-last}} | {{/-last}}{{/consumes}}{{^consumes}}string{{/consumes}}, {{#produces}}'{{mediaType}}'{{^-last}} | {{/-last}}{{/produces}}{{^produces}}string{{/produces}}>): Promise<{{#vendorExtensions}}{{#responses2xxReturnTypes}}{{.}}{{^-last}} | {{/-last}}{{/responses2xxReturnTypes}}{{^responses2xxReturnTypes}}never{{/responses2xxReturnTypes}}{{/vendorExtensions}}> {
     {{#allParams}}
       {{#defaultValue}}
     data['{{baseName}}'] = data['{{baseName}}'] !== undefined ? data['{{baseName}}'] : {{#isString}}'{{/isString}}{{defaultValue}}{{#isString}}'{{/isString}};
       {{/defaultValue}}
     {{/allParams}}
-    const queryParams = this.client.extractQueryParams<{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}RequestData>(data, [{{#trimComma}}{{#queryParams}}'{{baseName}}', {{/queryParams}}{{/trimComma}}]{{^queryParams}} as never[]{{/queryParams}});
+    const queryParams = this.client.extractQueryParams<{{classname}}{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}RequestData>(data, [{{#trimComma}}{{#queryParams}}'{{baseName}}', {{/queryParams}}{{/trimComma}}]{{^queryParams}} as never[]{{/queryParams}});
     const metadataHeaderAccept = metadata?.headerAccept || '{{#headerJsonMimeType}}{{#produces}}{{mediaType}}{{^-last}}, {{/-last}}{{/produces}}{{/headerJsonMimeType}}';
     const headers: { [key: string]: string | undefined } = {
   {{#trimComma}}    'Content-Type': metadata?.headerContentType || '{{#headerJsonMimeType}}{{#consumes}}{{mediaType}}{{^-last}}, {{/-last}}{{/consumes}}{{/headerJsonMimeType}}',

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/apis.mustache
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/apis.mustache
@@ -1,7 +1,7 @@
 {{#apiInfo}}
 {{#apis}}
 {{#operations}}
-export type { {{#operation}}{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}RequestData{{^-last}}, {{/-last}}{{/operation}} } from './{{#apiFolderName}}{{classname}}{{/apiFolderName}}/index';
+export type { {{#operation}}{{classname}}{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}RequestData{{^-last}}, {{/-last}}{{/operation}} } from './{{#apiFolderName}}{{classname}}{{/apiFolderName}}/index';
 export { {{classname}} } from './{{#apiFolderName}}{{classname}}{{/apiFolderName}}/index';
 {{/operations}}
 {{/apis}}

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/enums.mustache
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/enums.mustache
@@ -3,7 +3,7 @@
 {{#noEmptyExport}}
 {{#apis}}
 {{#operations}}
-export type { {{#trimComma}}{{#operation}}{{#allParams}}{{#isEnum}}{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}{{#uppercaseFirst}}{{paramName}}{{/uppercaseFirst}}Enum, {{/isEnum}}{{/allParams}}{{/operation}}{{/trimComma}} } from './{{#apiFolderName}}{{classname}}{{/apiFolderName}}/index';
+export type { {{#trimComma}}{{#operation}}{{#allParams}}{{#isEnum}}{{classname}}{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}{{#uppercaseFirst}}{{paramName}}{{/uppercaseFirst}}Enum, {{/isEnum}}{{/allParams}}{{/operation}}{{/trimComma}} } from './{{#apiFolderName}}{{classname}}{{/apiFolderName}}/index';
 {{/operations}}
 {{/apis}}
 {{/noEmptyExport}}

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/fixture.jest.mustache
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/fixture.jest.mustache
@@ -2,7 +2,7 @@
 {{/imports}}
 
 {{#operations}}
-import { {{#uppercaseFirst}}{{classname}}{{/uppercaseFirst}}{{#operation}}, {{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}RequestData{{/operation}} } from './{{#kebabCase}}{{classname}}{{/kebabCase}}';
+import { {{#uppercaseFirst}}{{classname}}{{/uppercaseFirst}}{{#operation}}, {{classname}}{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}RequestData{{/operation}} } from './{{#kebabCase}}{{classname}}{{/kebabCase}}';
 
 {{#description}}
 /**
@@ -17,7 +17,7 @@ export class {{#uppercaseFirst}}{{classname}}{{/uppercaseFirst}}Fixture implemen
   {{#operation}}  /**
    * Fixture associated to function {{nickname}}
    */
-  public {{nickname}}: jest.Mock<Promise<{{#vendorExtensions}}{{#responses2xxReturnTypes}}{{.}}{{^-last}} | {{/-last}}{{/responses2xxReturnTypes}}{{^responses2xxReturnTypes}}never{{/responses2xxReturnTypes}}{{/vendorExtensions}}>, [{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}RequestData]> = jest.fn();
+  public {{nickname}}: jest.Mock<Promise<{{#vendorExtensions}}{{#responses2xxReturnTypes}}{{.}}{{^-last}} | {{/-last}}{{/responses2xxReturnTypes}}{{^responses2xxReturnTypes}}never{{/responses2xxReturnTypes}}{{/vendorExtensions}}>, [{{classname}}{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}RequestData]> = jest.fn();
   {{/operation}}
 }
 {{/operations}}{{/noUnusedImport}}

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/interfaces.mustache
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/interfaces.mustache
@@ -3,10 +3,7 @@
 {{#apiInfo}}
 {{#apis}}
 {{#operations}}
-export type { {{#operation}}{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}RequestData{{^-last}}, {{/-last}}{{/operation}} } from './{{#apiFolderName}}{{classname}}{{/apiFolderName}}/index';
-{{/operations}}
-{{#operations}}
-export type { {{#operation}}{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}{{^-last}}, {{/-last}}{{/operation}} } from './{{#apiFolderName}}{{classname}}{{/apiFolderName}}/index';
+export type { {{#operation}}{{classname}}{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}RequestData{{^-last}}, {{/-last}}{{/operation}} } from './{{#apiFolderName}}{{classname}}{{/apiFolderName}}/index';
 {{/operations}}
 {{/apis}}
 {{/apiInfo}}


### PR DESCRIPTION
## Proposed change

Add the support of multi Api Tag via the duplication of the Api Class.

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes resolves #855 
- 🍒 Cherry-pick of #1739

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
