### PR TITLE
fix: missing permissions for first pr comment workflow

### DIFF
--- a/.github/workflows/first-pr.yml
+++ b/.github/workflows/first-pr.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: read
-  issues: read
+  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Proposed change
Adding missing permissions for first pr comment workflow

[Failed workflow](https://github.com/AmadeusITGroup/otter/actions/runs/10388255377/job/28764058469)
[Needed permissions](https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#create-an-issue-comment)
