### PR TITLE
fix(#2124): compute the scope first while generating a new sdk

### DIFF
--- a/packages/@o3r/workspace/schematics/index.it.spec.ts
+++ b/packages/@o3r/workspace/schematics/index.it.spec.ts
@@ -20,7 +20,7 @@ describe('new otter workspace', () => {
   test('should add sdk to an existing workspace', () => {
     const { workspacePath, isInWorkspace, untouchedProjectsPaths } = o3rEnvironment.testEnvironment;
     const execAppOptions = {...getDefaultExecSyncOptions(), cwd: workspacePath};
-    packageManagerExec({script: 'ng', args: ['g', 'sdk', '@my-sdk/sdk']}, execAppOptions);
+    packageManagerExec({script: 'ng', args: ['g', 'sdk', 'my-sdk']}, execAppOptions);
 
     const diff = getGitDiff(execAppOptions.cwd);
     untouchedProjectsPaths.forEach(untouchedProject => {

--- a/packages/@o3r/workspace/schematics/sdk/index.ts
+++ b/packages/@o3r/workspace/schematics/sdk/index.ts
@@ -22,8 +22,8 @@ import { NodePackageInstallTask, RunSchematicTask } from '@angular-devkit/schema
  */
 function generateSdkFn(options: NgGenerateSdkSchema): Rule {
   const splitName = options.name?.split('/');
-  const scope = splitName.length > 1 ? splitName[0].replace(/^@/, '') : '';
-  const projectName = strings.dasherize(splitName?.length === 2 ? splitName[1] : options.name);
+  const scope = strings.dasherize(splitName.length > 1 ? splitName[0].replace(/^@/, '') : options.name);
+  const projectName = splitName?.length === 2 ? strings.dasherize(splitName[1]) : 'sdk';
   const cleanName = strings.dasherize(options.name).replace(/^@/, '').replaceAll(/\//g, '-');
 
   return (tree, context) => {

--- a/packages/@o3r/workspace/schematics/sdk/schema.json
+++ b/packages/@o3r/workspace/schematics/sdk/schema.json
@@ -6,8 +6,8 @@
   "properties": {
     "name": {
       "type": "string",
-      "description": "Name of the SDK package",
-      "x-prompt": "Name of the new SDK package?",
+      "description": "Name of the SDK package (format: @scope/sdk-name)",
+      "x-prompt": "Name of the new SDK package? (format: @scope/sdk-name)",
       "$default": {
         "$source": "argv",
         "index": 0


### PR DESCRIPTION
## Proposed change
compute the scope first while generating a new sdk

## Related issues

- :bug: Fixes #2124 
