### PR TITLE
fix: migration scripts not checking latest semver version with npm

### DIFF
--- a/packages/@o3r/extractors/src/core/comparator/metadata-comparison.helper.ts
+++ b/packages/@o3r/extractors/src/core/comparator/metadata-comparison.helper.ts
@@ -132,7 +132,10 @@ Detection of package manager runner will fallback on the one used to execute the
 
   const packageLocator = `${packageJson.name as string}@${previousVersion}`;
   context.logger.info(`Fetching ${packageLocator} from the registry.`);
-  const previousFile = await getFilesFromRegistry(packageLocator, [options.metadataPath], packageManager, context.workspaceRoot);
+  const packageJsonFileName = 'package.json';
+  const previousFile = await getFilesFromRegistry(packageLocator, [options.metadataPath, packageJsonFileName], packageManager, context.workspaceRoot);
+
+  context.logger.info(`Resolved metadata from version ${JSON.parse(previousFile[packageJsonFileName]).version}.`);
 
   const metadataPathInWorkspace = posix.join(projectRoot, options.metadataPath);
   const newFile = getLocalMetadataFile<MetadataFile>(metadataPathInWorkspace);

--- a/packages/@o3r/extractors/src/core/comparator/package-managers-extractors/npm-file-extractor.helper.ts
+++ b/packages/@o3r/extractors/src/core/comparator/package-managers-extractors/npm-file-extractor.helper.ts
@@ -25,15 +25,27 @@ function sanitizeInput(input: string) {
  * @param packageDescriptor Package descriptor using the npm semver format (i.e. @o3r/demo@^1.2.3)
  * @param paths Paths of the files to extract
  */
-export function getFilesFromRegistry(packageDescriptor: string, paths: string[]): { [key: string]: string } {
+export async function getFilesFromRegistry(packageDescriptor: string, paths: string[]): Promise<Record<string, string>> {
+  const semver = await import('semver');
   const tempDirName = 'o3r-' + randomBytes(16).toString('hex');
   const tempDirPath = join(tmpdir(), tempDirName);
   let extractedFiles: { [key: string]: string } = {};
   mkdirSync(tempDirPath);
 
   try {
+    const npmViewCmd = runAndThrowOnError(
+      `npm view "${sanitizeInput(packageDescriptor)}" version --json`,
+      { shell: true, encoding: 'utf8' }
+    );
+    const versions = JSON.parse(npmViewCmd.stdout.trim()) as string[] | string;
+    if (typeof versions !== 'string') {
+      versions.sort((a, b) => semver.compare(b, a));
+    }
+    const latestVersion = typeof versions === 'string' ? versions : versions[0];
+    const packageName = packageDescriptor.replace(/\b@[^@]+$/, '');
+
     const npmPackCmd = runAndThrowOnError(
-      `npm pack "${sanitizeInput(packageDescriptor)}" --pack-destination "${pathToPosix(tempDirPath)}"`,
+      `npm pack "${packageName}@${sanitizeInput(latestVersion)}" --pack-destination "${pathToPosix(tempDirPath)}"`,
       { shell: true, encoding: 'utf8' }
     );
     const tgzFile = npmPackCmd.stdout.trim();


### PR DESCRIPTION
## Proposed change

**Context:** Migration scripts with npm implementation (also used for yarn1)

With the current implementation, when looking for a previous version, we will get the latest **published** version that match the range.
What we want is the most recent version according to semver.

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
