### PR TITLE
fix: correct dist path for dev builds on otter webapps

### DIFF
--- a/packages/@o3r/core/schematics/rule-factories/otter-environment/index.ts
+++ b/packages/@o3r/core/schematics/rule-factories/otter-environment/index.ts
@@ -56,18 +56,9 @@ export function updateOtterEnvironmentAdapter(
         }
       });
 
-      // force dist/ output folder for production build
-      if (workspaceProject.architect && workspaceProject.architect.build) {
-        workspaceProject.architect.build.configurations ||= {};
-        workspaceProject.architect.build.configurations.production ||= {};
-        workspaceProject.architect.build.configurations.production.outputPath ||= join(workspaceProject.root, 'dist');
-
-        if (workspaceProject.architect.build.configurations.options &&
-            workspaceProject.architect.build.configurations.options.outputPath &&
-            /^dist([/].+)?/i.test(workspaceProject.architect.build.configurations.options.outputPath)) {
-          workspaceProject.architect.build.configurations.options.outputPath ||= join(workspaceProject.root, 'dist-dev');
-        }
-
+      // override angular's dist/webapp output path with apps/webapp/dist
+      if (workspaceProject.architect?.build?.options?.outputPath) {
+        workspaceProject.architect.build.options.outputPath = join(workspaceProject.root, 'dist');
       }
 
       workspace.projects[options.projectName!] = workspaceProject;


### PR DESCRIPTION
## Proposed change

Before we were not even updating the development one because `workspaceProject.architect.build.configurations.options` does not exist. It should have been `workspaceProject.architect.build.configurations.development` instead. 
I propose we override the main `outputPath` and not just for production.


before
```json
      "architect": {
        "build": {
          "builder": "@angular-devkit/build-angular:application",
          "options": {
            "outputPath": "dist/webapp",
          },
          "configurations": {
            "production": {
              ....
              "outputPath": "apps/webapp/dist"
            },
            "development": {
              ...
            }
          },
          "defaultConfiguration": "production"
        },
```

after
```json
      "architect": {
        "build": {
          "builder": "@angular-devkit/build-angular:application",
          "options": {
            "outputPath": "apps/webapp/dist",
          },
          "configurations": {
            "production": {
              ....
            },
            "development": {
              ...
            }
          },
          "defaultConfiguration": "production"
        },
```