### PR TITLE
fix: reduce number of log for rules engine action

### DIFF
--- a/packages/@o3r/rules-engine/src/services/runner/rules-engine.runner.service.ts
+++ b/packages/@o3r/rules-engine/src/services/runner/rules-engine.runner.service.ts
@@ -74,9 +74,7 @@ export class RulesEngineRunnerService implements OnDestroy {
 
     this.subscription.add(
       this.events$.pipe(filter(() => this.enabled)).subscribe(async (events) => {
-        this.logger.debug('Start Rules Engine action executed');
         await this.executeActions(events);
-        this.logger.debug('All Rules Engine actions executed');
       })
     );
   }


### PR DESCRIPTION
a log is triggered for all the action blocks which does not scale if there are many rulesets

## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
