### PR TITLE
feat(eslint): change all warnings into errors

### DIFF
--- a/docs/linter/eslint-config.md
+++ b/docs/linter/eslint-config.md
@@ -29,3 +29,7 @@ Then the CLI can be called as following:
 ```shell
 yarn eslint --global fast
 ```
+
+## Warnings
+
+When a rule is set to `warn` in our config, it will be set to `error` on the next major.

--- a/packages/@o3r/eslint-config/src/rules/template/otter.cjs
+++ b/packages/@o3r/eslint-config/src/rules/template/otter.cjs
@@ -11,7 +11,7 @@ const o3rTemplateRecommended = (plugin) => [
     name: '@o3r/template-recommended',
     files: ['**/*.html'],
     rules: {
-      '@o3r/template-async-number-limitation': 'warn'
+      '@o3r/template-async-number-limitation': 'error'
     }
   }
 ];

--- a/packages/@o3r/eslint-config/src/rules/typescript.cjs
+++ b/packages/@o3r/eslint-config/src/rules/typescript.cjs
@@ -23,7 +23,7 @@ const getJestConfig = (type) => {
   try {
     require.resolve('jest');
     return type === 'overrides'
-      ? require('./rules/typescript/jest.js').default
+      ? require('./typescript/jest.cjs')
       : [{
         // Name added for debugging purpose with @eslint/config-inspector
         name: 'jest/flat-recommended',

--- a/packages/@o3r/eslint-config/src/rules/typescript/eslint-angular.cjs
+++ b/packages/@o3r/eslint-config/src/rules/typescript/eslint-angular.cjs
@@ -23,7 +23,8 @@ const config = [
           type: 'element',
           style: 'kebab-case'
         }
-      ]
+      ],
+      '@angular-eslint/use-lifecycle-interface': 'error'
     }
   }
 ];

