### PR TITLE
feat: otter sdk training - generate your first sdk specs and command

### DIFF
--- a/apps/showcase/src/assets/trainings/sdk/steps/sdk-generation/instructions.md
+++ b/apps/showcase/src/assets/trainings/sdk/steps/sdk-generation/instructions.md
@@ -1,0 +1,70 @@
+There are several command lines available to generate an SDK depending on the use cases. These cases are covered in the
+<a href="https://github.com/AmadeusITGroup/otter/tree/main/packages/%40ama-sdk/schematics" target="_blank">@ama-sdk/schematics documentation</a>.
+
+### Objective
+Generate a new SDK repository using the previous specification file (Swagger Petstore) and the provided command line.
+
+### Exercise
+#### Generation of the SDK repository
+To generate a new SDK repository, you can run the following command line (by replacing `<package-name>` with `training-sdk` for example):
+
+```bash
+npm create @ama-sdk typescript <package-name>
+```
+
+You will receive a prompt asking you to specify the project name. For example, you can set the project name to `training-project`.
+
+```bash
+? Project name (NPM package scope, package.json name will be @{projectName}/{packageName})? training-project
+```
+
+After setting the project name, you will see the shell of your SDK repository being generated with a structure that looks something like the following:
+```
+src
+├── api
+├── fixtures
+├── helpers
+├── models
+│   ├── base
+│   ├── core
+│   └── custom
+└── spec
+```
+
+You should also observe these scripts in the `package.json` file (with the correct project and package names):
+
+```json
+"generate": "schematics @ama-sdk/schematics:typescript-core",
+"spec:regen": "npm run generate -- --generator-key training-project-training-sdk && amasdk-clear-index",
+"spec:upgrade": "npm run spec:regen",
+```
+
+#### Generation of the API specifications
+
+The repository does not contain the specification file since we did not pass it as a parameter to the command, so it must be created manually.
+Create a new file with your API specifications (created in the previous step). The standard convention is to name this file `open-api.yaml`.
+
+*If you have an existing specification file, you have the option to pass the parameter `--spec-path [path to your openapi file]` to the
+create command used above, which will add your specification file to the repository.*
+
+
+Next, specify the path of your specification file in the `inputSpec` property of the `openapitools.json` file at the root.
+
+You can now run the command `yarn spec:upgrade` and notice that the **api** and **models/base** folders have been updated with the paths and definitions from your specification file.
+
+> [!NOTE]
+> Notice that the `yarn spec:upgrade` command is equivalent to running the command below, which means that we use the configuration of the
+> `openapitools.json` file. These configuration properties can also be passed as parameters to the command line (to set or override the property).
+> This tip will be useful for the next steps of the training.
+
+
+```bash
+yarn schematics @ama-sdk/schematics:typescript-core --generator-key training-project-training-sdk
+```
+
+You can find more information in the
+<a href="https://github.com/AmadeusITGroup/otter/tree/main/packages/%40ama-sdk/schematics#generator-configuration" target="_blank">generator configuration documentation</a>.
+
+#### Solution
+Once generated, you can compare your generated SDK to the <a href="https://github.com/AmadeusITGroup/otter/tree/main/packages/%40o3r-training/showcase-sdk" target="_blank">Otter Showcase SDK</a>.
+

--- a/apps/showcase/src/assets/trainings/sdk/steps/sdk-specs/instructions.md
+++ b/apps/showcase/src/assets/trainings/sdk/steps/sdk-specs/instructions.md
@@ -1,0 +1,16 @@
+The first step in the generation of an SDK is the definition of the specifications. These can be written in a file of type JSON or YAML.
+
+The <a href="https://github.com/AmadeusITGroup/otter/tree/main/packages/%40o3r-training/showcase-sdk" target="_blank">Otter Showcase SDK</a> has been created with the
+<a href="https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml" target="_blank">specifications</a> made available by the
+<a href="https://github.com/swagger-api/swagger-petstore" target="_blank">Swagger Petstore</a> repository.
+You can find these specifications in the `openapi.yml` file of the repository.
+
+### Objective
+The goal of this exercise is to get a basic understanding of the format of the specifications.
+
+### Exercise
+You can get to know the provided Swagger Petstore specifications and eventually copy them in order to generate your own SDK locally, which will be explained in the next part.
+
+To become familiar with the specifications format, you can also use the <a href="https://editor-next.swagger.io/" target="_blank">Swagger Editor</a> tool.\
+*(You can find the Swagger Petstore specifications by selecting **File** at the top of the page, then **Load Example** and selecting one of the OpenAPI
+Petstore examples, depending on the OpenAPI version you wish to target.)*


### PR DESCRIPTION
## Proposed change

Otter SDK Training - Generate your first SDK - Specifications step and command step

![image](https://github.com/user-attachments/assets/8fd6ef76-502c-44be-b53c-baf796039b74)
![image](https://github.com/user-attachments/assets/07740209-2c89-4f8c-8bb0-fee9739879ec)
![image](https://github.com/user-attachments/assets/4df6516e-20de-4669-a4af-d76cbfcc8873)


## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
