### PR TITLE
feat: move schematic to package dependencies to simplify ng-add

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -35,6 +35,7 @@
     ],
     "source": [
       "base-build",
+      "{projectRoot}/ng-package.json",
       "{projectRoot}/tsconfig.build.json",
       "{projectRoot}/tsconfig.build.*.json",
       "{projectRoot}/src/**/*",

--- a/packages/@ama-sdk/client-angular/package.json
+++ b/packages/@ama-sdk/client-angular/package.json
@@ -39,6 +39,7 @@
     "prepare:publish": "prepare-publish ./dist"
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "@swc/helpers": "~0.5.0",
     "tslib": "^2.6.2",
     "uuid": "^10.0.0"
@@ -48,7 +49,6 @@
     "@angular-devkit/schematics": "~18.2.0",
     "@angular/cli": "~18.2.0",
     "@angular/common": "~18.2.0",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "rxjs": "^7.8.1",
     "typescript": "~5.5.4"
@@ -61,9 +61,6 @@
       "optional": true
     },
     "@angular/common": {
-      "optional": true
-    },
-    "@o3r/schematics": {
       "optional": true
     },
     "@schematics/angular": {

--- a/packages/@ama-sdk/client-angular/schematics/ng-add/index.ts
+++ b/packages/@ama-sdk/client-angular/schematics/ng-add/index.ts
@@ -3,37 +3,28 @@ import type { NgAddSchematicsSchema } from './schema';
 import * as path from 'node:path';
 import { NodeDependencyType } from '@schematics/angular/utility/dependencies';
 import { mapMigrationFromCoreImports } from './migration/import-map';
+import {
+  applyEsLintFix,
+  createSchematicWithMetricsIfInstalled,
+  getExternalDependenciesVersionRange,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  setupDependencies,
+  updateImports
+} from '@o3r/schematics';
 
 const devDependenciesToInstall: string[] = [
 
 ];
-
-
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @ama-sdk/client-angular has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/schematics' as devDependency to be able to use this schematics. Please run 'ng add @o3r/schematics'.
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
 
 /**
  * Add SDk Angular Client to an Otter Project
  * @param options
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
-  return async (tree, context) => {
-    // use dynamic import to properly raise an exception if it is not an Otter project.
-    const {
-      getPackageInstallConfig,
-      applyEsLintFix,
-      setupDependencies,
-      getO3rPeerDeps,
-      getProjectNewDependenciesTypes,
-      getWorkspaceConfig,
-      getExternalDependenciesVersionRange,
-      updateImports
-    } = await import('@o3r/schematics');
-
+  return (tree, context) => {
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
     const depsInfo = getO3rPeerDeps(packageJsonPath);
@@ -77,7 +68,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add SDk Angular Client to an Otter Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createSchematicWithMetricsIfInstalled(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema): Rule => createSchematicWithMetricsIfInstalled(ngAddFn)(options);

--- a/packages/@ama-sdk/client-beacon/package.json
+++ b/packages/@ama-sdk/client-beacon/package.json
@@ -39,6 +39,7 @@
     "prepare:publish": "prepare-publish ./dist"
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "@swc/helpers": "~0.5.0",
     "tslib": "^2.6.2",
     "uuid": "^10.0.0"
@@ -48,7 +49,6 @@
     "@angular-devkit/schematics": "~18.2.0",
     "@angular/cli": "~18.2.0",
     "@angular/common": "~18.2.0",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "typescript": "~5.5.4"
   },
@@ -60,9 +60,6 @@
       "optional": true
     },
     "@angular/common": {
-      "optional": true
-    },
-    "@o3r/schematics": {
       "optional": true
     },
     "@schematics/angular": {

--- a/packages/@ama-sdk/client-beacon/schematics/ng-add/index.ts
+++ b/packages/@ama-sdk/client-beacon/schematics/ng-add/index.ts
@@ -3,37 +3,28 @@ import type { NgAddSchematicsSchema } from './schema';
 import * as path from 'node:path';
 import { NodeDependencyType } from '@schematics/angular/utility/dependencies';
 import { mapMigrationFromCoreImports } from './migration/import-map';
+import {
+  applyEsLintFix,
+  createSchematicWithMetricsIfInstalled,
+  getExternalDependenciesVersionRange,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  setupDependencies,
+  updateImports
+} from '@o3r/schematics';
 
 const devDependenciesToInstall: string[] = [
 
 ];
-
-
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @ama-sdk/client-beacon has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/schematics' as devDependency to be able to use this schematics. Please run 'ng add @o3r/schematics'.
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
 
 /**
  * Add SDk Beacon Client to an Otter Project
  * @param options
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
-  return async (tree, context) => {
-    // use dynamic import to properly raise an exception if it is not an Otter project.
-    const {
-      getPackageInstallConfig,
-      applyEsLintFix,
-      setupDependencies,
-      getO3rPeerDeps,
-      getProjectNewDependenciesTypes,
-      getWorkspaceConfig,
-      getExternalDependenciesVersionRange,
-      updateImports
-    } = await import('@o3r/schematics');
-
+  return (tree, context) => {
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
     const depsInfo = getO3rPeerDeps(packageJsonPath);
@@ -77,7 +68,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add SDk Beacon Client to an Otter Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createSchematicWithMetricsIfInstalled(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema): Rule => createSchematicWithMetricsIfInstalled(ngAddFn)(options);

--- a/packages/@ama-sdk/client-fetch/package.json
+++ b/packages/@ama-sdk/client-fetch/package.json
@@ -39,6 +39,7 @@
     "prepare:publish": "prepare-publish ./dist"
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "@swc/helpers": "~0.5.0",
     "tslib": "^2.6.2",
     "uuid": "^10.0.0"
@@ -48,7 +49,6 @@
     "@angular-devkit/schematics": "~18.2.0",
     "@angular/cli": "~18.2.0",
     "@angular/common": "~18.2.0",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "isomorphic-fetch": "^3.0.0",
     "typescript": "~5.5.4"
@@ -61,9 +61,6 @@
       "optional": true
     },
     "@angular/common": {
-      "optional": true
-    },
-    "@o3r/schematics": {
       "optional": true
     },
     "@schematics/angular": {

--- a/packages/@ama-sdk/client-fetch/schematics/ng-add/index.ts
+++ b/packages/@ama-sdk/client-fetch/schematics/ng-add/index.ts
@@ -3,36 +3,30 @@ import type { NgAddSchematicsSchema } from './schema';
 import * as path from 'node:path';
 import { NodeDependencyType } from '@schematics/angular/utility/dependencies';
 import { mapMigrationFromCoreImports } from './migration/import-map';
+import {
+  applyEsLintFix,
+  createSchematicWithMetricsIfInstalled,
+  getExternalDependenciesVersionRange,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  setupDependencies,
+  updateImports
+} from '@o3r/schematics';
 
 const devDependenciesToInstall: string[] = [
 
 ];
-
-
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @ama-sdk/client-fetch has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/schematics' as devDependency to be able to use this schematics. Please run 'ng add @o3r/schematics'.
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
 
 /**
  * Add SDk Fetch Client to an Otter Project
  * @param options
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
-  return async (tree, context) => {
+  return (tree, context) => {
     // use dynamic import to properly raise an exception if it is not an Otter project.
-    const {
-      getPackageInstallConfig,
-      applyEsLintFix,
-      setupDependencies,
-      getO3rPeerDeps,
-      getProjectNewDependenciesTypes,
-      getWorkspaceConfig,
-      getExternalDependenciesVersionRange,
-      updateImports
-    } = await import('@o3r/schematics');
+
 
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
@@ -77,7 +71,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add SDk Fetch Client to an Otter Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createSchematicWithMetricsIfInstalled(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema): Rule => createSchematicWithMetricsIfInstalled(ngAddFn)(options);

--- a/packages/@ama-sdk/core/package.json
+++ b/packages/@ama-sdk/core/package.json
@@ -82,6 +82,7 @@
     "prepare:publish": "prepare-publish ./dist"
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "@swc/helpers": "~0.5.0",
     "tslib": "^2.6.2",
     "uuid": "^10.0.0"
@@ -90,7 +91,6 @@
     "@angular-devkit/schematics": "~18.2.0",
     "@angular/cli": "~18.2.0",
     "@angular/common": "~18.2.0",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "isomorphic-fetch": "^3.0.0",
     "rxjs": "^7.8.1",
@@ -104,9 +104,6 @@
       "optional": true
     },
     "@angular/common": {
-      "optional": true
-    },
-    "@o3r/schematics": {
       "optional": true
     },
     "@schematics/angular": {

--- a/packages/@ama-sdk/schematics/package.json
+++ b/packages/@ama-sdk/schematics/package.json
@@ -67,12 +67,12 @@
     "@angular-devkit/core": "~18.2.0",
     "@angular-devkit/schematics-cli": "^18.0.5",
     "@angular/cli": "~18.2.0",
-    "@o3r/schematics": "workspace:^",
     "@openapitools/openapi-generator-cli": "~2.15.0",
     "openapi-types": "^12.0.0",
     "type-fest": "^4.10.2"
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "@angular-devkit/core": "~18.2.0",
     "@angular-devkit/schematics": "~18.2.0",
     "chokidar": "^3.5.2",
@@ -93,7 +93,6 @@
     "@nx/jest": "~19.5.0",
     "@o3r/build-helpers": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/telemetry": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@openapitools/openapi-generator-cli": "~2.15.0",

--- a/packages/@ama-sdk/schematics/schematics/api-extension/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/api-extension/index.ts
@@ -9,6 +9,9 @@ import {
   url
 } from '@angular-devkit/schematics';
 import { NgGenerateApiExtensionSchematicsSchema } from './schema';
+import {
+  createSchematicWithMetricsIfInstalled
+} from '@o3r/schematics';
 
 /**
  * Generate a Extension of a API core definition
@@ -31,7 +34,4 @@ function ngGenerateApiExtensionFn(options: NgGenerateApiExtensionSchematicsSchem
  * Generate a Extension of a API core definition
  * @param options
  */
-export const ngGenerateApiExtension = (options: NgGenerateApiExtensionSchematicsSchema) => async () => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics');
-  return createSchematicWithMetricsIfInstalled(ngGenerateApiExtensionFn)(options);
-};
+export const ngGenerateApiExtension = (options: NgGenerateApiExtensionSchematicsSchema) => createSchematicWithMetricsIfInstalled(ngGenerateApiExtensionFn)(options);

--- a/packages/@ama-sdk/schematics/schematics/java/client-core/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/java/client-core/index.ts
@@ -9,6 +9,9 @@ import * as path from 'node:path';
 import { treeGlob } from '../../helpers/tree-glob';
 import { NgGenerateJavaClientCoreSchematicsSchema } from './schema';
 import {SwaggerJavaGenerator} from '../../code-generator/swagger-java-generator/swagger-java.generator';
+import {
+  createSchematicWithMetricsIfInstalled
+} from '@o3r/schematics';
 
 /** Base path where to find codegen jars */
 const jarBasePath = path.resolve(__dirname, 'swagger-codegen-java-client', 'target');
@@ -91,7 +94,4 @@ function ngGenerateJavaClientCoreFn(options: NgGenerateJavaClientCoreSchematicsS
  * Generate a Java client SDK source code base on swagger specification
  * @param options
  */
-export const ngGenerateJavaClientCore = (options: NgGenerateJavaClientCoreSchematicsSchema) => async () => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics');
-  return createSchematicWithMetricsIfInstalled(ngGenerateJavaClientCoreFn)(options);
-};
+export const ngGenerateJavaClientCore = (options: NgGenerateJavaClientCoreSchematicsSchema) => createSchematicWithMetricsIfInstalled(ngGenerateJavaClientCoreFn)(options);

--- a/packages/@ama-sdk/schematics/schematics/migrate/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/migrate/index.ts
@@ -8,6 +8,9 @@ import { gt, minVersion } from 'semver';
 import { isTypescriptSdk } from '../helpers/is-typescript-project';
 import {updateOpenApiVersionInProject} from '../ng-update/typescript/v10.3/update-openapiversion';
 import { updateV11_4 as updateV114 } from '../ng-update/typescript';
+import {
+  createSchematicWithMetricsIfInstalled
+} from '@o3r/schematics';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 const tsMigrationMap: MigrationRulesMap = {
@@ -45,7 +48,4 @@ function migrateFn(options: MigrateSchematicsSchemaOptions): Rule {
  * Facilitate the migration of a version to another by the run of migration rules
  * @param options
  */
-export const migrate = (options: MigrateSchematicsSchemaOptions) => async () => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics');
-  return createSchematicWithMetricsIfInstalled(migrateFn)(options);
-};
+export const migrate = (options: MigrateSchematicsSchemaOptions) => createSchematicWithMetricsIfInstalled(migrateFn)(options);

--- a/packages/@ama-sdk/schematics/schematics/ng-add/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/ng-add/index.ts
@@ -6,6 +6,10 @@ import { readFileSync } from 'node:fs';
 import { lastValueFrom } from 'rxjs';
 import type { JsonObject, PackageJson } from 'type-fest';
 import { DevInstall } from '../helpers/node-install';
+import {
+  createSchematicWithMetricsIfInstalled,
+  registerPackageCollectionSchematics
+} from '@o3r/schematics';
 
 const packageJsonPath = '/package.json';
 const swaggerIgnorePath = '/.swagger-codegen-ignore';
@@ -151,10 +155,7 @@ const registerPackageSchematics = async (tree: Tree, context: SchematicContext) 
   }
   return () => chain([
     ...schematicsDependencies.map((dep) => externalSchematic(dep, 'ng-add', {})),
-    async (t, c) => {
-      const {registerPackageCollectionSchematics} = await import('@o3r/schematics');
-      return () => registerPackageCollectionSchematics(amaSdkSchematicsPackageJsonContent)(t, c);
-    }
+    (t, c) => registerPackageCollectionSchematics(amaSdkSchematicsPackageJsonContent)(t, c)
   ]);
 };
 
