### PR TITLE
feat: add lerna at the root of a new otter project

### DIFF
--- a/packages/@o3r/workspace/package.json
+++ b/packages/@o3r/workspace/package.json
@@ -110,7 +110,8 @@
     "@angular/material": "~18.0.0",
     "@ngrx/router-store": "~18.0.0",
     "@ngrx/effects": "~18.0.0",
-    "@ngrx/store-devtools": "~18.0.0"
+    "@ngrx/store-devtools": "~18.0.0",
+    "lerna": "^8.1.7"
   },
   "engines": {
     "node": "^18.19.1 || ^20.11.1 || >=22.0.0"

--- a/packages/@o3r/workspace/schematics/ng-add/helpers/npm-workspace.ts
+++ b/packages/@o3r/workspace/schematics/ng-add/helpers/npm-workspace.ts
@@ -2,7 +2,8 @@ import { chain } from '@angular-devkit/schematics';
 import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { SchematicsException } from '@angular-devkit/schematics';
 import type { PackageJson } from 'type-fest';
-import { DEFAULT_ROOT_FOLDERS, isNxContext, setupSchematicsParamsForProject, WorkspaceLayout, WorkspaceSchematics } from '@o3r/schematics';
+import { DEFAULT_ROOT_FOLDERS, getPackageManager, isNxContext, setupSchematicsParamsForProject, WorkspaceLayout, WorkspaceSchematics } from '@o3r/schematics';
+import type { MonorepoManager } from '../schema';
 
 /**
  * Update root package.json to include workspaces
@@ -74,4 +75,44 @@ export function filterPackageJsonScripts(tree: Tree, _context: SchematicContext)
 
   tree.overwrite(rootPackageJsonPath, JSON.stringify(rootPackageJsonObject, null, 2));
   return tree;
+}
+
+/**
+ * Add a monorepo manager at the root of the project
+ * @param o3rWorkspacePackageJson the @o3r/workspace package.json
+ * @param manager the monorepo manager
+ */
+export function addMonorepoManager(o3rWorkspacePackageJson: PackageJson & { generatorDependencies: Record<string, string> }, manager: MonorepoManager): Rule {
+  return (tree: Tree, _context: SchematicContext) => {
+    if (manager === 'lerna') {
+      const rootPackageJsonPath = '/package.json';
+      if (!tree.exists(rootPackageJsonPath)) {
+        throw new SchematicsException('Root package.json does not exist');
+      }
+
+      const rootPackageJsonObject = tree.readJson(rootPackageJsonPath) as PackageJson;
+      rootPackageJsonObject.devDependencies = {
+        ...rootPackageJsonObject.devDependencies,
+        'lerna': o3rWorkspacePackageJson.generatorDependencies.lerna
+      };
+      rootPackageJsonObject.scripts = {
+        ...rootPackageJsonObject.scripts,
+        'build': 'lerna run build',
+        'test': 'lerna run test',
+        'lint': 'lerna run lint'
+      };
+
+      const lernaJson: { $schema: string; version: string; npmClient?: string } = {
+        '$schema': 'https://github.com/lerna/lerna/blob/main/packages/lerna/schemas/lerna-schema.json',
+        'version': rootPackageJsonObject.version || '0.0.0-placeholder'
+      };
+      if (getPackageManager() === 'yarn') {
+        lernaJson.npmClient = 'yarn';
+      }
+      tree.create('/lerna.json', JSON.stringify(lernaJson, null, 2));
+
+      tree.overwrite(rootPackageJsonPath, JSON.stringify(rootPackageJsonObject, null, 2));
+    }
+    return tree;
+  };
 }

--- a/packages/@o3r/workspace/schematics/ng-add/schema.json
+++ b/packages/@o3r/workspace/schematics/ng-add/schema.json
@@ -50,6 +50,15 @@
       "type": "boolean",
       "description": "Use a pinned version for otter packages",
       "default": false
+    },
+    "monorepoManager": {
+      "description": "Which monorepo manager to use",
+      "type": "string",
+      "default": "lerna",
+      "enum": [
+        "lerna",
+        "none"
+      ]
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/workspace/schematics/ng-add/schema.ts
+++ b/packages/@o3r/workspace/schematics/ng-add/schema.ts
@@ -1,6 +1,7 @@
 import type { SchematicOptionObject } from '@o3r/schematics';
 
-export type PresetNames = 'basic' | 'cms';
+/** Monorepo manager to use */
+export type MonorepoManager = 'lerna' | 'none';
 
 export interface NgAddSchematicsSchema extends SchematicOptionObject {
   /** Skip the linter process */
@@ -17,4 +18,7 @@ export interface NgAddSchematicsSchema extends SchematicOptionObject {
 
   /** Use a pinned version for otter packages */
   exactO3rVersion?: boolean;
+
+  /** Monorepo manager to use */
+  monorepoManager: MonorepoManager;
 }

--- a/packages/@o3r/workspace/src/cli/set-version.cts
+++ b/packages/@o3r/workspace/src/cli/set-version.cts
@@ -7,7 +7,7 @@ import * as path from 'node:path';
 import * as winston from 'winston';
 import { clean } from 'semver';
 
-const defaultIncludedFiles = ['**/package.json', '!/**/templates/**/package.json', '!**/node_modules/**/package.json'];
+const defaultIncludedFiles = ['**/package.json', '!/**/templates/**/package.json', '!**/node_modules/**/package.json', '**/lerna.json'];
 
 const collect = (pattern: string, patterns: string[]) => {
   if (patterns === defaultIncludedFiles && pattern) {


### PR DESCRIPTION
## Proposed change

The goal is to add lerna at the root when creating an Otter project so that we can easily run the commands for all projects locally and on the CI with both npm and yarn.