### PR TITLE
feat(training): update css of the showcase to reduce the unused space on screen

### DIFF
--- a/apps/showcase/src/app/app.component.html
+++ b/apps/showcase/src/app/app.component.html
@@ -10,7 +10,7 @@
       <div class="d-none d-sm-block">Otter Showcase</div>
     </div>
   </header>
-  <div class="flex-fill container">
+  <div class="flex-fill container-fluid">
     <div class="row">
       <div class="left-nav pt-5 col-2 d-none d-xl-block">
         <o3r-sidenav-pres
@@ -18,7 +18,7 @@
         [activeUrl]="activeUrl$ | async"
         ></o3r-sidenav-pres>
       </div>
-      <div class="page-content col-12 col-xl-10">
+      <div class="page-content col-12 col-xl-10 px-3 px-md-6 px-lg-9">
         <router-outlet></router-outlet>
       </div>
     </div>

--- a/apps/showcase/src/app/app.component.scss
+++ b/apps/showcase/src/app/app.component.scss
@@ -34,6 +34,7 @@ header {
   max-height: calc(100vh - 4rem);
   overflow-y: auto;
   flex-grow: 1;
+  border-inline-end: 1px solid var(--df-gray-300);
 }
 
 .page-content {

--- a/apps/showcase/src/components/training/training.component.html
+++ b/apps/showcase/src/components/training/training.component.html
@@ -1,8 +1,21 @@
 @if (steps()[currentStepIndex()]; as currentStep){
-  <div class="mt-7 mb-3 d-flex justify-content-between">
-    <div class="align-self-center">
-      <h1 class="m-0">{{title()}}</h1>
-      <div ngbDropdown class="mt-2">
+  <div class="mt-5 mb-3 d-flex justify-content-between align-items-center gap-3 flex-wrap">
+    <h1 class="m-0 flex-grow-1">{{title()}}</h1>
+    <div class="d-flex gap-3">
+      @if (currentStep.dynamicContent.project() || currentStep.dynamicContent.solutionProject()) {
+        <button type="button" class="btn btn-outline-primary" (click)="toggleDisplayInstructions()">
+          {{showInstructions() ? 'Hide instructions' : 'Show instructions'}}
+        </button>
+        <button type="button" class="btn btn-outline-danger"
+                (click)="toggleDisplaySolution()"
+                [disabled]="!showSolution() && !currentStep.dynamicContent.solutionProject() || showSolution() && !currentStep.dynamicContent.project()"
+        >
+          {{showSolution() ? 'Show exercise' : 'Show solution'}}
+        </button>
+      }
+    </div>
+    <div class="d-flex gap-3">
+      <div ngbDropdown>
         <button type="button" class="btn btn-outline-primary" id="training-exercise-selection" ngbDropdownToggle>
           {{currentStep.description.title}}
         </button>
@@ -14,25 +27,10 @@
           }
         </div>
       </div>
-    </div>
-    <div class="align-self-center d-flex flex-wrap">
-      @if (currentStep.dynamicContent.project() || currentStep.dynamicContent.solutionProject()) {
-        <button type="button" class="btn btn-outline-primary mb-2 mb-md-0 me-5" (click)="toggleDisplayInstructions()">
-          {{showInstructions() ? 'Hide instructions' : 'Show instructions'}}
-        </button>
-        <button type="button" class="btn btn-outline-danger mb-2 mb-md-0 me-5"
-                (click)="toggleDisplaySolution()"
-                [disabled]="!showSolution() && !currentStep.dynamicContent.solutionProject() || showSolution() && !currentStep.dynamicContent.project()"
-        >
-          {{showSolution() ? 'Show exercise' : 'Show solution'}}
-        </button>
-      }
-      <div>
-        <button type="button" class="btn btn-outline-secondary df-btn-icononly fa-chevron-left me-2" [disabled]="currentStepIndex() <= 0"
-                aria-label="Previous step" (click)="setCurrentStep(currentStepIndex() - 1)"></button>
-        <button type="button" class="btn btn-outline-secondary df-btn-icononly fa-chevron-right ms-2" [disabled]="currentStepIndex() >= steps().length - 1"
-                aria-label="Next step" (click)="setCurrentStep(currentStepIndex() + 1)"></button>
-      </div>
+      <button type="button" class="btn btn-outline-secondary df-btn-icononly fa-chevron-left" [disabled]="currentStepIndex() <= 0"
+              aria-label="Previous step" (click)="setCurrentStep(currentStepIndex() - 1)"></button>
+      <button type="button" class="btn btn-outline-secondary df-btn-icononly fa-chevron-right" [disabled]="currentStepIndex() >= steps().length - 1"
+              aria-label="Next step" (click)="setCurrentStep(currentStepIndex() + 1)"></button>
     </div>
   </div>
   <o3r-training-step-pres


### PR DESCRIPTION
## Proposed change

https://fpaul-1a.github.io/otter/#/sdk-training#0
https://fpaul-1a.github.io/otter/#/sdk-training#4

![image](https://github.com/user-attachments/assets/fadd94bd-6558-426e-8dc8-687c3233a8de)


## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