@@ -177,7 +178,4 @@ function ngAddFn(): Rule {
 /**
  * Add Otter ama-sdk-schematics to a Project
  */
-export const ngAdd = (): Rule => async () => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics');
-  return createSchematicWithMetricsIfInstalled(ngAddFn)(undefined);
-};
+export const ngAdd = (): Rule => createSchematicWithMetricsIfInstalled(ngAddFn)(undefined);

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/index.ts
@@ -26,6 +26,9 @@ import { NgGenerateTypescriptSDKCoreSchematicsSchema } from './schema';
 import { OpenApiCliGenerator } from '../../code-generator/open-api-cli-generator/open-api-cli.generator';
 import { copyReferencedFiles, updateLocalRelativeRefs } from './helpers/copy-referenced-files';
 import { generateOperationFinderFromSingleFile } from './helpers/path-extractor';
+import {
+  createSchematicWithMetricsIfInstalled
+} from '@o3r/schematics';
 
 const JAVA_OPTIONS = ['specPath', 'specConfigPath', 'globalProperty', 'outputPath'];
 const OPEN_API_TOOLS_OPTIONS = ['generatorName', 'output', 'inputSpec', 'config', 'globalProperty'];
@@ -281,7 +284,4 @@ function ngGenerateTypescriptSDKFn(options: NgGenerateTypescriptSDKCoreSchematic
  * Generate a typescript SDK source code base on swagger specification
  * @param options
  */
-export const ngGenerateTypescriptSDK = (options: NgGenerateTypescriptSDKCoreSchematicsSchema) => async () => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics');
-  return createSchematicWithMetricsIfInstalled(ngGenerateTypescriptSDKFn)(options);
-};
+export const ngGenerateTypescriptSDK = (options: NgGenerateTypescriptSDKCoreSchematicsSchema) => createSchematicWithMetricsIfInstalled(ngGenerateTypescriptSDKFn)(options);

--- a/packages/@ama-sdk/schematics/schematics/typescript/mock/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/mock/index.ts
@@ -13,6 +13,9 @@ import {
 } from '@angular-devkit/schematics';
 import * as path from 'node:path';
 import {NgGenerateMockSchematicsSchema} from './schema';
+import {
+  createSchematicWithMetricsIfInstalled
+} from '@o3r/schematics';
 
 
 /**
@@ -101,7 +104,4 @@ function ngGenerateMockFn(options: NgGenerateMockSchematicsSchema): Rule {
  * Add mock
  * @param options
  */
-export const ngGenerateMock = (options: NgGenerateMockSchematicsSchema) => async () => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics');
-  return createSchematicWithMetricsIfInstalled(ngGenerateMockFn)(options);
-};
+export const ngGenerateMock = (options: NgGenerateMockSchematicsSchema) => createSchematicWithMetricsIfInstalled(ngGenerateMockFn)(options);

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/index.ts
@@ -15,6 +15,9 @@ import {isAbsolute, posix, relative} from 'node:path';
 import {getPackageManagerName, NpmInstall} from '../../helpers/node-install';
 import {readPackageJson} from '../../helpers/read-package';
 import type {NgGenerateTypescriptSDKShellSchematicsSchema} from './schema';
+import {
+  createSchematicWithMetricsIfInstalled
+} from '@o3r/schematics';
 
 /**
  * Generate Typescript SDK shell
@@ -169,7 +172,4 @@ function ngGenerateTypescriptSDKFn(options: NgGenerateTypescriptSDKShellSchemati
  * Generate Typescript SDK shell
  * @param options
  */
-export const ngGenerateTypescriptSDK = (options: NgGenerateTypescriptSDKShellSchematicsSchema) => async () => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics');
-  return createSchematicWithMetricsIfInstalled(ngGenerateTypescriptSDKFn)(options);
-};
+export const ngGenerateTypescriptSDK = (options: NgGenerateTypescriptSDKShellSchematicsSchema) => createSchematicWithMetricsIfInstalled(ngGenerateTypescriptSDKFn)(options);

--- a/packages/@o3r-training/training-tools/README.md
+++ b/packages/@o3r-training/training-tools/README.md
@@ -9,10 +9,11 @@ This package is a module to be used for Otter training purposes.
 
 ## Description
 
