### PR TITLE
ci: no install needed for new version computation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,9 @@ jobs:
       isPreRelease: ${{ contains( steps.newVersion.outputs.nextVersionTag, '-' ) || github.event_name == 'pull_request' || github.event_name == 'merge_group'}}
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
-      - uses: ./tools/github-actions/setup
+      - uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+        with:
+          node-version: 20
       - name: New Version
         if: github.event_name != 'merge_group'
         id: newVersion


### PR DESCRIPTION
## Proposed change

Only node and checkout are needed for computing the new version. No need to install.