### PR TITLE
deprecate(sdk-generator): default client api based mocks

### DIFF
--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/spec/api-mock.mustache
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/spec/api-mock.mustache
@@ -4,7 +4,10 @@ import { ApiFetchClient, type BaseApiFetchClientConstructor } from '@ama-sdk/cor
 
 import * as api from '../api';
 
-const MOCK_SERVER_BASE_PATH = 'http://localhost:10010/v2';
+/**
+ * Base path for the mock server
+ */
+export const MOCK_SERVER_BASE_PATH = 'http://localhost:10010/v2';
 const MOCK_SERVER = new ApiFetchClient({basePath: MOCK_SERVER_BASE_PATH});
 
 export interface Api {
@@ -15,6 +18,10 @@ export interface Api {
 {{/apis}}
 }
 
+/**
+ * Mock APIs
+ * @deprecated use `getMockedApi` with {@link ApiClient} instead, will be removed in v12.
+ */
 export const myApi: Api = {
 {{#noEmptyLines}}{{#trimComma}}{{#apis}}
 {{#operations}}
@@ -23,10 +30,25 @@ export const myApi: Api = {
 {{/apis}}{{/trimComma}}{{/noEmptyLines}}
 };
 
-
 /**
  * Retrieve mocked SDK Apis
- *
+ * @param config configuration of the Api Client
+ * @deprecated use `getMockedApi` with {@link ApiClient} instead, will be removed in v12.
+ */
+export function getMockedApi(config?: string | BaseApiFetchClientConstructor): Api;
+/**
+ * Retrieve mocked SDK Apis
+ * @param apiClient Api Client instance
+ * @example Default Mocked API usage
+ * ```typescript
+ * import { getMockedApi, MOCK_SERVER_BASE_PATH } from '@my/sdk/spec';
+ * import { ApiFetchClient } from '@ama-sdk/client-fetch';
+ * const mocks = getMockedApi(new ApiFetchClient({ basePath: MOCK_SERVER_BASE_PATH }));
+ * ```
+ */
+export function getMockedApi(apiClient: ApiClient): Api;
+/**
+ * Retrieve mocked SDK Apis
  * @param config configuration of the Api Client
  */
 export function getMockedApi(config?: string | BaseApiFetchClientConstructor | ApiClient): Api {

--- a/packages/@ama-sdk/showcase-sdk/src/spec/api-mock.ts
+++ b/packages/@ama-sdk/showcase-sdk/src/spec/api-mock.ts
@@ -3,7 +3,10 @@ import { ApiFetchClient, BaseApiFetchClientConstructor } from '@ama-sdk/client-f
 
 import * as api from '../api';
 
-const MOCK_SERVER_BASE_PATH = 'http://localhost:10010/v2';
+/**
+ * Base path for the mock server
+ */
+export const MOCK_SERVER_BASE_PATH = 'http://localhost:10010/v2';
 const MOCK_SERVER = new ApiFetchClient({basePath: MOCK_SERVER_BASE_PATH});
 
 export interface Api {
@@ -12,6 +15,10 @@ export interface Api {
   userApi: api.UserApi;
 }
 
+/**
+ * Mock APIs
+ * @deprecated use `getMockedApi` with {@link ApiClient} instead, will be removed in v12.
+ */
 export const myApi: Api = {
   petApi: new api.PetApi(MOCK_SERVER),
   storeApi: new api.StoreApi(MOCK_SERVER),
@@ -19,6 +26,23 @@ export const myApi: Api = {
 };
 
 
+/**
+ * Retrieve mocked SDK Apis
+ * @param config configuration of the Api Client
+ * @deprecated use `getMockedApi` with {@link ApiClient} instead, will be removed in v12.
+ */
+export function getMockedApi(config?: string | BaseApiFetchClientConstructor): Api;
+/**
+ * Retrieve mocked SDK Apis
+ * @param apiClient Api Client instance
+ * @example Default Mocked API usage
+ * ```typescript
+ * import { getMockedApi, MOCK_SERVER_BASE_PATH } from '@my/sdk/spec';
+ * import { ApiFetchClient } from '@ama-sdk/client-fetch';
+ * const mocks = getMockedApi(new ApiFetchClient({ basePath: MOCK_SERVER_BASE_PATH }));
+ * ```
+ */
+export function getMockedApi(apiClient: ApiClient): Api;
 /**
  * Retrieve mocked SDK Apis
  * @param config configuration of the Api Client


### PR DESCRIPTION
## Proposed change

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

deprecate the default client api based mocks in SDK generated mocks

## Related issues

- :rocket: Feature #2117

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
