### PR TITLE
fix(pipeline): action version and update npmRegistry

### DIFF
--- a/packages/@o3r/pipeline/schematics/ng-add/index.spec.ts
+++ b/packages/@o3r/pipeline/schematics/ng-add/index.spec.ts
@@ -46,4 +46,22 @@ describe('ng-add', () => {
 
   });
 
+  it('should generate a GitHub workflow with custom parameters when npmrc exists', async () => {
+    const runner = new SchematicTestRunner('@o3r/pipeline', collectionPath);
+    initialTree.create('.npmrc', 'registry=http://public.registry.com');
+    const tree = await runner.runSchematic('ng-add', {
+      toolchain: 'github',
+      runner: 'windows-latest',
+      npmRegistry: 'http://private.registry.com'
+    } as NgAddSchematicsSchema, initialTree);
+
+    expect(tree.exists('.github/actions/setup/action.yml')).toBe(true);
+    expect(tree.exists('.github/workflows/main.yml')).toBe(true);
+    expect(tree.exists('.npmrc')).toBe(true);
+
+    expect(tree.readText('.github/workflows/main.yml')).toContain('windows-latest');
+    expect(tree.readText('.npmrc')).toBe('registry=http://private.registry.com');
+
+  });
+
 });

--- a/tools/@o3r/build-helpers/scripts/write-git-hash.mjs
+++ b/tools/@o3r/build-helpers/scripts/write-git-hash.mjs
@@ -22,8 +22,10 @@ try {
   const data = readFileSync(packageJsonPath, { encoding: 'utf-8' });
   const packageJson = JSON.parse(data);
 
-  packageJson.o3rConfig = packageJson.o3rConfig || {};
-  packageJson.o3rConfig.commitHash = commitHash;
+
+  packageJson.config ||= {};
+  packageJson.config.o3r ||= {};
+  packageJson.config.o3r.commitHash = commitHash;
 
   writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2), { encoding: 'utf-8' });
   console.log(`package.json updated successfully with commit hash '${commitHash}'`);


### PR DESCRIPTION
## Proposed change

The version for Otter GitHub actions is incorrect.

Also, if a registry is already present in `.npmrc` but a value is passed to the ng add schematics, it should be updated.

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
