### PR TITLE
fix: make typings more accurate by avoiding explict cast on consts

### DIFF
--- a/apps/chrome-devtools/src/app-devtools/theming-panel/color.helpers.ts
+++ b/apps/chrome-devtools/src/app-devtools/theming-panel/color.helpers.ts
@@ -27,7 +27,7 @@ export enum PaletteVariant {
 export const DEFAULT_PALETTE_VARIANT: PaletteVariant = PaletteVariant.V500;
 
 /* eslint-disable @typescript-eslint/naming-convention */
-const SATURATION_VALUES: Record<PaletteVariant, number> = {
+const SATURATION_VALUES = {
   '50': 0.91,
   '100': 0.98,
   '200': 0.96,
@@ -42,9 +42,9 @@ const SATURATION_VALUES: Record<PaletteVariant, number> = {
   'A200': 1,
   'A400': 1,
   'A700': 1
-};
+} as const satisfies Record<PaletteVariant, number>;
 
-const LIGHTNESS_VALUES: Record<PaletteVariant, number> = {
+const LIGHTNESS_VALUES = {
   '50': 0.12,
   '100': 0.3,
   '200': 0.5,
@@ -59,7 +59,7 @@ const LIGHTNESS_VALUES: Record<PaletteVariant, number> = {
   'A200': 0.64,
   'A400': 0.49,
   'A700': 0.44
-};
+} as const satisfies Record<PaletteVariant, number>;
 /* eslint-enable @typescript-eslint/naming-convention */
 
 /**

--- a/apps/chrome-devtools/src/services/state.service.ts
+++ b/apps/chrome-devtools/src/services/state.service.ts
@@ -189,11 +189,11 @@ export class StateService {
         ...(override ? undefined : state.stylingVariables),
         ...changes.stylingVariables
       }).filter((entry): entry is [string, string] => entry[1] !== null));
-      const stateOverrides: StateOverride = {
+      const stateOverrides = {
         configurations: Object.keys(configurationOverrides).length ? configurationOverrides : undefined,
         localizations: Object.keys(localizationOverrides || {}).length ? localizationOverrides : undefined,
         stylingVariables: Object.keys(stylingOverrides).length ? stylingOverrides : undefined
-      };
+      } satisfies StateOverride;
       return {
         ...state,
         ...stateOverrides

--- a/apps/github-cascading-app/src/cascading/interfaces.ts
+++ b/apps/github-cascading-app/src/cascading/interfaces.ts
@@ -64,7 +64,7 @@ export type CheckConclusion = 'cancelled' | 'neutral' | 'success' | 'failure' | 
 /**
  * Default configuration
  */
-export const DEFAULT_CONFIGURATION: Readonly<CascadingConfiguration> = {
+export const DEFAULT_CONFIGURATION = {
   ignoredPatterns: [] as string[],
   defaultBranch: '',
   cascadingBranchesPattern: '^releases?/\\d+\\.\\d+',
@@ -73,4 +73,4 @@ export const DEFAULT_CONFIGURATION: Readonly<CascadingConfiguration> = {
   labels: [] as string[],
   pullRequestTitle: '[cascading] from $origin to $target',
   branchNamePrefix: 'cascading'
-} as const;
+} as const satisfies Readonly<CascadingConfiguration>;

--- a/apps/showcase/e2e-playwright/sanity/lighthouse-sanity.e2e.ts
+++ b/apps/showcase/e2e-playwright/sanity/lighthouse-sanity.e2e.ts
@@ -4,7 +4,7 @@ import { type playwrightLighthouseConfig } from 'playwright-lighthouse';
 import { AppFixtureComponent } from '../../src/app/app.fixture';
 
 const baseUrl = process.env.PLAYWRIGHT_TARGET_URL || 'http://localhost:4200/';
-const lighthouseConfig: playwrightLighthouseConfig = {
+const lighthouseConfig = {
   thresholds: {
     performance: 35,
     accessibility: 100,
@@ -21,7 +21,7 @@ const lighthouseConfig: playwrightLighthouseConfig = {
     directory: 'playwright-reports/lighthouse'
   },
   port: 9222
-};
+} as const satisfies playwrightLighthouseConfig;
 
 const performAudit = async (name: string, page: Page | string, testInfo: TestInfo) => {
   const { playAudit } = await import('playwright-lighthouse');

--- a/apps/showcase/src/app/app.module.ts
+++ b/apps/showcase/src/app/app.module.ts
@@ -33,14 +33,14 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 
 
-const runtimeChecks: Partial<RuntimeChecks> = {
+const runtimeChecks = {
   strictActionImmutability: false,
   strictActionSerializability: false,
   strictActionTypeUniqueness: !isDevMode(),
   strictActionWithinNgZone: !isDevMode(),
   strictStateImmutability: !isDevMode(),
   strictStateSerializability: false
-};
+} as const satisfies Partial<RuntimeChecks>;
 
 registerLocaleData(localeEN, 'en-GB');
 registerLocaleData(localeFR, 'fr-FR');

--- a/apps/showcase/src/app/configuration/configuration.component.ts
+++ b/apps/showcase/src/app/configuration/configuration.component.ts
@@ -6,7 +6,7 @@ import { O3rComponent } from '@o3r/core';
 import { ConfigurationPresComponent, CopyTextPresComponent, IN_PAGE_NAV_PRES_DIRECTIVES, InPageNavLink, InPageNavLinkDirective, InPageNavPresService } from '../../components/index';
 import { ConfigurationPresConfig } from '../../components/showcase/configuration/configuration-pres.config';
 
-const CONFIG_OVERRIDE: ConfigurationPresConfig = {
+const CONFIG_OVERRIDE = {
   inXDays: 30,
   destinations: [
     { cityName: 'Manchester', available: true },
@@ -14,7 +14,7 @@ const CONFIG_OVERRIDE: ConfigurationPresConfig = {
     { cityName: 'Dallas', available: true }
   ],
   shouldProposeRoundTrip: true
-};
+} as const satisfies ConfigurationPresConfig;
 
 @O3rComponent({ componentType: 'Page' })
 @Component({

--- a/apps/showcase/src/app/rules-engine/rules-engine.component.ts
+++ b/apps/showcase/src/app/rules-engine/rules-engine.component.ts
@@ -18,13 +18,11 @@ import {
 import {
   CurrentTimeFactsService,
   dateInNextMinutes,
-  Operator,
   Rule,
   RulesEngineDevtoolsModule,
   RulesEngineRunnerModule,
   RulesEngineRunnerService,
-  Ruleset,
-  UnaryOperator
+  Ruleset
 } from '@o3r/rules-engine';
 import { firstValueFrom } from 'rxjs';
 import { CopyTextPresComponent, IN_PAGE_NAV_PRES_DIRECTIVES, InPageNavLink, InPageNavLinkDirective, InPageNavPresService, RulesEnginePresComponent } from '../../components/index';
@@ -88,8 +86,8 @@ export class RulesEngineComponent implements AfterViewInit {
     this.rulesEngineService.actionHandlers.add(inject(ConfigurationRulesEngineActionHandler));
     this.rulesEngineService.actionHandlers.add(inject(AssetRulesEngineActionHandler));
     this.rulesEngineService.actionHandlers.add(inject(LocalizationRulesEngineActionHandler));
-    this.rulesEngineService.engine.upsertOperators([duringSummer] as UnaryOperator[]);
-    this.rulesEngineService.engine.upsertOperators([dateInNextMinutes] as Operator[]);
+    this.rulesEngineService.engine.upsertOperators([duringSummer]);
+    this.rulesEngineService.engine.upsertOperators([dateInNextMinutes]);
     inject(TripFactsService).register();
     const currentTimeFactsService = inject(CurrentTimeFactsService);
     currentTimeFactsService.register();

--- a/apps/showcase/src/components/showcase/configuration/configuration-pres.config.ts
+++ b/apps/showcase/src/components/showcase/configuration/configuration-pres.config.ts
@@ -40,7 +40,7 @@ export interface ConfigurationPresConfig extends Configuration {
   shouldProposeRoundTrip: boolean;
 }
 
-export const CONFIGURATION_PRES_DEFAULT_CONFIG: ConfigurationPresConfig = {
+export const CONFIGURATION_PRES_DEFAULT_CONFIG = {
   inXDays: 7,
   destinations: [
     { cityName: 'London', available: true },
@@ -48,6 +48,6 @@ export const CONFIGURATION_PRES_DEFAULT_CONFIG: ConfigurationPresConfig = {
     { cityName: 'New-York', available: false }
   ],
   shouldProposeRoundTrip: false
-};
+} as const satisfies ConfigurationPresConfig;
 
 export const CONFIGURATION_PRES_CONFIG_ID = computeItemIdentifier('ConfigurationPresConfig', 'showcase');

--- a/apps/showcase/src/components/showcase/localization/localization-pres.translation.ts
+++ b/apps/showcase/src/components/showcase/localization/localization-pres.translation.ts
@@ -31,7 +31,7 @@ export interface LocalizationPresTranslation extends Translation {
   cityName: string;
 }
 
-export const translations: LocalizationPresTranslation = {
+export const translations = {
   welcome: 'o3r-localization-pres.welcome',
   welcomeWithCityName: 'o3r-localization-pres.welcomeWithCityName',
   question: 'o3r-localization-pres.question',
@@ -39,4 +39,4 @@ export const translations: LocalizationPresTranslation = {
   departureLabel: 'o3r-localization-pres.departureLabel',
   cityName: 'o3r-localization-pres.cityName',
   destinationPlaceholder: 'o3r-localization-pres.destinationPlaceholder'
-};
+} as const satisfies LocalizationPresTranslation;

--- a/apps/showcase/src/components/showcase/rules-engine/rules-engine-pres.config.ts
+++ b/apps/showcase/src/components/showcase/rules-engine/rules-engine-pres.config.ts
@@ -29,7 +29,7 @@ export interface RulesEnginePresConfig extends Configuration {
   shouldProposeRoundTrip: boolean;
 }
 
-export const RULES_ENGINE_PRES_DEFAULT_CONFIG: RulesEnginePresConfig = {
+export const RULES_ENGINE_PRES_DEFAULT_CONFIG = {
   inXDays: 7,
   destinations: [
     { cityCode: 'LON', available: true },
@@ -37,6 +37,6 @@ export const RULES_ENGINE_PRES_DEFAULT_CONFIG: RulesEnginePresConfig = {
     { cityCode: 'NYC', available: false }
   ],
   shouldProposeRoundTrip: false
-};
+} as const satisfies RulesEnginePresConfig;
 
 export const RULES_ENGINE_PRES_CONFIG_ID = computeItemIdentifier('RulesEnginePresConfig', 'showcase');

--- a/apps/showcase/src/components/showcase/rules-engine/rules-engine-pres.translation.ts
+++ b/apps/showcase/src/components/showcase/rules-engine/rules-engine-pres.translation.ts
@@ -34,7 +34,7 @@ export interface RulesEnginePresTranslation extends Translation {
    */
   returnLabel: string;
 }
-export const translations: RulesEnginePresTranslation = {
+export const translations = {
   welcome: 'o3r-rules-engine-pres.welcome',
   welcomeWithCityName: 'o3r-rules-engine-pres.welcomeWithCityName',
   question: 'o3r-rules-engine-pres.question',
@@ -43,4 +43,4 @@ export const translations: RulesEnginePresTranslation = {
   cityName: 'o3r-rules-engine-pres.cityName',
   returnLabel: 'o3r-rules-engine-pres.returnLabel',
   destinationPlaceholder: 'o3r-rules-engine-pres.destinationPlaceholder'
-};
+} as const satisfies RulesEnginePresTranslation;

--- a/apps/showcase/src/components/showcase/sdk/sdk-pres.component.ts
+++ b/apps/showcase/src/components/showcase/sdk/sdk-pres.component.ts
@@ -135,14 +135,14 @@ export class SdkPresComponent {
    * Call the API to create a new pet
    */
   public async create() {
-    const pet: Pet = {
+    const pet = {
       id: this.getNextId(),
       name: this.petName(),
       category: {name: 'otter'},
       tags: [{name: 'otter'}],
       status: 'available',
       photoUrls: this.petName() ? [this.petImage()] : []
-    };
+    } as const satisfies Pet;
     this.isLoading.set(true);
     await this.petStoreApi.addPet({
       // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -152,7 +152,7 @@ export class SdkPresComponent {
       const filePath = `${this.baseUrl}${pet.photoUrls[0]}`;
       const blob = await (await fetch(filePath)).blob();
       await this.petStoreApi.uploadFile({
-        petId: pet.id!,
+        petId: pet.id,
         body: new File([blob], filePath, {type: blob.type})
       });
     }

--- a/packages/@ama-sdk/client-angular/src/api-angular-client.ts
+++ b/packages/@ama-sdk/client-angular/src/api-angular-client.ts
@@ -34,13 +34,13 @@ export interface BaseApiAngularClientOptions extends BaseApiClientOptions {
 export interface BaseApiAngularClientConstructor extends PartialExcept<BaseApiAngularClientOptions, 'basePath' | 'httpClient'> {
 }
 
-const DEFAULT_OPTIONS: Omit<BaseApiAngularClientOptions, 'basePath' | 'httpClient'> = {
+const DEFAULT_OPTIONS = {
   replyPlugins: [new ReviverReply(), new ExceptionReply()],
   angularPlugins: [],
   requestPlugins: [],
   enableTokenization: false,
   disableFallback: false
-};
+} as const satisfies Partial<BaseApiAngularClientOptions>;
 
 /** Client to process the call to the API using Angular API */
 export class ApiAngularClient implements ApiClient {

--- a/packages/@ama-sdk/client-beacon/src/api-beacon-client.ts
+++ b/packages/@ama-sdk/client-beacon/src/api-beacon-client.ts
@@ -25,11 +25,11 @@ export interface BaseApiBeaconClientOptions extends BaseApiClientOptions {
 export interface BaseApiBeaconClientConstructor extends PartialExcept<Omit<BaseApiBeaconClientOptions, 'replyPlugins'>, 'basePath'> {
 }
 
-const DEFAULT_OPTIONS: Omit<BaseApiBeaconClientOptions, 'basePath'> = {
+const DEFAULT_OPTIONS = {
   replyPlugins: [] as never[],
   requestPlugins: [],
   enableTokenization: false
-};
+} as const satisfies Omit<BaseApiBeaconClientOptions, 'basePath'>;
 
 /**
  * Determine if the given value is a promise

--- a/packages/@ama-sdk/client-fetch/src/api-fetch-client.ts
+++ b/packages/@ama-sdk/client-fetch/src/api-fetch-client.ts
@@ -34,13 +34,13 @@ export interface BaseApiFetchClientOptions extends BaseApiClientOptions {
 export interface BaseApiFetchClientConstructor extends PartialExcept<BaseApiFetchClientOptions, 'basePath'> {
 }
 
-const DEFAULT_OPTIONS: Omit<BaseApiFetchClientOptions, 'basePath'> = {
+const DEFAULT_OPTIONS = {
   replyPlugins: [new ReviverReply(), new ExceptionReply()],
   fetchPlugins: [],
   requestPlugins: [],
   enableTokenization: false,
   disableFallback: false
-};
+} as const satisfies Partial<BaseApiFetchClientOptions>;
 
 /** Client to process the call to the API using Fetch API */
 export class ApiFetchClient implements ApiClient {

--- a/packages/@ama-sdk/client-fetch/src/plugins/perf-metric/perf-metric.fetch.ts
+++ b/packages/@ama-sdk/client-fetch/src/plugins/perf-metric/perf-metric.fetch.ts
@@ -143,12 +143,12 @@ export class PerformanceMetricPlugin implements FetchPlugin {
     const markId = v4();
     const perfMark = this.performance?.mark(this.getPerformanceTag('start', markId)) || undefined;
     const startTime = perfMark?.startTime ?? this.getTime();
-    const mark: Mark = {
+    const mark = {
       markId,
       url,
       requestOptions,
       startTime
-    };
+    } as const satisfies Mark;
     this.openMarks[markId] = mark;
     if (this.onMarkOpen) {
       void this.onMarkOpen(mark);

--- a/packages/@ama-sdk/core/src/plugins/raw-response-info/raw-response-info.reply.ts
+++ b/packages/@ama-sdk/core/src/plugins/raw-response-info/raw-response-info.reply.ts
@@ -45,13 +45,13 @@ export class RawResponseInfoReply<V = {[key: string]: any} | undefined> implemen
       transform: (data: V) => {
         if (!context.response) { return data; }
 
-        const responseInfo: RawResponseReply = {
+        const responseInfo = {
           responseInfo: {
             ...context.response,
             apiType: context.apiType,
             apiName: context.apiName
           }
-        };
+        } as const satisfies RawResponseReply;
 
         return data ? Object.assign(data, responseInfo) : responseInfo as V & RawResponseReply;
       }

--- a/packages/@ama-sdk/core/src/plugins/reviver/reviver.reply.ts
+++ b/packages/@ama-sdk/core/src/plugins/reviver/reviver.reply.ts
@@ -15,10 +15,10 @@ export class ReviverReply<V = {[key: string]: any}> implements ReplyPlugin<undef
   }
 
   public load<K>(context: ReplyPluginContext<K>): PluginRunner<K | undefined, V> {
-    const options: ReviverOptions = {
+    const options = {
       logger: context.logger,
       ...this.options
-    };
+    } as const satisfies ReviverOptions;
 
     return {
       transform: (data?: V) => {

--- a/packages/@ama-sdk/core/src/plugins/simple-api-key-authentication/simple-api-key-authentication.request.ts
+++ b/packages/@ama-sdk/core/src/plugins/simple-api-key-authentication/simple-api-key-authentication.request.ts
@@ -18,10 +18,10 @@ export interface SimpleApiKeyAuthenticationRequestOptions {
 /**
  * Default values of optional parameters
  */
-const DEFAULT_OPTION: SimpleApiKeyAuthenticationRequestOptions = {
+const DEFAULT_OPTION = {
   apiKeyHeader: 'x-api-key',
   contextHeader: 'ama-ctx'
-};
+} as const satisfies SimpleApiKeyAuthenticationRequestOptions;
 
 /**
  * Plugin to handle the Simple API key authentication with Apigee.

--- a/packages/@ama-sdk/core/src/utils/generic-api.ts
+++ b/packages/@ama-sdk/core/src/utils/generic-api.ts
@@ -43,18 +43,18 @@ export class GenericApi implements Api {
    */
   public async request<T>(requestOptions: GenericRequestOptions<T>): Promise<T> {
     const metadataHeaderAccept = requestOptions.metadata?.headerAccept || 'application/json';
-    const headers: { [key: string]: string | undefined } = {
+    const headers = {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       'Content-Type': requestOptions.metadata?.headerContentType || 'application/json',
       // eslint-disable-next-line @typescript-eslint/naming-convention
       ...(metadataHeaderAccept ? { 'Accept': metadataHeaderAccept } : {})
-    };
+    } as const satisfies RequestOptionsParameters['headers'];
 
-    const requestParameters: RequestOptionsParameters = {
+    const requestParameters = {
       api: this,
       headers,
       ...requestOptions
-    };
+    } as const satisfies RequestOptionsParameters;
     const options = await this.client.getRequestOptions(requestParameters);
     const url = this.client.prepareUrl(options.basePath, options.queryParams);
 

--- a/packages/@ama-sdk/schematics/schematics/code-generator/code-generator.ts
+++ b/packages/@ama-sdk/schematics/schematics/code-generator/code-generator.ts
@@ -40,7 +40,7 @@ export abstract class CodeGenerator<T extends CodegenTaskOptions> {
    */
   private getTaskConfiguration(options: Partial<T>): TaskConfigurationGenerator<T> {
     const name = this.generatorName;
-    const opts: T = {...this.getDefaultOptions(), ...options};
+    const opts = {...this.getDefaultOptions(), ...options} as const satisfies T;
     return new (class implements TaskConfigurationGenerator<T> {
       public toConfiguration(): TaskConfiguration<T> {
         return {

--- a/packages/@ama-sdk/schematics/schematics/code-generator/open-api-cli-generator/open-api-cli.generator.ts
+++ b/packages/@ama-sdk/schematics/schematics/code-generator/open-api-cli-generator/open-api-cli.generator.ts
@@ -86,11 +86,11 @@ export class OpenApiCliGenerator extends CodeGenerator<OpenApiCliOptions> {
       if (!generatorOptions) {
         return Promise.reject('Missing options to run open api generator');
       }
-      const spawnOptions: SpawnOptions = {
+      const spawnOptions = {
         stdio: 'inherit',
         shell: true,
         cwd: rootDirectory
-      };
+      } as const satisfies SpawnOptions;
       if (generatorOptions.generatorVersion) {
         await this.runInstallOpenApiGenerator(generatorOptions.generatorVersion, spawnOptions);
       }

--- a/packages/@ama-sdk/schematics/schematics/code-generator/open-api-cli-generator/open-api-cli.options.ts
+++ b/packages/@ama-sdk/schematics/schematics/code-generator/open-api-cli-generator/open-api-cli.options.ts
@@ -60,7 +60,7 @@ export type OpenApiCliOptions = CodegenTaskOptions & {
 /**
  * Default options to run our custom typescript generator
  */
-export const defaultTypescriptGeneratorOptions: OpenApiCliOptions = {
+export const defaultTypescriptGeneratorOptions = {
   generatorVersion: '',
   generatorName: 'typescriptFetch',
   generatorCustomPath: path.join(__dirname, '..', '..', 'typescript', 'core', 'openapi-codegen-typescript', 'target', 'typescriptFetch-openapi-generator.jar'),
@@ -70,4 +70,4 @@ export const defaultTypescriptGeneratorOptions: OpenApiCliOptions = {
   globalProperty: '',
   generatorKey: '',
   openapiNormalizer: ''
-};
+} as const satisfies OpenApiCliOptions;

--- a/packages/@ama-sdk/schematics/schematics/code-generator/swagger-java-generator/swagger-java.generator.ts
+++ b/packages/@ama-sdk/schematics/schematics/code-generator/swagger-java-generator/swagger-java.generator.ts
@@ -20,11 +20,11 @@ export class SwaggerJavaGenerator extends CodeGenerator<JavaGeneratorTaskOptions
       if (!generatorOptions) {
         return Promise.reject('Missing options');
       }
-      const spawnOptions: SpawnOptions = {
+      const spawnOptions = {
         stdio: 'inherit',
         shell: true,
         cwd: rootDirectory
-      };
+      } as const satisfies SpawnOptions;
       const codegenPath = path.join(generatorOptions.targetFolder, `${generatorOptions.codegenLanguage}-${generatorOptions.codegenFileName}`);
       const cliPath = path.resolve(__dirname, '..', '..', 'resources', generatorOptions.cliFilename);
 

--- a/packages/@ama-sdk/schematics/schematics/code-generator/swagger-java-generator/swagger-java.options.ts
+++ b/packages/@ama-sdk/schematics/schematics/code-generator/swagger-java-generator/swagger-java.options.ts
@@ -30,7 +30,7 @@ export type JavaGeneratorTaskOptions = CodegenTaskOptions & {
 /**
  * Default options to generate a JAVA sdk using the Swagger 2 Generator
  */
-export const defaultOptions: JavaGeneratorTaskOptions = {
+export const defaultOptions = {
   apiTests: true,
   targetFolder: './',
   cliFilename: 'swagger-codegen-cli.jar',
@@ -39,4 +39,4 @@ export const defaultOptions: JavaGeneratorTaskOptions = {
   specPath: 'swagger-spec.yaml',
   outputPath: '.',
   specConfigPath: ''
-};
+} as const satisfies JavaGeneratorTaskOptions;

--- a/packages/@ama-sdk/schematics/schematics/migrate/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/migrate/index.ts
@@ -10,7 +10,7 @@ import {updateOpenApiVersionInProject} from '../ng-update/typescript/v10.3/updat
 import { updateV11_4 as updateV114 } from '../ng-update/typescript';
 
 /* eslint-disable @typescript-eslint/naming-convention */
-const tsMigrationMap: MigrationRulesMap = {
+const tsMigrationMap = {
   '~10.3.2': updateOpenApiVersionInProject(),
   '11.0.*': [
     updateRegenScript
@@ -18,7 +18,7 @@ const tsMigrationMap: MigrationRulesMap = {
   '11.4.0-alpha.0': [
     updateV114
   ]
-};
+} as const satisfies MigrationRulesMap;
 /* eslint-enable @typescript-eslint/naming-convention */
 /**
  * Facilitate the migration of a version to another by the run of migration rules

--- a/packages/@o3r/analytics/plugins/webpack/build-metrics/build-stats.plugin.ts
+++ b/packages/@o3r/analytics/plugins/webpack/build-metrics/build-stats.plugin.ts
@@ -18,12 +18,12 @@ export interface BuildStatsPluginOptions {
   sessionId: string;
 }
 
-const defaultOptions: BuildStatsPluginOptions = {
+const defaultOptions = {
   threshold: 50,
   appName: 'Test',
   reporters: [ console ],
   sessionId: randomUUID()
-};
+} as const satisfies BuildStatsPluginOptions;
 
 const PLUGIN_NAME = 'OtterBuildStatsPlugin';
 
@@ -98,7 +98,7 @@ export class BuildStatsPlugin implements WebpackPluginInstance {
       if (stats.compilation.endTime === undefined || stats.compilation.startTime === undefined) {
         return;
       }
-      const buildData: ReportData = {
+      const buildData = {
         compileTime: stats.compilation.endTime - stats.compilation.startTime,
         buildType: compiler.modifiedFiles?.size ? 'watch' : 'full',
         loadersAndCompilation: this.timingData,
@@ -112,7 +112,7 @@ export class BuildStatsPlugin implements WebpackPluginInstance {
         hostName: os.hostname(),
         appName: this.options.appName,
         sessionId: this.options.sessionId
-      };
+      } as const satisfies ReportData;
       this.reportData(buildData);
     });
   }

--- a/packages/@o3r/analytics/src/services/event-track/event-track.service.ts
+++ b/packages/@o3r/analytics/src/services/event-track/event-track.service.ts
@@ -8,12 +8,12 @@ import { CustomEventMarks, CustomEventPayload, EventTiming, FirstLoadDataPayload
 import { defaultEventTrackConfiguration, EVENT_TRACK_SERVICE_CONFIGURATION, EventTrackConfiguration } from './event-track.configuration';
 
 /** The initial value of the performance measurements */
-export const performanceMarksInitialState: PerfEventPayload = {
+export const performanceMarksInitialState = {
   page: '',
   perceived: {},
   serverCalls: [],
   customMarks: []
-};
+} as const satisfies PerfEventPayload;
 
 /**
  * Service to expose the tracked events as streams. Also provide a way to activate/deactivate the tracking
@@ -227,7 +227,7 @@ export class EventTrackService {
    */
   public async addCustomMark(label: string) {
     const timing = await this.getTiming();
-    const customMark: CustomEventMarks = {label, timing};
+    const customMark = {label, timing} as const satisfies CustomEventMarks;
     const perf = { ...this.performancePayload, customMarks: this.performancePayload.customMarks.concat(customMark) };
     this.performancePayload = perf;
   }
@@ -276,7 +276,7 @@ export class EventTrackService {
       return -1;
     }
     const startTime = Math.round(window.performance.now());
-    const customMark: CustomEventMarks = {label, timing: {startTime}};
+    const customMark = {label, timing: {startTime}} as const satisfies CustomEventMarks;
     const perf = { ...this.performancePayload, customMarks: this.performancePayload.customMarks.concat(customMark) };
     this.performancePayload = perf;
     return this.performancePayload.customMarks.length - 1;

--- a/packages/@o3r/analytics/src/stores/event-track/event-track.sync.ts
+++ b/packages/@o3r/analytics/src/stores/event-track/event-track.sync.ts
@@ -2,7 +2,7 @@ import type { Serializer } from '@o3r/core';
 import { eventTrackInitialState } from './event-track.reducer';
 import { EventTrackState } from './event-track.state';
 
-export const eventTrackStorageSync: Serializer<EventTrackState> = {
+export const eventTrackStorageSync = {
   deserialize: (rawObject: any) => {
     if (rawObject) {
       return rawObject as EventTrackState;
@@ -10,4 +10,4 @@ export const eventTrackStorageSync: Serializer<EventTrackState> = {
       return eventTrackInitialState;
     }
   }
-};
+} as const satisfies Serializer<EventTrackState>;

--- a/packages/@o3r/application/src/devkit/application-devtools.token.ts
+++ b/packages/@o3r/application/src/devkit/application-devtools.token.ts
@@ -1,8 +1,8 @@
 import { InjectionToken } from '@angular/core';
 import { ApplicationDevtoolsServiceOptions } from './application-devkit.interface';
 
-export const OTTER_APPLICATION_DEVTOOLS_DEFAULT_OPTIONS: ApplicationDevtoolsServiceOptions = {
+export const OTTER_APPLICATION_DEVTOOLS_DEFAULT_OPTIONS = {
   isActivatedOnBootstrap: false
-};
+} as const satisfies ApplicationDevtoolsServiceOptions;
 
-export const OTTER_APPLICATION_DEVTOOLS_OPTIONS: InjectionToken<ApplicationDevtoolsServiceOptions> = new InjectionToken<ApplicationDevtoolsServiceOptions>('Otter Application Devtools options');
+export const OTTER_APPLICATION_DEVTOOLS_OPTIONS = new InjectionToken<ApplicationDevtoolsServiceOptions>('Otter Application Devtools options');

--- a/packages/@o3r/components/builders/component-extractor/helpers/component/component.extractor.ts
+++ b/packages/@o3r/components/builders/component-extractor/helpers/component/component.extractor.ts
@@ -264,10 +264,10 @@ export class ComponentExtractor {
         } else {
           throw new O3rCliError(message);
         }
-        const configWithoutIncompatibleProperties: ComponentConfigOutput = {
+        const configWithoutIncompatibleProperties = {
           ...config,
           properties: propertiesWithDefaultValue
-        };
+        } as const satisfies ComponentConfigOutput;
         return acc.concat(configWithoutIncompatibleProperties);
       }
 

--- a/packages/@o3r/components/builders/metadata-check/helpers/config-metadata-comparison.helper.ts
+++ b/packages/@o3r/components/builders/metadata-check/helpers/config-metadata-comparison.helper.ts
@@ -46,8 +46,8 @@ const isMigrationConfigurationDataMatch = (config: ComponentConfigOutput, migrat
 /**
  * Comparator used to compare one version of config metadata with another
  */
-export const configMetadataComparator: MetadataComparator<ComponentConfigOutput, MigrationConfigData, ComponentConfigOutput[]> = {
+export const configMetadataComparator = {
   getArray: getConfigurationArray,
   getIdentifier: getConfigurationPropertyName,
   isMigrationDataMatch: isMigrationConfigurationDataMatch
-};
+} as const satisfies MetadataComparator<ComponentConfigOutput, MigrationConfigData, ComponentConfigOutput[]>;

--- a/packages/@o3r/components/schematics/ng-add/index.ts
+++ b/packages/@o3r/components/schematics/ng-add/index.ts
@@ -51,14 +51,14 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       };
       return acc;
     }, getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion));
-    const devDependencies: Record<string, DependencyToAdd> = {
+    const devDependencies = {
       chokidar: {
         inManifest: [{
           range: packageJson.peerDependencies.chokidar,
           types: [NodeDependencyType.Dev]
         }]
       }
-    };
+    } as const satisfies Record<string, DependencyToAdd>;
     const rule = chain([
       removePackages(['@otter/components']),
       setupDependencies({

--- a/packages/@o3r/components/src/devkit/components-devtools.token.ts
+++ b/packages/@o3r/components/src/devkit/components-devtools.token.ts
@@ -1,8 +1,8 @@
 import { InjectionToken } from '@angular/core';
 import { ComponentsDevtoolsServiceOptions } from './components-devkit.interface';
 
-export const OTTER_COMPONENTS_DEVTOOLS_DEFAULT_OPTIONS: ComponentsDevtoolsServiceOptions = {
+export const OTTER_COMPONENTS_DEVTOOLS_DEFAULT_OPTIONS = {
   isActivatedOnBootstrap: false
-};
+} as const satisfies ComponentsDevtoolsServiceOptions;
 
-export const OTTER_COMPONENTS_DEVTOOLS_OPTIONS: InjectionToken<ComponentsDevtoolsServiceOptions> = new InjectionToken<ComponentsDevtoolsServiceOptions>('Otter Components Devtools options');
+export const OTTER_COMPONENTS_DEVTOOLS_OPTIONS = new InjectionToken<ComponentsDevtoolsServiceOptions>('Otter Components Devtools options');

--- a/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.sync.ts
+++ b/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.sync.ts
@@ -17,7 +17,7 @@ export const placeholderRequestStorageDeserializer = (rawObject: any) => {
   return storeObject;
 };
 
-export const placeholderRequestStorageSync: Serializer<PlaceholderRequestState> = {
+export const placeholderRequestStorageSync = {
   serialize: placeholderRequestStorageSerializer,
   deserialize: placeholderRequestStorageDeserializer
-};
+} as const satisfies Serializer<PlaceholderRequestState>;

--- a/packages/@o3r/components/src/stores/placeholder-template/placeholder-template.sync.ts
+++ b/packages/@o3r/components/src/stores/placeholder-template/placeholder-template.sync.ts
@@ -14,6 +14,6 @@ export const placeholderTemplateStorageDeserializer = (rawObject: any) => {
   return storeObject;
 };
 
-export const placeholderTemplateStorageSync: Serializer<PlaceholderTemplateState> = {
+export const placeholderTemplateStorageSync = {
   deserialize: placeholderTemplateStorageDeserializer
-};
+} as const satisfies Serializer<PlaceholderTemplateState>;

--- a/packages/@o3r/configuration/src/devkit/configuration-devtools.token.ts
+++ b/packages/@o3r/configuration/src/devkit/configuration-devtools.token.ts
@@ -1,12 +1,12 @@
 import { InjectionToken } from '@angular/core';
 import { ConfigurationDevtoolsServiceOptions } from './configuration-devtools.interface';
 
-export const OTTER_CONFIGURATION_DEVTOOLS_DEFAULT_OPTIONS: ConfigurationDevtoolsServiceOptions = {
+export const OTTER_CONFIGURATION_DEVTOOLS_DEFAULT_OPTIONS = {
   defaultLibraryName: '@o3r/components',
   defaultJsonFilename: 'partial-static-config.json',
   isActivatedOnBootstrap: false,
   isActivatedOnBootstrapWhenCMSContext: true
-};
+} as const satisfies ConfigurationDevtoolsServiceOptions;
 
 // eslint-disable-next-line max-len
-export const OTTER_CONFIGURATION_DEVTOOLS_OPTIONS: InjectionToken<ConfigurationDevtoolsServiceOptions> = new InjectionToken<ConfigurationDevtoolsServiceOptions>('Otter Configuration Devtools options');
+export const OTTER_CONFIGURATION_DEVTOOLS_OPTIONS = new InjectionToken<ConfigurationDevtoolsServiceOptions>('Otter Configuration Devtools options');

--- a/packages/@o3r/core/builders/app-version/index.ts
+++ b/packages/@o3r/core/builders/app-version/index.ts
@@ -6,15 +6,15 @@ import { AppVersionBuilderSchema } from './schema';
 
 export * from './schema';
 
-const PACKAGE_JSON_NOT_FOUND: BuilderOutput = {
+const PACKAGE_JSON_NOT_FOUND = {
   error: 'package.json not found',
   success: false
-};
+} as const satisfies BuilderOutput;
 
-const PACKAGE_JSON_INCORRECT: BuilderOutput = {
+const PACKAGE_JSON_INCORRECT = {
   error: 'package.json incorrect',
   success: false
-};
+} as const satisfies BuilderOutput;
 
 /** Maximum number of steps */
 const STEP_NUMBER = 2;

--- a/packages/@o3r/core/schematics/ng-add/index.ts
+++ b/packages/@o3r/core/schematics/ng-add/index.ts
@@ -64,7 +64,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       async (t, c) => {
         const { preset, externalPresets, ...forwardOptions } = options;
         const presetRunner = await presets[preset]({ projectName: forwardOptions.projectName, forwardOptions });
-        const externalPresetRunner = externalPresets ? await getExternalPreset(externalPresets, t, c)?.({ projectName: forwardOptions.projectName, forwardOptions }) : undefined;
+        const externalPresetRunner = externalPresets ? await getExternalPreset(externalPresets, t, c)({ projectName: forwardOptions.projectName, forwardOptions }) : undefined;
         const modules = [...new Set([...(presetRunner.modules || []), ...(externalPresetRunner?.modules || [])])];
         if (modules.length) {
           c.logger.info(`The following modules will be installed: ${modules.join(', ')}`);

--- a/packages/@o3r/core/schematics/page/index.ts
+++ b/packages/@o3r/core/schematics/page/index.ts
@@ -205,11 +205,11 @@ function ngGeneratePageFn(options: NgGeneratePageSchematicsSchema): Rule {
    */
   const updateAppRoutingModule: Rule = (tree: Tree, context: SchematicContext) => {
     const indexFilePath = path.posix.join(strings.dasherize(options.scope), strings.dasherize(options.name), 'index');
-    const route: Route = {
+    const route = {
       path: strings.dasherize(options.name),
       import: `./${indexFilePath.replace(/[\\/]/g, '/')}`,
       module: `${pageName}${options.standalone ? 'Component' : 'Module'}`
-    };
+    } as const satisfies Route;
     if (options.appRoutingModulePath) {
       return insertRoute(tree, context, options.appRoutingModulePath, route, options.standalone);
     }

--- a/packages/@o3r/core/schematics/store/entity-async/index.ts
+++ b/packages/@o3r/core/schematics/store/entity-async/index.ts
@@ -22,7 +22,7 @@ function ngGenerateEntityAsyncStoreFn(options: NgGenerateEntityAsyncStoreSchemat
     options.modelIdPropName = options.modelIdPropName?.trim();
 
     // Add extra formatted properties
-    const formattedProperties: ExtraFormattedProperties = {
+    const formattedProperties = {
       isAsync: true,
       isEntity: true,
       storeName: strings.classify(options.storeName),
@@ -35,7 +35,7 @@ function ngGenerateEntityAsyncStoreFn(options: NgGenerateEntityAsyncStoreSchemat
       modelIdPropName: options.modelIdPropName ? options.modelIdPropName : 'id',
       reviverModelName: `revive${options.modelName}`,
       fileName: strings.dasherize(options.storeName)
-    };
+    } as const satisfies ExtraFormattedProperties;
     let currentStoreIndex = '';
     const barrelPath = path.join(destination, options.storeName, 'index.ts');
     if (tree.exists(barrelPath)) {

--- a/packages/@o3r/core/schematics/store/entity-sync/index.ts
+++ b/packages/@o3r/core/schematics/store/entity-sync/index.ts
@@ -23,7 +23,7 @@ function ngGenerateEntitySyncStoreFn(options: NgGenerateEntitySyncStoreSchematic
     options.modelIdPropName = options.modelIdPropName?.trim();
 
     // Add extra formatted properties
-    const formattedProperties: ExtraFormattedProperties = {
+    const formattedProperties = {
       isAsync: false,
       isEntity: true,
       storeName: strings.classify(options.storeName),
@@ -36,7 +36,7 @@ function ngGenerateEntitySyncStoreFn(options: NgGenerateEntitySyncStoreSchematic
       modelIdPropName: options.modelIdPropName ? options.modelIdPropName : 'id',
       reviverModelName: `revive${options.modelName}`,
       fileName: strings.dasherize(options.storeName)
-    };
+    } as const satisfies ExtraFormattedProperties;
     let currentStoreIndex = '';
     const barrelPath = path.join(destination, options.storeName, 'index.ts');
     if (tree.exists(barrelPath)) {

--- a/packages/@o3r/core/schematics/store/simple-async/index.ts
+++ b/packages/@o3r/core/schematics/store/simple-async/index.ts
@@ -20,7 +20,7 @@ function ngGenerateSimpleAsyncStoreFn(options: NgGenerateSimpleAsyncStoreSchemat
     options.modelName = options.modelName?.trim();
 
     // Add extra formatted properties
-    const formattedProperties: Partial<ExtraFormattedProperties> = {
+    const formattedProperties = {
       isAsync: true,
       isEntity: false,
       storeName: strings.classify(options.storeName),
@@ -31,7 +31,7 @@ function ngGenerateSimpleAsyncStoreFn(options: NgGenerateSimpleAsyncStoreSchemat
       payloadModelName: options.sdkPackage ? options.modelName : strings.classify(options.storeName),
       reviverModelName: `revive${options.modelName}`,
       fileName: strings.dasherize(options.storeName)
-    };
+    } as const satisfies Partial<ExtraFormattedProperties>;
     let currentStoreIndex = '';
     const barrelPath = path.join(destination, options.storeName, 'index.ts');
     if (tree.exists(barrelPath)) {

--- a/packages/@o3r/core/schematics/store/simple-sync/index.ts
+++ b/packages/@o3r/core/schematics/store/simple-sync/index.ts
@@ -20,14 +20,14 @@ function ngGenerateSimpleSyncStoreFn(options: NgGenerateSimpleSyncStoreSchematic
     options.storeName = options.storeName?.trim();
 
     // Add extra formatted properties
-    const formattedProperties: Partial<ExtraFormattedProperties> = {
+    const formattedProperties = {
       isAsync: false,
       isEntity: false,
       storeName: strings.classify(options.storeName),
       cStoreName: strings.camelize(options.storeName),
       scuStoreName: strings.underscore(options.storeName).toUpperCase(),
       fileName: strings.dasherize(options.storeName)
-    };
+    } as const satisfies Partial<ExtraFormattedProperties> ;
     let currentStoreIndex = '';
     const barrelPath = path.join(destination, options.storeName, 'index.ts');
     if (tree.exists(barrelPath)) {

--- a/packages/@o3r/core/src/core/application/build-properties.ts
+++ b/packages/@o3r/core/src/core/application/build-properties.ts
@@ -58,7 +58,7 @@ export interface BuildTimeProperties {
 /**
  * Library build time default properties
  */
-export const DEFAULT_BUILD_PROPERTIES: BuildTimeProperties = {
+export const DEFAULT_BUILD_PROPERTIES = {
   DEBUG_MODE: true,
   APP_BASE_HREF: '.',
   APP_VERSION: '0.0.0',
@@ -69,4 +69,4 @@ export const DEFAULT_BUILD_PROPERTIES: BuildTimeProperties = {
   ENVIRONMENT: 'dev',
   LOCALIZATION_BUNDLES_OUTPUT: 'localizations/',
   USE_MOCKS: false
-};
+} as const satisfies BuildTimeProperties;

--- a/packages/@o3r/create/src/index.ts
+++ b/packages/@o3r/create/src/index.ts
@@ -186,11 +186,11 @@ const createNgProject = () => {
 
 const prepareWorkspace = (relativeDirectory = '.', projectPackageManager = 'npm') => {
   const cwd = resolve(process.cwd(), relativeDirectory);
-  const spawnSyncOpts: SpawnSyncOptionsWithBufferEncoding = {
+  const spawnSyncOpts = {
     stdio: 'inherit',
     shell: true,
     cwd
-  };
+  } as const satisfies SpawnSyncOptionsWithBufferEncoding;
   const runner = process.platform === 'win32' ? `${projectPackageManager}.cmd` : projectPackageManager;
   const mandatoryDependencies = [
     '@angular-devkit/schematics',

--- a/packages/@o3r/design/builders/generate-css/index.ts
+++ b/packages/@o3r/design/builders/generate-css/index.ts
@@ -59,7 +59,7 @@ export default createBuilder<GenerateCssSchematicsSchema>(createBuilderWithMetri
     logger.info(`Updated ${file.toString()} with Design Token content.`);
     return res;
   };
-  const renderDesignTokenOptionsCss: DesignTokenRendererOptions = {
+  const renderDesignTokenOptionsCss = {
     writeFile: writeFileWithLogger,
     determineFileToUpdate,
     tokenDefinitionRenderer: getCssTokenDefinitionRenderer({
@@ -72,9 +72,9 @@ export default createBuilder<GenerateCssSchematicsSchema>(createBuilderWithMetri
       logger
     }),
     logger
-  };
+  } as const satisfies DesignTokenRendererOptions;
 
-  const renderDesignTokenOptionsSass: DesignTokenRendererOptions = {
+  const renderDesignTokenOptionsSass = {
     writeFile: writeFileWithLogger,
     determineFileToUpdate,
     tokenDefinitionRenderer: getSassTokenDefinitionRenderer({
@@ -82,14 +82,14 @@ export default createBuilder<GenerateCssSchematicsSchema>(createBuilderWithMetri
       logger
     }),
     logger
-  };
+  } as const satisfies DesignTokenRendererOptions;
 
-  const renderDesignTokenOptionsMetadata: DesignTokenRendererOptions = {
+  const renderDesignTokenOptionsMetadata = {
     determineFileToUpdate: () => resolve(context.workspaceRoot, options.metadataOutput!),
     styleContentUpdater: getMetadataStyleContentUpdater(),
     tokenDefinitionRenderer: getMetadataTokenDefinitionRenderer({ tokenVariableNameRenderer, ignorePrivateVariable: options.metadataIgnorePrivate }),
     logger
-  };
+  } as const satisfies DesignTokenRendererOptions;
 
   const execute = async (renderDesignTokenOptions: DesignTokenRendererOptions): Promise<BuilderOutput> => {
     let template: DesignTokenGroupTemplate | undefined;

--- a/packages/@o3r/design/schematics/generate-css/index.ts
+++ b/packages/@o3r/design/schematics/generate-css/index.ts
@@ -21,13 +21,13 @@ function generateCssFn(options: GenerateCssSchematicsSchema): Rule {
 
         return options.defaultStyleFile;
       };
-    const renderDesignTokenOptions: DesignTokenRendererOptions = {
+    const renderDesignTokenOptions = {
       readFile,
       writeFile,
       existsFile,
       determineFileToUpdate,
       logger: context.logger
-    };
+    } as const satisfies DesignTokenRendererOptions;
 
     const { globInTree } = await import('@o3r/schematics');
 

--- a/packages/@o3r/design/schematics/ng-add/register-generate-css/register-task.ts
+++ b/packages/@o3r/design/schematics/ng-add/register-generate-css/register-task.ts
@@ -15,14 +15,14 @@ export const registerGenerateCssBuilder = (projectName?: string, taskName = 'gen
     const workspaceRootPath = workspaceProject?.root || '.';
     const srcBasePath = workspaceProject?.sourceRoot || posix.join(workspaceRootPath, 'src');
     const themeFile = posix.join(srcBasePath, 'style', 'theme.scss');
-    const taskOptions: GenerateCssSchematicsSchema = {
+    const taskOptions = {
       defaultStyleFile: themeFile,
       templateFile: posix.join(workspaceRootPath, 'design-token.template.json'),
       designTokenFilePatterns: [
         posix.join(srcBasePath, 'style', '*.json'),
         posix.join(srcBasePath, '**', '*.theme.json')
       ]
-    };
+    } as const satisfies GenerateCssSchematicsSchema;
     const taskParameters = {
       builder: '@o3r/design:generate-css',
       options: taskOptions,

--- a/packages/@o3r/design/src/core/design-token/parsers/design-token.parser.ts
+++ b/packages/@o3r/design/src/core/design-token/parsers/design-token.parser.ts
@@ -154,7 +154,7 @@ const walkThroughDesignTokenNodes = (
     const parentNames = ancestors.map(({ name }) => name);
     const tokenReferenceName = getTokenReferenceName(nodeName, parentNames);
 
-    const tokenVariable: DesignTokenVariableStructure = {
+    const tokenVariable = {
       context,
       extensions: getExtensions([...ancestors, { name: nodeName, tokenNode: node }], context),
       node,
@@ -185,7 +185,7 @@ const walkThroughDesignTokenNodes = (
       getKey: function (keyRenderer) {
         return keyRenderer ? keyRenderer(this) : sanitizeKeyName(this.tokenReferenceName);
       }
-    };
+    } as const satisfies DesignTokenVariableStructure;
 
     mem.set(tokenReferenceName, tokenVariable);
   }
@@ -227,9 +227,9 @@ interface ParseDesignTokenFileOptions {
  */
 export const parseDesignTokenFile = async (specificationFilePath: string, options?: ParseDesignTokenFileOptions) => {
   const readFile = options?.readFile || ((filePath: string) => fs.readFile(filePath, { encoding: 'utf8' }));
-  const context: DesignTokenContext = {
+  const context = {
     basePath: dirname(specificationFilePath),
     ...options?.specificationContext
-  };
+  } as const satisfies DesignTokenContext;
   return parseDesignToken({ document: JSON.parse(await readFile(specificationFilePath)), context });
 };

--- a/packages/@o3r/dev-tools/src/cli/aql-artifact-cleaner.ts
+++ b/packages/@o3r/dev-tools/src/cli/aql-artifact-cleaner.ts
@@ -84,7 +84,7 @@ const isDownloadedTimeValueDefined = !!programOptions.lastDownloadedTimeValue;
 const downloadedTimeValue: number = programOptions.lastDownloadedTimeValue;
 const property: string = programOptions.property;
 const propertyValue: string = programOptions.propertyValue;
-const options: Options = {
+const options = {
   headers: authHeader,
   uri: url,
   body: `items.find(
@@ -103,7 +103,7 @@ const options: Options = {
   .include("name","repo","path","created","size")
   .sort({"$desc" : ["created"]}).offset(${offset})
   .limit(10000)`
-};
+} as const satisfies Options;
 // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
 logger.debug(`AQL search executed : ${options.body}`);
 logger.info(`Url called : ${url}`);

--- a/packages/@o3r/dynamic-content/schematics/ng-update/v10-0/index.ts
+++ b/packages/@o3r/dynamic-content/schematics/ng-update/v10-0/index.ts
@@ -2,14 +2,14 @@
 import { chain, Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { createSchematicWithMetricsIfInstalled, PipeReplacementInfo, updatePipes } from '@o3r/schematics';
 
-const pipeReplacementInfo: PipeReplacementInfo = {
+const pipeReplacementInfo = {
   dynamicContent: {
     new: {
       name: 'o3rDynamicContent'
     },
     import: 'DynamicContentModule'
   }
-};
+} as const satisfies PipeReplacementInfo;
 
 /**
  * Update of Otter library V10.0

--- a/packages/@o3r/dynamic-content/src/services/request-parameters/request-parameters.config.ts
+++ b/packages/@o3r/dynamic-content/src/services/request-parameters/request-parameters.config.ts
@@ -39,9 +39,9 @@ export interface RequestParametersConfig {
   postParamsValue: string;
 }
 
-export const defaultRequestParametersConfig: RequestParametersConfig = {
+export const defaultRequestParametersConfig = {
   storage: (typeof window !== 'undefined') ? window.sessionStorage : undefined,
   strategy: StorageStrategy.Rehydrate,
   queryParamsValue: typeof document !== 'undefined' && document.body && document.body.dataset && document.body.dataset.query || '{}',
   postParamsValue: typeof document !== 'undefined' && document.body && document.body.dataset && document.body.dataset.post || '{}'
-};
+} as const satisfies RequestParametersConfig;

--- a/packages/@o3r/extractors/src/core/comparator/package-managers-extractors/yarn2-file-extractor.helper.ts
+++ b/packages/@o3r/extractors/src/core/comparator/package-managers-extractors/yarn2-file-extractor.helper.ts
@@ -152,8 +152,8 @@ async function fetchPackage(project: Project, descriptor: Descriptor): Promise<F
     // eslint-disable-next-line new-cap
     (yarnNpmPlugin.fetchers || []).map((fetcher) => new fetcher())
   );
-  const fetchOptions: FetchOptions = { project, cache, checksums: project.storedChecksums, report, fetcher: multiFetcher };
-  const resolveOptions: ResolveOptions = { project, report, resolver: multiResolver, fetchOptions };
+  const fetchOptions = { project, cache, checksums: project.storedChecksums, report, fetcher: multiFetcher } as const satisfies FetchOptions;
+  const resolveOptions = { project, report, resolver: multiResolver, fetchOptions } as const satisfies ResolveOptions;
 
   const normalizedDescriptor = project.configuration.normalizeDependency(descriptor);
   const candidate = await multiResolver.getCandidates(normalizedDescriptor, {}, resolveOptions);
@@ -166,7 +166,7 @@ async function fetchPackage(project: Project, descriptor: Descriptor): Promise<F
   if (!isSupported) {
     throw new O3rCliError(`Fetcher does not support ${descriptorStringify}`);
   }
-  return multiFetcher.fetch(candidate[0], resolveOptions.fetchOptions!);
+  return multiFetcher.fetch(candidate[0], resolveOptions.fetchOptions);
 }
 
 /**

--- a/packages/@o3r/extractors/src/core/wrapper.ts
+++ b/packages/@o3r/extractors/src/core/wrapper.ts
@@ -40,7 +40,7 @@ export const createBuilderWithMetricsIfInstalled: BuilderWrapper = (builderFn) =
     ) {
       ctx.logger.debug('`@o3r/telemetry` is not available.\nAsking to add the dependency\n' + e.toString());
 
-      const question: Question = {
+      const question = {
         type: 'confirm',
         name: 'isReplyPositive',
         message: `
@@ -49,7 +49,7 @@ It will help us to improve our tools.
 For more details and instructions on how to change these settings, see https://github.com/AmadeusITGroup/otter/blob/main/docs/telemetry/PRIVACY_NOTICE.md.
         `,
         default: false
-      };
+      } as const satisfies Question;
       const { isReplyPositive } = await prompt([question]);
 
       if (isReplyPositive) {

--- a/packages/@o3r/localization/builders/metadata-check/helpers/localization-metadata-comparison.helper.ts
+++ b/packages/@o3r/localization/builders/metadata-check/helpers/localization-metadata-comparison.helper.ts
@@ -23,8 +23,8 @@ const isMigrationLocalizationDataMatch = (localization: JSONLocalization, migrat
 /**
  * Comparator used to compare one version of localization metadata with another
  */
-export const localizationMetadataComparator: MetadataComparator<JSONLocalization, MigrationLocalizationMetadata, LocalizationMetadata> = {
+export const localizationMetadataComparator = {
   getArray: getLocalizationArray,
   getIdentifier: getLocalizationName,
   isMigrationDataMatch: isMigrationLocalizationDataMatch
-};
+} as const satisfies MetadataComparator<JSONLocalization, MigrationLocalizationMetadata, LocalizationMetadata>;

--- a/packages/@o3r/localization/src/core/localization.configuration.ts
+++ b/packages/@o3r/localization/src/core/localization.configuration.ts
@@ -51,7 +51,7 @@ export interface LocalizationConfiguration {
 /**
  * Default configuration for LocalizationModule
  */
-export const DEFAULT_LOCALIZATION_CONFIGURATION: LocalizationConfiguration = {
+export const DEFAULT_LOCALIZATION_CONFIGURATION = {
   supportedLocales: [],
   endPointUrl: '',
   useDynamicContent: false,
@@ -61,4 +61,4 @@ export const DEFAULT_LOCALIZATION_CONFIGURATION: LocalizationConfiguration = {
   debugMode: false,
   enableTranslationDeactivation: false,
   mergeWithLocalTranslations: false
-};
+} as const satisfies LocalizationConfiguration;

--- a/packages/@o3r/localization/src/core/translate-messageformat-lazy.compiler.ts
+++ b/packages/@o3r/localization/src/core/translate-messageformat-lazy.compiler.ts
@@ -22,10 +22,10 @@ export interface LazyMessageFormatConfig extends Options {
 /**
  * Message format configuration default value
  */
-export const lazyMessageDefaultConfig: LazyMessageFormatConfig = {
+export const lazyMessageDefaultConfig = {
   enableCache: true,
   ignoreTag: true
-};
+} as const satisfies LazyMessageFormatConfig;
 
 /** Message Format configuration Token */
 export const MESSAGE_FORMAT_CONFIG = new InjectionToken<LazyMessageFormatConfig>('Message Format configuration');

--- a/packages/@o3r/localization/src/devkit/localization-devtools.token.ts
+++ b/packages/@o3r/localization/src/devkit/localization-devtools.token.ts
@@ -1,10 +1,10 @@
 import { InjectionToken } from '@angular/core';
 import { LocalizationDevtoolsServiceOptions } from './localization-devkit.interface';
 
-export const OTTER_LOCALIZATION_DEVTOOLS_DEFAULT_OPTIONS: LocalizationDevtoolsServiceOptions = {
+export const OTTER_LOCALIZATION_DEVTOOLS_DEFAULT_OPTIONS = {
   isActivatedOnBootstrap: false,
   isActivatedOnBootstrapWhenCMSContext: true,
   metadataFilePath: './metadata/localisation.metadata.json'
-};
+} as const satisfies LocalizationDevtoolsServiceOptions;
 
-export const OTTER_LOCALIZATION_DEVTOOLS_OPTIONS: InjectionToken<LocalizationDevtoolsServiceOptions> = new InjectionToken<LocalizationDevtoolsServiceOptions>('Otter Localization Devtools options');
+export const OTTER_LOCALIZATION_DEVTOOLS_OPTIONS = new InjectionToken<LocalizationDevtoolsServiceOptions>('Otter Localization Devtools options');

--- a/packages/@o3r/localization/src/tools/localization.provider.ts
+++ b/packages/@o3r/localization/src/tools/localization.provider.ts
@@ -20,8 +20,8 @@ export function createTranslateLoader(localizationConfiguration: LocalizationCon
 /**
  * TranslateLoader provider, using framework's TranslationsLoader class
  */
-export const translateLoaderProvider: FactoryProvider = {
+export const translateLoaderProvider = {
   provide: TranslateLoader,
   useFactory: createTranslateLoader,
   deps: [LOCALIZATION_CONFIGURATION_TOKEN, [new Optional(), LoggerService], [new Optional(), DynamicContentService]]
-};
+} as const satisfies FactoryProvider;

--- a/packages/@o3r/logger/src/services/logger/logger.noop.ts
+++ b/packages/@o3r/logger/src/services/logger/logger.noop.ts
@@ -6,7 +6,7 @@ import type { LoggerClient } from './logger.client';
  * Console logger used to display the logs in the browser console
  * Should be used in development mode.
  */
-export const noopLogger: LoggerClient = {
+export const noopLogger = {
   identify: () => {},
   event: () => {},
   getSessionURL: () => undefined,
@@ -18,4 +18,4 @@ export const noopLogger: LoggerClient = {
   info: console.info,
   log: console.log,
   createMetaReducer: (): MetaReducer<any, Action> => (reducer: ActionReducer<any>): ActionReducer<any> => reducer
-};
+} as const satisfies LoggerClient;

--- a/packages/@o3r/rules-engine/builders/rules-engine-extractor/helpers/rules-engine.extractor.ts
+++ b/packages/@o3r/rules-engine/builders/rules-engine-extractor/helpers/rules-engine.extractor.ts
@@ -36,7 +36,7 @@ export class RulesEngineExtractor {
   /** Interface of an action definition */
   public static readonly OPERATOR_ACTIONS_INTERFACE = 'RulesEngineAction';
   /** Reserved fact names that will be filtered out of metadata */
-  public static readonly RESERVED_FACT_NAMES: Readonly<string[]> = ['portalFacts'];
+  public static readonly RESERVED_FACT_NAMES = ['portalFacts'];
 
   /** TSConfig to parse the code  */
   private readonly tsconfig: any;
@@ -67,11 +67,11 @@ export class RulesEngineExtractor {
       )) : [];
     internalLibFiles.push(sourceFile);
     const program = tjs.getProgramFromFiles(internalLibFiles, this.tsconfig.compilerOptions, this.basePath);
-    const settings: tjs.PartialArgs = {
+    const settings = {
       required: true,
       aliasRef: this.tsconfig.compilerOptions?.paths,
       ignoreErrors: true
-    };
+    } as const satisfies tjs.PartialArgs;
     const schema = tjs.generateSchema(program, type, settings);
     if (schema?.definitions?.['utils.Date']) {
       schema.definitions['utils.Date'] = {type: 'string', format: 'date'};
@@ -193,7 +193,7 @@ export class RulesEngineExtractor {
             .filter(ts.isPropertySignature)
             .filter((prop) => {
               const name = prop.name.getText(source);
-              if (RulesEngineExtractor.RESERVED_FACT_NAMES.indexOf(name) > -1) {
+              if (RulesEngineExtractor.RESERVED_FACT_NAMES.includes(name)) {
                 this.logger.error(`Fact named "${name}" found in ${sourceFile} has a reserved name and will be ignored by the extractor, please consider renaming it.`);
                 return false;
               }

--- a/packages/@o3r/rules-engine/src/devkit/rules-engine-devtools.service.ts
+++ b/packages/@o3r/rules-engine/src/devkit/rules-engine-devtools.service.ts
@@ -31,7 +31,7 @@ export class OtterRulesEngineDevtools {
     private readonly rulesEngineService: RulesEngineRunnerService,
     @Optional() @Inject(OTTER_RULES_ENGINE_DEVTOOLS_OPTIONS) options: RulesEngineDevtoolsServiceOptions) {
 
-    const eventsStackLimit = (options || OTTER_RULES_ENGINE_DEVTOOLS_DEFAULT_OPTIONS).rulesEngineStackLimit;
+    const eventsStackLimit = (options || OTTER_RULES_ENGINE_DEVTOOLS_DEFAULT_OPTIONS as RulesEngineDevtoolsServiceOptions).rulesEngineStackLimit;
     this.rulesEngineEvents$ = this.rulesEngineService.engine.engineDebug?.debugEvents$.pipe(
       scan((previousEvents, currentEvent) => {
         const stack = eventsStackLimit && previousEvents.length === eventsStackLimit ? previousEvents.slice(1) : previousEvents;

--- a/packages/@o3r/rules-engine/src/devkit/rules-engine-devtools.token.ts
+++ b/packages/@o3r/rules-engine/src/devkit/rules-engine-devtools.token.ts
@@ -1,8 +1,8 @@
 import { InjectionToken } from '@angular/core';
 import { RulesEngineDevtoolsServiceOptions } from './rules-engine-devkit.interface';
 
-export const OTTER_RULES_ENGINE_DEVTOOLS_DEFAULT_OPTIONS: RulesEngineDevtoolsServiceOptions = {
+export const OTTER_RULES_ENGINE_DEVTOOLS_DEFAULT_OPTIONS = {
   isActivatedOnBootstrap: false
-};
+} as const satisfies RulesEngineDevtoolsServiceOptions;
 
-export const OTTER_RULES_ENGINE_DEVTOOLS_OPTIONS: InjectionToken<RulesEngineDevtoolsServiceOptions> = new InjectionToken<RulesEngineDevtoolsServiceOptions>('Otter RulesEngine Devtools options');
+export const OTTER_RULES_ENGINE_DEVTOOLS_OPTIONS = new InjectionToken<RulesEngineDevtoolsServiceOptions>('Otter RulesEngine Devtools options');

--- a/packages/@o3r/rules-engine/src/engine/engine.ts
+++ b/packages/@o3r/rules-engine/src/engine/engine.ts
@@ -177,7 +177,7 @@ export class RulesEngine {
    * Update or insert operator in rules engine
    * @param operators operator list to add / update
    */
-  public upsertOperators(operators: (Operator | UnaryOperator)[]) {
+  public upsertOperators(operators: (Operator<any, any> | UnaryOperator<any>)[]) {
     this.operators = operators.reduce((acc, operator) => {
       acc[operator.name] = operator;
       return acc;

--- a/packages/@o3r/rules-engine/src/services/rules-engine.token.ts
+++ b/packages/@o3r/rules-engine/src/services/rules-engine.token.ts
@@ -14,7 +14,7 @@ export interface RulesEngineServiceOptions {
 }
 
 /** Default Rules engine options */
-export const DEFAULT_RULES_ENGINE_OPTIONS: RulesEngineServiceOptions = {
+export const DEFAULT_RULES_ENGINE_OPTIONS = {
   dryRun: false,
   debug: false
-};
+} as const satisfies RulesEngineServiceOptions;

--- a/packages/@o3r/schematics/src/rule-factories/eslint-fix/index.ts
+++ b/packages/@o3r/schematics/src/rule-factories/eslint-fix/index.ts
@@ -21,11 +21,11 @@ export function applyEsLintFix(_prootPath = '/', extension: string[] = ['ts'], o
     return noop();
   }
 
-  const linterOptions: LinterOptions = {
+  const linterOptions = {
     continueOnError: true,
     hideWarnings: true,
     ...options
-  };
+  } as const satisfies LinterOptions;
 
   return (tree: Tree, context: SchematicContext) => {
     const filesToBeLint = tree.actions

--- a/packages/@o3r/schematics/src/utility/generation.ts
+++ b/packages/@o3r/schematics/src/utility/generation.ts
@@ -15,7 +15,7 @@ export type GeneratedItemType =
   '@o3r/testing:playwright-sanity';
 
 /** List of Otter items types */
-export const OTTER_ITEM_TYPES: GeneratedItemType[] = [
+export const OTTER_ITEM_TYPES = [
   '@o3r/core:component',
   '@o3r/core:page',
   '@o3r/core:service',
@@ -23,7 +23,7 @@ export const OTTER_ITEM_TYPES: GeneratedItemType[] = [
   '@o3r/core:schematics-update',
   '@o3r/testing:playwright-scenario',
   '@o3r/testing:playwright-sanity'
-];
+] as const satisfies GeneratedItemType[];
 
 /** List of the default destination paths for each generated entity */
 export const TYPES_DEFAULT_FOLDER: { [key in GeneratedItemType] : {app?: string; lib?: string} } = {

--- a/packages/@o3r/schematics/src/utility/logo.ts
+++ b/packages/@o3r/schematics/src/utility/logo.ts
@@ -36,9 +36,9 @@ const logoSmall = `
  * @param size Size of the logo to generate
  */
 export const getLogo = (size: 'medium' | 'small' = 'medium') => {
-  const logos: Record<typeof size, string> = {
+  const logos = {
     medium: logoMedium,
     small: logoSmall
-  };
+  } as const satisfies Record<typeof size, string>;
   return logos[size];
 };

--- a/packages/@o3r/schematics/src/utility/monorepo.ts
+++ b/packages/@o3r/schematics/src/utility/monorepo.ts
@@ -53,16 +53,16 @@ export const LIBRARIES_FOLDER_NAME = 'libs';
 export const APPLICATIONS_FOLDER_NAME = 'apps';
 
 /** Default directories for generated apps/libs inside a monorepo */
-export const DEFAULT_ROOT_FOLDERS: WorkspaceLayout = {
+export const DEFAULT_ROOT_FOLDERS = {
   libsDir: LIBRARIES_FOLDER_NAME,
   appsDir: APPLICATIONS_FOLDER_NAME
-};
+} as const satisfies WorkspaceLayout;
 
 /** Root folders map for apps/libs inside a monorepo */
-export const BASE_ROOT_FOLDERS_MAP: Record<WorkspaceProject['projectType'], keyof WorkspaceLayout> = {
+export const BASE_ROOT_FOLDERS_MAP = {
   library: 'libsDir',
   application: 'appsDir'
-};
+} as const satisfies Record<WorkspaceProject['projectType'], keyof WorkspaceLayout>;
 
 /**
  * Retrieve the project base root generation folder, based on the given projectType.

--- a/packages/@o3r/schematics/src/utility/package-manager-runner.ts
+++ b/packages/@o3r/schematics/src/utility/package-manager-runner.ts
@@ -12,10 +12,10 @@ export type SupportedPackageManagerRunners = `${SupportedPackageManagers} run` |
 /** Support NPM package managers */
 export type SupportedPackageManagerExecutors = `${SupportedPackageManagers} exec` | 'yarn' | 'npx';
 
-const PACKAGE_MANAGER_WORKSPACE_MAPPING: Record<SupportedPackageManagers, string> = {
+const PACKAGE_MANAGER_WORKSPACE_MAPPING = {
   npm: '--workspace',
   yarn: 'workspace'
-};
+} as const satisfies Record<SupportedPackageManagers, string>;
 
 /** Option to determine Package Manager */
 export interface PackageManagerOptions {

--- a/packages/@o3r/schematics/src/utility/wrapper.ts
+++ b/packages/@o3r/schematics/src/utility/wrapper.ts
@@ -67,7 +67,7 @@ export const createSchematicWithMetricsIfInstalled: SchematicWrapper = (schemati
     ) {
       context.logger.debug('`@o3r/telemetry` is not available.\nAsking to add the dependency\n' + e.toString());
 
-      const question: Question = {
+      const question = {
         type: 'confirm',
         name: 'isReplyPositive',
         message: `
@@ -76,7 +76,7 @@ It will help us to improve our tools.
 For more details and instructions on how to change these settings, see https://github.com/AmadeusITGroup/otter/blob/main/docs/telemetry/PRIVACY_NOTICE.md.
         `,
         default: false
-      };
+      } as const satisfies Question;
       const { isReplyPositive } = await prompt([question]);
       shouldInstallTelemetry = isReplyPositive;
     }

--- a/packages/@o3r/styling/builders/metadata-check/helpers/styling-metadata-comparison.helper.ts
+++ b/packages/@o3r/styling/builders/metadata-check/helpers/styling-metadata-comparison.helper.ts
@@ -21,8 +21,8 @@ const isMigrationCssVariableDataMatch = (cssVariable: CssVariable, migrationData
 /**
  * Comparator used to compare one version of styling metadata with another
  */
-export const stylingMetadataComparator: MetadataComparator<CssVariable, MigrationStylingData, CssMetadata> = {
+export const stylingMetadataComparator = {
   getArray: getCssVariablesArray,
   getIdentifier: getCssVariableName,
   isMigrationDataMatch: isMigrationCssVariableDataMatch
-};
+} as const satisfies MetadataComparator<CssVariable, MigrationStylingData, CssMetadata>;

--- a/packages/@o3r/styling/builders/style-extractor/index.ts
+++ b/packages/@o3r/styling/builders/style-extractor/index.ts
@@ -31,7 +31,7 @@ export default createBuilder(createBuilderWithMetricsIfInstalled<StyleExtractorB
   context.reportRunning();
   const libraryName = options.name || defaultLibraryName(context.currentDirectory);
 
-  const sassLogger: Logger = {
+  const sassLogger = {
     debug: (message, {span}) => context.logger.debug(`${span ? `${span.url?.toString() || ''}:${span.start.line}:${span.start.column}: ` : ''}${message}`),
     warn: (message, {deprecation, span, stack}) => {
       let log: string = deprecation ? `Deprecated function used${EOL}` : '';
@@ -41,7 +41,7 @@ export default createBuilder(createBuilderWithMetricsIfInstalled<StyleExtractorB
       log += `${span ? `${span.url?.toString() || ''}:${span.start.line}:${span.start.column}: ` : ''}${message}`;
       context.logger.warn(log);
     }
-  };
+  } as const satisfies Logger;
 
   const cssVariableExtractor = new CssVariableExtractor({ logger: sassLogger }, options);
 

--- a/packages/@o3r/styling/src/devkit/styling-devtools.token.ts
+++ b/packages/@o3r/styling/src/devkit/styling-devtools.token.ts
@@ -4,12 +4,12 @@ import type { StylingDevtoolsServiceOptions } from './styling-devkit.interface';
 /**
  * Default value for styling devtools
  */
-export const OTTER_STYLING_DEVTOOLS_DEFAULT_OPTIONS: StylingDevtoolsServiceOptions = {
+export const OTTER_STYLING_DEVTOOLS_DEFAULT_OPTIONS = {
   isActivatedOnBootstrap: false,
   stylingMetadataPath: './metadata/styling.metadata.json'
-};
+} as const satisfies StylingDevtoolsServiceOptions;
 
 /**
  * Token for styling devtools
  */
-export const OTTER_STYLING_DEVTOOLS_OPTIONS: InjectionToken<StylingDevtoolsServiceOptions> = new InjectionToken<StylingDevtoolsServiceOptions>('Otter Styling Devtools options');
+export const OTTER_STYLING_DEVTOOLS_OPTIONS = new InjectionToken<StylingDevtoolsServiceOptions>('Otter Styling Devtools options');

--- a/packages/@o3r/telemetry/src/builders/index.ts
+++ b/packages/@o3r/telemetry/src/builders/index.ts
@@ -41,7 +41,7 @@ export const createBuilderWithMetrics: BuilderWrapper = (builderFn, sendData = d
       const builderName = context.builder.name as string;
       context.logger.info(`${builderName} run in ${duration}ms`);
       const environment = await getEnvironmentInfo();
-      const data: BuilderMetricData = {
+      const data = {
         environment,
         duration,
         builder: {
@@ -58,7 +58,7 @@ export const createBuilderWithMetrics: BuilderWrapper = (builderFn, sendData = d
           )
         },
         error
-      };
+      } as const satisfies BuilderMetricData;
       context.logger.debug(JSON.stringify(data, null, 2));
       const packageJsonPath = path.join(context.currentDirectory, 'package.json');
       const packageJson = existsSync(packageJsonPath) ? JSON.parse(readFileSync(packageJsonPath, 'utf-8')) : {};

--- a/packages/@o3r/telemetry/src/cli/index.ts
+++ b/packages/@o3r/telemetry/src/cli/index.ts
@@ -57,7 +57,7 @@ export const createCliWithMetrics: CliWrapper = (cliFn, cliName, options) => asy
     logger.info(`${cliName} run in ${duration}ms`);
     const environment = await getEnvironmentInfo();
     const argv = minimist(process.argv.slice(2), { ...options?.minimistOptions, alias: { o3rMetrics: ['o3r-metrics']} });
-    const data: CliMetricData = {
+    const data = {
       environment,
       duration,
       cli: {
@@ -65,7 +65,7 @@ export const createCliWithMetrics: CliWrapper = (cliFn, cliName, options) => asy
         options: options?.preParsedOptions ?? argv
       },
       error
-    };
+    } as const satisfies CliMetricData;
     logger.debug(JSON.stringify(data, null, 2));
     const packageJsonPath = path.join(process.cwd(), 'package.json');
     const packageJson = existsSync(packageJsonPath) ? JSON.parse(readFileSync(packageJsonPath, 'utf-8')) : {};

--- a/packages/@o3r/telemetry/src/schematics/index.ts
+++ b/packages/@o3r/telemetry/src/schematics/index.ts
@@ -44,12 +44,12 @@ export const createSchematicWithMetrics: SchematicWrapper =
         options,
         interactive: context.interactive
       };
-      const data: SchematicMetricData = {
+      const data = {
         environment,
         schematic,
         duration,
         error
-      };
+      } as const satisfies SchematicMetricData;
       context.logger.debug(JSON.stringify(data, null, 2));
       const packageJson = (tree.exists('/package.json') ? tree.readJson('/package.json') : {}) as JsonObject;
       const shouldSendData = !!(

--- a/packages/@o3r/test-helpers/src/prepare-test-env.ts
+++ b/packages/@o3r/test-helpers/src/prepare-test-env.ts
@@ -59,12 +59,12 @@ export async function prepareTestEnv(folderName: string, options?: PrepareTestEn
 
   JSON.parse(readFileSync(path.join(rootFolderPath, 'packages', '@o3r', 'core', 'package.json')).toString());
   const yarnVersion: string = yarnVersionParam || getYarnVersionFromRoot(rootFolderPath);
-  const execAppOptions: ExecSyncOptions = {
+  const execAppOptions = {
     cwd: workspacePath,
     stdio: 'inherit',
     // eslint-disable-next-line @typescript-eslint/naming-convention
     env: {...process.env, NODE_OPTIONS: '', CI: 'true'}
-  };
+  } as const satisfies ExecSyncOptions;
 
   const packageManagerConfig = {
     yarnVersion,

--- a/packages/@o3r/test-helpers/src/test-environments/create-test-environment-blank.ts
+++ b/packages/@o3r/test-helpers/src/test-environments/create-test-environment-blank.ts
@@ -24,7 +24,7 @@ export interface CreateTestEnvironmentBlankOptions extends CreateWithLockOptions
  * @param inputOptions
  */
 export async function createTestEnvironmentBlank(inputOptions: Partial<CreateTestEnvironmentBlankOptions>) {
-  const options: CreateTestEnvironmentBlankOptions = {
+  const options = {
     appDirectory: 'test-app',
     cwd: process.cwd(),
     globalFolderPath: process.cwd(),
@@ -32,15 +32,15 @@ export async function createTestEnvironmentBlank(inputOptions: Partial<CreateTes
     lockTimeout: 10 * 60 * 1000,
     replaceExisting: true,
     ...inputOptions
-  };
+  } as const satisfies CreateTestEnvironmentBlankOptions;
   await createWithLock(async () => {
     const appFolderPath = path.join(options.cwd, options.appDirectory);
-    const execAppOptions: ExecSyncOptions = {
+    const execAppOptions = {
       cwd: appFolderPath,
       stdio: 'inherit',
       // eslint-disable-next-line @typescript-eslint/naming-convention
       env: {...process.env, NODE_OPTIONS: '', CI: 'true'}
-    };
+    } as const satisfies ExecSyncOptions;
 
     // Prepare folder
     if (existsSync(appFolderPath)) {

--- a/packages/@o3r/test-helpers/src/test-environments/create-test-environment-otter-project.ts
+++ b/packages/@o3r/test-helpers/src/test-environments/create-test-environment-otter-project.ts
@@ -48,7 +48,7 @@ const o3rVersion = '~999';
  * @param inputOptions
  */
 export async function createTestEnvironmentOtterProjectWithAppAndLib(inputOptions: Partial<CreateTestEnvironmentOtterProjectWithAppAndLibOptions>) {
-  const options: CreateTestEnvironmentOtterProjectWithAppAndLibOptions = {
+  const options = {
     appName: 'test-app',
     libName: 'test-lib',
     appDirectory: 'test-app',
@@ -59,16 +59,16 @@ export async function createTestEnvironmentOtterProjectWithAppAndLib(inputOption
     lockTimeout: 10 * 60 * 1000,
     replaceExisting: true,
     ...inputOptions
-  };
+  } as const satisfies CreateTestEnvironmentOtterProjectWithAppAndLibOptions;
 
   await createWithLock(() => {
     const appFolderPath = path.join(options.cwd, options.appDirectory);
-    const execAppOptions: ExecSyncOptions = {
+    const execAppOptions = {
       cwd: appFolderPath,
       stdio: 'inherit',
       // eslint-disable-next-line @typescript-eslint/naming-convention
       env: { ...process.env, NODE_OPTIONS: '', CI: 'true' }
-    };
+    } as const satisfies ExecSyncOptions;
 
     // Prepare folder
     if (existsSync(appFolderPath)) {

--- a/packages/@o3r/test-helpers/src/utilities/git.ts
+++ b/packages/@o3r/test-helpers/src/utilities/git.ts
@@ -26,7 +26,7 @@ export function setupGit(workingDirectory?: string) {
  * @param baseBranch
  */
 export function getGitDiff(workingDirectory?: string, baseBranch = 'after-init') {
-  const execOptions: ExecFileSyncOptionsWithStringEncoding = {stdio: ['pipe', 'pipe', 'ignore'], encoding: 'utf8', cwd: workingDirectory};
+  const execOptions = {stdio: ['pipe', 'pipe', 'ignore'], encoding: 'utf8', cwd: workingDirectory} as const satisfies ExecFileSyncOptionsWithStringEncoding;
   const untrackedFiles = execFileSync('git', ['ls-files', '--others', '--exclude-standard'], execOptions).split('\n');
   const trackedFiles = execFileSync('git', ['diff', '--name-status', baseBranch], execOptions).split('\n');
   const indexedFiles = execFileSync('git', ['diff', '--cached', '--name-status', baseBranch], execOptions).split('\n');

--- a/packages/@o3r/test-helpers/src/utilities/package-manager.ts
+++ b/packages/@o3r/test-helpers/src/utilities/package-manager.ts
@@ -26,7 +26,7 @@ type Command =
   | 'workspaceExec'
   | 'workspaceRun';
 
-const PACKAGE_MANAGERS_CMD: {[packageManager in SupportedPackageManagers]: {[command in Command]: string[]}} = {
+const PACKAGE_MANAGERS_CMD = {
   npm: {
     add: ['npm', 'install'],
     ci: ['npm', 'ci'],
@@ -53,7 +53,7 @@ const PACKAGE_MANAGERS_CMD: {[packageManager in SupportedPackageManagers]: {[com
     workspaceExec: ['yarn', 'workspace'],
     workspaceRun: ['yarn', 'workspace']
   }
-};
+} as const satisfies Record<SupportedPackageManagers, Record<Command, string[]>>;
 
 type CommandArguments = {
   /** Script to run or execute */

--- a/packages/@o3r/testing/schematics/add-functions-to-fixture/models.ts
+++ b/packages/@o3r/testing/schematics/add-functions-to-fixture/models.ts
@@ -13,7 +13,7 @@ export type MethodType =
 /**
  * Return type associated to the MethodType
  */
-export const returnType: Record<MethodType, string> = {
+export const returnType = {
   clickOnButton: 'Promise<void>',
   getText: 'Promise<string | undefined>',
   getInputValue: 'Promise<string | undefined>',
@@ -21,12 +21,12 @@ export const returnType: Record<MethodType, string> = {
   getTextInList: 'Promise<string | undefined>',
   clickButtonInList: 'Promise<void>',
   getNumberOfItems: 'Promise<number>'
-};
+} as const satisfies Record<MethodType, string>;
 
 /**
  * Description associated to the MethodType
  */
-export const description: Record<MethodType, string> = {
+export const description = {
   clickOnButton: `
   /**
    * Click on the button
@@ -68,4 +68,4 @@ export const description: Record<MethodType, string> = {
    *
    * @returns number of items
    */`
-};
+} as const satisfies Record<MethodType, string>;

--- a/packages/@o3r/testing/schematics/ng-update/v9-0/localization-imports/localization-imports-map.ts
+++ b/packages/@o3r/testing/schematics/ng-update/v9-0/localization-imports/localization-imports-map.ts
@@ -2,7 +2,7 @@
 import type { ImportsMapping } from '@o3r/schematics';
 
 /** Map to be used to double check that localization mocks from o3r testing package are well imported from the /localization subentry */
-export const mapImportLocalizationMocks: ImportsMapping = {
+export const mapImportLocalizationMocks = {
   '@o3r/testing': {
     TranslatePipeMock: {
       newPackage: '@o3r/testing/localization'
@@ -17,4 +17,4 @@ export const mapImportLocalizationMocks: ImportsMapping = {
       newPackage: '@o3r/testing/localization'
     }
   }
-};
+} as const satisfies ImportsMapping;

--- a/packages/@o3r/testing/src/core/playwright/angular-materials/autocomplete-material.ts
+++ b/packages/@o3r/testing/src/core/playwright/angular-materials/autocomplete-material.ts
@@ -27,7 +27,7 @@ export class MatAutocomplete extends O3rElement implements MatAutocompleteProfil
       throw new Error(`MatAutocomplete selectByValue works only for filtered autocomplete. Found multiple values: ${options.join(', ')}`);
     }
     if (matOptionsCount === 1) {
-      const selectedOption: PlaywrightSourceElement = {element: matOptions.nth(0), page: this.sourceElement.page};
+      const selectedOption = {element: matOptions.nth(0), page: this.sourceElement.page} as const satisfies PlaywrightSourceElement;
       await new O3rElement(selectedOption).click();
       return this.sourceElement.element.press('Tab');
     }

--- a/packages/@o3r/testing/src/core/playwright/angular-materials/select-material.ts
+++ b/packages/@o3r/testing/src/core/playwright/angular-materials/select-material.ts
@@ -16,7 +16,7 @@ export class MatSelect extends O3rElement implements MatSelectProfile {
     const options = this.sourceElement.page.locator('mat-option');
     await options.first().waitFor({state: 'attached', timeout});
     if ((await options.count()) >= index + 1) {
-      const selectedOption: PlaywrightSourceElement = {element: options.nth(index), page: this.sourceElement.page};
+      const selectedOption = {element: options.nth(index), page: this.sourceElement.page} as const satisfies PlaywrightSourceElement;
       const option = new O3rElement(selectedOption);
       return option.click();
     } else {
@@ -31,7 +31,7 @@ export class MatSelect extends O3rElement implements MatSelectProfile {
     await options.first().waitFor({state: 'attached', timeout});
     const optionsCount = await options.count();
     for (let i = 0; i < optionsCount; i++) {
-      const selectedOption: PlaywrightSourceElement = {element: options.nth(i), page: this.sourceElement.page};
+      const selectedOption = {element: options.nth(i), page: this.sourceElement.page} as const satisfies PlaywrightSourceElement;
       const option = new O3rElement(selectedOption);
       if (await option.getAttribute('ng-reflect-value') === value) {
         return option.click();
@@ -47,7 +47,7 @@ export class MatSelect extends O3rElement implements MatSelectProfile {
     await options.first().waitFor({state: 'attached', timeout});
     const optionsCount = await options.count();
     for (let i = 0; i < optionsCount; i++) {
-      const selectedOption: PlaywrightSourceElement = {element: options.nth(i), page: this.sourceElement.page};
+      const selectedOption = {element: options.nth(i), page: this.sourceElement.page} as const satisfies PlaywrightSourceElement;
       const option = new O3rElement(selectedOption);
       if (await option.getText() === label) {
         return option.click();

--- a/packages/@o3r/testing/src/core/playwright/component-fixture.ts
+++ b/packages/@o3r/testing/src/core/playwright/component-fixture.ts
@@ -154,7 +154,7 @@ export class O3rComponentFixture<V extends O3rElement = O3rElement> implements C
   public query<T extends O3rElement>(selector: string, returnType: O3rElementConstructor<T> | undefined): Promise<T | O3rElement> {
     const elements = this.rootElement.sourceElement.element.locator(selector);
     const element = elements.first();
-    const selectedElement: PlaywrightSourceElement = {element: element, page: this.rootElement.sourceElement.page};
+    const selectedElement = {element: element, page: this.rootElement.sourceElement.page} as const satisfies PlaywrightSourceElement;
     return Promise.resolve(new (returnType || O3rElement)(selectedElement));
   }
 
@@ -164,7 +164,7 @@ export class O3rComponentFixture<V extends O3rElement = O3rElement> implements C
   public queryNth<T extends O3rElement>(selector: string, index: number, returnType: O3rElementConstructor<T> | undefined): Promise<T | O3rElement> {
     const elements = this.rootElement.sourceElement.element.locator(selector);
     const element = elements.nth(index);
-    const selectedElement: PlaywrightSourceElement = {element: element, page: this.rootElement.sourceElement.page};
+    const selectedElement = {element: element, page: this.rootElement.sourceElement.page} as const satisfies PlaywrightSourceElement;
     return Promise.resolve(new (returnType || O3rElement)(selectedElement));
   }
 
@@ -186,7 +186,7 @@ export class O3rComponentFixture<V extends O3rElement = O3rElement> implements C
       const pElementsCount = await pElements.count();
       const elements = [];
       for (let i = 0; i < pElementsCount; i++) {
-        const selectedElement: PlaywrightSourceElement = {element: pElements.nth(i), page: this.rootElement.sourceElement.page};
+        const selectedElement = {element: pElements.nth(i), page: this.rootElement.sourceElement.page} as const satisfies PlaywrightSourceElement;
         elements.push(returnType ? new returnType(selectedElement) : new O3rElement(selectedElement));
       }
       if (groupType) {

--- a/packages/@o3r/testing/src/kassette/update-dates-in-mocks.ts
+++ b/packages/@o3r/testing/src/kassette/update-dates-in-mocks.ts
@@ -39,7 +39,7 @@ export interface UpdateDatesInMocksOptions {
  */
 export async function updateDatesInMocks(mock: IMock, inputOptions: Partial<UpdateDatesInMocksOptions> = {}) {
   const plainDateLength = 'YYYY-MM-DDThh:mm:ss'.length;
-  const options: UpdateDatesInMocksOptions = {
+  const options = {
     mode: 'day-offset',
     extractor: /\b(\d{4}-\d{2}-\d{2})[^"]*/g,
     converter: {
@@ -52,7 +52,7 @@ export async function updateDatesInMocks(mock: IMock, inputOptions: Partial<Upda
       }
     },
     ...inputOptions
-  };
+  } as const satisfies UpdateDatesInMocksOptions;
   const todayTime = Temporal.Now.plainDateISO();
 
   // Update request

--- a/packages/@o3r/testing/src/localization/localization-mock.ts
+++ b/packages/@o3r/testing/src/localization/localization-mock.ts
@@ -3,12 +3,12 @@ import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { LocalizationConfiguration, LocalizationModule, LocalizationTranslatePipe } from '@o3r/localization';
 import { of } from 'rxjs';
 
-const defaultLocalizationConfiguration: Partial<LocalizationConfiguration> = {
+const defaultLocalizationConfiguration = {
   supportedLocales: ['en'],
   language: 'en',
   endPointUrl: '',
   fallbackLanguage: 'en'
-};
+} as const satisfies Partial<LocalizationConfiguration>;
 
 @Pipe({ name: 'translate' })
 export class TranslatePipeMock implements PipeTransform {

--- a/packages/@o3r/testing/src/visual-test/visual-test.ts
+++ b/packages/@o3r/testing/src/visual-test/visual-test.ts
@@ -23,13 +23,13 @@ export interface VisualTestMessage {
 }
 
 /** Error messages in case of visual testing failure */
-export const visualTestMessages: VisualTestMessage = {
+export const visualTestMessages = {
   imagesSize: 'Image sizes do not match for:',
   diffMessage: 'Diff between images is greater than threshold for:',
   baseImgNotFound: 'Base screenshot file not found:',
   success: 'Visual test successful',
   generateMode: 'Run in generate screenshot mode'
-};
+} as const satisfies VisualTestMessage;
 
 /**
  * Object returned by a visual test operation

--- a/packages/@o3r/third-party/src/bridge/ab-testing/ab-testing-bridge.ts
+++ b/packages/@o3r/third-party/src/bridge/ab-testing/ab-testing-bridge.ts
@@ -41,11 +41,11 @@ export interface AbTestBridgeConfig {
 /**
  * Default options that will represent the interface
  */
-const defaultOptions: AbTestBridgeConfig = {
+const defaultOptions = {
   bridgeName: 'abTestBridge',
   readyEventName: 'ab-test-ready',
   logger: console
-};
+} as const satisfies AbTestBridgeConfig;
 
 /**
  * Bridge between the application and a third party A/B testing provider.

--- a/packages/@o3r/third-party/src/bridge/iframe/helpers.ts
+++ b/packages/@o3r/third-party/src/bridge/iframe/helpers.ts
@@ -3,11 +3,11 @@ import { IFrameBridgeOptions, InternalIframeMessage } from './contracts';
 /**
  * Default options for an IFrameBridge
  */
-export const IFRAME_BRIDGE_DEFAULT_OPTIONS: IFrameBridgeOptions = {
+export const IFRAME_BRIDGE_DEFAULT_OPTIONS = {
   handshakeTries: 10,
   handshakeTimeout: 200,
   messageWithResponseTimeout: 1000
-};
+} as const satisfies IFrameBridgeOptions;
 
 /**
  * Verifies if a message respects the format expected by an IFrameBridge

--- a/packages/@o3r/workspace/schematics/application/index.ts
+++ b/packages/@o3r/workspace/schematics/application/index.ts
@@ -65,7 +65,7 @@ function generateApplicationFn(options: NgGenerateApplicationSchema): Rule {
     };
     const angularOptions = getOptions(angularAppSchema);
 
-    const dependencies: Record<string, DependencyToAdd> = {
+    const dependencies = {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       '@o3r/core': {
         inManifest: [
@@ -76,7 +76,7 @@ function generateApplicationFn(options: NgGenerateApplicationSchema): Rule {
         ],
         ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
       }
-    };
+    } as const satisfies Record<string, DependencyToAdd>;
 
     return chain([
       externalSchematic<Partial<ApplicationOptions>>('@schematics/angular', 'application', {

--- a/packages/@o3r/workspace/schematics/library/index.ts
+++ b/packages/@o3r/workspace/schematics/library/index.ts
@@ -40,7 +40,7 @@ function generateModuleFn(options: NgGenerateModuleSchema): Rule {
     const targetPath = path.posix.resolve('/', options.path || defaultRoot, cleanName);
     const extendedOptions = { ...options, targetPath, name: cleanName, packageJsonName: packageJsonName };
 
-    const dependencies: Record<string, DependencyToAdd> = {
+    const dependencies = {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       '@o3r/core': {
         inManifest: [
@@ -51,7 +51,7 @@ function generateModuleFn(options: NgGenerateModuleSchema): Rule {
         ],
         ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
       }
-    };
+    } as const satisfies Record<string, DependencyToAdd>;
 
     return chain([
       isNx ? nxGenerateModule(extendedOptions) : ngGenerateModule(extendedOptions),

--- a/packages/@o3r/workspace/schematics/library/rules/rules.nx.ts
+++ b/packages/@o3r/workspace/schematics/library/rules/rules.nx.ts
@@ -85,7 +85,7 @@ export function nxGenerateModule(options: NgGenerateModuleSchema & {packageJsonN
     }
 
     const o3rCorePackageJsonPath = path.resolve(__dirname, '..', '..', '..', 'package.json');
-    const o3rCorePackageJson: PackageJson & { generatorDependencies?: Record<string, string> } = JSON.parse(readFileSync(o3rCorePackageJsonPath)!.toString());
+    const o3rCorePackageJson: PackageJson & { generatorDependencies?: Record<string, string> } = JSON.parse(readFileSync(o3rCorePackageJsonPath).toString());
     const otterVersion = o3rCorePackageJson.dependencies!['@o3r/schematics'];
 
     const templateNx = apply(url('./templates/nx'), [
@@ -119,12 +119,12 @@ export function nxGenerateModule(options: NgGenerateModuleSchema & {packageJsonN
 
   const nxCliUpdate: Rule = (tree, context) => {
     const mem: Record<string, Buffer | null> = savePreCommandContent(tree);
-    const config: Record<string, any> = {
+    const config = {
       name: options.name,
       importPath: options.packageJsonName,
       buildable: true,
       publishable: true
-    };
+    } as const;
     return chain([
       (t, c) => externalSchematic('@nx/angular', 'library', config)(t, c),
       restoreFiles(mem),

--- a/packages/@o3r/workspace/schematics/sdk/rules/rules.ng.ts
+++ b/packages/@o3r/workspace/schematics/sdk/rules/rules.ng.ts
@@ -10,7 +10,7 @@ import { getWorkspaceConfig, WorkspaceProject } from '@o3r/schematics';
  * @param projectName Name of the project
  */
 export function ngRegisterProjectTasks(_options: NgGenerateSdkSchema, targetPath: string, projectName: string): Rule {
-  const project: WorkspaceProject = {
+  const project = {
     projectType: 'library',
     root: targetPath,
     sourceRoot: path.posix.join(targetPath, 'src'),
@@ -35,7 +35,7 @@ export function ngRegisterProjectTasks(_options: NgGenerateSdkSchema, targetPath
         }
       }
     }
-  };
+  } as const satisfies WorkspaceProject;
 
   return (tree, context) => {
     const angularJson = getWorkspaceConfig(tree);

--- a/tools/github-actions/new-version/packaged-action/LICENSE.txt
+++ b/tools/github-actions/new-version/packaged-action/LICENSE.txt
@@ -94,6 +94,33 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 @o3r/new-version
+Copyright Amadeus SAS
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 
 @octokit/auth-token
 MIT


### PR DESCRIPTION
## Proposed change

When creating an object that is intended to be read-only, we should let typescript infer the type.

Not good:
```typescript
interface NamedObjectMaybe {
  name?: string;
}
const UNMOVABLE_OBJECT: NamedObjectMaybe = {
  name: 'unicorn'
};

// UNMOVABLE_OBJECT.name is typed as string | undefined
```

Nice:
```typescript
interface NamedObjectMaybe {
  name?: string;
}
const UNMOVABLE_OBJECT = {
  name: 'unicorn'
} as const satisfies NamedObjectMaybe;

// UNMOVABLE_OBJECT.name is typed as 'unicorn' but we still validate that UNMOVABLE_OBJECT matches the interface
```
## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
