### PR TITLE
feat(2388): check relevance of migration files items on metadata checks

### DIFF
--- a/packages/@o3r/components/builders/metadata-check/helpers/config-metadata-comparison.helper.ts
+++ b/packages/@o3r/components/builders/metadata-check/helpers/config-metadata-comparison.helper.ts
@@ -38,8 +38,9 @@ const getConfigurationArray = (content: ComponentConfigOutput[]): ComponentConfi
 
 const getConfigurationPropertyName = (config: ComponentConfigOutput) => `${config.library}#${config.name}` + (config.properties.length ? ` ${config.properties[0].name}` : '');
 
-const isMigrationConfigurationDataMatch = (config: ComponentConfigOutput, migrationData: MigrationConfigData, metadataType: string) =>
-  metadataType === 'CONFIG' &&
+const isRelevantContentType = (contentType: string) => contentType === 'CONFIG';
+
+const isMigrationConfigurationDataMatch = (config: ComponentConfigOutput, migrationData: MigrationConfigData) =>
   migrationData.libraryName === config.library
   && (!migrationData.configName || migrationData.configName === config.name)
   && (!migrationData.propertyName || config.properties[0]?.name === migrationData.propertyName);
@@ -50,5 +51,6 @@ const isMigrationConfigurationDataMatch = (config: ComponentConfigOutput, migrat
 export const configMetadataComparator: MetadataComparator<ComponentConfigOutput, MigrationConfigData, ComponentConfigOutput[]> = {
   getArray: getConfigurationArray,
   getIdentifier: getConfigurationPropertyName,
+  isRelevantContentType,
   isMigrationDataMatch: isMigrationConfigurationDataMatch
 };

--- a/packages/@o3r/components/builders/metadata-check/schema.json
+++ b/packages/@o3r/components/builders/metadata-check/schema.json
@@ -26,6 +26,11 @@
       "description": "Are breaking changes allowed.",
       "default": false
     },
+    "shouldCheckUnusedMigrationData": {
+      "type": "boolean",
+      "description": "Whether to throw an error in case of a migration item that is not used during metadata checks",
+      "default": false
+    },
     "packageManager": {
       "type": "string",
       "description": "Override of the package manager, otherwise it will be computed from the project setup."

--- a/packages/@o3r/extractors/src/core/comparator/metadata-comparator.interface.ts
+++ b/packages/@o3r/extractors/src/core/comparator/metadata-comparator.interface.ts
@@ -26,12 +26,17 @@ export interface MetadataComparator<MetadataItem, MigrationMetadataItem, Metadat
   isSame?: (item1: MetadataItem, item2: MetadataItem) => boolean;
 
   /**
+   * Returns true is the contentType is supported by the comparator
+   * @param contentType Content type of the migration item
+   */
+  isRelevantContentType: (contentType: string) => boolean;
+
+  /**
    * Returns true if a migration item matches a metadata item.
    * @param metadataItem Metadata item
    * @param migrationItem Migration item
-   * @param metadataType Type of the metadata
    */
-  isMigrationDataMatch: (metadataItem: MetadataItem, migrationItem: MigrationMetadataItem, metadataType: string) => boolean;
+  isMigrationDataMatch: (metadataItem: MetadataItem, migrationItem: MigrationMetadataItem) => boolean;
 }
 
 /**
@@ -76,6 +81,9 @@ export interface MigrationMetadataCheckBuilderOptions extends JsonObject {
 
   /** Whether breaking changes are allowed.*/
   allowBreakingChanges: boolean;
+
+  /** Whether to throw an error in case of a migration item that is not used during metadata checks */
+  shouldCheckUnusedMigrationData: boolean;
 
   /** Override of the package manager, otherwise it will be determined from the project. */
   packageManager: SupportedPackageManagers;

--- a/packages/@o3r/localization/builders/metadata-check/helpers/localization-metadata-comparison.helper.ts
+++ b/packages/@o3r/localization/builders/metadata-check/helpers/localization-metadata-comparison.helper.ts
@@ -17,8 +17,10 @@ const getLocalizationArray = (content: LocalizationMetadata) => content;
 
 const getLocalizationName = (localization: JSONLocalization) => localization.key;
 
