### PR TITLE
fix: remove IT test coverage publishing to CodeCov

### DIFF
--- a/.github/workflows/it-tests.yml
+++ b/.github/workflows/it-tests.yml
@@ -110,11 +110,12 @@ jobs:
       - name: Test
         id: it-tests
         run: yarn test-int --collectCoverage
-      - name: Upload results to Codecov
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
-        with:
-          flags: integration
-          token: ${{ secrets.CODECOV_TOKEN }}
+      # TODO: re-activate IT coverage publishing when #2455 is fixed
+      # - name: Upload results to Codecov
+      #   uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+      #   with:
+      #     flags: integration
+      #     token: ${{ secrets.CODECOV_TOKEN }}
       - name: Zip generated app on failure
         if: failure() && steps.it-tests.conclusion == 'failure'
         run: |

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 codecov:
-  require_ci_to_pass: false
+  require_ci_to_pass: true
 
 ignore:
   # Package Manager files


### PR DESCRIPTION
## Proposed change

disable temporary IT test coverage publishing to CodeCov.

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

* :bug: related to #2455
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
