### PR TITLE
fix: migrate ama-sdk in renovate template

### DIFF
--- a/tools/renovate/tasks/sdk-regenerate.json
+++ b/tools/renovate/tasks/sdk-regenerate.json
@@ -9,7 +9,7 @@
       "postUpgradeTasks": {
         "commands": [
           "{{arg0}} install",
-          "{{#if (equals arg0 'npm')}}npm exec --{{else}}{{arg0}} exec{{/if}} schematics @ama-sdk/schematics:migrate --from={{{currentVersion}}} --to={{{newVersion}}}",
+          "{{#if (equals '{{arg0}}' 'npm')}}npm exec --{{else}}{{arg0}} exec{{/if}} schematics @ama-sdk/schematics:migrate --from={{{currentVersion}}} --to={{{newVersion}}}",
           "{{arg0}} run spec:upgrade"
         ],
         "fileFilters": [


### PR DESCRIPTION
## Proposed change
- renovate replaces the args in the template which will be sent to handlebars
- prepare the string equals string in the check of the node runner
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
