### PR TITLE
fix: wait for language to be loaded before update

### DIFF
--- a/packages/@o3r/localization/src/devkit/localization-devtools.service.ts
+++ b/packages/@o3r/localization/src/devkit/localization-devtools.service.ts
@@ -1,6 +1,6 @@
 import { ApplicationRef, Injectable } from '@angular/core';
 import { TranslateCompiler } from '@ngx-translate/core';
-import { lastValueFrom, Subscription } from 'rxjs';
+import {firstValueFrom, lastValueFrom, Subscription} from 'rxjs';
 import { LocalizationService } from '../tools';
 import type { TranslateMessageFormatLazyCompiler } from '../core';
 
@@ -65,9 +65,10 @@ export class OtterLocalizationDevtools {
    * @param keyValues key/values to update
    * @param language if not provided, the current language value
    */
-  public updateLocalizationKeys(keyValues: { [key: string]: string }, language?: string): void | Promise<void> {
+  public async updateLocalizationKeys(keyValues: { [key: string]: string }, language?: string) {
     const lang = language || this.getCurrentLanguage();
     const translateService = this.localizationService.getTranslateService();
+    await firstValueFrom(translateService.getTranslation(lang));
     Object.entries(keyValues).forEach(([key, value]) => {
       translateService.set(key, value, lang);
     });


### PR DESCRIPTION
## Proposed change

Devtool state reload fails because the update localization message is sent before the reload of the language.