### PR TITLE
fix(sdk): relative local ref in specs are not always handled correctly

### DIFF
--- a/packages/@ama-sdk/schematics/schematics/typescript/core/helpers/copy-referenced-files.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/helpers/copy-referenced-files.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 import { copyFile, mkdir, readFile, rm } from 'node:fs/promises';
-import { dirname, join, normalize, posix, relative, resolve, sep } from 'node:path';
+import { dirname, isAbsolute, join, normalize, posix, relative, resolve, sep } from 'node:path';
 
 const refMatcher = /\B['"]?[$]ref['"]?\s*:\s*([^#\n]+)/g;
 
@@ -13,8 +13,11 @@ function extractRefPaths(specContent: string, basePath: string): string[] {
   const refs = specContent.match(refMatcher);
   return refs ?
     refs
-      .map((capture) => capture.replace(refMatcher, '$1').replace(/['"]/g, ''))
-      .filter((refPath) => refPath.startsWith('.'))
+      .map((capture) => capture.replace(refMatcher, '$1')
+        .replace(/['"]/g, '')
+        .trim()
+      )
+      .filter((refPath) => refPath && !isAbsolute(refPath) && !/^https?:\//.test(refPath))
       .map((refPath) => join(basePath, refPath))
     : [];
 }

--- a/packages/@ama-sdk/schematics/testing/mocks/split-spec/spec-chunk1.yaml
+++ b/packages/@ama-sdk/schematics/testing/mocks/split-spec/spec-chunk1.yaml
@@ -8,4 +8,6 @@ properties:
   category:
     $ref: './split-spec.yaml#/components/schemas/Category'
   category2:
+    $ref: 'split-spec.yaml#/components/schemas/Category'
+  category3:
       $ref: '../spec-chunk4/spec-chunk4.yaml#/components/schemas/Category'


### PR DESCRIPTION
## Proposed change

When creating an SDK with a local spec file with references to other local files, the following were not supported:
- Relative path not starting with a `.`
- Relative path with no quotes in CRLF (`\r` remains in the extracted path)
- Additional spaces before or after the unquoted path for some reasons

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