--- a/packages/@o3r/eslint-config/src/rules/typescript/eslint-typescript.cjs
+++ b/packages/@o3r/eslint-config/src/rules/typescript/eslint-typescript.cjs
@@ -17,7 +17,7 @@ const config = [
       '@typescript-eslint/consistent-type-assertions': 'error',
       '@typescript-eslint/dot-notation': 'error',
       '@typescript-eslint/explicit-member-accessibility': [
-        'warn',
+        'error',
         {
           accessibility: 'explicit',
           overrides: {
@@ -76,7 +76,7 @@ const config = [
       '@typescript-eslint/no-empty-function': 'off',
       '@typescript-eslint/no-empty-object-type': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
-      '@typescript-eslint/no-inferrable-types': 'warn',
+      '@typescript-eslint/no-inferrable-types': 'error',
       '@typescript-eslint/no-misused-promises': [
         'error',
         {
@@ -89,14 +89,14 @@ const config = [
       '@typescript-eslint/no-parameter-properties': 'off',
       '@typescript-eslint/no-redeclare': 'error',
       '@typescript-eslint/no-redundant-type-constituents': 'off',
-      '@typescript-eslint/no-require-imports': 'warn',
+      '@typescript-eslint/no-require-imports': 'error',
       '@typescript-eslint/no-shadow': [
         'error',
         {
           hoist: 'all'
         }
       ],
-      '@typescript-eslint/no-unsafe-enum-comparison': 'warn',
+      '@typescript-eslint/no-unsafe-enum-comparison': 'error',
       '@typescript-eslint/no-unused-vars': [
         'error',
         {
@@ -106,15 +106,15 @@ const config = [
         }
       ],
       '@typescript-eslint/no-use-before-define': 'off',
-      '@typescript-eslint/no-unsafe-assignment': 'warn',
-      '@typescript-eslint/no-unsafe-argument': 'warn',
-      '@typescript-eslint/no-unsafe-member-access': 'warn',
-      '@typescript-eslint/no-unsafe-call': 'warn',
-      '@typescript-eslint/no-unsafe-return': 'warn',
-      '@typescript-eslint/only-throw-error': 'warn',
+      '@typescript-eslint/no-unsafe-assignment': 'error',
+      '@typescript-eslint/no-unsafe-argument': 'error',
+      '@typescript-eslint/no-unsafe-member-access': 'error',
+      '@typescript-eslint/no-unsafe-call': 'error',
+      '@typescript-eslint/no-unsafe-return': 'error',
+      '@typescript-eslint/only-throw-error': 'error',
       '@typescript-eslint/prefer-for-of': 'error',
       '@typescript-eslint/prefer-function-type': 'error',
-      '@typescript-eslint/prefer-promise-reject-errors': 'warn',
+      '@typescript-eslint/prefer-promise-reject-errors': 'error',
       '@typescript-eslint/prefer-regexp-exec': 'off',
       '@typescript-eslint/triple-slash-reference': [
         'error',
@@ -124,7 +124,7 @@ const config = [
           lib: 'always'
         }
       ],
-      '@typescript-eslint/unbound-method': 'warn',
+      '@typescript-eslint/unbound-method': 'error',
       '@typescript-eslint/unified-signatures': 'error',
       '@typescript-eslint/prefer-readonly': 'error'
     }

--- a/packages/@o3r/eslint-config/src/rules/typescript/eslint.cjs
+++ b/packages/@o3r/eslint-config/src/rules/typescript/eslint.cjs
@@ -78,7 +78,7 @@ const config = [
       'no-inner-declarations': 'error',
       'no-invalid-this': 'off',
       'no-iterator': 'error',
-      'no-loop-func': 'warn',
+      'no-loop-func': 'error',
       'no-multi-str': 'error',
       'no-new-native-nonconstructor': 'error',
       'no-new-wrappers': 'error',

--- a/packages/@o3r/eslint-config/src/rules/typescript/jest.cjs
+++ b/packages/@o3r/eslint-config/src/rules/typescript/jest.cjs
@@ -8,8 +8,11 @@ const config = [
       '**/*.{c,m,}{t,j}s'
     ],
     rules: {
-      'jest/no-conditional-expect': 'warn',
-      'jest/no-done-callback': 'warn'
+      'jest/expect-expect': 'error',
+      'jest/no-commented-out-tests': 'error',
+      'jest/no-conditional-expect': 'error',
+      'jest/no-disabled-tests': 'error',
+      'jest/no-done-callback': 'error'
     }
   }
 ];

--- a/packages/@o3r/eslint-config/src/rules/typescript/jsdoc.cjs
+++ b/packages/@o3r/eslint-config/src/rules/typescript/jsdoc.cjs
@@ -8,30 +8,51 @@ const config = [
       '**/*.{c,m,}{t,j}s'
     ],
     rules: {
+      'jsdoc/check-access': 'error',
       'jsdoc/check-alignment': 'error',
       // TODO fix issue with ESLint v9+
       // 'jsdoc/check-examples': ['error', {
       //   'exampleCodeRegex': '^```(?:javascript|typescript|java|json|yaml|shell)?([\\s\\S]*)```\\s*$'
       // }],
+      'jsdoc/check-param-names': 'error',
+      'jsdoc/check-property-names': 'error',
       'jsdoc/check-tag-names': [
-        'warn',
+        'error',
         {
           definedTags: ['note', 'title', 'o3rCategory', 'o3rWidget', 'o3rWidgetParam', 'o3rRequired']
         }
       ],
+      'jsdoc/check-types': 'error',
+      'jsdoc/check-values': 'error',
+      'jsdoc/empty-tags': 'error',
+      'jsdoc/implements-on-classes': 'error',
+      'jsdoc/multiline-blocks': 'error',
       'jsdoc/no-defaults': 'off',
+      'jsdoc/no-multi-asterisks': 'error',
       'jsdoc/no-undefined-types': 'off',
-      'jsdoc/require-description': 'warn',
+      'jsdoc/require-description': 'error',
       'jsdoc/require-jsdoc': [
         'error',
         {
           publicOnly: true
         }
       ],
+      'jsdoc/require-param': 'error',
+      'jsdoc/require-param-description': 'error',
+      'jsdoc/require-param-name': 'error',
       'jsdoc/require-param-type': 'off',
+      'jsdoc/require-property': 'error',
+      'jsdoc/require-property-description': 'error',
+      'jsdoc/require-property-name': 'error',
       'jsdoc/require-property-type': 'off',
       'jsdoc/require-returns': 'off',
-      'jsdoc/require-returns-type': 'off'
+      'jsdoc/require-returns-check': 'error',
+      'jsdoc/require-returns-description': 'error',
+      'jsdoc/require-returns-type': 'off',
+      'jsdoc/require-yields': 'error',
+      'jsdoc/require-yields-check': 'error',
+      'jsdoc/tag-lines': 'error',
+      'jsdoc/valid-types': 'error'
     }
   }
 ];

--- a/packages/@o3r/eslint-config/src/rules/typescript/stylistic.cjs
+++ b/packages/@o3r/eslint-config/src/rules/typescript/stylistic.cjs
@@ -25,7 +25,7 @@ const config = [
         }
       ],
       '@stylistic/key-spacing': [
-        'warn',
+        'error',
         {
           beforeColon: false,
           afterColon: true
@@ -70,13 +70,13 @@ const config = [
         'always'
       ],
       '@stylistic/semi-spacing': [
-        'warn',
+        'error',
         {
           before: false,
           after: true
         }
       ],
-      '@stylistic/space-unary-ops': 'warn',
+      '@stylistic/space-unary-ops': 'error',
       '@stylistic/spaced-comment': [
         'error',
         'always',

--- a/packages/@o3r/eslint-config/src/rules/typescript/unicorn.cjs
+++ b/packages/@o3r/eslint-config/src/rules/typescript/unicorn.cjs
@@ -43,8 +43,8 @@ const config = [
       'unicorn/prefer-string-raw': 'off',
       'unicorn/prefer-string-replace-all': 'off',
       'unicorn/prevent-abbreviations': 'off',
-      'unicorn/switch-case-braces': 'warn',
-      'unicorn/text-encoding-identifier-case': 'warn'
+      'unicorn/switch-case-braces': 'error',
+      'unicorn/text-encoding-identifier-case': 'error'
     }
   }
 ];


### PR DESCRIPTION
## Proposed change
As discussed move all warnings into errors.
Open to discussion if some rules should become `off` instead of `errors`