### PR TITLE
feat(eslint): ng-add eslint-config

### DIFF
--- a/eslint.shared.config.mjs
+++ b/eslint.shared.config.mjs
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import globals from 'globals';
 import nxPlugin from '@nx/eslint-plugin';
 import o3rConfig from '@o3r/eslint-config';

--- a/packages/@o3r/core/schematics/ng-add/utils/linter/index.ts
+++ b/packages/@o3r/core/schematics/ng-add/utils/linter/index.ts
@@ -4,7 +4,6 @@ import { askConfirmation } from '@angular/cli/src/utilities/prompt';
 /**
  * Checks if `eslint` package is installed. If so, ask the user for otter linter rules install.
  * Otherwise displays a message to inform the user that otter linter rules can be added later.
- *
  * @param context Schematics context
  */
 export const shouldOtterLinterBeInstalled = async (context: SchematicContext): Promise<boolean> => {
@@ -14,11 +13,11 @@ export const shouldOtterLinterBeInstalled = async (context: SchematicContext): P
     require.resolve(`${linterPackageName}/package.json`);
     if (context.interactive) {
       useOtterLinter = await askConfirmation(`You already have ESLint installed. Would you like to add otter config rules for ESLint?
-Otherwise, you can add them later via this command: ng add @o3r/eslint-config-otter`, true);
+Otherwise, you can add them later via this command: ng add @o3r/eslint-config`, true);
     }
   } catch {
     context.logger.info(`ESLint package not installed. Skipping Otter linter phase!
-You can add Otter linter config rules later to the project via this command: ng add @o3r/eslint-config-otter`);
+You can add Otter linter config rules later to the project via this command: ng add @o3r/eslint-config`);
   }
 
   return useOtterLinter;

--- a/packages/@o3r/eslint-config/index.spec.ts
+++ b/packages/@o3r/eslint-config/index.spec.ts
@@ -1,5 +1,0 @@
-// TODO be removed as soon as we have one test in this package
-
-it('should be removed as soon as we have one test in this package', () => {
-  expect(true).toBe(true);
-});

--- a/packages/@o3r/eslint-config/schematics/index.it.spec.ts
+++ b/packages/@o3r/eslint-config/schematics/index.it.spec.ts
@@ -1,5 +1,40 @@
-// TODO be removed as soon as we have one test in this package
+/**
+ * Test environment exported by O3rEnvironment, must be first line of the file
+ * @jest-environment @o3r/test-helpers/jest-environment
+ * @jest-environment-o3r-app-folder test-app-eslint-config
+ */
+const o3rEnvironment = globalThis.o3rEnvironment;
 
