### PR TITLE
fix(create): version for root package.json should be 0.0.0-placeholder

### DIFF
--- a/packages/@o3r/workspace/schematics/ng-add/helpers/npm-workspace.ts
+++ b/packages/@o3r/workspace/schematics/ng-add/helpers/npm-workspace.ts
@@ -20,7 +20,7 @@ export function addWorkspacesToProject(directories: WorkspaceLayout = DEFAULT_RO
     }
 
     const rootPackageJsonObject = tree.readJson(rootPackageJsonPath) as PackageJson;
-
+    rootPackageJsonObject.version = '0.0.0-placeholder';
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     rootPackageJsonObject.workspaces = [...new Set(Object.values(directories).map(d => `${d}/*`).concat(rootPackageJsonObject.workspaces as string[] || []))];
 


### PR DESCRIPTION


## Proposed change

The angular schematic generates a `package.json` with version `0.0.0`. We should align the version with the rest of the workspaces (`0.0.0-placeholder`).