### PR TITLE
fix: missing css variables in chrome dev-tool

### DIFF
--- a/packages/@o3r/styling/builders/style-extractor/index.ts
+++ b/packages/@o3r/styling/builders/style-extractor/index.ts
@@ -92,7 +92,6 @@ export default createBuilder(createBuilderWithMetricsIfInstalled<StyleExtractorB
       cssVarList
         .forEach((item) => {
           acc.variables[item.name] = item;
-          delete (acc.variables[item.name] as any).name;
         });
       return acc;
     }, previousMetadata);

--- a/packages/@o3r/styling/scss/theming/otter-theme/_functions.scss
+++ b/packages/@o3r/styling/scss/theming/otter-theme/_functions.scss
@@ -17,7 +17,8 @@
 
     @each $key, $value in $meta-theme {
       $new-key: if($root-name != '', '#{$root-name}-#{$key}', $key);
-      $new-value: _meta-theme-to-otter($value, $new-key);
+      // We do not extract the metadata as (variable, value) pair
+      $new-value: if($key != details, _meta-theme-to-otter($value, $new-key), $value);
       $ret: map.merge($ret, ($key: $new-value));
     }
 

--- a/packages/@o3r/styling/scss/theming/otter-theme/_material.scss
+++ b/packages/@o3r/styling/scss/theming/otter-theme/_material.scss
@@ -141,6 +141,10 @@
     @return $meta-theme;
   }
 
+  @if (map.has-key($meta-theme, value) and map.has-key($meta-theme, details)) {
+    @return _meta-theme-to-material(map.get($meta-theme, value), $root-name, $enable-css-var);
+  }
+
   @else {
     $ret: $meta-theme;
 

--- a/packages/@o3r/styling/src/devkit/styling-devtools.message.service.ts
+++ b/packages/@o3r/styling/src/devkit/styling-devtools.message.service.ts
@@ -21,8 +21,8 @@ const getCSSRulesAppliedOnRoot = () => Array.from(document.styleSheets)
     let rules;
     try {
       rules = styleSheet.cssRules || styleSheet.rules;
-    } catch {
-      console.debug(`Could not access to stylesheet ${styleSheet.href}. This might be due to CORS issues.`);
+    } catch (err) {
+      console.debug(`Could not access to stylesheet ${styleSheet.href}. This might be due to CORS issues.`, err);
     }
 
     return acc.concat(

--- a/packages/@o3r/styling/src/devkit/styling-devtools.message.service.ts
+++ b/packages/@o3r/styling/src/devkit/styling-devtools.message.service.ts
@@ -22,7 +22,10 @@ const getCSSRulesAppliedOnRoot = () => Array.from(document.styleSheets)
     try {
       rules = styleSheet.cssRules || styleSheet.rules;
     } catch (err) {
-      console.debug(`Could not access to stylesheet ${styleSheet.href}. This might be due to CORS issues.`, err);
+      console.debug(`Could not access to stylesheet ${styleSheet.href}. This might be due to network issues, please check:
+- network connectivity
+- CORS setup
+- granted access to the stylesheet`, err);
     }
 
     return acc.concat(


### PR DESCRIPTION
## Proposed change

Do not remove css variable name from metadata extracted as it is used in the devtools
Do not fail on third party css scripts
Do not create variable for css var details
