### PR TITLE
fix: do not dynamically import @o3r/rules-engine during rules-engine install

### DIFF
--- a/packages/@o3r/core/README.md
+++ b/packages/@o3r/core/README.md
@@ -44,6 +44,10 @@ yarn create @o3r my-project
 > [!TIP]
 > Get more details on [@o3r/create](https://www.npmjs.com/package/@o3r/create).
 
+> [!NOTE]
+> If you want to add o3r to an existing project, you will first need to install @o3r/schematics via
+> `ng add @o3r/schematics` and then `ng add @o3r/core`.
+
 ### Adding Material design theming
 
 ```shell

--- a/packages/@o3r/schematics/schematics/ng-add/index.ts
+++ b/packages/@o3r/schematics/schematics/ng-add/index.ts
@@ -1,5 +1,5 @@
 import type { Rule } from '@angular-devkit/schematics';
-import type { DependencyToAdd } from '@o3r/schematics';
+import { createSchematicWithMetricsIfInstalled, type DependencyToAdd, getExternalDependenciesVersionRange, setupDependencies } from '../../src/public_api';
 import { NodeDependencyType } from '@schematics/angular/utility/dependencies';
 import * as path from 'node:path';
 import type { NgAddSchematicsSchema } from './schema';
@@ -10,9 +10,8 @@ import type { NgAddSchematicsSchema } from './schema';
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   const schematicsDependencies = ['@angular-devkit/architect', '@angular-devkit/schematics', '@angular-devkit/core', '@schematics/angular', 'globby'];
-  return async (_, context) => {
+  return (_, context) => {
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
-    const { getExternalDependenciesVersionRange, setupDependencies } = await import('@o3r/schematics');
     const dependencies = Object.entries(getExternalDependenciesVersionRange(schematicsDependencies, packageJsonPath, context.logger)).reduce((acc, [dep, range]) => {
       acc[dep] = {
         inManifest: [{
@@ -43,8 +42,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter schematics to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async () => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics');
+export const ngAdd = (options: NgAddSchematicsSchema): Rule => () => {
   return createSchematicWithMetricsIfInstalled(ngAddFn)(options);
 };
 

--- a/packages/@o3r/storybook/README.md
+++ b/packages/@o3r/storybook/README.md
@@ -35,7 +35,8 @@ Otter framework provides 2 mechanisms to setup Storybook on an application/libra
 
 ### When starting a new Application/Library
 
-When creating a new application/library (`ng new`), the Otter Framework can be added with the `ng add @o3r/core` command. When executing this command, the following question will be asked: *Add storybook setup?* (default value: `yes`).
+When creating a new application/library (`ng new`), the Otter Framework can be added with the `ng add @o3r/schematics` and
+`ng add @o3r/core` commands. When executing this command, the following question will be asked: *Add storybook setup?* (default value: `yes`).
 If `yes` is chosen, [Storybook mandatory configurations](#storybook-mandatory-configurations) will be automatically added.
 
 ### Storybook mandatory configurations

--- a/tools/github-actions/new-version/packaged-action/LICENSE.txt
+++ b/tools/github-actions/new-version/packaged-action/LICENSE.txt
@@ -94,6 +94,33 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 @o3r/new-version
+Copyright Amadeus SAS
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 
 @octokit/auth-token
 MIT


### PR DESCRIPTION

## Proposed change
@o3r/schematics is not fully installed and not accessible during ng-add
schematics run. A relative import allows to access the library during
the installation process.

The use of composite in tsconfig.builders.json (current setup) allow to make reference
to the dist/src folder without risking the override of the src build.
## Related issues

- :bug: Fixes #2334


<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
