### PR TITLE
feat(training): add load indicator on output

### DIFF
--- a/apps/showcase/src/components/training/code-editor-control/code-editor-control.component.html
+++ b/apps/showcase/src/components/training/code-editor-control/code-editor-control.component.html
@@ -6,10 +6,14 @@
       </ng-template>
     </li>
     <li ngbNavItem class="nav-item" role="presentation" [destroyOnHide]="false">
-      <a ngbNavLink class="nav-link" [class.active]="activeTab === 'output'" (click)="activeTab = 'output'">Output</a>
+      <a ngbNavLink class="nav-link ps-5" [class.active]="activeTab === 'output'" (click)="activeTab = 'output'">
+        Output
+        <span class="fa-arrows-rotate terminal-active-indicator" [class.invisible]="!isTerminalActive()"></span>
+      </a>
       <ng-template ngbNavContent>
         <code-editor-terminal id="tab-content2" class="d-block h-100"
                               (disposed)="webContainerService.runner.disposeCommandOutputTerminal()"
+                              (terminalActivity)="terminalActivity.next()"
                               (terminalUpdated)="webContainerService.runner.registerCommandOutputTerminal($event)">
         </code-editor-terminal>
       </ng-template>

--- a/apps/showcase/src/components/training/code-editor-control/code-editor-control.component.scss
+++ b/apps/showcase/src/components/training/code-editor-control/code-editor-control.component.scss
@@ -14,4 +14,21 @@ code-editor-control {
     border: 1px solid black;
     height: 100%;
   }
+
+  .terminal-active-indicator {
+    display: inline-block;
+    font-weight: bold;
+    color: var(--df-recommend-warning-color);
+    transform: rotate(0);
+    animation: rotate-animation 1s linear infinite;
+  }
+
+  @keyframes rotate-animation {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
 }

--- a/apps/showcase/src/components/training/code-editor-terminal/code-editor-terminal.component.ts
+++ b/apps/showcase/src/components/training/code-editor-terminal/code-editor-terminal.component.ts
@@ -3,8 +3,10 @@ import {
   type AfterViewInit,
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   ElementRef,
   EventEmitter,
+  inject,
   type OnDestroy,
   Output,
   ViewChild
@@ -41,6 +43,11 @@ export class CodeEditorTerminalComponent implements OnDestroy, AfterViewChecked,
   @Output()
   public readonly terminalUpdated = new EventEmitter<Terminal>();
   /**
+   * Inform the parent that something got written in the terminal
+   */
+  @Output()
+  public readonly terminalActivity = new EventEmitter<void>();
+  /**
    * Inform the parent that the terminal of the component has been disposed of
    */
   @Output()
@@ -48,6 +55,10 @@ export class CodeEditorTerminalComponent implements OnDestroy, AfterViewChecked,
 
   constructor() {
     this.terminal.loadAddon(this.fitAddon);
+    const disposable = this.terminal.onWriteParsed(() => {
+      this.terminalActivity.emit();
+    });
+    inject(DestroyRef).onDestroy(() => disposable.dispose());
   }
 
   /**


### PR DESCRIPTION
## Proposed change

Add an indicator on the terminal output to know that some work is in progress
![image](https://github.com/user-attachments/assets/5ec89ad1-859c-4db1-81c4-70998457d2e4)

Working example: https://fpaul-1a.github.io/otter/#/sdk-training#4

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
