### PR TITLE
fix: use only exposed type to fill operators metadata

### DIFF
--- a/packages/@o3r/rules-engine/builders/rules-engine-extractor/helpers/rules-engine.extractor.ts
+++ b/packages/@o3r/rules-engine/builders/rules-engine-extractor/helpers/rules-engine.extractor.ts
@@ -263,7 +263,6 @@ export class RulesEngineExtractor {
         if (!operatorDeclarations.length) {
           return;
         }
-
         operatorDeclarations.forEach((declaration) => {
           const operatorType = declaration.type.typeName.getText(source);
           const commentParsedDeclaration = this.commentParser.parseConfigDocFromNode(source, declaration);
@@ -291,9 +290,9 @@ export class RulesEngineExtractor {
               nbValues: 1
             };
           }
-
-          declaration.type.typeArguments?.forEach((argType, idx) => {
-            const operand = idx === 0 ? 'leftOperand' : 'rightOperand';
+          const operands: ('leftOperand' | 'rightOperand')[] = ['leftOperand', 'rightOperand'];
+          declaration.type.typeArguments?.slice(0, 2).forEach((argType, idx) => {
+            const operand = operands[idx];
             const operandObject = operator[operand]!;
 
             operandObject.nbValues = this.getTypeNbValue(argType);


### PR DESCRIPTION
## Proposed change
Operators have exposed and supported type.
The first type is what to extract for the CMS and the second is to be used for type check in the code.
Left operand runtime type was overriding right operand metadata (idx = 2, hence > 1).
Now, only extract "ExposedTypes"

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
