### PR TITLE
feat(eslint-plugin): renamed exported recommended

### DIFF
--- a/packages/@o3r/eslint-config-otter/migration.json
+++ b/packages/@o3r/eslint-config-otter/migration.json
@@ -5,6 +5,11 @@
       "version": "10.0.0-alpha.0",
       "description": "Updates of @o3r/eslint-config-otter to v10.0.*",
       "factory": "./schematics/ng-update/index#updateV100"
+    },
+    "migration-v11_6": {
+      "version": "11.6.0-prerelease.0",
+      "description": "Updates of @o3r/eslint-config-otter to v11.6.*",
+      "factory": "./schematics/ng-update/index#updateV116"
     }
   }
 }

--- a/packages/@o3r/eslint-config-otter/schematics/ng-update/index.ts
+++ b/packages/@o3r/eslint-config-otter/schematics/ng-update/index.ts
@@ -8,6 +8,9 @@ import {
 import {
   addStylistic,
 } from './v10.0/stylistic';
+import {
+  updateEslintRecommended,
+} from './v11.6/update-configs/update-configs';
 
 /**
  * Update of Otter library V10.0
@@ -23,6 +26,24 @@ function updateV100fn(): Rule {
 }
 
 /**
+ * Update of Otter library V11.6
+ */
+function updateV116Fn(): Rule {
+  return (tree, context) => {
+    const updateRules: Rule[] = [
+      updateEslintRecommended()
+    ];
+
+    return chain(updateRules)(tree, context);
+  };
+}
+
+/**
  * Update of Otter library V10.0
  */
 export const updateV100 = createSchematicWithMetricsIfInstalled(updateV100fn);
+
+/**
+ * Update of Otter library V11.6
+ */
+export const updateV116 = createSchematicWithMetricsIfInstalled(updateV116Fn);

--- a/packages/@o3r/eslint-config-otter/schematics/ng-update/v11.6/update-configs/update-configs.spec.ts
+++ b/packages/@o3r/eslint-config-otter/schematics/ng-update/v11.6/update-configs/update-configs.spec.ts
@@ -1,0 +1,43 @@
+import {
+  Tree,
+} from '@angular-devkit/schematics';
+import {
+  updateEslintRecommended,
+} from './update-configs';
+
+let findFilesInTreeFn: () => any[] = () => [];
+
+jest.mock('@o3r/schematics', () => ({
+  findFilesInTree: jest.fn().mockImplementation(() => findFilesInTreeFn())
+}));
+
+describe('updateEslintRecommended', () => {
+  beforeEach(() => jest.restoreAllMocks());
+
+  it('should update configs', async () => {
+    const initialTree = Tree.empty();
+    initialTree.create('random.file', 'a file containing json-recommended');
+    initialTree.create('/test/.eslintrc.json', '{ "extends": ["@o3r/json-recommended", "@other/json-recommended"] }');
+    findFilesInTreeFn = () => [
+      initialTree.get('random.file'),
+      initialTree.get('/test/.eslintrc.json')
+    ];
+    await updateEslintRecommended()(initialTree, null as any);
+
+    expect(initialTree.readText('random.file')).toContain('json-recommended');
+    expect(initialTree.readText('/test/.eslintrc.json')).toBe('{ "extends": ["@o3r/monorepo-recommended", "@other/json-recommended"] }');
+  });
+
+  it('should update configs on findFilesInTree failure', async () => {
+    findFilesInTreeFn = () => {
+      throw new Error('test');
+    };
+    const initialTree = Tree.empty();
+    initialTree.create('random.file', 'a file containing json-recommended');
+    initialTree.create('/test/.eslintrc.json', '{ "extends": ["@o3r/json-recommended", "@other/json-recommended"] }');
+    await updateEslintRecommended()(initialTree, null as any);
+
+    expect(initialTree.readText('random.file')).toContain('json-recommended');
+    expect(initialTree.readText('/test/.eslintrc.json')).toBe('{ "extends": ["@o3r/monorepo-recommended", "@other/json-recommended"] }');
+  });
+});

--- a/packages/@o3r/eslint-config-otter/schematics/ng-update/v11.6/update-configs/update-configs.ts
+++ b/packages/@o3r/eslint-config-otter/schematics/ng-update/v11.6/update-configs/update-configs.ts
@@ -1,0 +1,44 @@
+import {
+  basename,
+} from 'node:path';
+import type {
+  FileEntry,
+  Rule,
+} from '@angular-devkit/schematics';
+
+/**
+ * Update Eslint files to new recommended names
+ */
+export function updateEslintRecommended(): Rule {
+  const configFilePattern = /^.?eslint(:?rc)?\..*/;
+  const toReplace = {
+
+    'angular-template-recommended': /(['"](?:plugin:)?@o3r\/)template-recommended(['"])/g,
+
+    'monorepo-recommended': /(['"](?:plugin:)?@o3r\/)json-recommended(['"])/g
+  };
+
+  const isFileToParse = (path: string) => configFilePattern.test(basename(path));
+
+  return async (tree) => {
+    let files: FileEntry[];
+    try {
+      const { findFilesInTree } = await import('@o3r/schematics');
+      files = findFilesInTree(tree.getDir('/'), isFileToParse);
+    } catch {
+      files = [];
+      tree.visit((path) => isFileToParse(path) && files.push(tree.get(path)!));
+    }
+
+    files.forEach(({ content, path }) => {
+      const contentStr = content.toString();
+      const newContent = Object.entries(toReplace).reduce((acc, [rule, regexp]) => {
+        return acc.replaceAll(regexp, `$1${rule}$2`);
+      }, contentStr);
+
+      if (contentStr !== newContent) {
+        tree.overwrite(path, newContent);
+      }
+    });
+  };
+}

--- a/packages/@o3r/eslint-plugin/src/index.ts
+++ b/packages/@o3r/eslint-plugin/src/index.ts
@@ -38,6 +38,7 @@ module.exports = {
       }
     },
 
+    // deprecated: should use `angular-template-recommended` instead. Will be removed in v13.
     'template-recommended': {
       rules: {
         '@o3r/no-folder-import-for-module': 'error',
@@ -45,7 +46,21 @@ module.exports = {
       }
     },
 
+    // deprecated: should use `monorepo-recommended` instead. Will be removed in v13.
     'json-recommended': {
+      rules: {
+        '@o3r/json-dependency-versions-harmonize': 'error'
+      }
+    },
+
+    'angular-template-recommended': {
+      rules: {
+        '@o3r/no-inner-html': 'off',
+        '@o3r/template-async-number-limitation': 'error'
+      }
+    },
+
+    'monorepo-recommended': {
       rules: {
         '@o3r/json-dependency-versions-harmonize': 'error'
       }

--- a/packages/@o3r/eslint-plugin/src/rules/yaml/yarnrc-package-extensions-harmonize/yarnrc-package-extensions-harmonize.spec.ts
+++ b/packages/@o3r/eslint-plugin/src/rules/yaml/yarnrc-package-extensions-harmonize/yarnrc-package-extensions-harmonize.spec.ts
@@ -75,9 +75,18 @@ beforeAll(async () => {
   await fs.writeFile(path.join(fakeFolder, 'local', 'packages', 'my-package-2', 'package.json'), JSON.stringify(packageJson2));
 });
 
-ruleTester.run('json-dependency-versions-harmonize', yamlDependencyVersionsHarmonize, {
+ruleTester.run('yarnrc-dependency-versions-harmonize', yamlDependencyVersionsHarmonize, {
   valid: [
-    { code: bestVersionYaml, filename: packageToLint }
+    { code: bestVersionYaml, filename: packageToLint },
+    {
+      filename: packageToLint,
+      code: yamlToUpdate,
+      options: [{
+        ignoredDependencies: ['myDep']
+      }]
+    },
+    { filename: packageToLint, code: '' },
+    { filename: 'not/a/yaml.txt', code: 'not a yaml' }
   ],
   invalid: [
     {


### PR DESCRIPTION
## Proposed change

feat(eslint-plugin): renamed exported recommended
fix(eslint-plugin): turn yaml parser really optional
deprecate(eslint-plugin): recommended exports based on types

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that is required for this change. -->

## Related issues

- :rocket: Feature resolves #1487
- 🐛 Fix resolves #2482

<!-- Please make sure to follow the contributing guidelines on https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md -->
