### PR TITLE
chore: support NX_PARALLEL as default parallel CPUs number

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "nx": "nx",
     "ng": "yarn nx",
     "amaterasu": "node packages/@ama-terasu/cli/dist/src/cli/ama.js",
-    "get:cpus-number": "node -e 'process.stdout.write(`${Math.max(require(\"os\").cpus().length - 1, 2)}`);'",
+    "get:cpus-number": "node -e 'process.stdout.write(`${process.env.NX_PARALLEL || Math.max(require(\"os\").cpus().length - 1, 2)}`);'",
     "get:current-dir": "node -e 'process.stdout.write(process.cwd());'",
     "create:scope": "yarn create-monorepo-scope",
     "build": "yarn nx run-many --target=build --parallel $(yarn get:cpus-number)",


### PR DESCRIPTION
## Proposed change

chore: support NX_PARALLEL as default parallel CPUs number
see Nx Variable list: https://nx.dev/reference/environment-variables

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
