### PR TITLE
feat(eslint): provide a flatconfig for eslint v9

### DIFF
--- a/packages/@o3r/eslint-config-otter/README.md
+++ b/packages/@o3r/eslint-config-otter/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Otter eslint config</h1>
+<h1 align="center">Legacy Otter ESLint config</h1>
 <p align="center">
   <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/assets/logo/otter.png" alt="Super cute Otter!" width="40%"/>
 </p>
@@ -12,7 +12,7 @@ This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/ot
 [![Stable Version](https://img.shields.io/npm/v/@o3r/eslint-config-otter?style=for-the-badge)](https://www.npmjs.com/package/@o3r/eslint-config-otter)
 [![Bundle Size](https://img.shields.io/bundlephobia/min/@o3r/eslint-config-otter?color=green&style=for-the-badge)](https://www.npmjs.com/package/@o3r/eslint-config-otter)
 
-Recommended eslint configuration for Otter project
+Legacy ESLint configuration for an Otter project with [ESLint < 9](https://eslint.org/docs/latest/use/configure/configuration-files-deprecated).
 
 ## How to install
 

--- a/packages/@o3r/eslint-config/.eslintrc.js
+++ b/packages/@o3r/eslint-config/.eslintrc.js
@@ -1,0 +1,19 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable quote-props */
+
+module.exports = {
+  'root': true,
+  'parserOptions': {
+    'tsconfigRootDir': __dirname,
+    'sourceType': 'module',
+    'project': [
+      'tsconfig.build.json',
+      'tsconfig.builders.json',
+      'tsconfig.eslint.json',
+      'tsconfig.spec.json'
+    ]
+  },
+  'extends': [
+    '../../../.eslintrc.js'
+  ]
+};

--- a/packages/@o3r/eslint-config/README.md
+++ b/packages/@o3r/eslint-config/README.md
@@ -1,0 +1,21 @@
+<h1 align="center">Otter ESLint config</h1>
+<p align="center">
+  <img src="https://raw.githubusercontent.com/AmadeusITGroup/otter/main/assets/logo/otter.png" alt="Super cute Otter!" width="40%"/>
+</p>
+
+This package is an [Otter Framework Module](https://github.com/AmadeusITGroup/otter/tree/main/docs/core/MODULE.md).
+<br />
+<br />
+
+## Description
+
+[![Stable Version](https://img.shields.io/npm/v/@o3r/eslint-config?style=for-the-badge)](https://www.npmjs.com/package/@o3r/eslint-config)
+[![Bundle Size](https://img.shields.io/bundlephobia/min/@o3r/eslint-config?color=green&style=for-the-badge)](https://www.npmjs.com/package/@o3r/eslint-config)
+
+Recommended ESLint configuration for an Otter project with [ESLint FlatConfig](https://eslint.org/blog/2022/08/new-config-system-part-2/).
+
+## How to install
+
+```shell
+ng add @o3r/eslint-config
+```

--- a/packages/@o3r/eslint-config/collection.json
+++ b/packages/@o3r/eslint-config/collection.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/main/packages/angular_devkit/schematics/collection-schema.json",
+  "schematics": {
+    "ng-add": {
+      "description": "Add Otter eslint-config to the project.",
+      "factory": "./schematics/ng-add/index#ngAdd",
+      "schema": "./schematics/ng-add/schema.json",
+      "aliases": ["install", "i"]
+    }
+  }
+}

--- a/packages/@o3r/eslint-config/index.spec.ts
+++ b/packages/@o3r/eslint-config/index.spec.ts
@@ -1,0 +1,5 @@
+// TODO be removed as soon as we have one test in this package
+
+it('should be removed as soon as we have one test in this package', () => {
+  expect(true).toBe(true);
+});

--- a/packages/@o3r/eslint-config/jest.config.js
+++ b/packages/@o3r/eslint-config/jest.config.js
@@ -1,0 +1,10 @@
+const getJestGlobalConfig = require('../../../jest.config.ut').getJestGlobalConfig;
+
+/** @type {import('ts-jest/dist/types').JestConfigWithTsJest} */
+module.exports = {
+  ...getJestGlobalConfig(),
+  projects: [
+    '<rootDir>/testing/jest.config.ut.js',
+    '<rootDir>/testing/jest.config.ut.builders.js'
+  ]
+};

--- a/packages/@o3r/eslint-config/package.json
+++ b/packages/@o3r/eslint-config/package.json
@@ -1,38 +1,22 @@
 {
-  "name": "@o3r/eslint-config-otter",
+  "name": "@o3r/eslint-config",
   "version": "0.0.0-placeholder",
   "publishConfig": {
     "access": "public"
   },
-  "description": "Recommended eslint configuration for Otter project",
-  "main": "index.cjs",
+  "description": "Recommended eslint v9+ configuration for Otter project",
   "exports": {
     "./package.json": {
       "default": "./package.json"
     },
     ".": {
-      "default": "./index.cjs"
-    },
-    "./base": {
-      "default": "./typescript.cjs"
+      "default": "./dist/src/index.js"
     },
     "./typescript": {
-      "default": "./typescript.cjs"
-    },
-    "./fast": {
-      "default": "./typescript-fast.cjs"
-    },
-    "./typescript-fast": {
-      "default": "./typescript-fast.cjs"
-    },
-    "./jasmine": {
-      "default": "./jasmine.cjs"
-    },
-    "./jasmine-fast": {
-      "default": "./jasmine-fast.cjs"
+      "default": "./dist/src/typescript.js"
     },
     "./template": {
-      "default": "./template.cjs"
+      "default": "./dist/src/template.js"
     }
   },
   "keywords": [
@@ -43,54 +27,55 @@
     "otter-module"
   ],
   "scripts": {
-    "build": "yarn cpy --flat {typescript,typescript-fast,index,jasmine,jasmine-fast,template}.cjs package.json dist && yarn cpy rules dist && yarn postbuild",
-    "postbuild": "patch-package-json-main",
+    "postbuild": "patch-package-json-main && patch-package-json-exports",
     "prepare:publish": "prepare-publish ./dist",
-    "prepare:build:builders": "yarn cpy 'schematics/**/*.json' 'schematics/**/templates/**' dist/schematics && yarn cpy '{collection,migration}.json' dist",
+    "prepare:build:builders": "yarn cpy 'schematics/**/*.json' 'schematics/**/templates/**' dist/schematics && yarn cpy 'collection.json' dist",
     "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest"
   },
   "peerDependencies": {
     "@angular-devkit/schematics": "~18.2.0",
-    "@angular-eslint/builder": "~18.3.0",
-    "@angular-eslint/eslint-plugin": "~18.3.0",
-    "@angular-eslint/eslint-plugin-template": "~18.3.0",
-    "@angular-eslint/template-parser": "~18.3.0",
     "@angular/compiler": "~18.2.0",
+    "@eslint/js": "9.10.0",
     "@o3r/eslint-plugin": "workspace:^",
     "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
-    "@stylistic/eslint-plugin-ts": "~2.4.0",
-    "@typescript-eslint/eslint-plugin": "^7.14.1",
-    "@typescript-eslint/parser": "^7.14.1",
-    "@typescript-eslint/utils": "^7.14.1",
+    "@stylistic/eslint-plugin-js": "^2.4.0",
+    "@stylistic/eslint-plugin-ts": "^2.4.0",
+    "@typescript-eslint/utils": "^7.14.1 || ^8.0.0",
+    "angular-eslint": "^18.3.0",
     "eslint": "^8.57.0 || ^9.0.0",
     "eslint-import-resolver-node": "^0.3.4",
     "eslint-plugin-jasmine": "^4.1.3",
     "eslint-plugin-jest": "^28.0.0",
-    "eslint-plugin-jsdoc": "~48.11.0",
+    "eslint-plugin-jsdoc": "^48.11.0 || ^49.0.0 || ^50.0.0",
     "eslint-plugin-prefer-arrow": "^1.2.2",
-    "eslint-plugin-unicorn": "^54.0.0",
-    "typescript": "~5.5.4"
+    "eslint-plugin-unicorn": "^54.0.0 || ^55.0.0",
+    "jest": "~29.7.0",
+    "ts-node": "~10.9.2",
+    "typescript": "~5.5.4",
+    "typescript-eslint": "^8.0.0"
   },
   "devDependencies": {
     "@angular-devkit/core": "~18.2.0",
     "@angular-devkit/schematics": "~18.2.0",
     "@angular-eslint/eslint-plugin": "~18.3.0",
-    "@angular-eslint/eslint-plugin-template": "~18.3.0",
-    "@angular-eslint/template-parser": "~18.3.0",
     "@angular/compiler": "~18.2.0",
+    "@eslint/js": "9.10.0",
     "@nx/eslint-plugin": "~19.5.0",
     "@o3r/build-helpers": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
     "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~18.2.0",
+    "@stylistic/eslint-plugin-js": "~2.4.0",
     "@stylistic/eslint-plugin-ts": "~2.4.0",
+    "@types/eslint__js": "^8.42.3",
     "@types/jest": "~29.5.2",
     "@types/node": "^20.0.0",
     "@typescript-eslint/eslint-plugin": "^7.14.1",
     "@typescript-eslint/parser": "^7.14.1",
     "@typescript-eslint/utils": "^7.14.1",
+    "angular-eslint": "~18.3.0",
     "cpy-cli": "^5.0.0",
     "eslint": "^8.57.0",
     "eslint-import-resolver-node": "^0.3.9",
@@ -109,19 +94,11 @@
     "ts-jest": "~29.2.0",
     "ts-node": "~10.9.2",
     "tslib": "^2.6.2",
-    "typescript": "~5.5.4"
+    "typescript": "~5.5.4",
+    "typescript-eslint": "^8.0.0"
   },
   "peerDependenciesMeta": {
     "@angular-devkit/schematics": {
-      "optional": true
-    },
-    "@angular-eslint/builder": {
-      "optional": true
-    },
-    "@angular-eslint/eslint-plugin-template": {
-      "optional": true
-    },
-    "@angular-eslint/template-parser": {
       "optional": true
     },
     "@angular/compiler": {
@@ -143,8 +120,5 @@
       "optional": true
     }
   },
-  "schematics": "./collection.json",
-  "ng-update": {
-    "migrations": "./migration.json"
-  }
+  "schematics": "./collection.json"
 }

--- a/packages/@o3r/eslint-config/project.json
+++ b/packages/@o3r/eslint-config/project.json
@@ -1,0 +1,80 @@
+{
+  "name": "eslint-config",
+  "$schema": "https://raw.githubusercontent.com/nrwl/nx/master/packages/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "packages/@o3r/eslint-config",
+  "prefix": "o3r",
+  "targets": {
+    "build": {
+      "executor": "nx:run-script",
+      "outputs": ["{projectRoot}/dist/package.json"],
+      "options": {
+        "script": "postbuild"
+      },
+      "dependsOn": [
+        "^build",
+        "compile",
+        "build-builders"
+      ]
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "options": {
+        "jestConfig": "packages/@o3r/eslint-config/jest.config.js"
+      }
+    },
+    "test-int": {
+      "executor": "@nx/jest:jest",
+      "options": {
+        "jestConfig": "packages/@o3r/eslint-config/testing/jest.config.it.js"
+      }
+    },
+    "lint": {
+      "options": {
+        "eslintConfig": "packages/@o3r/eslint-config/.eslintrc.js",
+        "lintFilePatterns": [
+          "packages/@o3r/eslint-config/**/*.ts",
+          "packages/@o3r/eslint-config/package.json"
+        ]
+      }
+    },
+    "compile": {
+      "executor": "@nx/js:tsc",
+      "options": {
+        "main": "packages/@o3r/eslint-config/src/public_api.ts",
+        "tsConfig": "packages/@o3r/eslint-config/tsconfig.build.json",
+        "outputPath": "packages/@o3r/eslint-config/dist",
+        "clean": false
+      },
+      "inputs": [
+        "{projectRoot}/rules/**/*",
+        "{projectRoot}/*.ts"
+      ]
+    },
+    "prepare-build-builders": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "prepare:build:builders"
+      }
+    },
+    "prepare-publish": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "prepare:publish"
+      }
+    },
+    "build-builders": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "build:builders"
+      }
+    },
+    "publish": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm publish packages/@o3r/eslint-config/dist"
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/@o3r/eslint-config/schematics/index.it.spec.ts
+++ b/packages/@o3r/eslint-config/schematics/index.it.spec.ts
@@ -1,0 +1,5 @@
+// TODO be removed as soon as we have one test in this package
+
+it('should be removed as soon as we have one test in this package', () => {
+  expect(true).toBe(true);
+});

--- a/packages/@o3r/eslint-config/schematics/ng-add/index.js
+++ b/packages/@o3r/eslint-config/schematics/ng-add/index.js
@@ -1,0 +1,13 @@
+/*
+
+This files is used to allow the usage of the builder within @o3r/framework mono-repository.
+It should not be part of the package.
+
+*/
+
+const {resolve} = require('node:path');
+
+require('ts-node').register({ project: resolve(__dirname, '..', '..', 'tsconfig.builders.json') });
+require('ts-node').register = () => {};
+
+module.exports = require('./index.ts');

--- a/packages/@o3r/eslint-config/schematics/ng-add/index.ts
+++ b/packages/@o3r/eslint-config/schematics/ng-add/index.ts
@@ -1,0 +1,11 @@
+import { noop } from '@angular-devkit/schematics';
+import type { Rule } from '@angular-devkit/schematics';
+
+/**
+ * Add Otter eslint-config to an Angular Project
+ * @param options
+ */
+export function ngAdd(): Rule {
+  /* ng add rules */
+  return noop();
+}

--- a/packages/@o3r/eslint-config/schematics/ng-add/schema.json
+++ b/packages/@o3r/eslint-config/schematics/ng-add/schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "ngAddSchematicsSchema",
+  "title": "Add Otter eslint config",
+  "description": "ngAdd Otter eslint config",
+  "properties": {
+    "projectName": {
+      "type": "string",
+      "description": "Project name",
+      "$default": {
+        "$source": "projectName"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+  ]
+}

--- a/packages/@o3r/eslint-config/schematics/ng-add/schema.ts
+++ b/packages/@o3r/eslint-config/schematics/ng-add/schema.ts
@@ -1,0 +1,4 @@
+export interface NgAddSchematicsSchema {
+  /** Project name */
+  projectName?: string | undefined;
+}

--- a/packages/@o3r/eslint-config/src/public_api.ts
+++ b/packages/@o3r/eslint-config/src/public_api.ts
@@ -1,0 +1,2 @@
+import typescript from './rules/typescript';
+export default typescript;

--- a/packages/@o3r/eslint-config/src/rules/base.ts
+++ b/packages/@o3r/eslint-config/src/rules/base.ts
@@ -1,0 +1,14 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { TSESLint } from '@typescript-eslint/utils';
+
+export default (
+  plugin: TSESLint.FlatConfig.Plugin
+): TSESLint.FlatConfig.Config => ({
+  name: '@o3r/base',
+  languageOptions: {
+    sourceType: 'module'
+  },
+  plugins: {
+    '@o3r': plugin
+  }
+});

--- a/packages/@o3r/eslint-config/src/rules/template.ts
+++ b/packages/@o3r/eslint-config/src/rules/template.ts
@@ -1,0 +1,11 @@
+import type { TSESLint } from '@typescript-eslint/utils';
+import * as o3r from '@o3r/eslint-plugin';
+import angular from 'angular-eslint';
+import o3rConfig from './template/otter';
+
+const config: TSESLint.FlatConfig.ConfigArray = [
+  ...angular.configs.templateRecommended,
+  ...o3rConfig(o3r)
+];
+
+export default config;

--- a/packages/@o3r/eslint-config/src/rules/template/otter.ts
+++ b/packages/@o3r/eslint-config/src/rules/template/otter.ts
@@ -1,0 +1,16 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { TSESLint } from '@typescript-eslint/utils';
+import o3rBaseConfig from '../base';
+
+export default (
+  plugin: TSESLint.FlatConfig.Plugin
+): TSESLint.FlatConfig.ConfigArray => [
+  o3rBaseConfig(plugin),
+  {
+    name: '@o3r/template',
+    files: ['**/*.html'],
+    rules: {
+      '@o3r/template-async-number-limitation': 'warn'
+    }
+  }
+];

--- a/packages/@o3r/eslint-config/src/rules/typescript.ts
+++ b/packages/@o3r/eslint-config/src/rules/typescript.ts
@@ -1,0 +1,67 @@
+import eslint from '@eslint/js';
+import * as o3r from '@o3r/eslint-plugin';
+import type { TSESLint } from '@typescript-eslint/utils';
+import angular from 'angular-eslint';
+import jsdoc from 'eslint-plugin-jsdoc';
+import typescript from 'typescript-eslint';
+import angularConfigOverrides from './typescript/eslint-angular.js';
+import typescriptConfigOverrides from './typescript/eslint-typescript.js';
+import eslintConfigOverrides from './typescript/eslint.js';
+import jsdocConfigOverrides from './typescript/jsdoc.js';
+import otterConfig from './typescript/otter.js';
+import preferArrowConfig from './typescript/prefer-arrow.js';
+import stylisticConfig from './typescript/stylistic.js';
+import unicornConfig from './typescript/unicorn.js';
+
+const getJestConfig = (type: 'recommended' | 'overrides'): TSESLint.FlatConfig.ConfigArray => {
+  try {
+    require.resolve('jest');
+    return type === 'overrides'
+      ? require('./rules/typescript/jest.js').default
+      : [{
+        // Name added for debugging purpose with @eslint/config-inspector
+        name: 'jest/flat-recommended',
+        ...require('eslint-plugin-jest').configs['flat/recommended']
+      }];
+  }
+  catch { return []; }
+};
+
+const config: TSESLint.FlatConfig.ConfigArray = [
+  {
+    // Name added for debugging purpose with @eslint/config-inspector
+    name: '@eslint/js/recommended',
+    ...eslint.configs.recommended
+  },
+  // TODO remove the `as any` once migrate @typescript-eslint/utils to v8
+  ...typescript.configs.recommended as any,
+  ...typescript.configs.recommendedTypeChecked,
+  ...angular.configs.tsRecommended,
+  jsdoc.configs['flat/recommended'],
+  ...(getJestConfig('recommended')),
+  // All recommended first as the order has an importance
+  ...eslintConfigOverrides,
+  ...typescriptConfigOverrides,
+  ...angularConfigOverrides,
+  ...jsdocConfigOverrides,
+  ...(getJestConfig('overrides')),
+  ...preferArrowConfig,
+  ...stylisticConfig,
+  ...unicornConfig,
+  ...otterConfig(o3r),
+  {
+    name: '@o3r/typescript/language-options',
+    languageOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      parserOptions: {
+        ecmaFeatures: {
+          modules: true,
+          jsx: false
+        }
+      }
+    }
+  }
+];
+
+export default config;

--- a/packages/@o3r/eslint-config/src/rules/typescript/eslint-angular.ts
+++ b/packages/@o3r/eslint-config/src/rules/typescript/eslint-angular.ts
@@ -1,0 +1,29 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { TSESLint } from '@typescript-eslint/utils';
+
+const config: TSESLint.FlatConfig.ConfigArray = [
+  {
+    name: '@o3r/overrides/angular-eslint',
+    rules: {
+      '@angular-eslint/no-input-rename': 'off',
+      '@angular-eslint/directive-class-suffix': 'off',
+      '@angular-eslint/no-empty-lifecycle-method': 'off',
+      '@angular-eslint/directive-selector': [
+        'error',
+        {
+          'type': 'attribute',
+          'style': 'camelCase'
+        }
+      ],
+      '@angular-eslint/component-selector': [
+        'error',
+        {
+          'type': 'element',
+          'style': 'kebab-case'
+        }
+      ]
+    }
+  }
+];
+
+export default config;

--- a/packages/@o3r/eslint-config/src/rules/typescript/eslint-typescript.ts
+++ b/packages/@o3r/eslint-config/src/rules/typescript/eslint-typescript.ts
@@ -1,0 +1,132 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { TSESLint } from '@typescript-eslint/utils';
+
+const config: TSESLint.FlatConfig.ConfigArray = [
+  {
+    name: '@o3r/overrides/typescript-eslint',
+    // Same files as the ones asked by `typescript-eslint` recommendation
+    files: ['**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts'],
+    rules: {
+      '@typescript-eslint/adjacent-overload-signatures': 'error',
+      '@typescript-eslint/array-type': [
+        'error',
+        {
+          'default': 'array'
+        }
+      ],
+      '@typescript-eslint/consistent-type-assertions': 'error',
+      '@typescript-eslint/dot-notation': 'error',
+      '@typescript-eslint/explicit-member-accessibility': [
+        'warn',
+        {
+          'accessibility': 'explicit',
+          'overrides': {
+            'constructors': 'off'
+          }
+        }
+      ],
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/member-ordering': [
+        'error',
+        {
+          'default': [
+            'static-field',
+            'instance-field',
+            'constructor',
+            'decorated-method',
+            'private-instance-method',
+            'protected-instance-method',
+            'public-instance-method'
+          ]
+        }
+      ],
+      '@typescript-eslint/naming-convention': [
+        'error',
+        {
+          'selector': 'default',
+          'format': ['camelCase'],
+          'leadingUnderscore': 'allow',
+          'trailingUnderscore': 'allow'
+        },
+        {
+          'selector': 'variable',
+          'format': ['camelCase', 'UPPER_CASE'],
+          'leadingUnderscore': 'allow',
+          'trailingUnderscore': 'allow'
+        },
+        {
+          'selector': 'typeLike',
+          'format': ['PascalCase']
+        },
+        {
+          'selector': 'property',
+          'modifiers': ['readonly'],
+          'format': ['camelCase', 'UPPER_CASE']
+        },
+        {
+          'selector': 'enumMember',
+          'format': ['camelCase', 'UPPER_CASE']
+        },
+        {
+          'selector': 'import',
+          'format': ['camelCase', 'PascalCase']
+        }
+      ],
+      '@typescript-eslint/no-dupe-class-members': 'error',
+      '@typescript-eslint/no-empty-function': 'off',
+      '@typescript-eslint/no-empty-object-type': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-inferrable-types': 'warn',
+      '@typescript-eslint/no-misused-promises': [
+        'error',
+        {
+          'checksVoidReturn': false
+        }
+      ],
+      '@typescript-eslint/no-namespace': 'off',
+      '@typescript-eslint/no-non-null-asserted-optional-chain': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
+      '@typescript-eslint/no-parameter-properties': 'off',
+      '@typescript-eslint/no-redeclare': 'error',
+      '@typescript-eslint/no-require-imports': 'warn',
+      '@typescript-eslint/no-shadow': [
+        'error',
+        {
+          'hoist': 'all'
+        }
+      ],
+      '@typescript-eslint/no-unsafe-enum-comparison': 'warn',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          'argsIgnorePattern': '^_',
+          'caughtErrors': 'none'
+        }
+      ],
+      '@typescript-eslint/no-use-before-define': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'warn',
+      '@typescript-eslint/no-unsafe-argument': 'warn',
+      '@typescript-eslint/no-unsafe-member-access': 'warn',
+      '@typescript-eslint/no-unsafe-call': 'warn',
+      '@typescript-eslint/no-unsafe-return': 'warn',
+      '@typescript-eslint/only-throw-error': 'warn',
+      '@typescript-eslint/prefer-for-of': 'error',
+      '@typescript-eslint/prefer-function-type': 'error',
+      '@typescript-eslint/prefer-promise-reject-errors': 'warn',
+      '@typescript-eslint/prefer-regexp-exec': 'off',
+      '@typescript-eslint/triple-slash-reference': [
+        'error',
+        {
+          'path': 'always',
+          'types': 'prefer-import',
+          'lib': 'always'
+        }
+      ],
+      '@typescript-eslint/unbound-method': 'warn',
+      '@typescript-eslint/unified-signatures': 'error',
+      '@typescript-eslint/prefer-readonly': 'error'
+    }
+  }
+];
+
+export default config;

--- a/packages/@o3r/eslint-config/src/rules/typescript/eslint.ts
+++ b/packages/@o3r/eslint-config/src/rules/typescript/eslint.ts
@@ -1,0 +1,133 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { TSESLint } from '@typescript-eslint/utils';
+
+const config: TSESLint.FlatConfig.ConfigArray = [
+  {
+    name: '@o3r/overrides/eslint-js',
+    rules: {
+      'camelcase': 'error',
+      'complexity': 'off',
+      'constructor-super': 'error',
+      'curly': 'error',
+      'dot-notation': 'error',
+      'eqeqeq': [
+        'error',
+        'smart'
+      ],
+      'getter-return': 'error',
+      'guard-for-in': 'error',
+      'id-denylist': ['error',
+        'any',
+        'Number',
+        'String',
+        'string',
+        'Boolean',
+        'boolean',
+        'Undefined',
+        'undefined'
+      ],
+      'id-match': 'error',
+      'max-classes-per-file': 'off',
+      'new-cap': [
+        'error',
+        {
+          'newIsCap': true,
+          'capIsNew': true,
+          'properties': true,
+          'capIsNewExceptions': [
+            'AsyncInput',
+            'Component',
+            'Directive',
+            'HostBinding',
+            'HostListener',
+            'Inject',
+            'Injectable',
+            'Input',
+            'Localization',
+            'NgModule',
+            'Optional',
+            'Output',
+            'Pipe',
+            'ViewChild',
+            'ViewChildren',
+            'SkipSelf',
+            'Host',
+            'ContentChildren',
+            'O3rComponent',
+            'ConfigObserver',
+            'O3rConfig'
+          ]
+        }
+      ],
+      'no-alert': 'error',
+      'no-bitwise': 'error',
+      'no-caller': 'error',
+      'no-console': 'error',
+      'no-delete-var': 'error',
+      'no-dupe-args': 'error',
+      'no-dupe-keys': 'error',
+      'no-duplicate-case': 'error',
+      'no-empty': 'off',
+      'no-empty-function': 'off',
+      'no-eval': 'error',
+      'no-func-assign': 'error',
+      'no-import-assign': 'error',
+      'no-inner-declarations': 'error',
+      'no-invalid-this': 'off',
+      'no-iterator': 'error',
+      'no-loop-func': 'warn',
+      'no-multi-str': 'error',
+      'no-new-native-nonconstructor': 'error',
+      'no-new-wrappers': 'error',
+      'no-obj-calls': 'error',
+      'no-proto': 'error',
+      'no-restricted-imports': ['error', {
+        'patterns': [
+          'rxjs/internal/*'
+        ]
+      }],
+      'no-sequences': 'error',
+      'no-setter-return': 'error',
+      'no-shadow': 'off',
+      'no-this-before-super': 'error',
+      'no-throw-literal': 'error',
+      'no-undef': 'error',
+      'no-undef-init': 'error',
+      'no-underscore-dangle': [
+        'error',
+        {
+          'allowAfterThis': true
+        }
+      ],
+      'no-unreachable': 'error',
+      'no-unsafe-negation': 'error',
+      'no-use-before-define': [
+        'error',
+        {
+          'classes': false
+        }
+      ],
+      'object-shorthand': 'off',
+      'one-var': [
+        'error',
+        'never'
+      ],
+      'radix': 'error',
+      'sort-imports': [
+        'error',
+        {
+          'allowSeparatedGroups': true,
+          'ignoreDeclarationSort': true,
+          'ignoreCase': true
+        }
+      ],
+      'strict': [
+        'error',
+        'global'
+      ],
+      'use-isnan': 'error'
+    }
+  }
+];
+
+export default config;

--- a/packages/@o3r/eslint-config/src/rules/typescript/jest.ts
+++ b/packages/@o3r/eslint-config/src/rules/typescript/jest.ts
@@ -1,0 +1,14 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { TSESLint } from '@typescript-eslint/utils';
+
+const config: TSESLint.FlatConfig.ConfigArray = [
+  {
+    name: '@o3r/overrides/jest',
+    rules: {
+      'jest/no-conditional-expect': 'warn',
+      'jest/no-done-callback': 'warn'
+    }
+  }
+];
+
+export default config;

--- a/packages/@o3r/eslint-config/src/rules/typescript/jsdoc.ts
+++ b/packages/@o3r/eslint-config/src/rules/typescript/jsdoc.ts
@@ -1,0 +1,36 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { TSESLint } from '@typescript-eslint/utils';
+
+const config: TSESLint.FlatConfig.ConfigArray = [
+  {
+    name: '@o3r/overrides/jsdoc',
+    rules: {
+      'jsdoc/check-alignment': 'error',
+      // TODO fix issue with ESLint v9+
+      // 'jsdoc/check-examples': ['error', {
+      //   'exampleCodeRegex': '^```(?:javascript|typescript|java|json|yaml|shell)?([\\s\\S]*)```\\s*$'
+      // }],
+      'jsdoc/check-tag-names': [
+        'warn',
+        {
+          'definedTags': ['note', 'title', 'o3rCategory', 'o3rWidget', 'o3rWidgetParam', 'o3rRequired']
+        }
+      ],
+      'jsdoc/no-defaults': 'off',
+      'jsdoc/no-undefined-types': 'off',
+      'jsdoc/require-description': 'warn',
+      'jsdoc/require-jsdoc': [
+        'error',
+        {
+          'publicOnly': true
+        }
+      ],
+      'jsdoc/require-param-type': 'off',
+      'jsdoc/require-property-type': 'off',
+      'jsdoc/require-returns': 'off',
+      'jsdoc/require-returns-type': 'off'
+    }
+  }
+];
+
+export default config;

--- a/packages/@o3r/eslint-config/src/rules/typescript/otter.ts
+++ b/packages/@o3r/eslint-config/src/rules/typescript/otter.ts
@@ -1,0 +1,20 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { TSESLint } from '@typescript-eslint/utils';
+import o3rBaseConfig from '../base';
+
+export default (
+  plugin: TSESLint.FlatConfig.Plugin
+): TSESLint.FlatConfig.ConfigArray => [
+  o3rBaseConfig(plugin),
+  {
+    name: '@o3r/typescript',
+    // Same files as the ones asked by `typescript-eslint` recommendation
+    files: ['**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts'],
+    rules: {
+      '@o3r/matching-configuration-name': 'error',
+      '@o3r/no-multiple-type-configuration-property': 'error',
+      '@o3r/no-folder-import-for-module': 'error',
+      '@o3r/o3r-categories-tags': 'error'
+    }
+  }
+];

--- a/packages/@o3r/eslint-config/src/rules/typescript/prefer-arrow.ts
+++ b/packages/@o3r/eslint-config/src/rules/typescript/prefer-arrow.ts
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { TSESLint } from '@typescript-eslint/utils';
+// @ts-expect-error -- this package does not expose typings
+import preferArrowPlugin from 'eslint-plugin-prefer-arrow';
+
+const config: TSESLint.FlatConfig.ConfigArray = [
+  {
+    name: '@o3r/overrides/prefer-arrow',
+    plugins: {
+      'prefer-arrow': preferArrowPlugin
+    },
+    rules: {
+      'prefer-arrow/prefer-arrow-functions': [
+        'error',
+        {
+          'allowStandaloneDeclarations': true
+        }
+      ]
+    }
+  }
+];
+
+export default config;

--- a/packages/@o3r/eslint-config/src/rules/typescript/stylistic.ts
+++ b/packages/@o3r/eslint-config/src/rules/typescript/stylistic.ts
@@ -1,0 +1,146 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { TSESLint } from '@typescript-eslint/utils';
+import stylisticJs from '@stylistic/eslint-plugin-js';
+import stylisticTs from '@stylistic/eslint-plugin-ts';
+
+const config: TSESLint.FlatConfig.ConfigArray = [
+  {
+    name: '@o3r/overrides/stylistic-js',
+    plugins: {
+      '@stylistic/js': stylisticJs
+    },
+    rules: {
+      '@stylistic/js/comma-dangle': 'error',
+      '@stylistic/js/comma-style': [
+        'error',
+        'last'
+      ],
+      '@stylistic/js/dot-location': [
+        'error',
+        'property'
+      ],
+      '@stylistic/js/eol-last': 'error',
+      '@stylistic/js/indent': [
+        'error',
+        2,
+        {
+          'FunctionDeclaration': {
+            'parameters': 'off'
+          },
+          'SwitchCase': 1
+        }
+      ],
+      '@stylistic/js/key-spacing': [
+        'warn',
+        {
+          'beforeColon': false,
+          'afterColon': true
+        }
+      ],
+      '@stylistic/js/linebreak-style': [
+        'error',
+        'unix'
+      ],
+      '@stylistic/js/max-len': [
+        'error',
+        {
+          'code': 200
+        }
+      ],
+      '@stylistic/js/new-parens': 'error',
+      '@stylistic/js/no-mixed-spaces-and-tabs': 'error',
+      '@stylistic/js/no-multi-spaces': 'error',
+      '@stylistic/js/no-multiple-empty-lines': 'off',
+      '@stylistic/js/no-trailing-spaces': 'error',
+      '@stylistic/js/quotes': [
+        'error',
+        'single',
+        {
+          'allowTemplateLiterals': true
+        }
+      ],
+      '@stylistic/js/semi': [
+        'error',
+        'always'
+      ],
+      '@stylistic/js/semi-spacing': [
+        'warn',
+        {
+          'before': false,
+          'after': true
+        }
+      ],
+      '@stylistic/js/space-in-parens': [
+        'error',
+        'never'
+      ],
+      '@stylistic/js/space-unary-ops': 'warn',
+      '@stylistic/js/spaced-comment': [
+        'error',
+        'always',
+        {
+          'markers': [
+            '/'
+          ]
+        }
+      ],
+      '@stylistic/js/wrap-iife': [
+        'error',
+        'inside'
+      ]
+    }
+  },
+  {
+    name: '@o3r/overrides/stylistic-ts',
+    plugins: {
+      '@stylistic/ts': stylisticTs
+    },
+    rules: {
+      '@stylistic/ts/key-spacing': [
+        'warn',
+        {
+          'beforeColon': false,
+          'afterColon': true
+        }
+      ],
+      '@stylistic/ts/keyword-spacing': 'error',
+      '@stylistic/ts/semi': [
+        'error',
+        'always'
+      ],
+      '@stylistic/ts/space-infix-ops': 'error',
+      '@stylistic/ts/no-extra-semi': 'error',
+      '@stylistic/ts/space-before-function-paren': [
+        'error',
+        {
+          'anonymous': 'always',
+          'named': 'never',
+          'asyncArrow': 'always'
+        }
+      ],
+      '@stylistic/ts/quotes': [
+        'error',
+        'single',
+        {
+          'avoidEscape': true,
+          'allowTemplateLiterals': true
+        }
+      ],
+      '@stylistic/ts/member-delimiter-style': [
+        'error',
+        {
+          'multiline': {
+            'delimiter': 'semi',
+            'requireLast': true
+          },
+          'singleline': {
+            'delimiter': 'semi',
+            'requireLast': false
+          }
+        }
+      ]
+    }
+  }
+];
+
+export default config;

--- a/packages/@o3r/eslint-config/src/rules/typescript/unicorn.ts
+++ b/packages/@o3r/eslint-config/src/rules/typescript/unicorn.ts
@@ -1,0 +1,19 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { TSESLint } from '@typescript-eslint/utils';
+import unicornPlugin from 'eslint-plugin-unicorn';
+
+const config: TSESLint.FlatConfig.ConfigArray = [
+  {
+    name: '@o3r/overrides/unicorn',
+    plugins: {
+      unicorn: unicornPlugin
+    },
+    rules: {
+      'unicorn/prefer-node-protocol': 'error',
+      'unicorn/switch-case-braces': 'warn',
+      'unicorn/text-encoding-identifier-case': 'warn'
+    }
+  }
+];
+
+export default config;

--- a/packages/@o3r/eslint-config/testing/jest.config.it.js
+++ b/packages/@o3r/eslint-config/testing/jest.config.it.js
@@ -1,0 +1,8 @@
+const { join } = require('node:path');
+const getJestConfig = require('../../../../jest.config.it').getJestConfig;
+
+/** @type {import('ts-jest/dist/types').JestConfigWithTsJest} */
+module.exports = {
+  ...getJestConfig(join(__dirname, '..')),
+  displayName: require('../package.json').name
+};

--- a/packages/@o3r/eslint-config/testing/jest.config.ut.builders.js
+++ b/packages/@o3r/eslint-config/testing/jest.config.ut.builders.js
@@ -1,0 +1,16 @@
+const path = require('node:path');
+const getJestProjectConfig = require('../../../../jest.config.ut').getJestProjectConfig;
+const rootDir = path.join(__dirname, '..');
+
+/** @type {import('ts-jest/dist/types').JestConfigWithTsJest} */
+module.exports = {
+  ...getJestProjectConfig(rootDir, false),
+  displayName: `${require('../package.json').name}/builders`,
+  rootDir,
+  setupFilesAfterEnv: ['<rootDir>/testing/setup-jest.builders.ts'],
+  testPathIgnorePatterns: [
+    '<rootDir>/.*/templates/.*',
+    '<rootDir>/src/.*',
+    '\\.it\\.spec\\.ts$'
+  ]
+};

--- a/packages/@o3r/eslint-config/testing/jest.config.ut.js
+++ b/packages/@o3r/eslint-config/testing/jest.config.ut.js
@@ -1,0 +1,19 @@
+const path = require('node:path');
+const getJestProjectConfig = require('../../../../jest.config.ut').getJestProjectConfig;
+const rootDir = path.join(__dirname, '..');
+
+/** @type {import('ts-jest/dist/types').JestConfigWithTsJest} */
+module.exports = {
+  ...getJestProjectConfig(rootDir, false),
+  displayName: require('../package.json').name,
+  rootDir,
+  fakeTimers: {
+    enableGlobally: true,
+    advanceTimers: true
+  },
+  testPathIgnorePatterns: [
+    '<rootDir>/.*/templates/.*',
+    '<rootDir>/schematics/.*',
+    '\\.it\\.spec\\.ts$'
+  ]
+};

--- a/packages/@o3r/eslint-config/tsconfig.build.json
+++ b/packages/@o3r/eslint-config/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.build",
+  "compilerOptions": {
+    "incremental": true,
+    "composite": true,
+    "module": "CommonJS",
+    "esModuleInterop": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/@o3r/eslint-config/tsconfig.builders.json
+++ b/packages/@o3r/eslint-config/tsconfig.builders.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../../tsconfig.build",
+  "compilerOptions": {
+    "incremental": true,
+    "composite": true,
+    "outDir": "./dist",
+    "module": "CommonJS",
+    "rootDir": ".",
+    "tsBuildInfoFile": "build/.tsbuildinfo.builders"
+  },
+  "include": [
+    "schematics/**/*.ts",
+  ],
+  "exclude": [
+    "**/*.spec.ts",
+    "schematics/**/templates/**"
+  ]
+}

--- a/packages/@o3r/eslint-config/tsconfig.eslint.json
+++ b/packages/@o3r/eslint-config/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base",
+  "include": [
+    "testing/setup-jest.builders.ts",
+    "testing/setup-jest.ts",
+    ".eslintrc.js"
+  ]
+}

--- a/packages/@o3r/eslint-config/tsconfig.json
+++ b/packages/@o3r/eslint-config/tsconfig.json
@@ -1,0 +1,15 @@
+/* For IDE usage only */
+{
+  "extends": "../../../tsconfig.base",
+  "references": [
+    {
+      "path": "./tsconfig.build.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.builders.json"
+    }
+  ]
+}

--- a/packages/@o3r/eslint-config/tsconfig.spec.json
+++ b/packages/@o3r/eslint-config/tsconfig.spec.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.jest",
+  "references": [
+    {
+      "path": "./tsconfig.builders.json"
+    }
+  ],
+  "include": [
+    "**/*.spec.ts"
+  ],
+  "exclude": []
+}

--- a/packages/@o3r/eslint-plugin/src/rules/json/utils.ts
+++ b/packages/@o3r/eslint-plugin/src/rules/json/utils.ts
@@ -37,7 +37,7 @@ export function isObjectExpression(node?: { type: string }): node is AST.JSONObj
  * @param context Rule context
  */
 export function getJsoncParserServices(context: Readonly<TSESLint.RuleContext<string, readonly unknown[]>>) {
-  const parserService = context.parserServices;
+  const parserService = context.sourceCode.parserServices;
   if (!isJsoncParserServices(parserService)) {
     /*
      * The user needs to have configured "parser" in their eslint config and set it
@@ -56,7 +56,7 @@ export function getJsoncParserServices(context: Readonly<TSESLint.RuleContext<st
  * @param context
  */
 export function ensureJsoncParser(context: Readonly<TSESLint.RuleContext<string, readonly unknown[]>>): void {
-  if (!(context.parserServices)) {
+  if (!(context.sourceCode.parserServices)) {
     /*
      * The user needs to have configured "parser" in their eslint config and set it
      * to jsonc-eslint-parser

--- a/packages/@o3r/eslint-plugin/src/rules/template/utils.ts
+++ b/packages/@o3r/eslint-plugin/src/rules/template/utils.ts
@@ -34,7 +34,7 @@ export function isTemplateParserServices(parserServices: any): parserServices is
  * @param context Rule context
  */
 export function getTemplateParserServices(context: Readonly<TSESLint.RuleContext<string, readonly unknown[]>>) {
-  const parserService = context.parserServices;
+  const parserService = context.sourceCode.parserServices;
   if (!isTemplateParserServices(parserService)) {
     /*
      * The user needs to have configured "parser" in their eslint config and set it

--- a/packages/@o3r/eslint-plugin/src/rules/yaml/utils.ts
+++ b/packages/@o3r/eslint-plugin/src/rules/yaml/utils.ts
@@ -18,7 +18,7 @@ export function isYamlParserServices(parserServices: any): parserServices is Yam
  * @param context Rule context
  */
 export function getYamlParserServices(context: Readonly<TSESLint.RuleContext<string, readonly unknown[]>>) {
-  const parserService = context.parserServices;
+  const parserService = context.sourceCode.parserServices;
   if (!isYamlParserServices(parserService)) {
     /*
      * The user needs to have configured "parser" in their eslint config and set it
@@ -37,7 +37,7 @@ export function getYamlParserServices(context: Readonly<TSESLint.RuleContext<str
  * @param context
  */
 export function ensureJsoncParser(context: Readonly<TSESLint.RuleContext<string, readonly unknown[]>>): void {
-  if (!(context.parserServices)) {
+  if (!(context.sourceCode.parserServices)) {
     /*
      * The user needs to have configured "parser" in their eslint config and set it
      * to yaml-eslint-parser

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -130,6 +130,9 @@
       "@o3r/dynamic-content/*": [
         "packages/@o3r/dynamic-content/src/*/public_api"
       ],
+      "@o3r/eslint-config": [
+        "packages/@o3r/eslint-config/src/public_api"
+      ],
       "@o3r/eslint-config-otter": [
         "packages/@o3r/eslint-config-otter"
       ],

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -28,6 +28,7 @@
       "@o3r/design": ["packages/@o3r/design/dist", "packages/@o3r/design/src/public_api"],
       "@o3r/dynamic-content": ["packages/@o3r/dynamic-content/dist", "packages/@o3r/dynamic-content/src/public_api"],
       "@o3r/dynamic-content/*": ["packages/@o3r/dynamic-content/dist/*", "packages/@o3r/dynamic-content/src/*/public_api"],
+      "@o3r/eslint-config": ["packages/@o3r/eslint-config/dist", "packages/@o3r/eslint-config/src/public_api"],
       "@o3r/eslint-config-otter": ["packages/@o3r/eslint-config-otter"],
       "@o3r/eslint-plugin": ["packages/@o3r/eslint-plugin/dist", "packages/@o3r/eslint-plugin/src/public_api"],
       "@o3r/extractors": ["packages/@o3r/extractors/dist", "packages/@o3r/extractors/src/public_api"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1024,7 +1024,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular-eslint/builder@npm:~18.3.0":
+"@angular-eslint/builder@npm:18.3.0, @angular-eslint/builder@npm:~18.3.0":
   version: 18.3.0
   resolution: "@angular-eslint/builder@npm:18.3.0"
   peerDependencies:
@@ -1041,7 +1041,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular-eslint/eslint-plugin-template@npm:~18.3.0":
+"@angular-eslint/eslint-plugin-template@npm:18.3.0, @angular-eslint/eslint-plugin-template@npm:~18.3.0":
   version: 18.3.0
   resolution: "@angular-eslint/eslint-plugin-template@npm:18.3.0"
   dependencies:
@@ -1057,7 +1057,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular-eslint/eslint-plugin@npm:~18.3.0":
+"@angular-eslint/eslint-plugin@npm:18.3.0, @angular-eslint/eslint-plugin@npm:~18.3.0":
   version: 18.3.0
   resolution: "@angular-eslint/eslint-plugin@npm:18.3.0"
   dependencies:
@@ -1071,7 +1071,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular-eslint/template-parser@npm:~18.3.0":
+"@angular-eslint/schematics@npm:18.3.0":
+  version: 18.3.0
+  resolution: "@angular-eslint/schematics@npm:18.3.0"
+  dependencies:
+    "@angular-eslint/eslint-plugin": "npm:18.3.0"
+    "@angular-eslint/eslint-plugin-template": "npm:18.3.0"
+    ignore: "npm:5.3.2"
+    semver: "npm:7.6.3"
+    strip-json-comments: "npm:3.1.1"
+  peerDependencies:
+    "@angular-devkit/core": ">= 18.0.0 < 19.0.0"
+    "@angular-devkit/schematics": ">= 18.0.0 < 19.0.0"
+  checksum: 10/2dd32c7d250a605ed95266f084ea6a6253c3a62158c34ee375a74248273be44e8457b320d28136cfb69993a9affd02040cce964981f7fefb65846d609a1b725d
+  languageName: node
+  linkType: hard
+
+"@angular-eslint/template-parser@npm:18.3.0, @angular-eslint/template-parser@npm:~18.3.0":
   version: 18.3.0
   resolution: "@angular-eslint/template-parser@npm:18.3.0"
   dependencies:
@@ -4383,6 +4399,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/js@npm:9.10.0":
+  version: 9.10.0
+  resolution: "@eslint/js@npm:9.10.0"
+  checksum: 10/cbda2bf268c8ac7a2b2493aaaa0113a78165a576ee5178b9fbdaf245c3d40ffaf41d006f75afab5718f68d816f00319e267b4c88ead100b19022fe491f9e0175
+  languageName: node
+  linkType: hard
+
 "@fal-works/esbuild-plugin-global-externals@npm:^2.1.2":
   version: 2.1.2
   resolution: "@fal-works/esbuild-plugin-global-externals@npm:2.1.2"
@@ -7618,7 +7641,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^7.14.1
     "@typescript-eslint/parser": ^7.14.1
     "@typescript-eslint/utils": ^7.14.1
-    eslint: ^8.57.0
+    eslint: ^8.57.0 || ^9.0.0
     eslint-import-resolver-node: ^0.3.4
     eslint-plugin-jasmine: ^4.1.3
     eslint-plugin-jest: ^28.0.0
@@ -7634,6 +7657,90 @@ __metadata:
     "@angular-eslint/eslint-plugin-template":
       optional: true
     "@angular-eslint/template-parser":
+      optional: true
+    "@angular/compiler":
+      optional: true
+    "@o3r/schematics":
+      optional: true
+    "@schematics/angular":
+      optional: true
+    eslint-plugin-jasmine:
+      optional: true
+    eslint-plugin-jest:
+      optional: true
+    typescript:
+      optional: true
+  languageName: unknown
+  linkType: soft
+
+"@o3r/eslint-config@workspace:packages/@o3r/eslint-config":
+  version: 0.0.0-use.local
+  resolution: "@o3r/eslint-config@workspace:packages/@o3r/eslint-config"
+  dependencies:
+    "@angular-devkit/core": "npm:~18.2.0"
+    "@angular-devkit/schematics": "npm:~18.2.0"
+    "@angular-eslint/eslint-plugin": "npm:~18.3.0"
+    "@angular/compiler": "npm:~18.2.0"
+    "@eslint/js": "npm:9.10.0"
+    "@nx/eslint-plugin": "npm:~19.5.0"
+    "@o3r/build-helpers": "workspace:^"
+    "@o3r/eslint-plugin": "workspace:^"
+    "@o3r/schematics": "workspace:^"
+    "@o3r/test-helpers": "workspace:^"
+    "@schematics/angular": "npm:~18.2.0"
+    "@stylistic/eslint-plugin-js": "npm:~2.4.0"
+    "@stylistic/eslint-plugin-ts": "npm:~2.4.0"
+    "@types/eslint__js": "npm:^8.42.3"
+    "@types/jest": "npm:~29.5.2"
+    "@types/node": "npm:^20.0.0"
+    "@typescript-eslint/eslint-plugin": "npm:^7.14.1"
+    "@typescript-eslint/parser": "npm:^7.14.1"
+    "@typescript-eslint/utils": "npm:^7.14.1"
+    angular-eslint: "npm:~18.3.0"
+    cpy-cli: "npm:^5.0.0"
+    eslint: "npm:^8.57.0"
+    eslint-import-resolver-node: "npm:^0.3.9"
+    eslint-plugin-jasmine: "npm:^4.1.3"
+    eslint-plugin-jest: "npm:~28.8.0"
+    eslint-plugin-jsdoc: "npm:~48.11.0"
+    eslint-plugin-prefer-arrow: "npm:~1.2.3"
+    eslint-plugin-unicorn: "npm:^54.0.0"
+    jest: "npm:~29.7.0"
+    jest-junit: "npm:~16.0.0"
+    jsonc-eslint-parser: "npm:~2.4.0"
+    nx: "npm:~19.5.0"
+    pid-from-port: "npm:^1.1.3"
+    rxjs: "npm:^7.8.1"
+    semver: "npm:^7.5.2"
+    ts-jest: "npm:~29.2.0"
+    ts-node: "npm:~10.9.2"
+    tslib: "npm:^2.6.2"
+    typescript: "npm:~5.5.4"
+    typescript-eslint: "npm:^8.0.0"
+  peerDependencies:
+    "@angular-devkit/schematics": ~18.2.0
+    "@angular/compiler": ~18.2.0
+    "@eslint/js": 9.10.0
+    "@o3r/eslint-plugin": "workspace:^"
+    "@o3r/schematics": "workspace:^"
+    "@schematics/angular": ~18.2.0
+    "@stylistic/eslint-plugin-js": ^2.4.0
+    "@stylistic/eslint-plugin-ts": ^2.4.0
+    "@typescript-eslint/utils": ^7.14.1 || ^8.0.0
+    angular-eslint: ^18.3.0
+    eslint: ^8.57.0 || ^9.0.0
+    eslint-import-resolver-node: ^0.3.4
+    eslint-plugin-jasmine: ^4.1.3
+    eslint-plugin-jest: ^28.0.0
+    eslint-plugin-jsdoc: ^48.11.0 || ^49.0.0 || ^50.0.0
+    eslint-plugin-prefer-arrow: ^1.2.2
+    eslint-plugin-unicorn: ^54.0.0 || ^55.0.0
+    jest: ~29.7.0
+    ts-node: ~10.9.2
+    typescript: ~5.5.4
+    typescript-eslint: ^8.0.0
+  peerDependenciesMeta:
+    "@angular-devkit/schematics":
       optional: true
     "@angular/compiler":
       optional: true
@@ -11459,7 +11566,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stylistic/eslint-plugin-js@npm:2.4.0":
+"@stylistic/eslint-plugin-js@npm:2.4.0, @stylistic/eslint-plugin-js@npm:~2.4.0":
   version: 2.4.0
   resolution: "@stylistic/eslint-plugin-js@npm:2.4.0"
   dependencies:
@@ -12011,13 +12118,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint@npm:^9.6.0, @types/eslint@npm:~9.6.0":
+"@types/eslint@npm:*, @types/eslint@npm:^9.6.0, @types/eslint@npm:~9.6.0":
   version: 9.6.1
   resolution: "@types/eslint@npm:9.6.1"
   dependencies:
     "@types/estree": "npm:*"
     "@types/json-schema": "npm:*"
   checksum: 10/719fcd255760168a43d0e306ef87548e1e15bffe361d5f4022b0f266575637acc0ecb85604ac97879ee8ae83c6a6d0613b0ed31d0209ddf22a0fe6d608fc56fe
+  languageName: node
+  linkType: hard
+
+"@types/eslint__js@npm:^8.42.3":
+  version: 8.42.3
+  resolution: "@types/eslint__js@npm:8.42.3"
+  dependencies:
+    "@types/eslint": "npm:*"
+  checksum: 10/e31f19de642d35a664695d0cab873ce6de19b8a3506755835b91f8a49a8c41099dcace449df49f1a486de6fa6565d21ceb1fa33be6004fc7adef9226e5d256a1
   languageName: node
   linkType: hard
 
@@ -12682,6 +12798,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/eslint-plugin@npm:8.5.0":
+  version: 8.5.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.5.0"
+  dependencies:
+    "@eslint-community/regexpp": "npm:^4.10.0"
+    "@typescript-eslint/scope-manager": "npm:8.5.0"
+    "@typescript-eslint/type-utils": "npm:8.5.0"
+    "@typescript-eslint/utils": "npm:8.5.0"
+    "@typescript-eslint/visitor-keys": "npm:8.5.0"
+    graphemer: "npm:^1.4.0"
+    ignore: "npm:^5.3.1"
+    natural-compare: "npm:^1.4.0"
+    ts-api-utils: "npm:^1.3.0"
+  peerDependencies:
+    "@typescript-eslint/parser": ^8.0.0 || ^8.0.0-alpha.0
+    eslint: ^8.57.0 || ^9.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/344f5aca7e167544af718b81269b87b8c2a041210882cac76e1608dbec7c2a646de74387920ca9a5704fcd4c24ada052c2bc5adbeee39e950e7bce83647dae7d
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/eslint-plugin@npm:^7.14.1":
   version: 7.18.0
   resolution: "@typescript-eslint/eslint-plugin@npm:7.18.0"
@@ -12702,6 +12841,24 @@ __metadata:
     typescript:
       optional: true
   checksum: 10/6ee4c61f145dc05f0a567b8ac01b5399ef9c75f58bc6e9a3ffca8927b15e2be2d4c3fd32a2c1a7041cc0848fdeadac30d9cb0d3bcd3835d301847a88ffd19c4d
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/parser@npm:8.5.0":
+  version: 8.5.0
+  resolution: "@typescript-eslint/parser@npm:8.5.0"
+  dependencies:
+    "@typescript-eslint/scope-manager": "npm:8.5.0"
+    "@typescript-eslint/types": "npm:8.5.0"
+    "@typescript-eslint/typescript-estree": "npm:8.5.0"
+    "@typescript-eslint/visitor-keys": "npm:8.5.0"
+    debug: "npm:^4.3.4"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/f0d5a11a8d4b42750c3e7a3a8f6874740c7bb006b6bf3037a2b1422ba8f4eb2ff2d46e673a9f54007b95d3e4302b7966677b2481da58b6307d0ceb962478ee95
   languageName: node
   linkType: hard
 
@@ -12777,6 +12934,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/type-utils@npm:8.5.0":
+  version: 8.5.0
+  resolution: "@typescript-eslint/type-utils@npm:8.5.0"
+  dependencies:
+    "@typescript-eslint/typescript-estree": "npm:8.5.0"
+    "@typescript-eslint/utils": "npm:8.5.0"
+    debug: "npm:^4.3.4"
+    ts-api-utils: "npm:^1.3.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/ed487c8b530a0a6ea292385c82b2d9d9d94b99768ddd93882899be3319ea6af09c1b9f1a07e0381beb6149bbbb1f66ae95a635279fad8946345fd2298bce3549
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/types@npm:7.18.0, @typescript-eslint/types@npm:^7.14.1":
   version: 7.18.0
   resolution: "@typescript-eslint/types@npm:7.18.0"
@@ -12843,7 +13015,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
+"@typescript-eslint/utils@npm:8.5.0, @typescript-eslint/utils@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
   version: 8.5.0
   resolution: "@typescript-eslint/utils@npm:8.5.0"
   dependencies:
@@ -14179,6 +14351,23 @@ __metadata:
     "@algolia/requester-node-http": "npm:4.24.0"
     "@algolia/transporter": "npm:4.24.0"
   checksum: 10/fba851fb719529754b450c3d366de72289351c864aea56aa1c167ff0e36d5b015dddae7d720fe649a00d6c91d94a2091fb27789e553eb79c8d28a885585ccc6f
+  languageName: node
+  linkType: hard
+
+"angular-eslint@npm:~18.3.0":
+  version: 18.3.0
+  resolution: "angular-eslint@npm:18.3.0"
+  dependencies:
+    "@angular-eslint/builder": "npm:18.3.0"
+    "@angular-eslint/eslint-plugin": "npm:18.3.0"
+    "@angular-eslint/eslint-plugin-template": "npm:18.3.0"
+    "@angular-eslint/schematics": "npm:18.3.0"
+    "@angular-eslint/template-parser": "npm:18.3.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+    typescript: "*"
+    typescript-eslint: ^8.0.0
+  checksum: 10/e8c14311e1e2c933b74aa3e02e8ecbc7493f8b3b103fd6ee7f07ca51200476075814f6dbd8e371bddaaf29cd0960bf52f97db956c503b31a4fa240e71634e462
   languageName: node
   linkType: hard
 
@@ -21360,7 +21549,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.0.4, ignore@npm:^5.1.9, ignore@npm:^5.2.0, ignore@npm:^5.2.4, ignore@npm:^5.3.1, ignore@npm:^5.3.2":
+"ignore@npm:5.3.2, ignore@npm:^5.0.4, ignore@npm:^5.1.9, ignore@npm:^5.2.0, ignore@npm:^5.2.4, ignore@npm:^5.3.1, ignore@npm:^5.3.2":
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
   checksum: 10/cceb6a457000f8f6a50e1196429750d782afce5680dd878aa4221bd79972d68b3a55b4b1458fc682be978f4d3c6a249046aa0880637367216444ab7b014cfc98
@@ -30318,7 +30507,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-json-comments@npm:^3.1.1":
+"strip-json-comments@npm:3.1.1, strip-json-comments@npm:^3.1.1":
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 10/492f73e27268f9b1c122733f28ecb0e7e8d8a531a6662efbd08e22cccb3f9475e90a1b82cab06a392f6afae6d2de636f977e231296400d0ec5304ba70f166443
@@ -31658,6 +31847,20 @@ __metadata:
   bin:
     typedoc: bin/typedoc
   checksum: 10/1b8ff53fa108fec664af5497c7a11d72074f6e58e7bac7e3e884a8ee9173b38efad50e67df7d961830e218af58429760bfe464739a9e26b03e1c0d3937d5424d
+  languageName: node
+  linkType: hard
+
+"typescript-eslint@npm:^8.0.0":
+  version: 8.5.0
+  resolution: "typescript-eslint@npm:8.5.0"
+  dependencies:
+    "@typescript-eslint/eslint-plugin": "npm:8.5.0"
+    "@typescript-eslint/parser": "npm:8.5.0"
+    "@typescript-eslint/utils": "npm:8.5.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/d6be19355c5bca594af3cfb7df6c882d8c91a00d8e31bd0176e20b161ac9fb3c50b6aaf51d0995bd77f5d2fda75ed46531e2d8c2dca82a2b934811c7d2faf781
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed change

Provide a FlatConfig for ESLint v9 migration

> [!NOTE]
> This PR is not targetting `main`.
> I will create a PR for `main` once everything below will be merged on `feat/migrate-eslint-9-flat-config`

Will be done in others PRs:
- [ ] Migrate the repo to `FlatConfig` using `@o3r/eslint-config` instead of `@o3r/eslint-config-otter` (+ fix errors and warnings due to the new config)
- [ ] Create `@o3r/eslint-config` ng-add and update `@o3r/core` ng-add to install `@o3r/eslint-config` or `@o3r/eslint-config-otter` depending on ESLint configuration found (FlatConfig or LegacyConfig)
- [ ] Review with the team the config exposed in `@o3r/eslint-config` (fix `jsdoc/check-examples`)
- [ ] Document the difference of rules between the 2 configs (+ link to migrate to ESLint v9) + update global documentation (docs/linter/*)
- [ ] Bonus: CLI to detect deprecated rules