### PR TITLE
fix: clean unreferenced cached values of translations and configs

### DIFF
--- a/packages/@o3r/configuration/src/core/configuration.ts
+++ b/packages/@o3r/configuration/src/core/configuration.ts
@@ -58,6 +58,6 @@ export function getConfiguration<T extends Record<string, unknown>>(defaultValue
         return deepFill(defaultValue, configOverride);
       }),
       distinctUntilChanged((prev, current) => JSON.stringify(prev) === JSON.stringify(current)),
-      shareReplay(1)
+      shareReplay({ refCount: true, bufferSize: 1 })
     );
 }

--- a/packages/@o3r/configuration/src/tools/configuration.observer.ts
+++ b/packages/@o3r/configuration/src/tools/configuration.observer.ts
@@ -28,7 +28,7 @@ export class ConfigurationObserver<T extends Configuration> implements Observer<
     this.observable = this.subscriber
       .pipe(
         configurationService ? configurationService.getComponentConfig(configId, defaultConfig) : getConfiguration(defaultConfig),
-        shareReplay(1)
+        shareReplay({ refCount: true, bufferSize: 1 })
       );
   }
 

--- a/packages/@o3r/localization/src/tools/localization.service.ts
+++ b/packages/@o3r/localization/src/tools/localization.service.ts
@@ -220,7 +220,7 @@ export class LocalizationService {
   public translate(key: string, interpolateParams?: object) {
     return this.getKey(key).pipe(
       switchMap((translationKey) => this.getTranslationStream(translationKey, interpolateParams)),
-      shareReplay(1)
+      shareReplay({ refCount: true, bufferSize: 1 })
     );
   }
 }


### PR DESCRIPTION
## Proposed change
If translation or config is no longer subscribed to the value should be cleaned up

## Related issues

* :bug: Fix #2509