-const isMigrationLocalizationDataMatch = (localization: JSONLocalization, migrationData: MigrationLocalizationMetadata, metadataType: string) =>
-  metadataType === 'LOCALIZATION' && getLocalizationName(localization) === migrationData.key;
+const isRelevantContentType = (contentType: string) => contentType === 'LOCALIZATION';
+
+const isMigrationLocalizationDataMatch = (localization: JSONLocalization, migrationData: MigrationLocalizationMetadata) =>
+  getLocalizationName(localization) === migrationData.key;
 
 
 /**
@@ -27,5 +29,6 @@ const isMigrationLocalizationDataMatch = (localization: JSONLocalization, migrat
 export const localizationMetadataComparator: MetadataComparator<JSONLocalization, MigrationLocalizationMetadata, LocalizationMetadata> = {
   getArray: getLocalizationArray,
   getIdentifier: getLocalizationName,
+  isRelevantContentType,
   isMigrationDataMatch: isMigrationLocalizationDataMatch
 };

--- a/packages/@o3r/localization/builders/metadata-check/schema.json
+++ b/packages/@o3r/localization/builders/metadata-check/schema.json
@@ -26,6 +26,11 @@
       "description": "Are breaking changes allowed.",
       "default": false
     },
+    "shouldCheckUnusedMigrationData": {
+      "type": "boolean",
+      "description": "Whether to throw an error in case of a migration item that is not used during metadata checks",
+      "default": false
+    },
     "packageManager": {
       "type": "string",
       "description": "Override of the package manager, otherwise it will be determined from the project."

--- a/packages/@o3r/styling/builders/metadata-check/helpers/styling-metadata-comparison.helper.ts
+++ b/packages/@o3r/styling/builders/metadata-check/helpers/styling-metadata-comparison.helper.ts
@@ -16,8 +16,10 @@ const getCssVariablesArray = (content: CssMetadata): CssVariable[] => Object.key
 
 const getCssVariableName = (cssVariable: CssVariable) => cssVariable.name;
 
-const isMigrationCssVariableDataMatch = (cssVariable: CssVariable, migrationData: MigrationStylingData, metadataType: string) =>
-  metadataType === 'STYLE' && getCssVariableName(cssVariable) === migrationData.name;
+const isRelevantContentType = (contentType: string) => contentType === 'STYLE';
+
+const isMigrationCssVariableDataMatch = (cssVariable: CssVariable, migrationData: MigrationStylingData) =>
+  getCssVariableName(cssVariable) === migrationData.name;
 
 /**
  * Comparator used to compare one version of styling metadata with another
@@ -25,5 +27,6 @@ const isMigrationCssVariableDataMatch = (cssVariable: CssVariable, migrationData
 export const stylingMetadataComparator: MetadataComparator<CssVariable, MigrationStylingData, CssMetadata> = {
   getArray: getCssVariablesArray,
   getIdentifier: getCssVariableName,
+  isRelevantContentType,
   isMigrationDataMatch: isMigrationCssVariableDataMatch
 };

--- a/packages/@o3r/styling/builders/metadata-check/schema.json
+++ b/packages/@o3r/styling/builders/metadata-check/schema.json
@@ -26,6 +26,11 @@
       "description": "Are breaking changes allowed.",
       "default": false
     },
+    "shouldCheckUnusedMigrationData": {
+      "type": "boolean",
+      "description": "Whether to throw an error in case of a migration item that is not used during metadata checks",
+      "default": false
+    },
     "packageManager": {
       "type": "string",
       "description": "Override of the package manager, otherwise it will be determined from the project."


### PR DESCRIPTION
## Proposed change

Add an optional check on migration files to detect unused migration items.

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
* :rocket: Feature resolves #2388 
<!-- * :octocat: Pull Request #issue -->