-[![Stable Version](https://img.shields.io/npm/v/@o3r/schematics?style=for-the-badge)](https://www.npmjs.com/package/@o3r/schematics)
-[![Bundle Size](https://img.shields.io/bundlephobia/min/@o3r/schematics?color=green&style=for-the-badge)](https://www.npmjs.com/package/@o3r/schematics)
+[![Stable Version](https://img.shields.io/npm/v/@o3r-training/training-tools?style=for-the-badge)](https://www.npmjs.com/package/@o3r-training/training-tools)
+[![Bundle Size](https://img.shields.io/bundlephobia/min/@o3r-training/training-tools?color=green&style=for-the-badge)](https://www.npmjs.com/package/@o3r-training/training-tools)
 
 This module provides basic utilities to use the Otter training such as:
+
 - A code source extractor to generate JSON files compatible with [WebContainer](https://webcontainers.io/guides/working-with-the-file-system).
 
 ## How to install
@@ -22,11 +23,15 @@ ng add @o3r-training/training-tools
 ```
 
 ## How to use
+
 You can use the extractor via the CLI to extract a folder from your file system:
+
 ```shell
 o3r-extract-folder-structure --files \".\path-to-source-folder\" -o webcontainer-folder-structure.js
 ```
+
 You can also use the `getFilesTree` function with the `WebContainer` file system to serialize its tree:
+
 ```typescript
 const serializedFiles = await getFilesTree([{
     path,

--- a/packages/@o3r-training/training-tools/package.json
+++ b/packages/@o3r-training/training-tools/package.json
@@ -32,7 +32,6 @@
   },
   "peerDependencies": {
     "@angular-devkit/schematics": "~18.2.0",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "@webcontainer/api": "~1.5.0",
     "eslint": "^8.57.0",
@@ -53,9 +52,6 @@
     "@angular/cli": {
       "optional": true
     },
-    "@o3r/schematics": {
-      "optional": true
-    },
     "eslint": {
       "optional": true
     },
@@ -64,6 +60,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "commander": "^12.0.0",
     "tslib": "^2.6.2"
   },
@@ -88,7 +85,6 @@
     "@nx/js": "~19.5.0",
     "@o3r/build-helpers": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "@stylistic/eslint-plugin-ts": "~2.4.0",
     "@swc/cli": "~0.5.0",

--- a/packages/@o3r-training/training-tools/schematics/ng-add/index.ts
+++ b/packages/@o3r-training/training-tools/schematics/ng-add/index.ts
@@ -1,15 +1,19 @@
 import type { Rule } from '@angular-devkit/schematics';
 import * as path from 'node:path';
 import type { NgAddSchematicsSchema } from './schema';
+import {
+  createSchematicWithMetricsIfInstalled,
+  getPackageInstallConfig,
+  setupDependencies
+} from '@o3r/schematics';
 
 /**
  * Add Otter training tools to an Angular Project
  * @param options
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
-  return async (tree) => {
+  return (tree) => {
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
-    const { getPackageInstallConfig, setupDependencies } = await import('@o3r/schematics');
     return setupDependencies({
       projectName: options.projectName,
       dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, false)
@@ -21,8 +25,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter training tools to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async () => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics');
-  return createSchematicWithMetricsIfInstalled(ngAddFn)(options);
-};
-
+export const ngAdd = (options: NgAddSchematicsSchema): Rule => createSchematicWithMetricsIfInstalled(ngAddFn)(options);

--- a/packages/@o3r/analytics/package.json
+++ b/packages/@o3r/analytics/package.json
@@ -33,7 +33,6 @@
     "@angular/router": "~18.2.0",
     "@ngrx/store": "~18.0.0",
     "@o3r/core": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "jasmine": "^5.0.0",
     "rxjs": "^7.8.1",
@@ -42,9 +41,6 @@
   },
   "peerDependenciesMeta": {
     "@angular-devkit/schematics": {
-      "optional": true
-    },
-    "@o3r/schematics": {
       "optional": true
     },
     "@schematics/angular": {
@@ -61,6 +57,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/packages/@o3r/analytics/schematics/analytics-to-component/index.ts
+++ b/packages/@o3r/analytics/schematics/analytics-to-component/index.ts
@@ -13,7 +13,6 @@ import {
   Tree,
   url
 } from '@angular-devkit/schematics';
-import { getPropertyFromDecoratorFirstArgument, O3rCliError } from '@o3r/schematics';
 import {
   addCommentsOnClassProperties,
   addImportsRule,
@@ -23,9 +22,11 @@ import {
   createSchematicWithMetricsIfInstalled,
   generateClassElementsFromString,
   getO3rComponentInfoOrThrowIfNotFound,
+  getPropertyFromDecoratorFirstArgument,
   isNgClassDecorator,
   isO3rClassComponent,
   NoOtterComponent,
+  O3rCliError,
   sortClassElement
 } from '@o3r/schematics';
 import { addImportToModule } from '@schematics/angular/utility/ast-utils';

--- a/packages/@o3r/analytics/schematics/ng-add/index.ts
+++ b/packages/@o3r/analytics/schematics/ng-add/index.ts
@@ -1,15 +1,13 @@
 import type { Rule } from '@angular-devkit/schematics';
 import type { NgAddSchematicsSchema } from './schema';
 import * as path from 'node:path';
+import {
+  createSchematicWithMetricsIfInstalled,
+  getPackageInstallConfig,
+  setupDependencies
+} from '@o3r/schematics';
 
 const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
-
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/analytics has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/core'. Please run 'ng add @o3r/core'.
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
 
 /**
  * Add Otter analytics to an Angular Project
@@ -17,8 +15,7 @@ Otherwise, use the error message as guidance.`);
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
-  return async (tree) => {
-    const { getPackageInstallConfig, setupDependencies } = await import('@o3r/schematics');
+  return (tree) => {
     return setupDependencies({
       projectName: options.projectName,
       dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion)
@@ -27,7 +24,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
 }
 
 
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, {logger}) => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createSchematicWithMetricsIfInstalled(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema): Rule => createSchematicWithMetricsIfInstalled(ngAddFn)(options);

--- a/packages/@o3r/analytics/src/ng-package.json
+++ b/packages/@o3r/analytics/src/ng-package.json
@@ -2,6 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",
   "deleteDestPath": false,
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
 
   "lib": {
     "entryFile": "public_api.ts"

--- a/packages/@o3r/apis-manager/ng-package.json
+++ b/packages/@o3r/apis-manager/ng-package.json
@@ -2,6 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "./dist",
   "deleteDestPath": false,
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
 
   "lib": {
     "entryFile": "src/public_api.ts"

--- a/packages/@o3r/apis-manager/package.json
+++ b/packages/@o3r/apis-manager/package.json
@@ -24,7 +24,6 @@
     "@angular-devkit/schematics": "~18.2.0",
     "@angular/common": "~18.2.0",
     "@angular/core": "~18.2.0",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "rxjs": "^7.8.1",
     "typescript": "~5.5.4"
@@ -36,14 +35,12 @@
     "@angular-devkit/schematics": {
       "optional": true
     },
-    "@o3r/schematics": {
-      "optional": true
-    },
     "@schematics/angular": {
       "optional": true
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -69,7 +66,6 @@
     "@nx/js": "~19.5.0",
     "@o3r/build-helpers": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "@stylistic/eslint-plugin-ts": "~2.4.0",

--- a/packages/@o3r/apis-manager/schematics/ng-add/index.ts
+++ b/packages/@o3r/apis-manager/schematics/ng-add/index.ts
@@ -1,22 +1,23 @@
 import { chain, noop, type Rule } from '@angular-devkit/schematics';
 import * as path from 'node:path';
 import type { NgAddSchematicsSchema } from './schema';
-
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/apis-manager has failed.
-You need to install '@o3r/schematics' to be able to use the o3r apis-manager package. Please run 'ng add @o3r/schematics'.`);
-  throw reason;
-};
+import {
+  applyEsLintFix,
+  createSchematicWithMetricsIfInstalled,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  setupDependencies
+} from '@o3r/schematics';
+import { updateApiDependencies } from '../helpers/update-api-deps';
 
 /**
  * Add Otter apis manager to an Angular Project
  * @param options
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
-  return async (tree) => {
-    const { getPackageInstallConfig } = await import('@o3r/schematics');
-    const { setupDependencies, getO3rPeerDeps, applyEsLintFix, getWorkspaceConfig, getProjectNewDependenciesTypes } = await import('@o3r/schematics');
-    const { updateApiDependencies } = await import('../helpers/update-api-deps');
+  return (tree) => {
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
     const depsInfo = getO3rPeerDeps(packageJsonPath);
     const rulesToExecute: Rule[] = [];
@@ -57,7 +58,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter apis manager to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createSchematicWithMetricsIfInstalled(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema): Rule => createSchematicWithMetricsIfInstalled(ngAddFn)(options);

--- a/packages/@o3r/application/ng-package.json
+++ b/packages/@o3r/application/ng-package.json
@@ -2,7 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "./dist",
   "deleteDestPath": false,
-
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
   "lib": {
     "entryFile": "src/public_api.ts"
   },

--- a/packages/@o3r/application/package.json
+++ b/packages/@o3r/application/package.json
@@ -30,7 +30,6 @@
     "@o3r/core": "workspace:^",
     "@o3r/logger": "workspace:^",
     "@o3r/routing": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/testing": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "rxjs": "^7.8.1",
@@ -40,14 +39,12 @@
     "@angular-devkit/schematics": {
       "optional": true
     },
-    "@o3r/schematics": {
-      "optional": true
-    },
     "typescript": {
       "optional": true
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -74,7 +71,6 @@
     "@o3r/eslint-plugin": "workspace:^",
     "@o3r/logger": "workspace:^",
     "@o3r/routing": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@o3r/testing": "workspace:^",
     "@schematics/angular": "~18.2.0",

--- a/packages/@o3r/application/schematics/ng-add/helpers/devtools-registration.ts
+++ b/packages/@o3r/application/schematics/ng-add/helpers/devtools-registration.ts
@@ -2,6 +2,7 @@ import { chain, Rule } from '@angular-devkit/schematics';
 import * as path from 'node:path';
 import type { NgAddSchematicsSchema } from '../schema';
 import { readFileSync } from 'node:fs';
+import { registerDevtoolsToApplication } from '@o3r/schematics';
 
 const DEVTOOL_MODULE_NAME = 'ApplicationDevtoolsModule';
 const CONSOLE_DEVTOOL_SERVICE_NAME = 'ApplicationDevtoolsConsoleService';
@@ -14,8 +15,7 @@ const PACKAGE_NAME: string = JSON.parse(readFileSync(path.resolve(__dirname, '..
  * @param context
  * @param options
  */
-export const registerDevtools = async (options: NgAddSchematicsSchema): Promise<Rule> => {
-  const { registerDevtoolsToApplication } = await import('@o3r/schematics');
+export const registerDevtools = (options: NgAddSchematicsSchema): Rule => {
   return chain([
     registerDevtoolsToApplication({
       moduleName: DEVTOOL_MODULE_NAME,

--- a/packages/@o3r/components/package.json
+++ b/packages/@o3r/components/package.json
@@ -51,7 +51,6 @@
     "@o3r/localization": "workspace:^",
     "@o3r/logger": "workspace:^",
     "@o3r/rules-engine": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/testing": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "@yarnpkg/cli": "^4.0.0",
@@ -94,9 +93,6 @@
     "@o3r/rules-engine": {
       "optional": true
     },
-    "@o3r/schematics": {
-      "optional": true
-    },
     "@schematics/angular": {
       "optional": true
     },
@@ -132,6 +128,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -166,7 +163,6 @@
     "@o3r/localization": "workspace:^",
     "@o3r/logger": "workspace:^",
     "@o3r/rules-engine": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@o3r/testing": "workspace:^",
     "@schematics/angular": "~18.2.0",

--- a/packages/@o3r/components/schematics/ng-add/helpers/devtools-registration.ts
+++ b/packages/@o3r/components/schematics/ng-add/helpers/devtools-registration.ts
@@ -2,6 +2,9 @@ import { Rule } from '@angular-devkit/schematics';
 import * as path from 'node:path';
 import type { NgAddSchematicsSchema } from '../schema';
 import { readFileSync } from 'node:fs';
+import {
+  registerDevtoolsToApplication
+} from '@o3r/schematics';
 
 const DEVTOOL_MODULE_NAME = 'ComponentsDevtoolsModule';
 const DEVTOOL_SERVICE_NAME = 'ComponentsDevtoolsMessageService';
@@ -13,8 +16,7 @@ const PACKAGE_NAME: string = JSON.parse(readFileSync(path.resolve(__dirname, '..
  * @param context
  * @param options
  */
-export const registerDevtools = async (options: NgAddSchematicsSchema): Promise<Rule> => {
-  const { registerDevtoolsToApplication } = await import('@o3r/schematics');
+export const registerDevtools = (options: NgAddSchematicsSchema): Rule => {
   return registerDevtoolsToApplication({
     moduleName: DEVTOOL_MODULE_NAME,
     packageName: PACKAGE_NAME,

--- a/packages/@o3r/components/src/ng-package.json
+++ b/packages/@o3r/components/src/ng-package.json
@@ -2,6 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",
   "deleteDestPath": false,
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
 
   "lib": {
     "entryFile": "public_api.ts"

--- a/packages/@o3r/core/ng-package.json
+++ b/packages/@o3r/core/ng-package.json
@@ -6,6 +6,6 @@
     "entryFile": "src/public_api.ts"
   },
   "allowedNonPeerDependencies": [
-    "tslib", "uuid", "@o3r/schematics"
+    "uuid", "@o3r/schematics"
   ]
 }

--- a/packages/@o3r/core/schematics/ng-add-create/index.ts
+++ b/packages/@o3r/core/schematics/ng-add-create/index.ts
@@ -8,7 +8,6 @@ import { NgGenerateUpdateSchematicsSchema } from './schema';
 
 /**
  * Rule factory to include `ng add` skeleton
- *
  * @param options
  */
 function updateTemplatesFn(options: NgGenerateUpdateSchematicsSchema): Rule {
@@ -26,7 +25,7 @@ function updateTemplatesFn(options: NgGenerateUpdateSchematicsSchema): Rule {
         return tree;
       }
       const o3rCorePackageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
-      const o3rCorePackageJson: PackageJson & { generatorDependencies?: Record<string, string> } = JSON.parse(fs.readFileSync(o3rCorePackageJsonPath)!.toString());
+      const o3rCorePackageJson: PackageJson & { generatorDependencies?: Record<string, string> } = JSON.parse(fs.readFileSync(o3rCorePackageJsonPath).toString());
       // prepare needed deps for schematics
       const angularVersion = packageJson.devDependencies?.['@angular/cli'] || packageJson.devDependencies?.['@angular/core'];
       const otterVersion = o3rCorePackageJson.dependencies!['@o3r/schematics'];
@@ -39,16 +38,15 @@ function updateTemplatesFn(options: NgGenerateUpdateSchematicsSchema): Rule {
       packageJson.peerDependencies ||= {};
       packageJson.peerDependencies['@angular-devkit/schematics'] = angularVersion;
       packageJson.peerDependencies['@angular-devkit/core'] = angularVersion;
-      packageJson.peerDependencies['@o3r/schematics'] = otterVersion;
       packageJson.peerDependenciesMeta ||= {};
       packageJson.peerDependenciesMeta['@angular-devkit/schematics'] = {optional: true};
       packageJson.peerDependenciesMeta['@angular-devkit/core'] = { optional: true };
       packageJson.peerDependenciesMeta['@schematics/angular'] = { optional: true };
-      packageJson.peerDependenciesMeta['@o3r/schematics'] = {optional: true};
       packageJson.devDependencies['@angular-devkit/schematics'] = angularVersion;
       packageJson.devDependencies['@angular-devkit/core'] = angularVersion;
-      packageJson.devDependencies['@o3r/schematics'] = otterVersion;
       packageJson.devDependencies['cpy-cli'] = o3rCorePackageJson.generatorDependencies!['cpy-cli'];
+      packageJson.dependencies ||= {};
+      packageJson.dependencies['@o3r/schematics'] = otterVersion;
 
       tree.overwrite(packageJsonPath, JSON.stringify(packageJson, null, 2));
     }
@@ -71,14 +69,12 @@ function updateTemplatesFn(options: NgGenerateUpdateSchematicsSchema): Rule {
 
 /**
  * Rule factory to include `ng add` skeleton
- *
  * @param options
  */
 export const updateTemplates = createSchematicWithMetricsIfInstalled(updateTemplatesFn);
 
 /**
  * add a new ngUpdate function
- *
  * @param options
  */
 function ngAddCreateFn(options: NgGenerateUpdateSchematicsSchema): Rule {
@@ -89,7 +85,6 @@ function ngAddCreateFn(options: NgGenerateUpdateSchematicsSchema): Rule {
 
 /**
  * add a new ngUpdate function
- *
  * @param options
  */
 export const ngAddCreate = createSchematicWithMetricsIfInstalled(ngAddCreateFn);

--- a/packages/@o3r/core/schematics/ng-add-create/templates/schematics/ng-add/index.ts.template
+++ b/packages/@o3r/core/schematics/ng-add-create/templates/schematics/ng-add/index.ts.template
@@ -1,7 +1,13 @@
 import { chain, noop, Rule } from '@angular-devkit/schematics';
 import type { NgAddSchematicsSchema } from './schema';
 import * as path from 'node:path';
-import type { DependencyToAdd } from '@o3r/schematics';
+import {
+  type DependencyToAdd,
+  getProjectNewDependenciesTypes,
+  getPackageInstallConfig,
+  applyEsLintFix,
+  install
+} from '@o3r/schematics';
 
 const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
 
@@ -18,22 +24,14 @@ const dependenciesToNgAdd = [
   // Add the dependencies to install with NgAdd here
 ];
 
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding <%= featureName %> has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/core' to be able to use the <%= featureName %> package. Please run 'ng add @o3r/core' .
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
-
 /**
  * Add Otter <%= featureName %> to an Otter Project
  *
  * @param options
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
-  return async (tree, context) => {
+  return (tree, context) => {
     // use dynamic import to properly raise an exception if it is not an Otter project.
-    const { getProjectNewDependenciesTypes, getPackageInstallConfig, applyEsLintFix, install } = await import('@o3r/schematics');
     // current package version
     const version = JSON.stringify(fs.readFileSync(packageJsonPath)).version;
     const dependencies = [...dependenciesToInstall, ...dependenciesToNgAdd].reduce((acc, dep) => {
@@ -63,7 +61,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add module to an Angular Project
  * @param options ng add options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createSchematicWithMetricsIfInstalled(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema): Rule => createSchematicWithMetricsIfInstalled(ngAddFn)(options);

--- a/packages/@o3r/core/schematics/ng-add/component-decorator/index.ts
+++ b/packages/@o3r/core/schematics/ng-add/component-decorator/index.ts
@@ -1,6 +1,9 @@
-import { Rule, Tree } from '@angular-devkit/schematics';
+import { type Rule } from '@angular-devkit/schematics';
 import { insertImport } from '@schematics/angular/utility/ast-utils';
 import { InsertChange } from '@schematics/angular/utility/change';
+import {
+  getFilesInFolderFromWorkspaceProjectsInTree
+} from '@o3r/schematics';
 import * as ts from 'typescript';
 
 interface RemovePosition {
@@ -27,8 +30,7 @@ const removeImport = (source: ts.SourceFile, symbolName: string, fileName: strin
  * Update component file with new decorators for otter devtools
  * @param tree Tree
  */
-export const updateComponentDecorators: Rule = async (tree: Tree) => {
-  const { getFilesInFolderFromWorkspaceProjectsInTree } = await import('@o3r/schematics');
+export const updateComponentDecorators: Rule = (tree) => {
   const componentFiles = new Set<string>(getFilesInFolderFromWorkspaceProjectsInTree(tree, '', 'component.ts'));
   componentFiles.forEach((filePath) => {
     const source = ts.createSourceFile(filePath, tree.readText(filePath), ts.ScriptTarget.ES2015, true);

--- a/packages/@o3r/core/schematics/rule-factories/store/index.ts
+++ b/packages/@o3r/core/schematics/rule-factories/store/index.ts
@@ -8,9 +8,9 @@ import {
   isApplicationThatUsesRouterModule,
   insertBeforeModule as o3rInsertBeforeModule,
   insertImportToModuleFile as o3rInsertImportToModuleFile,
-  type SetupDependenciesOptions
+  type SetupDependenciesOptions,
+  WorkspaceProject
 } from '@o3r/schematics';
-import { WorkspaceProject } from '@o3r/schematics';
 import { addRootImport } from '@schematics/angular/utility';
 import { isImported } from '@schematics/angular/utility/ast-utils';
 import * as path from 'node:path';
@@ -37,6 +37,7 @@ const ngrxRouterStoreDevToolDep = '@ngrx/store-devtools';
  * @param projectType
  * @param options.dependenciesSetupConfig
  * @param options.workingDirector
+ * @param options.exactO3rVersion
  */
 export function updateStore(
   options: { projectName?: string | undefined; workingDirector?: string | undefined; dependenciesSetupConfig: SetupDependenciesOptions; exactO3rVersion?: boolean },

--- a/packages/@o3r/create/src/index.ts
+++ b/packages/@o3r/create/src/index.ts
@@ -196,8 +196,7 @@ const prepareWorkspace = (relativeDirectory = '.', projectPackageManager = 'npm'
     '@angular-devkit/schematics',
     '@schematics/angular',
     '@angular-devkit/core',
-    '@angular-devkit/architect',
-    '@o3r/schematics'
+    '@angular-devkit/architect'
   ];
 
   const packageJsonPath = resolve(cwd, 'package.json');

--- a/packages/@o3r/design/package.json
+++ b/packages/@o3r/design/package.json
@@ -47,6 +47,7 @@
     "o3r-css-from-design-token": "./dist/cli/generate-css-from-design-token.cli.cjs"
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "jsonschema": "~1.4.1",
     "minimatch": "~9.0.3",
     "minimist": "^1.2.6",
@@ -56,7 +57,6 @@
     "@angular-devkit/architect": "~0.1802.0",
     "@angular-devkit/schematics": "~18.2.0",
     "@o3r/core": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/styling": "workspace:^",
     "@o3r/telemetry": "workspace:^",
     "chokidar": "^3.5.2",
@@ -71,9 +71,6 @@
       "optional": true
     },
     "@o3r/core": {
-      "optional": true
-    },
-    "@o3r/schematics": {
       "optional": true
     },
     "@o3r/styling": {
@@ -116,7 +113,6 @@
     "@o3r/build-helpers": "workspace:^",
     "@o3r/core": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/styling": "workspace:^",
     "@o3r/telemetry": "workspace:^",
     "@o3r/test-helpers": "workspace:^",

--- a/packages/@o3r/design/schematics/design-token-to-component/index.ts
+++ b/packages/@o3r/design/schematics/design-token-to-component/index.ts
@@ -10,7 +10,9 @@ import {
 } from '@angular-devkit/schematics';
 import { basename, dirname, relative } from 'node:path';
 import type { NgAddDesignTokenSchematicsSchema } from './schema';
-import type { createSchematicWithMetricsIfInstalled } from '@o3r/schematics';
+import {
+  createSchematicWithMetricsIfInstalled
+} from '@o3r/schematics';
 
 /**
  * Add Design Token to an existing component
@@ -37,15 +39,4 @@ export function ngAddDesignTokenFn(options: NgAddDesignTokenSchematicsSchema): R
  * Add Design Token to an existing component
  * @param options
  */
-export const ngAddDesignToken = (options: NgAddDesignTokenSchematicsSchema) => async () => {
-  let createSchematicWithMetrics: typeof createSchematicWithMetricsIfInstalled | undefined;
-  try {
-    ({ createSchematicWithMetricsIfInstalled: createSchematicWithMetrics } = await import('@o3r/schematics'));
-  } catch {
-    // No @o3r/schematics detected
-  }
-  if (!createSchematicWithMetrics) {
-    return ngAddDesignTokenFn(options);
-  }
-  return createSchematicWithMetrics(ngAddDesignTokenFn)(options);
-};
+export const ngAddDesignToken = (options: NgAddDesignTokenSchematicsSchema) => createSchematicWithMetricsIfInstalled(ngAddDesignTokenFn)(options);

--- a/packages/@o3r/design/schematics/extract-token/index.ts
+++ b/packages/@o3r/design/schematics/extract-token/index.ts
@@ -1,8 +1,9 @@
 import type { Rule } from '@angular-devkit/schematics';
-import type { createSchematicWithMetricsIfInstalled } from '@o3r/schematics';
+import { createSchematicWithMetricsIfInstalled } from '@o3r/schematics';
 import { posix, resolve } from 'node:path';
 import { AUTO_GENERATED_END, AUTO_GENERATED_START, DesignToken, DesignTokenGroup, DesignTokenNode } from '../../src/public_api';
 import type { ExtractTokenSchematicsSchema } from './schema';
+import { filter } from 'minimatch';
 
 const patternToDetect = 'o3r.var';
 
@@ -34,7 +35,6 @@ function extractTokenFn(options: ExtractTokenSchematicsSchema): Rule {
     try {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       const { CssVariableExtractor } = await import('@o3r/styling/builders/style-extractor/helpers');
-      const { filter } = await import('minimatch');
       const filterFunctions = options.componentFilePatterns.map((pattern) => filter(
         '/' + pattern.replace(/[\\/]+/g, '/'),
         { dot: true }
@@ -110,15 +110,4 @@ function extractTokenFn(options: ExtractTokenSchematicsSchema): Rule {
  * Extract the token from o3r mixin sass file
  * @param options
  */
-export const extractToken = (options: ExtractTokenSchematicsSchema) => async () => {
-  let createSchematicWithMetrics: typeof createSchematicWithMetricsIfInstalled | undefined;
-  try {
-    ({ createSchematicWithMetricsIfInstalled: createSchematicWithMetrics } = await import('@o3r/schematics'));
-  } catch {
-    // No @o3r/schematics detected
-  }
-  if (!createSchematicWithMetrics) {
-    return extractTokenFn(options);
-  }
-  return createSchematicWithMetrics(extractTokenFn)(options);
-};
+export const extractToken = (options: ExtractTokenSchematicsSchema) => createSchematicWithMetricsIfInstalled(extractTokenFn)(options);

--- a/packages/@o3r/design/schematics/generate-css/index.ts
+++ b/packages/@o3r/design/schematics/generate-css/index.ts
@@ -1,6 +1,6 @@
 import type { GenerateCssSchematicsSchema } from './schema';
 import type { Rule } from '@angular-devkit/schematics';
-import type { createSchematicWithMetricsIfInstalled } from '@o3r/schematics';
+import { createSchematicWithMetricsIfInstalled, globInTree } from '@o3r/schematics';
 import { parseDesignTokenFile, renderDesignTokens } from '@o3r/design';
 import type { DesignTokenRendererOptions, DesignTokenVariableSet, DesignTokenVariableStructure } from '@o3r/design';
 
@@ -29,8 +29,6 @@ function generateCssFn(options: GenerateCssSchematicsSchema): Rule {
       logger: context.logger
     };
 
-    const { globInTree } = await import('@o3r/schematics');
-
     const files = globInTree(tree, Array.isArray(options.designTokenFilePatterns) ? options.designTokenFilePatterns : [options.designTokenFilePatterns]);
 
     const duplicatedToken: DesignTokenVariableStructure[] = [];
@@ -55,15 +53,4 @@ function generateCssFn(options: GenerateCssSchematicsSchema): Rule {
  * Generate CSS from Design Token files
  * @param options
  */
-export const generateCss = (options: GenerateCssSchematicsSchema) => async () => {
-  let createSchematicWithMetrics: typeof createSchematicWithMetricsIfInstalled | undefined;
-  try {
-    ({ createSchematicWithMetricsIfInstalled: createSchematicWithMetrics } = await import('@o3r/schematics'));
-  } catch {
-    // No @o3r/schematics detected
-  }
-  if (!createSchematicWithMetrics) {
-    return generateCssFn(options);
-  }
-  return createSchematicWithMetrics(generateCssFn)(options);
-};
+export const generateCss = (options: GenerateCssSchematicsSchema) => createSchematicWithMetricsIfInstalled(generateCssFn)(options);

--- a/packages/@o3r/design/schematics/ng-add/index.ts
+++ b/packages/@o3r/design/schematics/ng-add/index.ts
@@ -3,6 +3,12 @@ import { registerGenerateCssBuilder } from './register-generate-css';
 import { extractToken } from '../extract-token';
 import type { NgAddSchematicsSchema } from './schema';
 import * as path from 'node:path';
+import {
+  createSchematicWithMetricsIfInstalled,
+  getPackageInstallConfig,
+  setupDependencies,
+  setupSchematicsParamsForProject
+} from '@o3r/schematics';
 
 const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
 
@@ -12,8 +18,7 @@ const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
  */
 export function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
-  return async (tree) => {
-    const { getPackageInstallConfig, setupDependencies, setupSchematicsParamsForProject } = await import('@o3r/schematics');
+  return (tree) => {
     return chain([
       registerGenerateCssBuilder(options.projectName),
       setupSchematicsParamsForProject({
@@ -43,18 +48,4 @@ export function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter design to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const missingSchematicDependencyMessage = 'Missing @o3r/schematics';
-  try {
-    const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics').catch(() => { throw new Error(missingSchematicDependencyMessage); });
-    return createSchematicWithMetricsIfInstalled(ngAddFn)(options);
-  } catch (err) {
-    if (err instanceof Error && err.message === missingSchematicDependencyMessage) {
-      logger.warn(`[WARNING]: The run of the ng-add schematics of @o3r/design has failed, the setup of default features will not be done.
-The failure is due to miss of the package '@o3r/schematics'.
-To get benefit of the setup scripts, please run 'ng add @o3r/schematics' before.`);
-    } else {
-      throw err;
-    }
-  }
-};
+export const ngAdd = (options: NgAddSchematicsSchema): Rule => createSchematicWithMetricsIfInstalled(ngAddFn)(options);

--- a/packages/@o3r/design/schematics/ng-add/register-generate-css/register-task.ts
+++ b/packages/@o3r/design/schematics/ng-add/register-generate-css/register-task.ts
@@ -1,6 +1,7 @@
 import { apply, chain, MergeStrategy, mergeWith, move, renameTemplateFiles, type Rule, template, url } from '@angular-devkit/schematics';
 import type { GenerateStyleSchematicsSchema } from '../../../builders/generate-style/schema';
 import { posix } from 'node:path';
+import { getWorkspaceConfig, registerBuilder } from '@o3r/schematics';
 
 /**
  * Register the Design Token CSS generator
@@ -9,7 +10,6 @@ import { posix } from 'node:path';
  */
 export const registerGenerateCssBuilder = (projectName?: string, taskName = 'generate-css'): Rule => {
   const registerBuilderRule: Rule = async (tree, { logger }) => {
-    const { getWorkspaceConfig, registerBuilder } = await import('@o3r/schematics');
     const workspace = getWorkspaceConfig(tree);
     const workspaceProject = projectName ? workspace?.projects[projectName] : undefined;
     const workspaceRootPath = workspaceProject?.root || '.';
@@ -40,7 +40,6 @@ export const registerGenerateCssBuilder = (projectName?: string, taskName = 'gen
   };
 
   const generateDesignTokenFilesRule: Rule = async (tree) => {
-    const { getWorkspaceConfig } = await import('@o3r/schematics');
     const workspaceProject = projectName ? getWorkspaceConfig(tree)?.projects[projectName] : undefined;
     const srcBasePath = workspaceProject?.sourceRoot || (workspaceProject?.root ? posix.join(workspaceProject.root, 'src') : './src');
     const themeFolder = posix.join(srcBasePath, 'style');
@@ -52,7 +51,6 @@ export const registerGenerateCssBuilder = (projectName?: string, taskName = 'gen
   };
 
   const generateTemplateFilesRule: Rule = async (tree) => {
-    const { getWorkspaceConfig } = await import('@o3r/schematics');
     const workspaceProject = projectName ? getWorkspaceConfig(tree)?.projects[projectName] : undefined;
     const workspaceRootPath = workspaceProject?.root || '.';
     return mergeWith(apply(url('./register-generate-css/templates-workspace'), [
@@ -63,7 +61,6 @@ export const registerGenerateCssBuilder = (projectName?: string, taskName = 'gen
   };
 
   const importTheme: Rule = async (tree, context) => {
-    const { getWorkspaceConfig } = await import('@o3r/schematics');
     const workspaceProject = projectName ? getWorkspaceConfig(tree)?.projects[projectName] : undefined;
     const srcBasePath = workspaceProject?.sourceRoot || (workspaceProject?.root ? posix.join(workspaceProject.root, 'src') : './src');
     const styleFile = posix.join(srcBasePath, 'styles.scss');

--- a/packages/@o3r/dynamic-content/package.json
+++ b/packages/@o3r/dynamic-content/package.json
@@ -36,7 +36,6 @@
     "@angular/platform-browser-dynamic": "~18.2.0",
     "@ngrx/store": "~18.0.0",
     "@o3r/core": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "cheerio": "^1.0.0-rc.10",
     "express-interceptor": "^1.2.0",
@@ -45,9 +44,6 @@
   },
   "peerDependenciesMeta": {
     "@angular-devkit/schematics": {
-      "optional": true
-    },
-    "@o3r/schematics": {
       "optional": true
     },
     "@schematics/angular": {
@@ -64,6 +60,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -91,7 +88,6 @@
     "@o3r/core": "workspace:^",
     "@o3r/eslint-config-otter": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "@stylistic/eslint-plugin-ts": "~2.4.0",
     "@types/cheerio": "~0.22.35",

--- a/packages/@o3r/dynamic-content/schematics/ng-add/index.ts
+++ b/packages/@o3r/dynamic-content/schematics/ng-add/index.ts
@@ -1,14 +1,13 @@
 import type { Rule } from '@angular-devkit/schematics';
 import * as path from 'node:path';
 import type { NgAddSchematicsSchema } from './schema';
+import {
+  createSchematicWithMetricsIfInstalled,
+  getPackageInstallConfig,
+  setupDependencies
+} from '@o3r/schematics';
 
 const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
-
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/apis-manager has failed.
-You need to install '@o3r/schematics' to be able to use the o3r apis-manager package. Please run 'ng add @o3r/schematics' .`);
-  throw reason;
-};
 
 /**
  * Add Otter dynamic-content to an Angular Project
@@ -17,7 +16,6 @@ You need to install '@o3r/schematics' to be able to use the o3r apis-manager pac
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
   return async (tree) => {
-    const { getPackageInstallConfig, setupDependencies } = await import('@o3r/schematics');
     return setupDependencies({
       projectName: options.projectName,
       dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion)
@@ -29,7 +27,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter dynamic-content to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createSchematicWithMetricsIfInstalled(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema): Rule => createSchematicWithMetricsIfInstalled(ngAddFn)(options);

--- a/packages/@o3r/dynamic-content/src/ng-package.json
+++ b/packages/@o3r/dynamic-content/src/ng-package.json
@@ -2,7 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",
   "deleteDestPath": false,
-
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/packages/@o3r/eslint-config-otter/package.json
+++ b/packages/@o3r/eslint-config-otter/package.json
@@ -49,6 +49,9 @@
     "prepare:build:builders": "yarn cpy 'schematics/**/*.json' 'schematics/**/templates/**' dist/schematics && yarn cpy '{collection,migration}.json' dist",
     "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest"
   },
+  "dependencies": {
+    "@o3r/schematics": "workspace:^"
+  },
   "peerDependencies": {
     "@angular-devkit/schematics": "~18.2.0",
     "@angular-eslint/builder": "~18.3.0",
@@ -57,7 +60,6 @@
     "@angular-eslint/template-parser": "~18.3.0",
     "@angular/compiler": "~18.2.0",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "@stylistic/eslint-plugin-ts": "~2.4.0",
     "@typescript-eslint/eslint-plugin": "^7.14.1",
@@ -82,7 +84,6 @@
     "@nx/eslint-plugin": "~19.5.0",
     "@o3r/build-helpers": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "@stylistic/eslint-plugin-ts": "~2.4.0",
@@ -125,9 +126,6 @@
       "optional": true
     },
     "@angular/compiler": {
-      "optional": true
-    },
-    "@o3r/schematics": {
       "optional": true
     },
     "@schematics/angular": {

--- a/packages/@o3r/eslint-config-otter/schematics/ng-add/linter/index.ts
+++ b/packages/@o3r/eslint-config-otter/schematics/ng-add/linter/index.ts
@@ -1,6 +1,10 @@
 import { apply, chain, MergeStrategy, mergeWith, move, renameTemplateFiles, Rule, SchematicContext, template, Tree, url } from '@angular-devkit/schematics';
 import { posix } from 'node:path';
-
+import {
+  getAllFilesInTree,
+  getTemplateFolder,
+  getWorkspaceConfig
+} from '@o3r/schematics';
 /**
  * Add or update the Linter configuration
  * @param options @see RuleFactory.options
@@ -14,7 +18,7 @@ export function updateLinterConfigs(options: { projectName?: string | null | und
    * @param tree
    * @param context
    */
-  const updateTslintExtend: Rule = async (tree: Tree, context: SchematicContext) => {
+  const updateTslintExtend: Rule = (tree: Tree, context: SchematicContext) => {
     const eslintFilePath = '/.eslintrc.json';
 
     if (tree.exists(eslintFilePath)) {
@@ -28,7 +32,6 @@ export function updateLinterConfigs(options: { projectName?: string | null | und
 
       tree.overwrite(eslintFilePath, JSON.stringify(eslintFile, null, 2));
     } else {
-      const { getAllFilesInTree, getTemplateFolder } = await import('@o3r/schematics');
       const eslintConfigFiles = getAllFilesInTree(tree, '/', ['**/.eslintrc.js'], false).filter((file) => /\.eslintrc/i.test(file));
       if (!eslintConfigFiles.length) {
         return mergeWith(apply(url(getTemplateFolder(rootPath, __dirname, 'templates/workspace')), [
@@ -50,11 +53,10 @@ export function updateLinterConfigs(options: { projectName?: string | null | und
    * @param tree
    * @param context
    */
-  const createProjectFiles: Rule = async (tree: Tree, context: SchematicContext) => {
+  const createProjectFiles: Rule = (tree: Tree, context: SchematicContext) => {
     if (!options.projectName) {
       return;
     }
-    const { getWorkspaceConfig } = await import('@o3r/schematics');
     const workspace = getWorkspaceConfig(tree);
     if (!workspace) {
       return;
@@ -73,7 +75,6 @@ export function updateLinterConfigs(options: { projectName?: string | null | und
       context.logger.info(`${eslintFilePath} already exists.`);
       return;
     } else {
-      const { getTemplateFolder } = await import('@o3r/schematics');
       const rootRelativePath = posix.relative(projectRoot, tree.root.path.replace(/^\//, './'));
       return mergeWith(apply(url(getTemplateFolder(rootPath, __dirname, 'templates/project')), [
         template({
@@ -91,8 +92,7 @@ export function updateLinterConfigs(options: { projectName?: string | null | und
    * @param tree
    * @param context
    */
-  const editAngularJson: Rule = async (tree: Tree, context: SchematicContext) => {
-    const { getWorkspaceConfig } = await import('@o3r/schematics');
+  const editAngularJson: Rule = (tree: Tree, context: SchematicContext) => {
     const workspace = getWorkspaceConfig(tree);
     if (!workspace) {
       return;
@@ -124,11 +124,10 @@ export function updateLinterConfigs(options: { projectName?: string | null | und
    * @param tree
    * @param context
    */
-  const handleOtterEslintErrors: Rule = async (tree: Tree, context: SchematicContext) => {
+  const handleOtterEslintErrors: Rule = (tree: Tree, context: SchematicContext) => {
     if (!options.projectName) {
       return;
     }
-    const { getWorkspaceConfig } = await import('@o3r/schematics');
     const workspace = getWorkspaceConfig(tree);
     if (!workspace) {
       return;

--- a/packages/@o3r/extractors/package.json
+++ b/packages/@o3r/extractors/package.json
@@ -25,7 +25,6 @@
     "@angular-devkit/core": "~18.2.0",
     "@angular-devkit/schematics": "~18.2.0",
     "@o3r/core": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/telemetry": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "@yarnpkg/cli": "^4.0.0",

--- a/packages/@o3r/forms/ng-package.json
+++ b/packages/@o3r/forms/ng-package.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "./dist",
   "deleteDestPath": false,
-
+  "allowedNonPeerDependencies": ["@o3r/schematics"],
   "lib": {
     "entryFile": "src/public_api.ts"
   }

--- a/packages/@o3r/forms/package.json
+++ b/packages/@o3r/forms/package.json
@@ -27,7 +27,6 @@
     "@ngrx/entity": "~18.0.0",
     "@ngrx/store": "~18.0.0",
     "@o3r/core": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "rxjs": "^7.8.1"
   },
@@ -35,14 +34,12 @@
     "@angular-devkit/schematics": {
       "optional": true
     },
-    "@o3r/schematics": {
-      "optional": true
-    },
     "@schematics/angular": {
       "optional": true
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/packages/@o3r/forms/schematics/ng-add/index.ts
+++ b/packages/@o3r/forms/schematics/ng-add/index.ts
@@ -1,14 +1,13 @@
 import type { Rule } from '@angular-devkit/schematics';
 import type { NgAddSchematicsSchema } from './schema';
 import * as path from 'node:path';
+import {
+  createSchematicWithMetricsIfInstalled,
+  getPackageInstallConfig,
+  setupDependencies
+} from '@o3r/schematics';
 
 const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
-
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/form has failed.
-You need to install '@o3r/core' package to be able to use the form package. Please run 'ng add @o3r/core'.`);
-  throw reason;
-};
 
 /**
  * Add Otter forms to an Angular Project
@@ -16,8 +15,7 @@ You need to install '@o3r/core' package to be able to use the form package. Plea
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
-  return async (tree) => {
-    const { getPackageInstallConfig, setupDependencies } = await import('@o3r/schematics');
+  return (tree) => {
     return setupDependencies({
       projectName: options.projectName,
       dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion)
@@ -29,7 +27,5 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter forms to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createSchematicWithMetricsIfInstalled(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema): Rule => createSchematicWithMetricsIfInstalled(ngAddFn)(options);
+

--- a/packages/@o3r/localization/package.json
+++ b/packages/@o3r/localization/package.json
@@ -46,7 +46,6 @@
     "@o3r/dynamic-content": "workspace:^",
     "@o3r/extractors": "workspace:^",
     "@o3r/logger": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "@yarnpkg/cli": "^4.3.1",
     "@yarnpkg/core": "^4.1.1",
@@ -63,9 +62,6 @@
   },
   "peerDependenciesMeta": {
     "@angular-devkit/core": {
-      "optional": true
-    },
-    "@angular-devkit/schematics": {
       "optional": true
     },
     "@angular/cli": {
@@ -112,6 +108,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -145,7 +142,6 @@
     "@o3r/eslint-plugin": "workspace:^",
     "@o3r/extractors": "workspace:^",
     "@o3r/logger": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "@stylistic/eslint-plugin-ts": "~2.4.0",

--- a/packages/@o3r/localization/schematics/ng-add/helpers/devtools-registration.ts
+++ b/packages/@o3r/localization/schematics/ng-add/helpers/devtools-registration.ts
@@ -2,6 +2,7 @@ import { chain, Rule } from '@angular-devkit/schematics';
 import * as path from 'node:path';
 import type { NgAddSchematicsSchema } from '../schema';
 import { readFileSync } from 'node:fs';
+import { registerDevtoolsToApplication } from '@o3r/schematics';
 
 const DEVTOOL_MODULE_NAME = 'LocalizationDevtoolsModule';
 const MESSAGE_DEVTOOL_SERVICE_NAME = 'LocalizationDevtoolsMessageService';
@@ -15,8 +16,7 @@ const PACKAGE_NAME: string = JSON.parse(readFileSync(path.resolve(__dirname, '..
  * @param options
  * @param options.projectName
  */
-export const registerDevtools = async (options: NgAddSchematicsSchema): Promise<Rule> => {
-  const { registerDevtoolsToApplication } = await import('@o3r/schematics');
+export const registerDevtools = (options: NgAddSchematicsSchema): Rule => {
   return chain([
     registerDevtoolsToApplication({
       moduleName: DEVTOOL_MODULE_NAME,

--- a/packages/@o3r/localization/src/ng-package.json
+++ b/packages/@o3r/localization/src/ng-package.json
@@ -2,6 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",
   "deleteDestPath": false,
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/packages/@o3r/logger/package.json
+++ b/packages/@o3r/logger/package.json
@@ -26,7 +26,6 @@
     "@fullstory/browser": "^2.0.0",
     "@ngrx/store": "~18.0.0",
     "@o3r/core": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "logrocket": "~8.1.0",
     "logrocket-ngrx": "~0.2.1",
@@ -38,9 +37,6 @@
       "optional": true
     },
     "@fullstory/browser": {
-      "optional": true
-    },
-    "@o3r/schematics": {
       "optional": true
     },
     "@schematics/angular": {
@@ -57,6 +53,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -85,7 +82,6 @@
     "@o3r/core": "workspace:^",
     "@o3r/eslint-config-otter": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "@stylistic/eslint-plugin-ts": "~2.4.0",
     "@types/jest": "~29.5.2",

--- a/packages/@o3r/logger/schematics/ng-add/index.ts
+++ b/packages/@o3r/logger/schematics/ng-add/index.ts
@@ -1,15 +1,13 @@
 import type { Rule } from '@angular-devkit/schematics';
 import type { NgAddSchematicsSchema } from './schema';
 import * as path from 'node:path';
+import {
+  createSchematicWithMetricsIfInstalled,
+  getPackageInstallConfig,
+  setupDependencies
+} from '@o3r/schematics';
 
 const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
-
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/logger has failed.
-      If the error is related to missing @o3r dependencies you need to install '@o3r/core' to be able to use the logger package. Please run 'ng add @o3r/core' .
-      Otherwise, use the error message as guidance.`);
-  throw reason;
-};
 
 /**
  * Add Otter logger to an Angular Project
@@ -18,7 +16,6 @@ const reportMissingSchematicsDep = (logger: { error: (message: string) => any })
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
   return async (tree) => {
-    const { getPackageInstallConfig, setupDependencies } = await import('@o3r/schematics');
     return setupDependencies({
       projectName: options.projectName,
       dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion)
@@ -30,7 +27,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter logger to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createSchematicWithMetricsIfInstalled(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema): Rule => createSchematicWithMetricsIfInstalled(ngAddFn)(options);

--- a/packages/@o3r/logger/src/ng-package.json
+++ b/packages/@o3r/logger/src/ng-package.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",
   "deleteDestPath": false,
-
+  "allowedNonPeerDependencies": ["@o3r/schematics"],
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/packages/@o3r/mobile/ng-package.json
+++ b/packages/@o3r/mobile/ng-package.json
@@ -6,6 +6,6 @@
     "entryFile": "src/public_api.ts"
   },
   "allowedNonPeerDependencies": [
-    "commander", "winston", "form-data", "node-fetch"
+    "commander", "winston", "form-data", "node-fetch", "@o3r/schematics"
   ]
 }

--- a/packages/@o3r/mobile/package.json
+++ b/packages/@o3r/mobile/package.json
@@ -27,6 +27,7 @@
     "prepare:publish": "prepare-publish ./dist"
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "commander": "^12.0.0",
     "form-data": "^4.0.0",
     "node-fetch": "^3.0.0",
@@ -44,7 +45,6 @@
     "@ngrx/store": "~18.0.0",
     "@o3r/core": "workspace:^",
     "@o3r/logger": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/store-sync": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "fast-deep-equal": "^3.1.3",
@@ -52,9 +52,6 @@
   },
   "peerDependenciesMeta": {
     "@angular-devkit/schematics": {
-      "optional": true
-    },
-    "@o3r/schematics": {
       "optional": true
     },
     "@schematics/angular": {
@@ -91,7 +88,6 @@
     "@o3r/core": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
     "@o3r/logger": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/store-sync": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "@stylistic/eslint-plugin-ts": "~2.4.0",

--- a/packages/@o3r/mobile/schematics/ng-add/index.ts
+++ b/packages/@o3r/mobile/schematics/ng-add/index.ts
@@ -1,15 +1,17 @@
 import { chain, Rule } from '@angular-devkit/schematics';
 import * as path from 'node:path';
 import type { NgAddSchematicsSchema } from './schema';
+import {
+  createSchematicWithMetricsIfInstalled,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  removePackages,
+  setupDependencies
+} from '@o3r/schematics';
 
 const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
-
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/mobile has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/core' to be able to use the mobile package. Please run 'ng add @o3r/core' .
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
 
 /**
  * Add Otter mobile to an Angular Project
@@ -17,8 +19,7 @@ Otherwise, use the error message as guidance.`);
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
-  return async (tree) => {
-    const { getPackageInstallConfig, getProjectNewDependenciesTypes, setupDependencies, getO3rPeerDeps, getWorkspaceConfig, removePackages } = await import('@o3r/schematics');
+  return (tree) => {
     const depsInfo = getO3rPeerDeps(path.resolve(__dirname, '..', '..', 'package.json'));
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
     const dependencies = depsInfo.o3rPeerDeps.reduce((acc, dep) => {
@@ -46,7 +47,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter mobile to an Angular Project
  * @param options ng add options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createSchematicWithMetricsIfInstalled(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema): Rule => createSchematicWithMetricsIfInstalled(ngAddFn)(options);

--- a/packages/@o3r/new-version/package.json
+++ b/packages/@o3r/new-version/package.json
@@ -19,18 +19,15 @@
     "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest"
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "semver": "^7.5.2",
     "tslib": "^2.6.2"
   },
   "peerDependencies": {
-    "@angular-devkit/schematics": "~18.2.0",
-    "@o3r/schematics": "workspace:^"
+    "@angular-devkit/schematics": "~18.2.0"
   },
   "peerDependenciesMeta": {
     "@angular-devkit/schematics": {
-      "optional": true
-    },
-    "@o3r/schematics": {
       "optional": true
     }
   },

--- a/packages/@o3r/new-version/schematics/ng-add/index.ts
+++ b/packages/@o3r/new-version/schematics/ng-add/index.ts
@@ -1,6 +1,11 @@
 import type { Rule } from '@angular-devkit/schematics';
 import type { NgAddSchematicsSchema } from './schema';
 import * as path from 'node:path';
+import {
+  createSchematicWithMetricsIfInstalled,
+  getPackageInstallConfig,
+  setupDependencies
+} from '@o3r/schematics';
 
 const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
 
@@ -10,9 +15,7 @@ const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
-  return async (tree) => {
-    const { getPackageInstallConfig, setupDependencies } = await import('@o3r/schematics');
-
+  return (tree) => {
     return setupDependencies({
       projectName: options.projectName,
       dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, true, !!options.exactO3rVersion)
@@ -21,7 +24,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
 }
 
 
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async () => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics');
-  return createSchematicWithMetricsIfInstalled(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema): Rule => createSchematicWithMetricsIfInstalled(ngAddFn)(options);

--- a/packages/@o3r/pipeline/package.json
+++ b/packages/@o3r/pipeline/package.json
@@ -35,20 +35,17 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "js-yaml": "^4.1.0",
     "tslib": "^2.6.2"
   },
   "peerDependencies": {
     "@angular-devkit/schematics": "~18.2.0",
-    "@o3r/schematics": "workspace:^",
     "@o3r/telemetry": "workspace:^",
     "type-fest": "^4.10.2"
   },
   "peerDependenciesMeta": {
     "@angular-devkit/schematics": {
-      "optional": true
-    },
-    "@o3r/schematics": {
       "optional": true
     },
     "@o3r/telemetry": {
@@ -69,7 +66,6 @@
     "@nx/js": "~19.5.0",
     "@o3r/build-helpers": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/telemetry": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~18.2.0",

--- a/packages/@o3r/routing/package.json
+++ b/packages/@o3r/routing/package.json
@@ -34,16 +34,12 @@
     "@ngrx/store": "~18.0.0",
     "@o3r/core": "workspace:^",
     "@o3r/routing": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "jasmine": "^5.0.0",
     "rxjs": "^7.8.1"
   },
   "peerDependenciesMeta": {
     "@angular-devkit/schematics": {
-      "optional": true
-    },
-    "@o3r/schematics": {
       "optional": true
     },
     "@schematics/angular": {
@@ -54,6 +50,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -86,7 +83,6 @@
     "@o3r/eslint-config-otter": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
     "@o3r/routing": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "@stylistic/eslint-plugin-ts": "~2.4.0",
     "@types/jasmine": "~5.1.0",

--- a/packages/@o3r/routing/schematics/ng-add/index.ts
+++ b/packages/@o3r/routing/schematics/ng-add/index.ts
@@ -1,22 +1,20 @@
 import type { Rule } from '@angular-devkit/schematics';
 import type { NgAddSchematicsSchema } from './schema';
 import * as path from 'node:path';
+import {
+  createSchematicWithMetricsIfInstalled,
+  getPackageInstallConfig,
+  setupDependencies
+} from '@o3r/schematics';
 
 const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
 
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/routing has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/core' to be able to use the mobile package. Please run 'ng add @o3r/core' .
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
 /**
  * Add Otter routing to an Angular Project
  * @param options
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
-  return async (tree) => {
-    const { getPackageInstallConfig, setupDependencies } = await import('@o3r/schematics');
+  return (tree) => {
     return setupDependencies({
       projectName: options.projectName,
       dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion)
@@ -28,7 +26,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter routing to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createSchematicWithMetricsIfInstalled(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema): Rule => createSchematicWithMetricsIfInstalled(ngAddFn)(options);

--- a/packages/@o3r/routing/src/ng-package.json
+++ b/packages/@o3r/routing/src/ng-package.json
@@ -2,7 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",
   "deleteDestPath": false,
-
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/packages/@o3r/rules-engine/package.json
+++ b/packages/@o3r/rules-engine/package.json
@@ -45,7 +45,6 @@
     "@o3r/core": "workspace:^",
     "@o3r/extractors": "workspace:^",
     "@o3r/logger": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "globby": "^11.1.0",
     "jasmine": "^5.0.0",
@@ -62,9 +61,6 @@
       "optional": true
     },
     "@o3r/extractors": {
-      "optional": true
-    },
-    "@o3r/schematics": {
       "optional": true
     },
     "@schematics/angular": {
@@ -84,6 +80,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/packages/@o3r/rules-engine/schematics/ng-add/helpers/devtools-registration.ts
+++ b/packages/@o3r/rules-engine/schematics/ng-add/helpers/devtools-registration.ts
@@ -2,6 +2,7 @@ import { chain, Rule } from '@angular-devkit/schematics';
 import * as path from 'node:path';
 import type { NgAddSchematicsSchema } from '../schema';
 import { readFileSync } from 'node:fs';
+import { registerDevtoolsToApplication } from '@o3r/schematics';
 
 const DEVTOOL_MODULE_NAME = 'RulesEngineDevtoolsModule';
 const MESSAGE_DEVTOOL_SERVICE_NAME = 'RulesEngineDevtoolsMessageService';
@@ -15,8 +16,7 @@ const PACKAGE_NAME: string = JSON.parse(readFileSync(path.resolve(__dirname, '..
  * @param options
  * @param options.projectName
  */
-export const registerDevtools = async (options: NgAddSchematicsSchema): Promise<Rule> => {
-  const { registerDevtoolsToApplication } = await import('@o3r/schematics');
+export const registerDevtools = (options: NgAddSchematicsSchema): Rule => {
   return chain([
     registerDevtoolsToApplication({
       moduleName: DEVTOOL_MODULE_NAME,

--- a/packages/@o3r/rules-engine/src/ng-package.json
+++ b/packages/@o3r/rules-engine/src/ng-package.json
@@ -2,7 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",
   "deleteDestPath": false,
-
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/packages/@o3r/schematics/schematics/ng-add/index.ts
+++ b/packages/@o3r/schematics/schematics/ng-add/index.ts
@@ -3,6 +3,11 @@ import type { DependencyToAdd } from '@o3r/schematics';
 import { NodeDependencyType } from '@schematics/angular/utility/dependencies';
 import * as path from 'node:path';
 import type { NgAddSchematicsSchema } from './schema';
+import {
+  createSchematicWithMetricsIfInstalled,
+  getExternalDependenciesVersionRange,
+  setupDependencies
+} from '@o3r/schematics';
 
 /**
  * Add Otter schematics to an Angular Project
@@ -10,9 +15,8 @@ import type { NgAddSchematicsSchema } from './schema';
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   const schematicsDependencies = ['@angular-devkit/architect', '@angular-devkit/schematics', '@angular-devkit/core', '@schematics/angular', 'globby'];
-  return async (_, context) => {
+  return (_, context) => {
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
-    const { getExternalDependenciesVersionRange, setupDependencies } = await import('@o3r/schematics');
     const dependencies = Object.entries(getExternalDependenciesVersionRange(schematicsDependencies, packageJsonPath, context.logger)).reduce((acc, [dep, range]) => {
       acc[dep] = {
         inManifest: [{
@@ -43,8 +47,5 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter schematics to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async () => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics');
-  return createSchematicWithMetricsIfInstalled(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema): Rule => createSchematicWithMetricsIfInstalled(ngAddFn)(options);
 

--- a/packages/@o3r/store-sync/ng-package.json
+++ b/packages/@o3r/store-sync/ng-package.json
@@ -2,7 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "./dist",
   "deleteDestPath": false,
-
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
   "lib": {
     "entryFile": "src/public_api.ts"
   }

--- a/packages/@o3r/store-sync/package.json
+++ b/packages/@o3r/store-sync/package.json
@@ -29,7 +29,6 @@
     "@ngrx/store": "~18.0.0",
     "@o3r/core": "workspace:^",
     "@o3r/logger": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "fast-deep-equal": "^3.1.3",
     "rxjs": "^7.8.1"
@@ -41,14 +40,12 @@
     "@angular-devkit/schematics": {
       "optional": true
     },
-    "@o3r/schematics": {
-      "optional": true
-    },
     "@schematics/angular": {
       "optional": true
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -74,7 +71,6 @@
     "@o3r/eslint-config-otter": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
     "@o3r/logger": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "@stylistic/eslint-plugin-ts": "~2.4.0",
     "@types/jest": "~29.5.2",

--- a/packages/@o3r/store-sync/schematics/ng-add/index.ts
+++ b/packages/@o3r/store-sync/schematics/ng-add/index.ts
@@ -2,35 +2,28 @@ import { chain, noop, Rule } from '@angular-devkit/schematics';
 import type { NgAddSchematicsSchema } from './schema';
 import * as path from 'node:path';
 import { NodeDependencyType } from '@schematics/angular/utility/dependencies';
+import {
+  applyEsLintFix,
+  createSchematicWithMetricsIfInstalled,
+  getExternalDependenciesVersionRange,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  setupDependencies
+} from '@o3r/schematics';
 
 const devDependenciesToInstall = [
   'fast-deep-equal'
 ];
-
-
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding store-sync has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/core' to be able to use the store-sync package. Please run 'ng add @o3r/core' .
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
 
 /**
  * Add Otter store-sync to an Otter Project
  * @param options
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
-  return async (tree, context) => {
+  return (tree, context) => {
     // use dynamic import to properly raise an exception if it is not an Otter project.
-    const {
-      getPackageInstallConfig,
-      applyEsLintFix,
-      setupDependencies,
-      getO3rPeerDeps,
-      getProjectNewDependenciesTypes,
-      getWorkspaceConfig,
-      getExternalDependenciesVersionRange
-    } = await import('@o3r/schematics');
 
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
@@ -73,7 +66,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter store-sync to an Otter Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createSchematicWithMetricsIfInstalled(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema): Rule => createSchematicWithMetricsIfInstalled(ngAddFn)(options);

--- a/packages/@o3r/storybook/package.json
+++ b/packages/@o3r/storybook/package.json
@@ -42,6 +42,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "color": "^4.2.3",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
@@ -57,7 +58,6 @@
     "@o3r/core": "workspace:^",
     "@o3r/localization": "workspace:^",
     "@o3r/logger": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/styling": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "@storybook/addons": "^7.5.3",
@@ -69,9 +69,6 @@
   },
   "peerDependenciesMeta": {
     "@angular-devkit/schematics": {
-      "optional": true
-    },
-    "@o3r/schematics": {
       "optional": true
     }
   },
@@ -103,7 +100,6 @@
     "@o3r/eslint-plugin": "workspace:^",
     "@o3r/localization": "workspace:^",
     "@o3r/logger": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/styling": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~18.2.0",

--- a/packages/@o3r/storybook/schematics/ng-add/index.ts
+++ b/packages/@o3r/storybook/schematics/ng-add/index.ts
@@ -1,15 +1,18 @@
 import { chain, noop, type Rule } from '@angular-devkit/schematics';
 import * as path from 'node:path';
 import type { NgAddSchematicsSchema } from './schema';
+import {
+  applyEsLintFix,
+  createSchematicWithMetricsIfInstalled,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  removePackages,
+  setupDependencies
+} from '@o3r/schematics';
 
 const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
-
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/storybook has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/core' to be able to use the storybook package. Please run 'ng add @o3r/core' .
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
 
 /**
  * Add Otter storybook to an Angular Project
@@ -17,7 +20,6 @@ Otherwise, use the error message as guidance.`);
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   return async (tree) => {
-    const { applyEsLintFix, getPackageInstallConfig, setupDependencies, getO3rPeerDeps, getProjectNewDependenciesTypes, getWorkspaceConfig, removePackages } = await import('@o3r/schematics');
     const { updateStorybook } = await import('../storybook-base');
     const depsInfo = getO3rPeerDeps(packageJsonPath);
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
@@ -48,7 +50,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter storybook to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createSchematicWithMetricsIfInstalled(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema): Rule => createSchematicWithMetricsIfInstalled(ngAddFn)(options);

--- a/packages/@o3r/stylelint-plugin/package.json
+++ b/packages/@o3r/stylelint-plugin/package.json
@@ -24,21 +24,17 @@
     "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest"
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "peerDependencies": {
     "@angular-devkit/schematics": "~18.2.0",
-    "@o3r/schematics": "workspace:^",
-    "@schematics/angular": "~18.2.0",
     "postcss": "^8.4.5",
     "postcss-scss": "^4.0.9",
     "stylelint": "^16.0.2"
   },
   "peerDependenciesMeta": {
     "@angular-devkit/schematics": {
-      "optional": true
-    },
-    "@o3r/schematics": {
       "optional": true
     },
     "@schematics/angular": {

--- a/packages/@o3r/stylelint-plugin/schematics/ng-add/index.ts
+++ b/packages/@o3r/stylelint-plugin/schematics/ng-add/index.ts
@@ -1,6 +1,16 @@
 import type { Rule } from '@angular-devkit/schematics';
 import type { NgAddSchematicsSchema } from './schema';
 import * as path from 'node:path';
+import type { NodeDependencyType } from '@schematics/angular/utility/dependencies';
+import {
+  createSchematicWithMetricsIfInstalled,
+  getExternalDependenciesVersionRange,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  setupDependencies
+} from '@o3r/schematics';
 
 const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
 const dependenciesToInstall = [
@@ -9,13 +19,6 @@ const dependenciesToInstall = [
   'stylelint'
 ];
 
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/stylelint-plugin has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/core' to be able to use the mobile package. Please run 'ng add @o3r/core' .
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
-
 /**
  * Add Otter stylelint-plugin to an Angular Project
  * @param options
@@ -23,16 +26,8 @@ Otherwise, use the error message as guidance.`);
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
   return async (tree, context) => {
-    const {
-      getExternalDependenciesVersionRange,
-      getPackageInstallConfig,
-      getProjectNewDependenciesTypes,
-      getO3rPeerDeps,
-      getWorkspaceConfig,
-      setupDependencies
-    } = await import('@o3r/schematics');
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    const { NodeDependencyType } = await import('@schematics/angular/utility/dependencies');
+    const { NodeDependencyType } = await import('@schematics/angular/utility/dependencies').catch(() => ({ NodeDependencyType: { Dev: 'devDependencies' as NodeDependencyType.Dev } }));
     const depsInfo = getO3rPeerDeps(packageJsonPath);
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
     const dependencies = depsInfo.o3rPeerDeps.reduce((acc, dep) => {
@@ -63,7 +58,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter stylelint-plugin to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const { createSchematicWithMetricsIfInstalled } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createSchematicWithMetricsIfInstalled(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema): Rule => createSchematicWithMetricsIfInstalled(ngAddFn)(options);

--- a/packages/@o3r/styling/ng-package.json
+++ b/packages/@o3r/styling/ng-package.json
@@ -5,6 +5,9 @@
   "lib": {
     "entryFile": "src/public_api.ts"
   },
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
   "assets": [
     "schemas/*.json",
     "scss/**/*",

--- a/packages/@o3r/styling/package.json
+++ b/packages/@o3r/styling/package.json
@@ -47,7 +47,6 @@
     "@o3r/dynamic-content": "workspace:^",
     "@o3r/extractors": "workspace:^",
     "@o3r/logger": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "@yarnpkg/cli": "^4.3.1",
     "@yarnpkg/core": "^4.1.1",
@@ -89,9 +88,6 @@
     "@o3r/logger": {
       "optional": true
     },
-    "@o3r/schematics": {
-      "optional": true
-    },
     "@schematics/angular": {
       "optional": true
     },
@@ -127,6 +123,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -158,7 +155,6 @@
     "@o3r/eslint-config-otter": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
     "@o3r/extractors": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "@stylistic/eslint-plugin-ts": "~2.4.0",

--- a/packages/@o3r/styling/schematics/ng-add/theme-files/index.ts
+++ b/packages/@o3r/styling/schematics/ng-add/theme-files/index.ts
@@ -1,6 +1,11 @@
 import { strings } from '@angular-devkit/core';
 import { apply, MergeStrategy, mergeWith, move, noop, Rule, SchematicContext, template, Tree, url } from '@angular-devkit/schematics';
 import * as path from 'node:path';
+import {
+  getTemplateFolder,
+  getWorkspaceConfig,
+  writeAngularJson
+} from '@o3r/schematics';
 
 /**
  * Added styling support
@@ -9,8 +14,7 @@ import * as path from 'node:path';
  * @param rootPath @see RuleFactory.rootPath
  */
 export function updateThemeFiles(rootPath: string, options: { projectName?: string | null | undefined }): Rule {
-  return async (tree: Tree, context: SchematicContext) => {
-    const { getTemplateFolder, getWorkspaceConfig } = await import('@o3r/schematics');
+  return (tree: Tree, context: SchematicContext) => {
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
     if (!workspaceProject || workspaceProject.projectType === 'library') {
       return noop;
@@ -68,8 +72,7 @@ export function updateThemeFiles(rootPath: string, options: { projectName?: stri
  */
 export function removeV7OtterAssetsInAngularJson(options: { projectName?: string | null | undefined }): Rule {
 
-  return async (tree: Tree, context: SchematicContext) => {
-    const { writeAngularJson, getWorkspaceConfig } = await import('@o3r/schematics');
+  return (tree: Tree, context: SchematicContext) => {
     const workspace = getWorkspaceConfig(tree);
     const projectName = options.projectName;
     const workspaceProject = options.projectName ? workspace?.projects[options.projectName] : undefined;

--- a/packages/@o3r/testing/package.json
+++ b/packages/@o3r/testing/package.json
@@ -110,7 +110,6 @@
     "@ngx-translate/core": "~15.0.0",
     "@o3r/core": "workspace:^",
     "@o3r/localization": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@playwright/test": "~1.48.0",
     "@schematics/angular": "~18.2.0",
     "pixelmatch": "^5.2.1",
@@ -146,9 +145,6 @@
     "@o3r/localization": {
       "optional": true
     },
-    "@o3r/schematics": {
-      "optional": true
-    },
     "@playwright/test": {
       "optional": true
     },
@@ -172,6 +168,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "esbuild": "~0.24.0",
     "module-from-string": "^3.2.0",
     "tslib": "^2.6.2"
@@ -202,7 +199,6 @@
     "@o3r/core": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
     "@o3r/localization": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@playwright/test": "~1.48.0",
     "@schematics/angular": "~18.2.0",

--- a/packages/@o3r/testing/schematics/ng-add/fixture/index.ts
+++ b/packages/@o3r/testing/schematics/ng-add/fixture/index.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { chain, Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import type { TsConfigJson } from 'type-fest';
+import {
+  getTestFramework,
+  getWorkspaceConfig
+} from '@o3r/schematics';
 
 import * as ts from 'typescript';
 
@@ -18,8 +22,7 @@ export function updateFixtureConfig(options: { projectName?: string | null | und
    * @param tree
    * @param context
    */
-  const updateTestTsconfig: Rule = async (tree: Tree, context: SchematicContext) => {
-    const { getTestFramework, getWorkspaceConfig } = await import('@o3r/schematics');
+  const updateTestTsconfig: Rule = (tree: Tree, context: SchematicContext) => {
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
 
     if (!workspaceProject) {

--- a/packages/@o3r/third-party/ng-package.json
+++ b/packages/@o3r/third-party/ng-package.json
@@ -6,6 +6,7 @@
     "entryFile": "src/index.ts"
   },
   "allowedNonPeerDependencies": [
-    "uuid"
+    "uuid",
+    "@o3r/schematics"
   ]
 }

--- a/packages/@o3r/third-party/package.json
+++ b/packages/@o3r/third-party/package.json
@@ -20,13 +20,13 @@
     "prepare:publish": "prepare-publish ./dist"
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2",
     "uuid": "^10.0.0"
   },
   "peerDependencies": {
     "@angular-devkit/schematics": "~18.2.0",
     "@o3r/core": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "rxjs": "^7.8.1",
     "typescript": "~5.5.4"
@@ -36,9 +36,6 @@
       "optional": true
     },
     "@o3r/core": {
-      "optional": true
-    },
-    "@o3r/schematics": {
       "optional": true
     },
     "@schematics/angular": {
@@ -70,7 +67,6 @@
     "@o3r/core": "workspace:^",
     "@o3r/eslint-config-otter": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "@stylistic/eslint-plugin-ts": "~2.4.0",

--- a/packages/@o3r/workspace/package.json
+++ b/packages/@o3r/workspace/package.json
@@ -82,7 +82,6 @@
     "@o3r/build-helpers": "workspace:^",
     "@o3r/core": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~18.2.0",
     "@stylistic/eslint-plugin-ts": "~2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -281,6 +281,7 @@ __metadata:
     "@nx/jest": "npm:~19.5.0"
     "@o3r/build-helpers": "workspace:^"
     "@o3r/eslint-plugin": "workspace:^"
+    "@o3r/schematics": "workspace:^"
     "@o3r/test-helpers": "workspace:^"
     "@schematics/angular": "npm:~18.2.0"
     "@stylistic/eslint-plugin-ts": "npm:~2.4.0"
@@ -320,7 +321,6 @@ __metadata:
     "@angular-devkit/schematics": ~18.2.0
     "@angular/cli": ~18.2.0
     "@angular/common": ~18.2.0
-    "@o3r/schematics": "workspace:^"
     "@schematics/angular": ~18.2.0
     rxjs: ^7.8.1
     typescript: ~5.5.4
@@ -330,8 +330,6 @@ __metadata:
     "@angular/cli":
       optional: true
     "@angular/common":
-      optional: true
-    "@o3r/schematics":
       optional: true
     "@schematics/angular":
       optional: true
@@ -354,6 +352,7 @@ __metadata:
     "@nx/jest": "npm:~19.5.0"
     "@o3r/build-helpers": "workspace:^"
     "@o3r/eslint-plugin": "workspace:^"
+    "@o3r/schematics": "workspace:^"
     "@o3r/test-helpers": "workspace:^"
     "@schematics/angular": "npm:~18.2.0"
     "@stylistic/eslint-plugin-ts": "npm:~2.4.0"
@@ -393,7 +392,6 @@ __metadata:
     "@angular-devkit/schematics": ~18.2.0
     "@angular/cli": ~18.2.0
     "@angular/common": ~18.2.0
-    "@o3r/schematics": "workspace:^"
     "@schematics/angular": ~18.2.0
     typescript: ~5.5.4
   peerDependenciesMeta:
@@ -402,8 +400,6 @@ __metadata:
     "@angular/cli":
       optional: true
     "@angular/common":
-      optional: true
-    "@o3r/schematics":
       optional: true
     "@schematics/angular":
       optional: true
@@ -426,6 +422,7 @@ __metadata:
     "@nx/jest": "npm:~19.5.0"
     "@o3r/build-helpers": "workspace:^"
     "@o3r/eslint-plugin": "workspace:^"
+    "@o3r/schematics": "workspace:^"
     "@o3r/test-helpers": "workspace:^"
     "@schematics/angular": "npm:~18.2.0"
     "@stylistic/eslint-plugin-ts": "npm:~2.4.0"
@@ -466,7 +463,6 @@ __metadata:
     "@angular-devkit/schematics": ~18.2.0
     "@angular/cli": ~18.2.0
     "@angular/common": ~18.2.0
-    "@o3r/schematics": "workspace:^"
     "@schematics/angular": ~18.2.0
     isomorphic-fetch: ^3.0.0
     typescript: ~5.5.4
@@ -476,8 +472,6 @@ __metadata:
     "@angular/cli":
       optional: true
     "@angular/common":
-      optional: true
-    "@o3r/schematics":
       optional: true
     "@schematics/angular":
       optional: true
@@ -501,6 +495,7 @@ __metadata:
     "@nx/jest": "npm:~19.5.0"
     "@o3r/build-helpers": "workspace:^"
     "@o3r/eslint-plugin": "workspace:^"
+    "@o3r/schematics": "workspace:^"
     "@o3r/test-helpers": "workspace:^"
     "@schematics/angular": "npm:~18.2.0"
     "@stylistic/eslint-plugin-ts": "npm:~2.4.0"
@@ -540,7 +535,6 @@ __metadata:
     "@angular-devkit/schematics": ~18.2.0
     "@angular/cli": ~18.2.0
     "@angular/common": ~18.2.0
-    "@o3r/schematics": "workspace:^"
     "@schematics/angular": ~18.2.0
     isomorphic-fetch: ^3.0.0
     rxjs: ^7.8.1
@@ -551,8 +545,6 @@ __metadata:
     "@angular/cli":
       optional: true
     "@angular/common":
-      optional: true
-    "@o3r/schematics":
       optional: true
     "@schematics/angular":
       optional: true
@@ -7041,7 +7033,6 @@ __metadata:
     zone.js: "npm:~0.14.2"
   peerDependencies:
     "@angular-devkit/schematics": ~18.2.0
-    "@o3r/schematics": "workspace:^"
     "@schematics/angular": ~18.2.0
     "@webcontainer/api": ~1.5.0
     eslint: ^8.57.0
@@ -7056,8 +7047,6 @@ __metadata:
     "@angular-devkit/schematics":
       optional: true
     "@angular/cli":
-      optional: true
-    "@o3r/schematics":
       optional: true
     eslint:
       optional: true
@@ -7255,6 +7244,7 @@ __metadata:
     "@o3r/build-helpers": "workspace:^"
     "@o3r/core": "workspace:^"
     "@o3r/eslint-plugin": "workspace:^"
+    "@o3r/schematics": "workspace:^"
     "@o3r/test-helpers": "workspace:^"
     "@schematics/angular": "npm:~18.2.0"
     "@stylistic/eslint-plugin-ts": "npm:~2.4.0"
@@ -7297,7 +7287,6 @@ __metadata:
     "@angular/router": ~18.2.0
     "@ngrx/store": ~18.0.0
     "@o3r/core": "workspace:^"
-    "@o3r/schematics": "workspace:^"
     "@schematics/angular": ~18.2.0
     jasmine: ^5.0.0
     rxjs: ^7.8.1
@@ -7305,8 +7294,6 @@ __metadata:
     webpack: ~5.96.0
   peerDependenciesMeta:
     "@angular-devkit/schematics":
-      optional: true
-    "@o3r/schematics":
       optional: true
     "@schematics/angular":
       optional: true
@@ -7381,7 +7368,6 @@ __metadata:
     "@angular-devkit/schematics": ~18.2.0
     "@angular/common": ~18.2.0
     "@angular/core": ~18.2.0
-    "@o3r/schematics": "workspace:^"
     "@schematics/angular": ~18.2.0
     rxjs: ^7.8.1
     typescript: ~5.5.4
@@ -7389,8 +7375,6 @@ __metadata:
     "@ama-sdk/client-fetch":
       optional: true
     "@angular-devkit/schematics":
-      optional: true
-    "@o3r/schematics":
       optional: true
     "@schematics/angular":
       optional: true
@@ -7462,15 +7446,12 @@ __metadata:
     "@o3r/core": "workspace:^"
     "@o3r/logger": "workspace:^"
     "@o3r/routing": "workspace:^"
-    "@o3r/schematics": "workspace:^"
     "@o3r/testing": "workspace:^"
     "@schematics/angular": ~18.2.0
     rxjs: ^7.8.1
     typescript: ~5.5.4
   peerDependenciesMeta:
     "@angular-devkit/schematics":
-      optional: true
-    "@o3r/schematics":
       optional: true
     typescript:
       optional: true
@@ -7801,7 +7782,6 @@ __metadata:
     "@o3r/localization": "workspace:^"
     "@o3r/logger": "workspace:^"
     "@o3r/rules-engine": "workspace:^"
-    "@o3r/schematics": "workspace:^"
     "@o3r/testing": "workspace:^"
     "@schematics/angular": ~18.2.0
     "@yarnpkg/cli": ^4.0.0
@@ -7833,8 +7813,6 @@ __metadata:
     "@o3r/localization":
       optional: true
     "@o3r/rules-engine":
-      optional: true
-    "@o3r/schematics":
       optional: true
     "@schematics/angular":
       optional: true
@@ -8197,7 +8175,6 @@ __metadata:
     "@angular-devkit/architect": ~0.1802.0
     "@angular-devkit/schematics": ~18.2.0
     "@o3r/core": "workspace:^"
-    "@o3r/schematics": "workspace:^"
     "@o3r/styling": "workspace:^"
     "@o3r/telemetry": "workspace:^"
     chokidar: ^3.5.2
@@ -8209,8 +8186,6 @@ __metadata:
     "@angular-devkit/schematics":
       optional: true
     "@o3r/core":
-      optional: true
-    "@o3r/schematics":
       optional: true
     "@o3r/styling":
       optional: true
@@ -8373,7 +8348,6 @@ __metadata:
     "@angular/platform-browser-dynamic": ~18.2.0
     "@ngrx/store": ~18.0.0
     "@o3r/core": "workspace:^"
-    "@o3r/schematics": "workspace:^"
     "@schematics/angular": ~18.2.0
     cheerio: ^1.0.0-rc.10
     express-interceptor: ^1.2.0
@@ -8381,8 +8355,6 @@ __metadata:
     rxjs: ^7.8.1
   peerDependenciesMeta:
     "@angular-devkit/schematics":
-      optional: true
-    "@o3r/schematics":
       optional: true
     "@schematics/angular":
       optional: true
@@ -8444,7 +8416,6 @@ __metadata:
     "@angular-eslint/template-parser": ~18.3.0
     "@angular/compiler": ~18.2.0
     "@o3r/eslint-plugin": "workspace:^"
-    "@o3r/schematics": "workspace:^"
     "@schematics/angular": ~18.2.0
     "@stylistic/eslint-plugin-ts": ~2.4.0
     "@typescript-eslint/eslint-plugin": ^7.14.1
@@ -8468,8 +8439,6 @@ __metadata:
     "@angular-eslint/template-parser":
       optional: true
     "@angular/compiler":
-      optional: true
-    "@o3r/schematics":
       optional: true
     "@schematics/angular":
       optional: true
@@ -8631,7 +8600,6 @@ __metadata:
     "@angular-devkit/core": ~18.2.0
     "@angular-devkit/schematics": ~18.2.0
     "@o3r/core": "workspace:^"
-    "@o3r/schematics": "workspace:^"
     "@o3r/telemetry": "workspace:^"
     "@schematics/angular": ~18.2.0
     "@yarnpkg/cli": ^4.0.0
@@ -8735,13 +8703,10 @@ __metadata:
     "@ngrx/entity": ~18.0.0
     "@ngrx/store": ~18.0.0
     "@o3r/core": "workspace:^"
-    "@o3r/schematics": "workspace:^"
     "@schematics/angular": ~18.2.0
     rxjs: ^7.8.1
   peerDependenciesMeta:
     "@angular-devkit/schematics":
-      optional: true
-    "@o3r/schematics":
       optional: true
     "@schematics/angular":
       optional: true
@@ -9037,7 +9002,6 @@ __metadata:
     "@o3r/dynamic-content": "workspace:^"
     "@o3r/extractors": "workspace:^"
     "@o3r/logger": "workspace:^"
-    "@o3r/schematics": "workspace:^"
     "@schematics/angular": ~18.2.0
     "@yarnpkg/cli": ^4.3.1
     "@yarnpkg/core": ^4.1.1
@@ -9053,8 +9017,6 @@ __metadata:
     typescript: ~5.5.4
   peerDependenciesMeta:
     "@angular-devkit/core":
-      optional: true
-    "@angular-devkit/schematics":
       optional: true
     "@angular/cli":
       optional: true
@@ -9154,7 +9116,6 @@ __metadata:
     "@fullstory/browser": ^2.0.0
     "@ngrx/store": ~18.0.0
     "@o3r/core": "workspace:^"
-    "@o3r/schematics": "workspace:^"
     "@schematics/angular": ~18.2.0
     logrocket: ~8.1.0
     logrocket-ngrx: ~0.2.1
@@ -9164,8 +9125,6 @@ __metadata:
     "@angular-devkit/schematics":
       optional: true
     "@fullstory/browser":
-      optional: true
-    "@o3r/schematics":
       optional: true
     "@schematics/angular":
       optional: true
@@ -9256,15 +9215,12 @@ __metadata:
     "@ngrx/store": ~18.0.0
     "@o3r/core": "workspace:^"
     "@o3r/logger": "workspace:^"
-    "@o3r/schematics": "workspace:^"
     "@o3r/store-sync": "workspace:^"
     "@schematics/angular": ~18.2.0
     fast-deep-equal: ^3.1.3
     rxjs: ^7.8.1
   peerDependenciesMeta:
     "@angular-devkit/schematics":
-      optional: true
-    "@o3r/schematics":
       optional: true
     "@schematics/angular":
       optional: true
@@ -9287,6 +9243,7 @@ __metadata:
     "@nx/jest": "npm:~19.5.0"
     "@o3r/build-helpers": "workspace:^"
     "@o3r/eslint-plugin": "workspace:^"
+    "@o3r/schematics": "workspace:^"
     "@o3r/test-helpers": "workspace:^"
     "@stylistic/eslint-plugin-ts": "npm:~2.4.0"
     "@types/jest": "npm:~29.5.2"
@@ -9313,11 +9270,8 @@ __metadata:
     typescript: "npm:~5.5.4"
   peerDependencies:
     "@angular-devkit/schematics": ~18.2.0
-    "@o3r/schematics": "workspace:^"
   peerDependenciesMeta:
     "@angular-devkit/schematics":
-      optional: true
-    "@o3r/schematics":
       optional: true
   languageName: unknown
   linkType: soft
@@ -9368,13 +9322,10 @@ __metadata:
     typescript: "npm:~5.5.4"
   peerDependencies:
     "@angular-devkit/schematics": ~18.2.0
-    "@o3r/schematics": "workspace:^"
     "@o3r/telemetry": "workspace:^"
     type-fest: ^4.10.2
   peerDependenciesMeta:
     "@angular-devkit/schematics":
-      optional: true
-    "@o3r/schematics":
       optional: true
     "@o3r/telemetry":
       optional: true
@@ -9456,14 +9407,11 @@ __metadata:
     "@ngrx/store": ~18.0.0
     "@o3r/core": "workspace:^"
     "@o3r/routing": "workspace:^"
-    "@o3r/schematics": "workspace:^"
     "@schematics/angular": ~18.2.0
     jasmine: ^5.0.0
     rxjs: ^7.8.1
   peerDependenciesMeta:
     "@angular-devkit/schematics":
-      optional: true
-    "@o3r/schematics":
       optional: true
     "@schematics/angular":
       optional: true
@@ -9561,7 +9509,6 @@ __metadata:
     "@o3r/core": "workspace:^"
     "@o3r/extractors": "workspace:^"
     "@o3r/logger": "workspace:^"
-    "@o3r/schematics": "workspace:^"
     "@schematics/angular": ~18.2.0
     globby: ^11.1.0
     jasmine: ^5.0.0
@@ -9575,8 +9522,6 @@ __metadata:
     "@angular-devkit/schematics":
       optional: true
     "@o3r/extractors":
-      optional: true
-    "@o3r/schematics":
       optional: true
     "@schematics/angular":
       optional: true
@@ -9853,7 +9798,6 @@ __metadata:
     "@ngrx/store": ~18.0.0
     "@o3r/core": "workspace:^"
     "@o3r/logger": "workspace:^"
-    "@o3r/schematics": "workspace:^"
     "@schematics/angular": ~18.2.0
     fast-deep-equal: ^3.1.3
     rxjs: ^7.8.1
@@ -9861,8 +9805,6 @@ __metadata:
     "@angular-devkit/core":
       optional: true
     "@angular-devkit/schematics":
-      optional: true
-    "@o3r/schematics":
       optional: true
     "@schematics/angular":
       optional: true
@@ -9950,7 +9892,6 @@ __metadata:
     "@o3r/core": "workspace:^"
     "@o3r/localization": "workspace:^"
     "@o3r/logger": "workspace:^"
-    "@o3r/schematics": "workspace:^"
     "@o3r/styling": "workspace:^"
     "@schematics/angular": ~18.2.0
     "@storybook/addons": ^7.5.3
@@ -9961,8 +9902,6 @@ __metadata:
     typescript: ~5.5.4
   peerDependenciesMeta:
     "@angular-devkit/schematics":
-      optional: true
-    "@o3r/schematics":
       optional: true
   languageName: unknown
   linkType: soft
@@ -9983,6 +9922,7 @@ __metadata:
     "@o3r/build-helpers": "workspace:^"
     "@o3r/eslint-config-otter": "workspace:^"
     "@o3r/eslint-plugin": "workspace:^"
+    "@o3r/schematics": "workspace:^"
     "@o3r/test-helpers": "workspace:^"
     "@schematics/angular": "npm:~18.2.0"
     "@stylistic/eslint-plugin-ts": "npm:~2.4.0"
@@ -10014,15 +9954,11 @@ __metadata:
     typescript: "npm:~5.5.4"
   peerDependencies:
     "@angular-devkit/schematics": ~18.2.0
-    "@o3r/schematics": "workspace:^"
-    "@schematics/angular": ~18.2.0
     postcss: ^8.4.5
     postcss-scss: ^4.0.9
     stylelint: ^16.0.2
   peerDependenciesMeta:
     "@angular-devkit/schematics":
-      optional: true
-    "@o3r/schematics":
       optional: true
     "@schematics/angular":
       optional: true
@@ -10116,7 +10052,6 @@ __metadata:
     "@o3r/dynamic-content": "workspace:^"
     "@o3r/extractors": "workspace:^"
     "@o3r/logger": "workspace:^"
-    "@o3r/schematics": "workspace:^"
     "@schematics/angular": ~18.2.0
     "@yarnpkg/cli": ^4.3.1
     "@yarnpkg/core": ^4.1.1
@@ -10147,8 +10082,6 @@ __metadata:
     "@o3r/extractors":
       optional: true
     "@o3r/logger":
-      optional: true
-    "@o3r/schematics":
       optional: true
     "@schematics/angular":
       optional: true
@@ -10372,7 +10305,6 @@ __metadata:
     "@ngx-translate/core": ~15.0.0
     "@o3r/core": "workspace:^"
     "@o3r/localization": "workspace:^"
-    "@o3r/schematics": "workspace:^"
     "@playwright/test": ~1.48.0
     "@schematics/angular": ~18.2.0
     pixelmatch: ^5.2.1
@@ -10398,8 +10330,6 @@ __metadata:
     "@o3r/core":
       optional: true
     "@o3r/localization":
-      optional: true
-    "@o3r/schematics":
       optional: true
     "@playwright/test":
       optional: true
@@ -10479,7 +10409,6 @@ __metadata:
   peerDependencies:
     "@angular-devkit/schematics": ~18.2.0
     "@o3r/core": "workspace:^"
-    "@o3r/schematics": "workspace:^"
     "@schematics/angular": ~18.2.0
     rxjs: ^7.8.1
     typescript: ~5.5.4
@@ -10487,8 +10416,6 @@ __metadata:
     "@angular-devkit/schematics":
       optional: true
     "@o3r/core":
-      optional: true
-    "@o3r/schematics":
       optional: true
     "@schematics/angular":
       optional: true


### PR DESCRIPTION
## Proposed change

move @o3r/schematic package to packages dependencies to simplify ng-add and supporting it outside of Otter project.

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
