### PR TITLE
feat: otter sdk training - sdk with date generation and usage

### DIFF
--- a/apps/showcase/.eslintrc.js
+++ b/apps/showcase/.eslintrc.js
@@ -3,6 +3,7 @@
 
 module.exports = {
   'root': true,
+  'ignorePatterns': ['/src/assets/trainings/sdk'],
   'overrides': [
     {
       'files': [

--- a/apps/showcase/src/assets/trainings/sdk/steps/date-sdk-generation/exercise/open-api.yaml
+++ b/apps/showcase/src/assets/trainings/sdk/steps/date-sdk-generation/exercise/open-api.yaml
@@ -1,0 +1,25 @@
+# TEMPLATE: This is a template spec file to be used to complete the exercise in your local environment
+openapi: 3.0.2
+info:
+  description: This is a sample SDK for the Otter training
+  version: 1.0.0
+  title: Otter Training SDK
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+tags:
+  - name: dummy
+    description: Dummy operations
+paths:
+  /dummy:
+    get:
+      tags:
+        - "dummy"
+      operationId: dummy
+      responses:
+        200:
+          description: "Successful operation"
+components:
+  schemas:
+    Flight:
+    # Complete these specifications with the provided instructions

--- a/apps/showcase/src/assets/trainings/sdk/steps/date-sdk-generation/instructions.html
+++ b/apps/showcase/src/assets/trainings/sdk/steps/date-sdk-generation/instructions.html
@@ -1,0 +1,75 @@
+<p>
+  If your specification file includes dates, there are multiple options for the generation of your SDK.
+</p>
+<p>
+  For this exercise, let's consider a specific use case. Imagine your SDK is used on a flight booking site, including international travel.
+  A user who is currently in France is planning a round trip from Paris to New York City. These cities are in different timezones, which needs
+  to be taken into account when the user books their flights. The outbound and return flights must be relative to the timezones of the airports.
+</p>
+<p>
+  To do so, the dates of the flights must be of type <code>utils.DateTime</code>.
+</p>
+<p>
+  Also, for this flight booking site, each flight has an expiration date-time for the payment, which is relative to the user's timezone.
+</p>
+
+<h3>Exercise</h3>
+<p>
+  <i>
+    This exercise should be done in your local environment (such as the SDK repository you created in the previous step).
+    We have provided the template and the solution on the right.
+    (Due to a Java constraint, you won't be able to generate your own SDK in the code editor provided on the right.)
+  </i>
+</p>
+<p>
+  Let's create a specification file for our flight booking site. This SDK should contain a definition with the properties to book a flight:
+</p>
+<ul>
+  <li>Origin location code</li>
+  <li>Destination location code</li>
+  <li>Departure date-time</li>
+  <li>Payment expiration date</li>
+</ul>
+<p>
+  As mentioned above, the type of the departure date-time should be <code>utils.DateTime</code> after generation, which can be defined by setting the
+  type of the property to <code>string</code> and adding the <code>x-local-timezone</code> vendor (more information on how to do this in the
+  <a href="https://github.com/AmadeusITGroup/otter/tree/main/packages/%40ama-sdk/schematics/schematics/typescript/shell/templates/base#manage-dates" target="_blank">documentation</a>).
+  Once your specification file is created, you can generate your SDK using the command below or the corresponding script in your <code>package.json</code> file.
+</p>
+<pre class="w-100 bg-body-tertiary px-5 pre-whitespace">
+  <code>
+yarn schematics @ama-sdk/schematics:typescript-core --spec-path ./path/to/openapi.yaml
+  </code>
+</pre>
+<p>
+  As you may notice, the generated date object is of type <code>string</code> instead of <code>Date</code>. This is normal since the default configuration
+  of the SDK generator has an option <code>stringifyDate</code> that is set to <code>true</code>. To ensure that the date object is generated correctly,
+  this option needs to be set to false either through the command line or in <code>openapitools.json</code>.
+</p>
+<p>For example:</p>
+<pre class="w-100 bg-body-tertiary px-5 pre-whitespace">
+  <code>
+yarn schematics @ama-sdk/schematics:typescript-core --spec-path ./path/to/openapi.yaml --global-property stringifyDate=false
+  </code>
+</pre>
+<p>or</p>
+<pre class="w-100 bg-body-tertiary px-5 pre-whitespace">
+  <code>
+"generators": {
+  "training-project-training-sdk": {
+    "generatorName": "typescriptFetch",
+    "output": ".",
+    "inputSpec": "./open-api.yaml"
+    "globalProperty": {
+      "stringifyDate": false
+    }
+  }
+}
+  </code>
+</pre>
+<p>
+  <i><u>Note:</u> The <code>stringifyDate</code> option does not impact the generation of a <code>utils.Date</code> object.</i>
+</p>
+<p>
+  To make sure you have generated the correct SDK locally, check out the file <code>src/models/base/flight/flight.ts</code> of the solution.
+</p>

--- a/apps/showcase/src/assets/trainings/sdk/steps/date/exercise/app.component.html
+++ b/apps/showcase/src/assets/trainings/sdk/steps/date/exercise/app.component.html
@@ -1,0 +1,17 @@
+<button type="button" class="btn btn-primary" (click)="updateValues()">Update Values</button>
+<table class="table">
+  <thead>
+  <tr>
+    <th scope="col"></th>
+    <th scope="col">Date</th>
+    <th scope="col">utils.DateTime</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <th scope="row">Value</th>
+    <td>{{date}}</td>
+    <td>{{dateTime}}</td>
+  </tr>
+  </tbody>
+</table>

--- a/apps/showcase/src/assets/trainings/sdk/steps/date/exercise/app.component.ts
+++ b/apps/showcase/src/assets/trainings/sdk/steps/date/exercise/app.component.ts
@@ -1,0 +1,29 @@
+import { utils } from '@ama-sdk/core';
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [],
+  templateUrl: './app.component.html',
+  styleUrl: './app.component.scss'
+})
+export class AppComponent {
+  /** Title of the application */
+  public title = 'tutorial-app';
+
+  /** Date value used to initialize the two date variables */
+  public dateValue = '';
+  /** Date variable of type Date */
+  public date: Date | null = null;
+  /** Date variable of type utils.DateTime */
+  public dateTime: utils.DateTime | null = null;
+
+  constructor() {
+    this.updateValues();
+  }
+
+  public updateValues() {
+    /* Set the values of the two variables here */
+  }
+}

--- a/apps/showcase/src/assets/trainings/sdk/steps/date/instructions.html
+++ b/apps/showcase/src/assets/trainings/sdk/steps/date/instructions.html
@@ -1,0 +1,44 @@
+<p>
+  As previously explained, dates can be generated differently based on the specifications and the generator options.
+  The possible types include:
+</p>
+<ul>
+  <li><code>Date</code></li>
+  <li><code>string</code></li>
+  <li><code>utils.Date</code></li>
+  <li><code>utils.DateTime</code></li>
+</ul>
+<p>
+  For this exercise, we will focus on the types <code>Date</code> and <code>utils.DateTime</code> to compare how
+  these are impacted by timezones.
+</p>
+
+<h3>Exercise</h3>
+<p>
+  As you can see on the right, we have provided a template component file to be filled. There are three variables to update:
+</p>
+<ul>
+  <li><code>dateValue</code> : A stringified date value that will be used to initialize the other two variables</li>
+  <li><code>date</code> : Date variable of type <code>Date</code></li>
+  <li><code>utils.Date</code> : Date variable of type <code>utils.DateTime</code></li>
+</ul>
+<p>
+  Start by setting <code>dateValue</code>, which should respect the following format that includes the timezone:
+  <b>YYYY-MM-DDTHH:MM:SS+HH:MM</b>. It is best to set a timezone different than your local environment to notice a
+  difference between the two variables later on.
+</p>
+<p>
+  Next, initialize the values of <code>date</code> and <code>dateTime</code> in the function <code>updateValues()</code>.
+  This function is called in the constructor and can be triggered when clicking the <b>"Update Values"</b> button in the
+  preview of the application.
+</p>
+<p>
+  If correctly set, you should see the values appear in the table of the application. Since you have set the date value in
+  a timezone different from your local environment, you can see that the values of the two variables are different.
+  This is normal since <code>utils.DateTime</code> ignores the timezone of the date value (as explained in its documentation).
+</p>
+<p>
+  You can play around with these values to see how they are impacted by changing the timezone of your local environment
+  and clicking on the <b>"Update Values"</b> button (do not refresh the page). You should observe that the <code>Date</code>
+  value is updated while the <code>utils.DateTime</code> value is not impacted.
+</p>

--- a/apps/showcase/src/assets/trainings/sdk/steps/date/solution/app.component.ts
+++ b/apps/showcase/src/assets/trainings/sdk/steps/date/solution/app.component.ts
@@ -1,0 +1,31 @@
+import { utils } from '@ama-sdk/core';
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [],
+  templateUrl: './app.component.html',
+  styleUrl: './app.component.scss'
+})
+export class AppComponent {
+  /** Title of the application */
+  public title = 'tutorial-app';
+
+  /** Date value used to initialize the two date variables */
+  public dateValue = '2024-09-01T10:00:00+02:00';
+  /** Date variable of type Date */
+  public date: Date | null = null;
+  /** Date variable of type utils.DateTime */
+  public dateTime: utils.DateTime | null = null;
+
+  constructor() {
+    this.updateValues();
+  }
+
+  public updateValues() {
+    /* Set the values of the two variables here */
+    this.date = new Date(this.dateValue);
+    this.dateTime = new utils.DateTime(this.dateValue);
+  }
+}


### PR DESCRIPTION
## Proposed change

Otter SDK Training - SDK with Dates - Generation step and How to use step

NOTE: the app.component files are those that are added to the webcontainer (these are converted to a JSON format and then added to the webcontainer for the exercises)



Generation step:
![image](https://github.com/user-attachments/assets/e74aa0ab-aa9d-4846-af76-928ef1298b33)
![image](https://github.com/user-attachments/assets/d1cf75c4-a17d-431c-a8a8-6122532e6513)
Show solution:
![image](https://github.com/user-attachments/assets/ee6a6f93-62cf-4cf0-9ae2-aee5b317043b)

How to use:
![image](https://github.com/user-attachments/assets/93401778-b55a-4533-96d0-5c4d353a11d1)
![image](https://github.com/user-attachments/assets/37a60396-af3e-4e61-92b8-21f18caa0f9f)
Show solution:
![image](https://github.com/user-attachments/assets/c6bdbf47-3a90-45a8-b96e-8e4eaa17f21d)

## Related issues

- :bug: Fixes #(issue)
- :rocket: Feature #(issue)

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
