### PR TITLE
feat(cascading): option to bypass non-latest minor branch

### DIFF
--- a/.github/.cascadingrc.json
+++ b/.github/.cascadingrc.json
@@ -1,6 +1,5 @@
 {
   "$schema": "../apps/github-cascading-app/schemas/config.schema.json",
-  "bypassReviewers": true,
   "labels": ["cascading"],
   "ignoredPatterns": [
     "-next$"

--- a/apps/github-cascading-app/schemas/config.schema.json
+++ b/apps/github-cascading-app/schemas/config.schema.json
@@ -31,6 +31,11 @@
       "description": "Pattern determining if the branch is part of the cascading strategy",
       "default": "^releases?/\\d+\\.\\d+"
     },
+    "onlyCascadeOnHighestMinors": {
+      "type": "boolean",
+      "description": "Determine if the branches for which a higher minor version exists should be skipped during the cascading",
+      "default": false
+    },
     "versionCapturePattern": {
       "type": "string",
       "description": "Pattern containing a capture to extract the version of a cascading branch",

--- a/apps/github-cascading-app/src/cascading/interfaces.ts
+++ b/apps/github-cascading-app/src/cascading/interfaces.ts
@@ -11,6 +11,8 @@ export interface CascadingConfiguration {
   defaultBranch: string;
   /** Pattern determining if the branch is part of the cascading strategy */
   cascadingBranchesPattern: string;
+  /** Determine if the branches for which a higher minor version exists should be skipped during the cascading */
+  onlyCascadeOnHighestMinors: boolean;
   /** Pattern containing a capture to extract the version of a cascading branch */
   versionCapturePattern: string;
   /** Bypass the reviewers validation for the pull request, only the CI checks will be executed */
@@ -34,7 +36,10 @@ export interface PullRequestContext {
   currentBranch: string;
   /** Cascading Pull Request Target Branch */
   targetBranch: string;
-  /** Determine if the reviewers are bypassed */
+  /**
+   * Determine if the reviewers are bypassed
+   * Note: This option is not supported on Github anymore due to Github Api change.
+   */
   bypassReviewers: boolean;
   /** Is the an update of the {@link currentBranch} conflicting */
   isConflicting: boolean;
@@ -68,6 +73,7 @@ export const DEFAULT_CONFIGURATION: Readonly<CascadingConfiguration> = {
   ignoredPatterns: [] as string[],
   defaultBranch: '',
   cascadingBranchesPattern: '^releases?/\\d+\\.\\d+',
+  onlyCascadeOnHighestMinors: false,
   versionCapturePattern: '/((?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:\\.0-[^ ]+)?)$',
   bypassReviewers: false,
   labels: [] as string[],


### PR DESCRIPTION
## Proposed change

Option to bypass non-latest minor branch on cascading bot

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
