### PR TITLE
feat: update cod enforcement contact

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,7 +61,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[Github Report Abuse or Spam](https://support.github.com/contact/report-abuse?category=report-abuse&report=other&report_type=unspecified).
+opensource@amadeus.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
## Proposed change

There is an official email address that can be used to contact Amadeus OpenSource organization, may it be for abuse reports or other subject.
This PR proposes to update Otter Code of Conduct accordingly.