-it('should be removed as soon as we have one test in this package', () => {
-  expect(true).toBe(true);
+import {
+  getDefaultExecSyncOptions,
+  getGitDiff,
+  packageManagerExec,
+  packageManagerInstall,
+  packageManagerRunOnProject
+} from '@o3r/test-helpers';
+import * as path from 'node:path';
+
+describe('new otter application with eslint config', () => {
+  test('should add eslint config to existing application', () => {
+    const { workspacePath, appName, isInWorkspace, untouchedProjectsPaths, o3rVersion } = o3rEnvironment.testEnvironment;
+    const execAppOptions = { ...getDefaultExecSyncOptions(), cwd: workspacePath };
+    packageManagerExec({ script: 'ng', args: ['add', `@o3r/eslint-config@${o3rVersion}`, '--skip-confirmation', '--project-name', appName] }, execAppOptions);
+
+    expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(appName, isInWorkspace, { script: 'build' }, execAppOptions)).not.toThrow();
+
+    const diff = getGitDiff(workspacePath);
+    expect(diff.modified).toContain('package.json');
+    expect(diff.added).toContain('tsconfig.eslint.json');
+    expect(diff.added).toContain('eslint.shared.config.mjs');
+    expect(diff.added).toContain('eslint.local.config.mjs');
+    expect(diff.added).toContain('eslint.config.mjs');
+    expect(diff.added).toContain(path.posix.join('apps', appName, 'tsconfig.eslint.json'));
+    expect(diff.added).toContain(path.posix.join('apps', appName, 'eslint.local.config.mjs'));
+    expect(diff.added).toContain(path.posix.join('apps', appName, 'eslint.config.mjs'));
+
+    untouchedProjectsPaths.forEach((untouchedProject) => {
+      expect(diff.all.some((file) => file.startsWith(path.posix.relative(workspacePath, untouchedProject)))).toBe(false);
+    });
+  });
 });

--- a/packages/@o3r/eslint-config/schematics/ng-add/eslint/index.spec.ts
+++ b/packages/@o3r/eslint-config/schematics/ng-add/eslint/index.spec.ts
@@ -1,0 +1,25 @@
+import { callRule, Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import * as path from 'node:path';
+import { firstValueFrom } from 'rxjs';
+import { updateEslintConfig } from './index';
+
+const collectionPath = path.join(__dirname, '..', '..', '..', 'collection.json');
+const context = { description: { path: __dirname } };
+
+describe('update eslint config', () => {
+  it('should add a eslint config on workspace', async () => {
+    const initialTree = Tree.empty();
+    initialTree.create('package.json', JSON.stringify({ name: '@scope/package' }));
+    const runner = new SchematicTestRunner('schematics', collectionPath);
+
+    const tree = await firstValueFrom(callRule(updateEslintConfig(), initialTree, runner.engine.createContext(context as any)));
+    expect(tree.exists('eslint.config.mjs')).toBeTruthy();
+    expect(tree.exists('eslint.local.config.mjs')).toBeTruthy();
+    expect(tree.exists('eslint.shared.config.mjs')).toBeTruthy();
+    expect(tree.exists('tsconfig.eslint.json')).toBeTruthy();
+    expect(tree.readText('eslint.local.config.mjs')).toContain('@scope/package/projects');
+    expect(tree.readText('eslint.shared.config.mjs')).toContain('@scope/package/report-unused-disable-directives');
+    expect(tree.readText('eslint.shared.config.mjs')).toContain('@scope/package/eslint-config');
+  });
+});

--- a/packages/@o3r/eslint-config/schematics/ng-add/eslint/index.ts
+++ b/packages/@o3r/eslint-config/schematics/ng-add/eslint/index.ts
@@ -1,0 +1,66 @@
+import type { JsonObject } from '@angular-devkit/core';
+import {
+  apply,
+  chain,
+  MergeStrategy,
+  mergeWith,
+  renameTemplateFiles,
+  type Rule,
+  template,
+  url
+} from '@angular-devkit/schematics';
+import * as path from 'node:path';
+import { updateOrAddTsconfigEslint } from '../tsconfig/index';
+
+/**
+ * Update ESLint Config
+ * @param isWorkspace
+ * @param rootPath
+ */
+export const updateEslintConfig = (isWorkspace = true, rootPath = __dirname): Rule => async (tree, context) => {
+  const { findFilesInTree, getTemplateFolder } = await import('@o3r/schematics');
+  const eslintConfigFiles = findFilesInTree(tree.root, (file) => /eslint.config.[mc]?js/.test(file));
+  if (eslintConfigFiles.length > 1) {
+    context.logger.warn(
+      'Unable to add the "@o3r/eslint-config" recommendation because several ESLint config file detected.\n'
+      + eslintConfigFiles.map((file) => `\t- ${file.path.toString()}`).join('\n')
+    );
+    return;
+  }
+  const templateOptions = {
+    extension: 'mjs',
+    codeBeforeConfig: '',
+    codeAfterConfig: '',
+    oldConfig: '',
+    packageName: (tree.readJson('package.json') as JsonObject).name,
+    detectedTsConfigs: findFilesInTree(tree.root, (f) => /tsconfig.*\.json/.test(f)).map((entry) => path.basename(entry.path)).concat('tsconfig.eslint.json')
+  };
+  if (eslintConfigFiles.length === 1) {
+    const file = eslintConfigFiles[0];
+    const filePath = file.path.toString();
+    const fileContent = file.content.toString();
+    const extension = path.extname(filePath) as 'mjs' | 'cjs' | 'js';
+    const regexp = extension === 'mjs' ? /export\s+default\s+[^;]*;/ : /module.exportss+=\s+[^;]*;/;
+    const [codeBeforeConfig, codeAfterConfig] = fileContent.split(regexp);
+    if (!codeAfterConfig) {
+      context.logger.warn(
+        `Unable to add the "@o3r/eslint-config" recommendation because no ESLint config detected in ${filePath}`
+      );
+      return;
+    }
+    const oldConfig = fileContent.match(regexp)![1];
+    templateOptions.extension = extension;
+    templateOptions.codeBeforeConfig = codeBeforeConfig;
+    templateOptions.codeAfterConfig = codeAfterConfig;
+    templateOptions.oldConfig = oldConfig;
+    tree.delete(filePath);
+  }
+
+  return chain([
+    updateOrAddTsconfigEslint(undefined, __dirname),
+    mergeWith(apply(url(getTemplateFolder(rootPath, __dirname, `./templates/${isWorkspace ? 'workspace' : 'project'}`)), [
+      template(templateOptions),
+      renameTemplateFiles()
+    ]), MergeStrategy.Overwrite)
+  ]);
+};

--- a/packages/@o3r/eslint-config/schematics/ng-add/eslint/templates/project/eslint.config.__extension__.template
+++ b/packages/@o3r/eslint-config/schematics/ng-add/eslint/templates/project/eslint.config.__extension__.template
@@ -1,0 +1,10 @@
+<% if (extension === 'mjs') { %>import local from './eslint.local.config.mjs';
+import shared from '<%= relativePathToRoot %>/eslint.shared.config.mjs';
+<% } else { %>const local = require('./eslint.local.config.<%= extension %>');
+const shared = require('<%= relativePathToRoot %>/eslint.shared.config.<%= extension %>');
+<% } %>
+
+<%= extension === 'mjs' ? 'export default' : 'module.exports =' %> [
+  ...shared,
+  ...local
+];

--- a/packages/@o3r/eslint-config/schematics/ng-add/eslint/templates/project/eslint.local.config.__extension__.template
+++ b/packages/@o3r/eslint-config/schematics/ng-add/eslint/templates/project/eslint.local.config.__extension__.template
@@ -1,0 +1,19 @@
+<% if (extension === 'mjs') { %>import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+// __dirname is not defined in ES module scope
+const __dirname = dirname(__filename);
+
+<% } %><%= extension === 'mjs' ? 'export default' : 'module.exports =' %> [
+  {
+    name: '<%= packageName %>/projects',
+    languageOptions: {
+      sourceType: 'commonjs',
+      parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: [<%= detectedTsConfigs.map((tsconfig) => `'${tsconfig}'`).join(', ') %>]
+      }
+    }
+  }
+];

--- a/packages/@o3r/eslint-config/schematics/ng-add/eslint/templates/workspace/eslint.config.__extension__.template
+++ b/packages/@o3r/eslint-config/schematics/ng-add/eslint/templates/workspace/eslint.config.__extension__.template
@@ -1,0 +1,59 @@
+<% if (extension === 'mjs') { %>import { sync } from 'globby';
+import { dirname } from 'node:path';
+import shared from './eslint.shared.config.mjs';
+<% } else { %>
+  const { sync } = require('globby');
+  const { dirname } from 'node:path';
+  cons shared from './eslint.shared.config.<%= extension %>';
+<% } %>
+
+/**
+ * Add a prefix to a path glob
+ * @param {string} prefix
+ * @param {string | undefined} pathGlob
+ * @returns {string}
+ */
+const addPrefix = (prefix, pathGlob = '**/*') => pathGlob.replace(/^(!?)(\.?\/)?/, `$1${prefix}/`);
+
+/**
+ * Merge ESLint config
+ * @param {string | string[]} globs List of globs to findpath ESLint config
+ * @returns {Promise<import('@typescript-eslint/utils').TSESLint.FlatConfig.ConfigArray>}
+ */
+const mergeESLintConfigs = async (globs) => {
+  const localConfigFiles = sync(globs, { absolute: true });
+  /** @type {import('@typescript-eslint/utils').TSESLint.FlatConfig.ConfigArray} */
+  let localConfigs = [];
+  for (const localConfigFile of localConfigFiles) {
+    const module = await import(localConfigFile);
+    const moduleConfig = await (module.default ?? module);
+    /** @type {import('@typescript-eslint/utils').TSESLint.FlatConfig.ConfigArray} */
+    const configArray = Array.isArray(moduleConfig) ? moduleConfig : [moduleConfig];
+    const directory = dirname(localConfigFile);
+    /**
+     * Add the directory as prefix to the glob
+     * @param {string} pathGlob
+     * @returns {string}
+     */
+    const addDirectoryFn = (pathGlob) => addPrefix(directory, pathGlob);
+    localConfigs = localConfigs.concat(
+      configArray.map((config) => ({
+        ...config,
+        files: (config.files || ['**/*']).flat().map(addDirectoryFn),
+        ...(
+          config.ignores
+            ? { ignores: config.ignores.map(addDirectoryFn) }
+            : {}
+        )
+      }))
+    );
+  }
+
+  return [
+    ...shared,
+    ...localConfigs
+  ];
+};
+
+// eslint-disable-next-line unicorn/prefer-top-level-await
+<%= extension === 'mjs' ? 'export default' : 'module.exports =' %> mergeESLintConfigs('**/eslint.local.config.mjs');

--- a/packages/@o3r/eslint-config/schematics/ng-add/eslint/templates/workspace/eslint.local.config.__extension__.template
+++ b/packages/@o3r/eslint-config/schematics/ng-add/eslint/templates/workspace/eslint.local.config.__extension__.template
@@ -1,0 +1,20 @@
+<% if (extension === 'mjs') { %>import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+// __dirname is not defined in ES module scope
+const __dirname = dirname(__filename);
+
+<% } %><%= codeBeforeConfig %><%= extension === 'mjs' ? 'export default' : 'module.exports =' %> [
+  {
+    name: '<%= packageName %>/projects',
+    languageOptions: {
+      sourceType: 'commonjs',
+      parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: [<%= detectedTsConfigs.map((tsconfig) => `'${tsconfig}'`).join(', ') %>]
+      }
+    }
+  }
+].concat(<%= oldConfig %>);
+<%= codeAfterConfig %>

