### PR TITLE
fix(sdk-core): rollback api-mock.ts to use deprecate fetch client from core

### DIFF
--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/spec/api-mock.mustache
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/spec/api-mock.mustache
@@ -1,6 +1,6 @@
 {{#apiInfo}}
 import { type ApiClient, isApiClient } from '@ama-sdk/core';
-import { ApiFetchClient, type BaseApiFetchClientConstructor } from '@ama-sdk/client-fetch';
+import { ApiFetchClient, type BaseApiFetchClientConstructor } from '@ama-sdk/core';
 
 import * as api from '../api';
 


### PR DESCRIPTION
## Proposed change

Rollback `api-mock.ts` to use deprecate fetch client from core.
This change will be part of #2117.

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- 🔗  Related to: #2117 

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
