### PR TITLE
ci: check releases

### DIFF
--- a/.github/check-release-issue-template.md
+++ b/.github/check-release-issue-template.md
@@ -1,0 +1,6 @@
+---
+title: Some releases are failing the automated checks
+labels: bug
+---
+On {{ date | date('D MMM YYYY') }} some releases failed the automated checks.
+Check the [action result]({{ env.RUN_URL }}).

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,11 +1,16 @@
 name: NPM Audit
 
 concurrency:
-  group: ci-${{ github.ref }}-audit
+  group: ci-${{ github.ref }}-${{ inputs.ref }}-audit
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        type: string
+        default: ''
+        description: The branch, tag or SHA to checkout.
   push:
     branches:
       - main
@@ -25,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.ref }}
       - name: Setup
         uses: ./tools/github-actions/setup
       - name: Audit

--- a/.github/workflows/check-all-releases.yml
+++ b/.github/workflows/check-all-releases.yml
@@ -1,0 +1,78 @@
+name: Check all releases (latest patch of each minor version for the last 3 majors)
+
+on:
+  workflow_dispatch:
+    performAudit:
+      type: boolean
+      default: true
+      description: Run Audit
+    performITTests:
+      type: boolean
+      default: false
+      description: Run IT Tests
+  schedule:
+    - cron: "0 0 * * 6"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  findTags:
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.getTags.outputs.TAGS }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Get the latest patch of each minor version for the last 3 majors
+        run: |
+          # Extract all releases
+          RELEASE_TAG_PATTERN="^v[0-9]+\.[0-9]+\.[0-9]+$"
+          ALL_RELEASES=$(git tag -l | sort -V | grep -E $RELEASE_TAG_PATTERN)
+          SUPPORTED_MAJORS=$(echo $ALL_RELEASES | tr ' ' '\n' | awk -F. '{print $1}' | uniq | tail -n 3)
+          ALL_SUPPORTED_RELEASES=$(echo $ALL_RELEASES | tr ' ' '\n' | grep -E "^($(echo $SUPPORTED_MAJORS | tr ' ' '|'))\.")
+          echo "Supported releases: $ALL_SUPPORTED_RELEASES"
+
+          # Take the latest minor for each previous major version
+          LATEST_MINOR_OF_EACH_MAJOR=$(echo $ALL_SUPPORTED_RELEASES | tr ' ' '\n' | awk -F. '{print $1}' | uniq | xargs -I {} sh -c "echo '$ALL_SUPPORTED_RELEASES' | grep -E '^{}.*' | tail -n 1" | head -n -1)
+          echo "Found latest minor of each major versions: $LATEST_MINOR_OF_EACH_MAJOR"
+
+          # Take the latest patch for each minor version of the current major
+          ALL_LATEST_MAJOR_RELEASES=$(echo $ALL_SUPPORTED_RELEASES | tr ' ' '\n' | awk -F. '{print $1}' | uniq | tail -n 1 | xargs -I {} sh -c "echo '$ALL_SUPPORTED_RELEASES' | grep -E '^{}.*'")
+          LATEST_PATCH_OF_EACH_MINOR=$(echo $ALL_LATEST_MAJOR_RELEASES | tr ' ' '\n' | awk -F. '{print $1 "." $2}' | uniq | xargs -I {} sh -c "echo '$ALL_LATEST_MAJOR_RELEASES' | grep -E '^{}.*' | tail -n 1")
+          echo "Found latest patch of each minor versions: $LATEST_PATCH_OF_EACH_MINOR"
+
+          # Export output in JSON format
+          TAGS=$(echo $LATEST_MINOR_OF_EACH_MAJOR $LATEST_PATCH_OF_EACH_MINOR | tr ' ' '\n' | awk '{print "\"" $0 "\""}' | tr '\n' ',')
+          echo "TAGS=[$TAGS]" >> "$GITHUB_OUTPUT"
+        id: getTags
+
+  checkRelease:
+    needs: findTags
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: ${{ fromJSON(needs.findTags.outputs.tags) }}
+    uses: ./.github/workflows/check-release.yml
+    with:
+      ref: ${{ matrix.tag }}
+      performAudit: ${{ inputs.performAudit || true }}
+      performITTests: ${{ inputs.performITTests || false }}
+
+  report:
+    runs-on: ubuntu-latest
+    needs: checkRelease
+    if: failure()
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Create an issue
+        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ format('https://github.com/{0}/actions/runs/{1}/attempts/{2}', github.repository, github.run_id, github.run_attempt || 1) }}
+        with:
+          filename: .github/check-release-issue-template.md
+          update_existing: true

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -1,0 +1,67 @@
+name: Check release
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        type: string
+        required: true
+        description: The branch, tag or SHA to checkout.
+      performAudit:
+        type: boolean
+        default: true
+        description: Run Audit
+      performITTests:
+        type: boolean
+        default: false
+        description: Run IT Tests
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        default: ''
+        description: The branch, tag or SHA to checkout.
+      performAudit:
+        type: boolean
+        default: true
+        description: Run Audit
+      performITTests:
+        type: boolean
+        default: false
+        description: Run IT Tests
+    secrets:
+      NX_CLOUD_ACCESS_TOKEN:
+        required: false
+        description: Token to use Nx Cloud token
+
+jobs:
+  auditRelease:
+    if: inputs.performAudit
+    uses: ./.github/workflows/audit.yml
+    with:
+      ref: ${{ inputs.ref }}
+
+  buildRelease:
+    if: inputs.performITTests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: ./tools/github-actions/setup
+      - uses: ./.github/actions/setup-java
+        with:
+          install-jdk: 'true'
+      - run: yarn build:swagger-gen
+      - run: yarn build
+      - uses: ./tools/github-actions/upload-build-output
+        with:
+          artifactName: 'dist-${{ inputs.ref }}'
+
+  testRelease:
+    if: inputs.performITTests
+    needs: [buildRelease]
+    uses: ./.github/workflows/it-tests.yml
+    with:
+      ref: ${{ inputs.ref }}
+      skipNxCache: true

