### PR TITLE
fix: metadata checks fail when migration file contains an element without a before

### DIFF
--- a/packages/@o3r/components/builders/metadata-check/helpers/config-metadata-comparison.helper.ts
+++ b/packages/@o3r/components/builders/metadata-check/helpers/config-metadata-comparison.helper.ts
@@ -38,7 +38,8 @@ const getConfigurationArray = (content: ComponentConfigOutput[]): ComponentConfi
 
 const getConfigurationPropertyName = (config: ComponentConfigOutput) => `${config.library}#${config.name}` + (config.properties.length ? ` ${config.properties[0].name}` : '');
 
-const isMigrationConfigurationDataMatch = (config: ComponentConfigOutput, migrationData: MigrationConfigData) =>
+const isMigrationConfigurationDataMatch = (config: ComponentConfigOutput, migrationData: MigrationConfigData, metadataType: string) =>
+  metadataType === 'CONFIG' &&
   migrationData.libraryName === config.library
   && (!migrationData.configName || migrationData.configName === config.name)
   && (!migrationData.propertyName || config.properties[0]?.name === migrationData.propertyName);

--- a/packages/@o3r/extractors/src/core/comparator/metadata-comparator.interface.ts
+++ b/packages/@o3r/extractors/src/core/comparator/metadata-comparator.interface.ts
@@ -29,8 +29,9 @@ export interface MetadataComparator<MetadataItem, MigrationMetadataItem, Metadat
    * Returns true if a migration item matches a metadata item.
    * @param metadataItem Metadata item
    * @param migrationItem Migration item
+   * @param metadataType Type of the metadata
    */
-  isMigrationDataMatch: (metadataItem: MetadataItem, migrationItem: MigrationMetadataItem) => boolean;
+  isMigrationDataMatch: (metadataItem: MetadataItem, migrationItem: MigrationMetadataItem, metadataType: string) => boolean;
 }
 
 /**

--- a/packages/@o3r/extractors/src/core/comparator/metadata-comparison.helper.ts
+++ b/packages/@o3r/extractors/src/core/comparator/metadata-comparison.helper.ts
@@ -33,7 +33,7 @@ function checkMetadataFile<MetadataItem, MigrationMetadataItem, MetadataFile>(
         continue;
       }
 
-      const migrationMetadataValue = migrationData.find((metadata) => comparator.isMigrationDataMatch(lastValue, metadata.before));
+      const migrationMetadataValue = migrationData.find((metadata) => metadata.before && comparator.isMigrationDataMatch(lastValue, metadata.before, metadata.contentType));
 
       if (!migrationMetadataValue) {
         errors.push(new Error(`Property ${comparator.getIdentifier(lastValue)} has been modified but is not documented in the migration document`));
@@ -41,7 +41,7 @@ function checkMetadataFile<MetadataItem, MigrationMetadataItem, MetadataFile>(
       }
 
       if (migrationMetadataValue.after) {
-        const isNewValueInNewMetadata = newMetadataArray.some((newValue) => comparator.isMigrationDataMatch(newValue, migrationMetadataValue.after!));
+        const isNewValueInNewMetadata = newMetadataArray.some((newValue) => comparator.isMigrationDataMatch(newValue, migrationMetadataValue.after!, migrationMetadataValue.contentType));
         if (!isNewValueInNewMetadata) {
           errors.push(new Error(`Property ${comparator.getIdentifier(lastValue)} has been modified but the new property is not present in the new metadata`));
           continue;

--- a/packages/@o3r/localization/builders/metadata-check/helpers/localization-metadata-comparison.helper.ts
+++ b/packages/@o3r/localization/builders/metadata-check/helpers/localization-metadata-comparison.helper.ts
@@ -17,7 +17,8 @@ const getLocalizationArray = (content: LocalizationMetadata) => content;
 
 const getLocalizationName = (localization: JSONLocalization) => localization.key;
 
-const isMigrationLocalizationDataMatch = (localization: JSONLocalization, migrationData: MigrationLocalizationMetadata) => getLocalizationName(localization) === migrationData.key;
+const isMigrationLocalizationDataMatch = (localization: JSONLocalization, migrationData: MigrationLocalizationMetadata, metadataType: string) =>
+  metadataType === 'LOCALIZATION' && getLocalizationName(localization) === migrationData.key;
 
 
 /**

--- a/packages/@o3r/styling/builders/metadata-check/helpers/styling-metadata-comparison.helper.ts
+++ b/packages/@o3r/styling/builders/metadata-check/helpers/styling-metadata-comparison.helper.ts
@@ -16,7 +16,8 @@ const getCssVariablesArray = (content: CssMetadata): CssVariable[] => Object.key
 
 const getCssVariableName = (cssVariable: CssVariable) => cssVariable.name;
 
-const isMigrationCssVariableDataMatch = (cssVariable: CssVariable, migrationData: MigrationStylingData) => getCssVariableName(cssVariable) === migrationData.name;
+const isMigrationCssVariableDataMatch = (cssVariable: CssVariable, migrationData: MigrationStylingData, metadataType: string) =>
+  metadataType === 'STYLE' && getCssVariableName(cssVariable) === migrationData.name;
 
 /**
  * Comparator used to compare one version of styling metadata with another


### PR DESCRIPTION
## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :bug: Fixes #2296 
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
