### PR TITLE
chore: exclude build.gradle.kts from OxyFlax codeowners setup for intellij-extension folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,3 +14,4 @@
 
 ## Default reviewers for Intellij extension
 /apps/intellij-extension/ @OxyFlax
+/apps/intellij-extension/build.gradle.kts @AmadeusITGroup/otter_admins


### PR DESCRIPTION
## Proposed change

Removing my ownership of the build.gradle.kts file to avoid blocking the merges for simple version change

## Related issues

Currently without this change I'm being requested to review PRs for just renovate version bumps

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
