### PR TITLE
fix: error message is empty on logged rule engine errors

### DIFF
--- a/packages/@o3r/rules-engine/src/engine/ruleset-executor.ts
+++ b/packages/@o3r/rules-engine/src/engine/ruleset-executor.ts
@@ -267,7 +267,15 @@ export class RulesetExecutor {
               if (this.rulesEngine.debugMode) {
                 output.evaluation = handleRuleEvaluationDebug({ ...rule, inputFacts }, this.ruleset.name, output.actions, output.error, runtimeFactValues, factValues, oldFactValues);
               } else if (output.error) {
-                this.rulesEngine.logger?.error(output.error);
+                let errorMsg;
+                if (output.error instanceof Error) {
+                  errorMsg = output.error.toString();
+                } else if (typeof output.error === 'string') {
+                  errorMsg = output.error;
+                } else {
+                  errorMsg = JSON.stringify(output.error);
+                }
+                this.rulesEngine.logger?.error(errorMsg);
                 this.rulesEngine.logger?.warn(`Skipping rule ${rule.name}, and the associated ruleset`);
               }
               return output;

--- a/packages/@o3r/rules-engine/src/engine/ruleset-executor.ts
+++ b/packages/@o3r/rules-engine/src/engine/ruleset-executor.ts
@@ -268,10 +268,8 @@ export class RulesetExecutor {
                 output.evaluation = handleRuleEvaluationDebug({ ...rule, inputFacts }, this.ruleset.name, output.actions, output.error, runtimeFactValues, factValues, oldFactValues);
               } else if (output.error) {
                 let errorMsg;
-                if (output.error instanceof Error) {
+                if (output.error instanceof Error || typeof output.error === 'string') {
                   errorMsg = output.error.toString();
-                } else if (typeof output.error === 'string') {
-                  errorMsg = output.error;
                 } else {
                   errorMsg = JSON.stringify(output.error);
                 }


### PR DESCRIPTION
## Proposed change

Catch returns an Error which can only be stringified with toString since JSON.stringify(new Error('Message') will always return {}