--- a/packages/@o3r/eslint-config/schematics/ng-add/eslint/templates/workspace/eslint.shared.config.__extension__.template
+++ b/packages/@o3r/eslint-config/schematics/ng-add/eslint/templates/workspace/eslint.shared.config.__extension__.template
@@ -1,0 +1,28 @@
+<% if (extension === 'mjs') { %>import o3rConfig from '@o3r/eslint-config';
+import o3rTemplate from '@o3r/eslint-config/template';
+<% } else { %>const o3rConfig = require('@o3r/eslint-config');
+const o3rTemplate = require('@o3r/eslint-config/template');
+<% } %>
+
+<%= extension === 'mjs' ? 'export default' : 'module.exports =' %> [
+  ...o3rConfig,
+  ...o3rTemplate,
+  {
+    name: '<%= packageName %>/report-unused-disable-directives',
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error'
+    }
+  }<% if (extension === 'mjs') { %>,
+  {
+    name: '<%= packageName %>/eslint-config',
+    files: ['**/eslint*.config.mjs'],
+    rules: {
+      'no-underscore-dangle': [
+        'error',
+        {
+          allow: ['__filename', '__dirname']
+        }
+      ]
+    }
+  }<% } %>
+];

--- a/packages/@o3r/eslint-config/schematics/ng-add/index.spec.ts
+++ b/packages/@o3r/eslint-config/schematics/ng-add/index.spec.ts
@@ -1,0 +1,71 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+const setupDependenciesMock = jest.fn(() => () => {});
+const updateVscodeMock = jest.fn(() => {});
+const updateEslintConfigMock = jest.fn(() => () => {});
+
+jest.mock('@o3r/schematics', () => ({
+  ...jest.requireActual('@o3r/schematics'),
+  createSchematicWithMetricsIfInstalled: jest.fn((schematicFn) => schematicFn),
+  setupDependencies: setupDependenciesMock
+}));
+jest.mock('./vscode/index', () => ({
+  updateVscode: updateVscodeMock
+}));
+jest.mock('./eslint/index', () => ({
+  updateEslintConfig: updateEslintConfigMock
+}));
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import * as path from 'node:path';
+
+
+const collectionPath = path.join(__dirname, '..', '..', 'collection.json');
+
+describe('ng add eslint-config', () => {
+  beforeEach(() => {
+    setupDependenciesMock.mockClear();
+    updateVscodeMock.mockClear();
+    updateEslintConfigMock.mockClear();
+  });
+
+  it('should run add on workspace', async () => {
+    const runner = new SchematicTestRunner('schematics', collectionPath);
+    await runner.runSchematic('ng-add', {}, Tree.empty());
+    expect(setupDependenciesMock).toHaveBeenCalledWith(expect.objectContaining({
+      dependencies: expect.objectContaining({
+        '@o3r/eslint-plugin': expect.objectContaining({}),
+        '@stylistic/eslint-plugin': expect.objectContaining({}),
+        'angular-eslint': expect.objectContaining({}),
+        'eslint': expect.objectContaining({}),
+        'eslint-plugin-jsdoc': expect.objectContaining({}),
+        'eslint-plugin-prefer-arrow': expect.objectContaining({}),
+        'eslint-plugin-unicorn': expect.objectContaining({}),
+        'globby': expect.objectContaining({}),
+        'jsonc-eslint-parser': expect.objectContaining({}),
+        'typescript-eslint': expect.objectContaining({})
+      }),
+      ngAddToRun: expect.arrayContaining(['@o3r/eslint-plugin'])
+    }));
+    expect(updateVscodeMock).toHaveBeenCalled();
+    expect(updateEslintConfigMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should run add on project', async () => {
+    const runner = new SchematicTestRunner('schematics', collectionPath);
+    const initialTree = Tree.empty();
+    initialTree.create('angular.json', JSON.stringify({
+      projects: {
+        'project-test': {
+          root: 'project-test'
+        }
+      }
+    }, null, 2));
+
+    await runner.runSchematic('ng-add', { projectName: 'project-test' }, initialTree);
+    expect(setupDependenciesMock).toHaveBeenCalled();
+    expect(updateVscodeMock).toHaveBeenCalled();
+    expect(updateEslintConfigMock).toHaveBeenCalledTimes(2);
+    expect(updateEslintConfigMock).toHaveBeenCalledWith();
+    expect(updateEslintConfigMock).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/@o3r/eslint-config/schematics/ng-add/index.ts
+++ b/packages/@o3r/eslint-config/schematics/ng-add/index.ts
@@ -1,11 +1,95 @@
-import { noop } from '@angular-devkit/schematics';
-import type { Rule } from '@angular-devkit/schematics';
+import {
+  applyToSubtree,
+  chain,
+  noop,
+  type Rule,
+  type SchematicContext,
+  type Tree
+} from '@angular-devkit/schematics';
+import * as path from 'node:path';
+import { updateVscode } from './vscode/index';
+import type { NgAddSchematicsSchema } from './schema';
+import { updateEslintConfig } from './eslint/index';
+
+const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
+  logger.error(`[ERROR]: Adding @o3r/eslint-config has failed.
+You need to install '@o3r/schematics' package to be able to use the eslint-config package. Please run 'ng add @o3r/schematics' .`);
+  throw reason;
+};
+
 
 /**
  * Add Otter eslint-config to an Angular Project
  * @param options
  */
-export function ngAdd(): Rule {
+function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
-  return noop();
+  return async (tree: Tree, context: SchematicContext) => {
+    const devDependenciesToInstall = [
+      '@stylistic/eslint-plugin',
+      'angular-eslint',
+      'eslint',
+      'eslint-plugin-jsdoc',
+      'eslint-plugin-prefer-arrow',
+      'eslint-plugin-unicorn',
+      'globby',
+      'typescript-eslint',
+      'jsonc-eslint-parser'
+    ];
+
+    const {
+      getExternalDependenciesVersionRange,
+      setupDependencies,
+      getWorkspaceConfig,
+      getO3rPeerDeps,
+      getProjectNewDependenciesTypes,
+      getPackageInstallConfig
+    } = await import('@o3r/schematics');
+    const depsInfo = getO3rPeerDeps(path.resolve(__dirname, '..', '..', 'package.json'), true, /^@(?:o3r|ama-sdk|eslint-)/);
+    const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const { NodeDependencyType } = await import('@schematics/angular/utility/dependencies');
+    const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
+    const dependencies = depsInfo.o3rPeerDeps.reduce((acc, dep) => {
+      acc[dep] = {
+        inManifest: [{
+          range: `${options.exactO3rVersion ? '' : '~'}${depsInfo.packageVersion}`,
+          types: getProjectNewDependenciesTypes(workspaceProject)
+        }],
+        ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
+      };
+      return acc;
+    }, getPackageInstallConfig(packageJsonPath, tree, options.projectName, true, !!options.exactO3rVersion));
+    Object.entries(getExternalDependenciesVersionRange(devDependenciesToInstall, packageJsonPath, context.logger))
+      .forEach(([dep, range]) => {
+        dependencies[dep] = {
+          inManifest: [{
+            range,
+            types: [NodeDependencyType.Dev]
+          }]
+        };
+      });
+
+    return () => chain([
+      setupDependencies({
+        projectName: options.projectName,
+        dependencies,
+        ngAddToRun: depsInfo.o3rPeerDeps
+      }),
+      updateVscode,
+      updateEslintConfig(),
+      options.projectName && workspaceProject?.root
+        ? applyToSubtree(workspaceProject.root, [updateEslintConfig(false)])
+        : noop()
+    ])(tree, context);
+  };
 }
+
+/**
+ * Add Otter eslint-config to an Angular Project
+ * @param options
+ */
+export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
+  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
+  return createSchematicWithMetricsIfInstalled(ngAddFn)(options);
+};

--- a/packages/@o3r/eslint-config/schematics/ng-add/schema.json
+++ b/packages/@o3r/eslint-config/schematics/ng-add/schema.json
@@ -10,9 +10,14 @@
       "$default": {
         "$source": "projectName"
       }
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages",
+      "default": false
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
   ]
 }

--- a/packages/@o3r/eslint-config/schematics/ng-add/schema.ts
+++ b/packages/@o3r/eslint-config/schematics/ng-add/schema.ts
@@ -1,4 +1,8 @@
-export interface NgAddSchematicsSchema {
+import type { SchematicOptionObject } from '@o3r/schematics';
+
+export interface NgAddSchematicsSchema extends SchematicOptionObject {
   /** Project name */
   projectName?: string | undefined;
+  /** Use a pinned version for otter packages */
+  exactO3rVersion?: boolean;
 }

--- a/packages/@o3r/eslint-config/schematics/ng-add/tsconfig/index.spec.ts
+++ b/packages/@o3r/eslint-config/schematics/ng-add/tsconfig/index.spec.ts
@@ -1,0 +1,51 @@
+import { callRule } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { firstValueFrom } from 'rxjs';
+import * as path from 'node:path';
+import { updateOrAddTsconfigEslint } from './index';
+import { Tree } from '@angular-devkit/schematics';
+
+const collectionPath = path.join(__dirname, '..', '..', '..', 'collection.json');
+const tsconfigEslintPath = 'tsconfig.eslint.json';
+const context = { description: { path: __dirname } };
+
+
+describe('update tsconfig', () => {
+  it('should create a tsconfig eslint', async () => {
+    const runner = new SchematicTestRunner('schematics', collectionPath);
+
+    let tree = await firstValueFrom(callRule(updateOrAddTsconfigEslint(), Tree.empty(), runner.engine.createContext(context as any)));
+    expect(tree.readJson(tsconfigEslintPath)).toEqual(expect.objectContaining({
+      extends: './tsconfig',
+      include: [
+        'eslint*.config.*js'
+      ]
+    }));
+
+    tree = await firstValueFrom(callRule(updateOrAddTsconfigEslint('tsconfig.custom'), Tree.empty(), runner.engine.createContext(context as any)));
+    expect(tree.readJson(tsconfigEslintPath)).toEqual(expect.objectContaining({
+      extends: './tsconfig.custom',
+      include: [
+        'eslint*.config.*js'
+      ]
+    }));
+  });
+
+  it('should update the tsconfig eslint include but not the extends', async () => {
+    const initialTree = Tree.empty();
+    initialTree.create(tsconfigEslintPath, JSON.stringify({ extends: './tsconfig', include: ['include-path'] }, null, 2));
+    const runner = new SchematicTestRunner('schematics', collectionPath);
+
+    const tree = await firstValueFrom(callRule(updateOrAddTsconfigEslint('tsconfig.custom'), initialTree, runner.engine.createContext(context as any)));
+    expect(tree.readJson(tsconfigEslintPath)).toEqual(expect.objectContaining({
+      extends: './tsconfig',
+      include: [
+        'include-path',
+        'eslint*.config.*js'
+      ]
+    }));
+  });
+});
+
+
+

--- a/packages/@o3r/eslint-config/schematics/ng-add/tsconfig/index.ts
+++ b/packages/@o3r/eslint-config/schematics/ng-add/tsconfig/index.ts
@@ -1,0 +1,22 @@
+import { type JsonArray, type JsonObject } from '@angular-devkit/core';
+import { apply, MergeStrategy, mergeWith, renameTemplateFiles, type Rule, template, url } from '@angular-devkit/schematics';
+
+/**
+ * Update or add tsconfig.eslint.json file
+ * @param projectTsConfig
+ * @param rootPath
+ */
+export const updateOrAddTsconfigEslint = (projectTsConfig = 'tsconfig', rootPath = __dirname): Rule => async (tree) => {
+  const tsconfigPath = 'tsconfig.eslint.json';
+  if (tree.exists(tsconfigPath)) {
+    const tsconfig = tree.readJson(tsconfigPath) as JsonObject;
+    tsconfig.include = (tsconfig.include as JsonArray || []).concat(`eslint*.config.*js`);
+    tree.overwrite(tsconfigPath, JSON.stringify(tsconfig, null, 2));
+    return () => tree;
+  }
+  const { getTemplateFolder } = await import('@o3r/schematics');
+  return () => mergeWith(apply(url(getTemplateFolder(rootPath, __dirname)), [
+    template({ projectTsConfig }),
+    renameTemplateFiles()
+  ]), MergeStrategy.Overwrite);
+};

--- a/packages/@o3r/eslint-config/schematics/ng-add/tsconfig/templates/tsconfig.eslint.json.template
+++ b/packages/@o3r/eslint-config/schematics/ng-add/tsconfig/templates/tsconfig.eslint.json.template
@@ -1,0 +1,6 @@
+{
+  "extends": "./<%= projectTsConfig %>",
+  "include": [
+    "eslint*.config.*js"
+  ]
+}

--- a/packages/@o3r/eslint-config/schematics/ng-add/vscode/index.spec.ts
+++ b/packages/@o3r/eslint-config/schematics/ng-add/vscode/index.spec.ts
@@ -1,0 +1,38 @@
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { firstValueFrom } from 'rxjs';
+import * as path from 'node:path';
+import { updateVscode } from './index';
+import { Tree } from '@angular-devkit/schematics';
+
+const collectionPath = path.join(__dirname, '..', '..', '..', 'collection.json');
+const extensionFile = '.vscode/extensions.json';
+const settingFile = '.vscode/settings.json';
+
+describe('update vscode', () => {
+  it('should update vscode recommendations and create vscode settings', async () => {
+    const initialTree = Tree.empty();
+    initialTree.create(extensionFile, JSON.stringify({ recommendations: [] }));
+    const runner = new SchematicTestRunner('schematics', collectionPath);
+
+    const tree = await firstValueFrom(runner.callRule(updateVscode, initialTree, { interactive: false }));
+    expect((tree.readJson(extensionFile) as any).recommendations).toEqual(expect.arrayContaining(['dbaeumer.vscode-eslint', 'stylelint.vscode-stylelint']));
+    expect((tree.readJson(settingFile) as any)['eslint.useFlatConfig']).toBe(true);
+    expect((tree.readJson(settingFile) as any)['editor.defaultFormatter']).toBe('dbaeumer.vscode-eslint');
+  });
+
+
+  it('should update vscode settings', async () => {
+    const initialTree = Tree.empty();
+    initialTree.create(extensionFile, JSON.stringify({ recommendations: [] }));
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    initialTree.create(settingFile, JSON.stringify({ 'eslint.useFlatConfig': false, 'editor.defaultFormatter': 'prettier' }));
+    const runner = new SchematicTestRunner('schematics', collectionPath);
+
+    const tree = await firstValueFrom(runner.callRule(updateVscode, initialTree, { interactive: false }));
+    expect((tree.readJson(settingFile) as any)['eslint.useFlatConfig']).toBe(true);
+    expect((tree.readJson(settingFile) as any)['editor.defaultFormatter']).toBe('dbaeumer.vscode-eslint');
+  });
+});
+
+
+

--- a/packages/@o3r/eslint-config/schematics/ng-add/vscode/index.ts
+++ b/packages/@o3r/eslint-config/schematics/ng-add/vscode/index.ts
@@ -1,0 +1,24 @@
+import type { JsonObject } from '@angular-devkit/core';
+import { chain, type Rule } from '@angular-devkit/schematics';
+
+/**
+ * Update VSCode recommendations and settings
+ */
+export const updateVscode: Rule = async () => {
+  const { addVsCodeRecommendations } = await import('@o3r/schematics');
+  return chain([
+    addVsCodeRecommendations(['dbaeumer.vscode-eslint', 'stylelint.vscode-stylelint']),
+    (tree) => {
+      const vscodeSettingsPath = '.vscode/settings.json';
+      const settings = tree.exists(vscodeSettingsPath) ? (tree.readJson(vscodeSettingsPath) || {}) as JsonObject : {};
+      settings['eslint.useFlatConfig'] = true;
+      settings['editor.defaultFormatter'] = 'dbaeumer.vscode-eslint';
+      if (tree.exists(vscodeSettingsPath)) {
+        tree.overwrite(vscodeSettingsPath, JSON.stringify(settings, null, 2));
+      } else {
+        tree.create(vscodeSettingsPath, JSON.stringify(settings, null, 2));
+      }
+      return tree;
+    }
+  ]);
+};


### PR DESCRIPTION
## Proposed change
`ng-add` of the `@o3r/eslint-config` package

> [!NOTE]
> This PR is not targetting `main`.
> I will create a PR for `main` once everything below will be merged on
`feat/migrate-eslint-9-flat-config`

Will be done in others PRs:
- [ ] Update `@o3r/core` ng-add to install `@o3r/eslint-config` or `@o3r/eslint-config-otter` depending on ESLint configuration found (FlatConfig or LegacyConfig)
- [ ] Review with the team the config exposed in `@o3r/eslint-config` (fix `jsdoc/check-examples`)
- [ ] Fix errors and warnings due to the new config
- [ ] Document the difference of rules between the 2 configs (+ link to migrate to ESLint v9) + update global documentation (docs/linter/*)
- [ ] Bonus: CLI to detect deprecated rules
