### PR TITLE
fix(design): typo in interface name

### DIFF
--- a/packages/@o3r/design/src/core/design-token/renderers/design-token.renderer.interface.ts
+++ b/packages/@o3r/design/src/core/design-token/renderers/design-token.renderer.interface.ts
@@ -20,7 +20,7 @@ export type TokenDefinitionRenderer = (tokenStructure: DesignTokenVariableStruct
 /**
  * Options of the Design Token list transform function
  */
-export interface DesignTTokenListTransformOptions {
+export interface DesignTokenListTransformOptions {
   /**
    * Renderer the name of generated variable (without the prefix required by the target language)
    */
@@ -30,7 +30,7 @@ export interface DesignTTokenListTransformOptions {
 /**
  * Function defining the way the variable should be sorted before being generated
  */
-export type DesignTokenListTransform = (variableSet: DesignTokenVariableSet, options?: DesignTTokenListTransformOptions) => (tokens: DesignTokenVariableStructure[]) => DesignTokenVariableStructure[];
+export type DesignTokenListTransform = (variableSet: DesignTokenVariableSet, options?: DesignTokenListTransformOptions) => (tokens: DesignTokenVariableStructure[]) => DesignTokenVariableStructure[];
 
 /**
  * Options of the Design Token Renderer value


### PR DESCRIPTION
## Proposed change

Fix typo in Design interface name (not used and introduced in this version)

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
