### PR TITLE
fix: upgrade jsonpath-plus to non vulnerable version

### DIFF
--- a/packages/@o3r/rules-engine/package.json
+++ b/packages/@o3r/rules-engine/package.json
@@ -48,7 +48,7 @@
     "@schematics/angular": "~16.2.0",
     "globby": "^11.1.0",
     "jasmine": "^5.0.0",
-    "jsonpath-plus": "^7.0.0",
+    "jsonpath-plus": ">= 7.0.0",
     "rxjs": "^7.8.1",
     "typescript": "~5.1.6",
     "typescript-json-schema": "~0.62.0"
@@ -143,7 +143,7 @@
     "jest-junit": "~16.0.0",
     "jest-preset-angular": "~13.1.1",
     "jsonc-eslint-parser": "~2.4.0",
-    "jsonpath-plus": "^7.0.0",
+    "jsonpath-plus": "^10.0.0",
     "memfs": "~4.6.0",
     "nx": "~16.10.0",
     "pid-from-port": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4880,6 +4880,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jsep-plugin/assignment@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@jsep-plugin/assignment@npm:1.2.1"
+  peerDependencies:
+    jsep: ^0.4.0||^1.0.0
+  checksum: d8db45f052fd95b33207ded7f49af9ae48ff5ce10cb898e28a6fca722863f4a3330892c3a2c355a1a8c94fd230eef3db9be0c45324cb526e5edff7085c1f7a37
+  languageName: node
+  linkType: hard
+
+"@jsep-plugin/regex@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@jsep-plugin/regex@npm:1.0.3"
+  peerDependencies:
+    jsep: ^0.4.0||^1.0.0
+  checksum: c08c7bd79a164995923ea799949b9f6b18dcf2bd314522ed0dcfc669fd249a06fea200606086c7d54b12d39ce3cfa61d910229e5184c667ead135f6da6997532
+  languageName: node
+  linkType: hard
+
 "@juggle/resize-observer@npm:^3.3.1":
   version: 3.4.0
   resolution: "@juggle/resize-observer@npm:3.4.0"
@@ -8590,7 +8608,7 @@ __metadata:
     jest-junit: "npm:~16.0.0"
     jest-preset-angular: "npm:~13.1.1"
     jsonc-eslint-parser: "npm:~2.4.0"
-    jsonpath-plus: "npm:^7.0.0"
+    jsonpath-plus: "npm:^10.0.0"
     memfs: "npm:~4.6.0"
     nx: "npm:~16.10.0"
     pid-from-port: "npm:^1.1.3"
@@ -8628,7 +8646,7 @@ __metadata:
     "@schematics/angular": ~16.2.0
     globby: ^11.1.0
     jasmine: ^5.0.0
-    jsonpath-plus: ^7.0.0
+    jsonpath-plus: ">= 7.0.0"
     rxjs: ^7.8.1
     typescript: ~5.1.6
     typescript-json-schema: ~0.62.0
@@ -23694,6 +23712,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsep@npm:^1.3.9":
+  version: 1.3.9
+  resolution: "jsep@npm:1.3.9"
+  checksum: c60d7064c3b5047f58345e65e7618bbaecf2f46338e56689244db057b0550bf8fb7c1457a7384dfd38aca9acde3ff851d062c3f182cc1fbc66c13cb2ca0b579d
+  languageName: node
+  linkType: hard
+
 "jsesc@npm:^2.5.1":
   version: 2.5.2
   resolution: "jsesc@npm:2.5.2"
@@ -23882,10 +23907,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonpath-plus@npm:^7.0.0":
-  version: 7.2.0
-  resolution: "jsonpath-plus@npm:7.2.0"
-  checksum: f602445b1aa2d55abc2875859fd948f942980ef6400ca2a0362c7a6aa6f912467865262f4d092e04a16889fa74f0dbf6fd67b9dc9583485a5059be6e0a62c6c2
+"jsonpath-plus@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "jsonpath-plus@npm:10.0.0"
+  dependencies:
+    "@jsep-plugin/assignment": "npm:^1.2.1"
+    "@jsep-plugin/regex": "npm:^1.0.3"
+    jsep: "npm:^1.3.9"
+  bin:
+    jsonpath: bin/jsonpath-cli.js
+    jsonpath-plus: bin/jsonpath-cli.js
+  checksum: cd8d3f9ebfa2f0b26a362e9b9fb8cf293a6b5798f76e20b3d2ab93da3e885b99dfbba9ac8aa448d62da5a1f4dc327f636ffb242054ee827d27e75500372557c3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