--- a/.github/workflows/it-tests.yml
+++ b/.github/workflows/it-tests.yml
@@ -8,6 +8,10 @@ on:
         default: false
         required: false
         description: Skip the nx cache
+      ref:
+        type: string
+        default: ''
+        description: The branch, tag or SHA to checkout.
     secrets:
       NX_CLOUD_ACCESS_TOKEN:
         required: false
@@ -30,7 +34,11 @@ jobs:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.ref }}
       - uses: ./tools/github-actions/download-build-output
+        with:
+          artifactName: ${{ inputs.ref && format('dist-{0}', inputs.ref) || 'dist' }}
       - uses: ./tools/github-actions/setup
       - name: Setup verdaccio once for all tests
         id: setup-verdaccio
@@ -46,7 +54,7 @@ jobs:
       - name: Publish verdaccio storage
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: verdaccio
+          name: ${{ inputs.ref && format('verdaccio-{0}', inputs.ref) || 'verdaccio' }}
           path: verdaccio.zip
       - name: Stop verdaccio
         if: always()
@@ -67,7 +75,11 @@ jobs:
       PREPARE_TEST_ENV_TYPE: ${{ matrix.testEnvironment }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.ref }}
       - uses: ./tools/github-actions/download-build-output
+        with:
+          artifactName: ${{ inputs.ref && format('dist-{0}', inputs.ref) || 'dist' }}
       - uses: ./tools/github-actions/setup
       - shell: bash
         run: |
@@ -80,6 +92,7 @@ jobs:
         run: echo "currentMonth=$(date +'%Y-%m')" >> $GITHUB_ENV
         shell: bash
       - name: Cache test-app yarn
+        if: inputs.ref == ''
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: |
@@ -92,7 +105,7 @@ jobs:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         name: Download verdaccio storage prepared in the previous job
         with:
-          name: verdaccio
+          name: ${{ inputs.ref && format('verdaccio-{0}', inputs.ref) || 'verdaccio' }}
           path: '.'
       - name: Setup verdaccio once for all tests
         id: setup-verdaccio
@@ -125,13 +138,13 @@ jobs:
         if: failure() && steps.it-tests.conclusion == 'failure'
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: it-tests-${{ matrix.os }}-${{ matrix.packageManager }}
+          name: it-tests-${{ matrix.os }}-${{ matrix.packageManager }}-${{ inputs.ref }}
           path: it-tests.zip
       - name: Publish tests reports
         if: always()
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: it-reports-${{ matrix.os }}-${{ matrix.packageManager }}
+          name: it-reports-${{ matrix.os }}-${{ matrix.packageManager }}-${{ inputs.ref }}
           path: 'packages/**/dist-test/it-report.xml'
       - name: Stop verdaccio
         if: always() && runner.os == 'Linux'


### PR DESCRIPTION
## Proposed change

Weekly job that tests that all currently supported versions are still passing the audits and it-tests
Check on IT-tests are currently disabled by default for the weekly job because of instability and discrepancy between yarn3 and yarn4 

Example of run: https://github.com/fpaul-1A/otter/actions/runs/12199946300

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
