### PR TITLE
fix: missing permissions for pr labels workflow

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -13,6 +13,7 @@ jobs:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     permissions:
       pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:


### PR DESCRIPTION
## Proposed change
Add all the necessary permissions to add a label on a PR
[doc](https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#add-labels-to-an-issue)

## Example of failing pipeline
https://github.com/AmadeusITGroup/otter/actions/runs/10487211477/job/29047084682?pr=2080

## Related issues

- :rocket: Feature #711 

