### PR TITLE
fix: metadata checks run on the wrong prerelease

### DIFF
--- a/packages/@o3r/extractors/src/core/comparator/metadata-files.helper.spec.ts
+++ b/packages/@o3r/extractors/src/core/comparator/metadata-files.helper.spec.ts
@@ -85,8 +85,8 @@ describe('metadata files helpers', () => {
       const major = 1;
       const minor = 3;
       mockCoerce.mockReturnValue({ major, minor});
-      await expect(getVersionRangeFromLatestVersion(`${major}.${minor}.14`, 'major')).resolves.toBe(`<${major}.0.0`);
-      await expect(getVersionRangeFromLatestVersion(`${major}.${minor}.14`, 'minor')).resolves.toBe(`<${major}.${minor}.0`);
+      await expect(getVersionRangeFromLatestVersion(`${major}.${minor}.14`, 'major')).resolves.toBe(`<${major}.0.0-a`);
+      await expect(getVersionRangeFromLatestVersion(`${major}.${minor}.14`, 'minor')).resolves.toBe(`<${major}.${minor}.0-a`);
     });
   });
 

--- a/packages/@o3r/extractors/src/core/comparator/metadata-files.helper.ts
+++ b/packages/@o3r/extractors/src/core/comparator/metadata-files.helper.ts
@@ -54,5 +54,5 @@ export async function getVersionRangeFromLatestVersion(latestMigrationVersion: s
   if (!semver) {
     throw new O3rCliError(`${latestMigrationVersion} is not a valid version.`);
   }
-  return `<${semver.major}.${granularity === 'minor' ? semver.minor : 0}.0`;
+  return `<${semver.major}.${granularity === 'minor' ? semver.minor : 0}.0-a`;
 }


### PR DESCRIPTION
## Proposed change

When running the metadata checks we use the version in the JSON migration file to compute the range that will be used to get the previous version.
E.g. version `11.1.0` will generate the range `<11.1.0` with `{includePrerelease: true}`
Unfortunately, this range include the prereleases of the current version `11.1.0-alpha.0`
We want to include the prerelease of the previous versions but not of the current

The solution is to add `-a` in the range to exclude them -> `<11.1.0-a`

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
