### PR TITLE
fix(eslint): set relative path instead of absolute path in the merge config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,11 @@
 import { sync } from 'globby';
-import { dirname } from 'node:path';
+import { dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import shared from './eslint.shared.config.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+// __dirname is not defined in ES module scope
+const __dirname = dirname(__filename);
 
 /**
  * Add a prefix to a path glob
@@ -24,7 +29,7 @@ const mergeESLintConfigs = async (globs) => {
     const moduleConfig = await (module.default ?? module);
     /** @type {import('@typescript-eslint/utils').TSESLint.FlatConfig.ConfigArray} */
     const configArray = Array.isArray(moduleConfig) ? moduleConfig : [moduleConfig];
-    const directory = dirname(localConfigFile);
+    const directory = relative(__dirname, dirname(localConfigFile));
     /**
      * Add the directory as prefix to the glob
      * @param {string} pathGlob

--- a/packages/@o3r/eslint-config/schematics/ng-add/eslint/templates/workspace/eslint.config.__extension__.template
+++ b/packages/@o3r/eslint-config/schematics/ng-add/eslint/templates/workspace/eslint.config.__extension__.template
@@ -1,9 +1,14 @@
 <% if (extension === 'mjs') { %>import { sync } from 'globby';
-import { dirname } from 'node:path';
+import { dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import shared from './eslint.shared.config.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+// __dirname is not defined in ES module scope
+const __dirname = dirname(__filename);
 <% } else { %>
   const { sync } = require('globby');
-  const { dirname } from 'node:path';
+  const { dirname, relative } from 'node:path';
   cons shared from './eslint.shared.config.<%= extension %>';
 <% } %>
 
@@ -29,7 +34,7 @@ const mergeESLintConfigs = async (globs) => {
     const moduleConfig = await (module.default ?? module);
     /** @type {import('@typescript-eslint/utils').TSESLint.FlatConfig.ConfigArray} */
     const configArray = Array.isArray(moduleConfig) ? moduleConfig : [moduleConfig];
-    const directory = dirname(localConfigFile);
+    const directory = relative(__dirname, dirname(localConfigFile));
     /**
      * Add the directory as prefix to the glob
      * @param {string} pathGlob


### PR DESCRIPTION
## Proposed change

Set relative path instead of absolute path in the merge config
