### PR TITLE
fix: metadata checks should look for cms-metadata in package.json for previous version

### DIFF
--- a/packages/@o3r/components/builders/metadata-check/index.ts
+++ b/packages/@o3r/components/builders/metadata-check/index.ts
@@ -4,5 +4,5 @@ import { configMetadataComparator } from './helpers/config-metadata-comparison.h
 import type { ConfigMigrationMetadataCheckBuilderSchema } from './schema';
 
 export default createBuilder<ConfigMigrationMetadataCheckBuilderSchema>(createBuilderWithMetricsIfInstalled((options, context): Promise<BuilderOutput> => {
-  return checkMetadataBuilder(options, context, configMetadataComparator);
+  return checkMetadataBuilder({...options, packageJsonEntry: 'configurationFilePath'}, context, configMetadataComparator);
 }));

--- a/packages/@o3r/extractors/src/core/comparator/metadata-comparator.interface.ts
+++ b/packages/@o3r/extractors/src/core/comparator/metadata-comparator.interface.ts
@@ -1,5 +1,6 @@
 import type { JsonObject } from '@angular-devkit/core';
 import type { SupportedPackageManagers } from '@o3r/schematics';
+import type { CmsMetadataData } from '../../interfaces';
 
 /**
  * Interface of the comparator used to compare 2 different versions of the same metadata file.
@@ -80,4 +81,7 @@ export interface MigrationMetadataCheckBuilderOptions extends JsonObject {
 
   /** Path of the metadata file to check */
   metadataPath: string;
+
+  /** Entry to check for previous metadata in the `package.json` file under `cmsMetadata`. */
+  packageJsonEntry: keyof Omit<CmsMetadataData, 'libraryName'>;
 }

--- a/packages/@o3r/extractors/src/core/comparator/package-managers-extractors/npm-file-extractor.helper.ts
+++ b/packages/@o3r/extractors/src/core/comparator/package-managers-extractors/npm-file-extractor.helper.ts
@@ -1,5 +1,5 @@
 import { spawnSync, SpawnSyncOptionsWithStringEncoding, SpawnSyncReturns } from 'node:child_process';
-import { mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { randomBytes } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join, posix, sep } from 'node:path';
@@ -53,11 +53,14 @@ export async function getFilesFromRegistry(packageDescriptor: string, paths: str
     extractedFiles = paths.reduce((filesContent, path) => {
       // tar expects a posix path
       const pathInTgz = posix.join('./package', path);
-      runAndThrowOnError(
+      spawnSync(
         `tar -zxvf "${pathToPosix(tgzFile)}" -C "${pathToPosix(tempDirPath)}" "${pathInTgz}"`,
         { shell: true, cwd: tempDirPath, encoding: 'utf8' }
       );
-      filesContent[path] = readFileSync(join(tempDirPath, pathInTgz)).toString();
+      const extractedFilePath = join(tempDirPath, pathInTgz);
+      if (existsSync(extractedFilePath)) {
+        filesContent[path] = readFileSync(extractedFilePath).toString();
+      }
       return filesContent;
     }, extractedFiles);
   } finally {

--- a/packages/@o3r/extractors/src/core/comparator/package-managers-extractors/yarn2-file-extractor.helper.ts
+++ b/packages/@o3r/extractors/src/core/comparator/package-managers-extractors/yarn2-file-extractor.helper.ts
@@ -181,10 +181,10 @@ export async function getFilesFromRegistry(packageDescriptor: string, paths: str
   const descriptor = getDescriptorFromReference(packageDescriptor);
   const result = await fetchPackage(project, descriptor);
   const extractedFiles = paths.reduce((acc: Record<string, string>, path) => {
-    acc[path] = result.packageFs.readFileSync(
-      npath.toPortablePath(join(result.prefixPath, path)),
-      'utf-8'
-    );
+    const portablePath = npath.toPortablePath(join(result.prefixPath, path));
+    if (result.packageFs.existsSync(portablePath)) {
+      acc[path] = result.packageFs.readFileSync(portablePath, 'utf-8');
+    }
     return acc;
   }, {});
   if (result.releaseFs) {

--- a/packages/@o3r/localization/builders/metadata-check/index.ts
+++ b/packages/@o3r/localization/builders/metadata-check/index.ts
@@ -4,5 +4,5 @@ import { localizationMetadataComparator } from './helpers';
 import type { LocalizationMigrationMetadataCheckBuilderSchema } from './schema';
 
 export default createBuilder<LocalizationMigrationMetadataCheckBuilderSchema>(createBuilderWithMetricsIfInstalled((options, context): Promise<BuilderOutput> => {
-  return checkMetadataBuilder(options, context, localizationMetadataComparator);
+  return checkMetadataBuilder({...options, packageJsonEntry: 'localizationFilePath'}, context, localizationMetadataComparator);
 }));

--- a/packages/@o3r/styling/builders/metadata-check/index.ts
+++ b/packages/@o3r/styling/builders/metadata-check/index.ts
@@ -4,5 +4,5 @@ import { stylingMetadataComparator } from './helpers';
 import type { StylingMigrationMetadataCheckBuilderSchema } from './schema';
 
 export default createBuilder<StylingMigrationMetadataCheckBuilderSchema>(createBuilderWithMetricsIfInstalled((options, context): Promise<BuilderOutput> => {
-  return checkMetadataBuilder(options, context, stylingMetadataComparator);
+  return checkMetadataBuilder({...options, packageJsonEntry: 'styleFilePath'}, context, stylingMetadataComparator);
 }));


### PR DESCRIPTION
## Proposed change

There can be a discrepancy between the path to cms metadata between 2 version of an application.
However, we only specify one path when running the metadata-checks.
We can use the path to the metadata specified in `package.json` under `cmsMetadata` to find the files even if the option passed to the script doesn't match.

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
