### PR TITLE
docs: create new otter project

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ Also, to customize an application, metadata can be extracted from the applicatio
 
 ## Get Started
 
-A new application can be set up with this simple command:
+To set up a new Otter project with a monorepo structure, use the following simple command:
 
 ```shell
-# Starting a new Otter application
-npm create @o3r my-app
+# Creating a new Otter monorepo
+npm create @o3r my-project
 ```
 
 > [!TIP]

--- a/docs/core/START_NEW_APPLICATION.md
+++ b/docs/core/START_NEW_APPLICATION.md
@@ -13,13 +13,25 @@ Start a new Otter application.
   * This is used to run tests and generate distributable files. We strongly encourage to use an up-to-date LTS version of Node.js to ensure the support of all the Otter packages.
     Each package comes with a minimum Node.js version range defined in the `engine` property of its package.json file.
 
-## Creating a new Otter application
+## Creating a new Otter project
 
 ```shell
-# Create new application
 npm create @o3r my-project
-# Or
-yarn create @o3r my-project
+# Or a project using the yarn package manager
+npm create @o3r my-project -- --package-manager=yarn
+```
+
+### Generate a new application, library or SDK in the project
+
+Once created, you can generate a new application, library or SDK in the project using the following commands:
+
+```shell
+# Application
+npm run ng generate application my-webapp
+# Library
+npm run ng generate library my-library
+# SDK
+npm run ng generate sdk my-sdk
 ```
 
 The application will contain the minimum setup to follow the otter recommendations and to activate the features requested
@@ -61,7 +73,7 @@ to create components and services consistent with your project.
 }
 ```
 
-## Adding Material design theming
+### Adding Material design theming
 
 ```shell
 # Add material design

--- a/packages/@o3r/core/README.md
+++ b/packages/@o3r/core/README.md
@@ -32,13 +32,12 @@ during the installation of the `@o3r/core`.
 npm install --global yarn
 ```
 
-### Creating a new Otter application
+### Creating a new Otter project
 
 ```shell
-# Create new application
 npm create @o3r my-project
-# Or
-yarn create @o3r my-project
+# Or a project using the yarn package manager
+npm create @o3r my-project -- --package-manager=yarn
 ```
 
 > [!TIP]


### PR DESCRIPTION
## Proposed change

The documentation on creating a new Otter-based project is wrong.
It doesn't specify that the create command actually generates a monorepo structure. 

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
