### PR TITLE
fix(chrome-devtools): set version in manifest.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "update-yarn-sdks": "node -e \"'pnp' !== '$(yarn config get nodeLinker)' || process.exit(1)\" || yarn dlx @yarnpkg/sdks",
     "build:storybook": "yarn doc:generate:json && yarn ng run storybook:extract-style && build-storybook",
     "clear": "rimraf -g './{packages,tools,apps}/{@*/,}{amaterasu/,}*/{dist,build,dist-*}/'",
-    "set:version": "yarn o3r-set-version --placeholder 0.0.0-placeholder --include '{apps,packages}/**/dist/package.json'",
+    "set:version": "yarn o3r-set-version --placeholder 0.0.0-placeholder --include '{apps,packages}/**/dist/{package,manifest}.json'",
     "harmonize:version": "eslint '**/package.json*' '.yarnrc.yml' --quiet --fix",
     "doc:packages": "yarn nx run-many --target=documentation --parallel $(yarn get:cpus-number)",
     "doc:root": "yarn prepare-doc-root-menu-template && yarn update-doc-summary ./docs && yarn compodoc",


### PR DESCRIPTION
## Proposed change

The version placeholder is not updated in the `manifest.json` in the Chrome Extension package. 
![image](https://github.com/user-attachments/assets/728e4c7c-3a94-4fa1-809c-e00a60229233)

The goal is to run the `set-version` script also over `manifest.json` files under `dist`, not only on `package.json`.

