### PR TITLE
fix(eslint): turn no-require rule to warn to keep compatibility

### DIFF
--- a/packages/@o3r/eslint-config-otter/rules/typescript/eslint-typescript.cjs
+++ b/packages/@o3r/eslint-config-otter/rules/typescript/eslint-typescript.cjs
@@ -124,7 +124,7 @@ module.exports = {
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-parameter-properties': 'off',
     '@typescript-eslint/no-redeclare': 'error',
-    '@typescript-eslint/no-require-imports': 'error',
+    '@typescript-eslint/no-require-imports': 'warn',
     '@typescript-eslint/no-shadow': [
       'error',
       {


### PR DESCRIPTION
## Proposed change

fix(eslint): turn no-require rule to warn to keep compatibility

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :octocat: Pull Request: #2076

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
