### PR TITLE
fix: header of sdk readme file in schematics for clarity on versions

### DIFF
--- a/packages/@ama-sdk/schematics/schematics/typescript/core/index.spec.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/index.spec.ts
@@ -13,7 +13,7 @@ describe('Typescript Core Generator', () => {
   beforeEach(async () => {
     const runner = new SchematicTestRunner('@ama-sdk/schematics', collectionPath);
     const tree = Tree.empty();
-    tree.create('/readme.md', 'Based on OpenAPI spec 0.1.0');
+    tree.create('/readme.md', 'Based on API specification version 0.1.0 (using OpenAPI 0.0.0)');
     baseTree = await runner.runSchematic('typescript-shell', {
       name: 'test-sdk',
       package: 'sdk',
@@ -27,7 +27,7 @@ describe('Typescript Core Generator', () => {
       specPath: path.join(__dirname, '..', '..', '..', 'testing', 'MOCK_swagger.yaml')
     }, baseTree);
 
-    expect(tree.readContent('/readme.md')).toContain('Based on OpenAPI spec 1.0.0');
+    expect(tree.readContent('/readme.md')).toContain('Based on API specification version 1.0.0 (using swagger 2.0)');
   });
 
   it('should update openapitools file with yaml', async () => {

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/index.ts
@@ -227,10 +227,14 @@ function ngGenerateTypescriptSDKFn(options: NgGenerateTypescriptSDKCoreSchematic
       const readmeFile = path.posix.join(targetPath, 'readme.md');
       if (tree.exists(readmeFile)) {
         const specVersion = /version: *([0-9]+\.[0-9]+\.[0-9]+(?:-[^ ]+)?)/.exec(specContent);
+        const generatorVersion = /(openapi|swagger): *['"]?([0-9]+(?:\.[0-9]+){1,2}(?:-[^ ]+)?)['"]?/.exec(specContent);
 
-        if (specVersion) {
+        if (specVersion && generatorVersion) {
           const readmeContent = tree.read(readmeFile)!.toString('utf8');
-          tree.overwrite(readmeFile, readmeContent.replace(/Based on (.+) spec .*/i, `Based on $1 spec ${specVersion[1]}`));
+          tree.overwrite(
+            readmeFile,
+            readmeContent.replace(/Based on .+ spec.*/i, `Based on API specification version ${specVersion[1] || '0.0.0'} (using ${generatorVersion[1]} ${generatorVersion[2]})`)
+          );
         }
       }
       return tree;

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/readme.md
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/readme.md
@@ -1,6 +1,6 @@
 <% if (projectDescription) { %># <%=projectDescription%><% } %>
 
-### Based on OpenAPI spec 0.0.0
+### Based on API specification version 0.0.0 (using OpenAPI 0.0.0)
 
 The SDK contains 2 different parts:
 


### PR DESCRIPTION
## Proposed change

Modify the header of the SDK readme file to clarify the version of the SDK spec and the version of OpenAPI used to generate the SDK.

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
