### PR TITLE
fix(pipeline): release name is correctly computed based on latest tag

### DIFF
--- a/packages/@o3r/pipeline/schematics/ng-add/templates/github/__dot__github/workflows/main.yml
+++ b/packages/@o3r/pipeline/schematics/ng-add/templates/github/__dot__github/workflows/main.yml
@@ -45,12 +45,12 @@ jobs:
       contents: write
     runs-on: <%= runner %>
     outputs:
-      nextVersionTag: ${{ steps.new-version.outputs.nextVersionTag }}
+      nextVersionTag: ${{ steps.newVersion.outputs.nextVersionTag }}
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: New version
         if: github.event_name != 'merge_group'
-        id: new-version
+        id: newVersion
         uses: AmadeusITGroup/otter/tools/github-actions/new-version@<%= actionVersionString %>
         with:
           defaultBranch: ${{ env.DEFAULT_BRANCH }}


### PR DESCRIPTION
## Proposed change

In the CI generated by `@o3r/pipeline`, the step ID was incorrect resulting in a wrong GitHub release name.

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
