### PR TITLE
fix(localization): do not declare pipes that override another one

### DIFF
--- a/packages/@o3r/localization/src/tools/localization.module.ts
+++ b/packages/@o3r/localization/src/tools/localization.module.ts
@@ -39,9 +39,9 @@ export function localeIdNgBridge(localizationService: LocalizationService) {
 export const CUSTOM_LOCALIZATION_CONFIGURATION_TOKEN = new InjectionToken<Partial<LocalizationConfiguration>>('Partial Localization configuration');
 
 @NgModule({
-  declarations: [LocalizationTranslatePipe, LocalizationTranslateDirective, LocalizedDatePipe, LocalizedDecimalPipe, LocalizedCurrencyPipe],
+  declarations: [LocalizationTranslatePipe, LocalizationTranslateDirective],
   imports: [TranslateModule, BidiModule, DynamicContentModule, CommonModule],
-  exports: [TranslateModule, LocalizationTranslatePipe, LocalizationTranslateDirective, LocalizedDatePipe, LocalizedDecimalPipe, LocalizedCurrencyPipe],
+  exports: [TranslateModule, LocalizationTranslatePipe, LocalizationTranslateDirective],
   providers: [
     {provide: LOCALIZATION_CONFIGURATION_TOKEN, useFactory: createLocalizationConfiguration, deps: [[new Optional(), CUSTOM_LOCALIZATION_CONFIGURATION_TOKEN]]},
     {provide: LOCALE_ID, useFactory: localeIdNgBridge, deps: [LocalizationService]},

--- a/packages/@o3r/testing/src/localization/localization-mock.ts
+++ b/packages/@o3r/testing/src/localization/localization-mock.ts
@@ -17,10 +17,7 @@ export class TranslatePipeMock implements PipeTransform {
   }
 }
 
-@NgModule({
-  declarations: [TranslatePipeMock],
-  exports: [TranslatePipeMock]
-})
+@NgModule()
 export class LocalizationDependencyMocks {
   public static forTest(): ModuleWithProviders<LocalizationDependencyMocks> {
     return {


### PR DESCRIPTION
## Proposed change
Do not declare pipes that override another one
Else we have 2 declaration of pipes with the same name and it causes `NG0313`

## Related issues

- :bug: Fixes #1960