### PR TITLE
fix(training): monaco editor tooltips not fully visible

### DIFF
--- a/apps/showcase/src/app/app.component.scss
+++ b/apps/showcase/src/app/app.component.scss
@@ -5,7 +5,7 @@ header {
   width: 100%;
   background: var(--df-primary-800);
   box-shadow: 0 0.5rem 1rem rgba(0,0,0,0.15), inset 0 -1px 0 rgba(255,255,255,0.15);
-  z-index: 1021;
+  z-index: var(--o3r-header-zindex);
   display: flex;
   align-items: center;
   justify-content: flex-start;

--- a/apps/showcase/src/components/training/code-editor-view/code-editor-view.component.html
+++ b/apps/showcase/src/components/training/code-editor-view/code-editor-view.component.html
@@ -1,6 +1,6 @@
 <as-split direction="vertical">
   <as-split-area [size]="50">
-    <form [formGroup]="form" class="editor overflow-hidden h-100">
+    <form [formGroup]="form" class="editor h-100">
       <as-split direction="horizontal">
         <as-split-area [size]="25">
           <monaco-tree (clickFile)="onClickFile($event)"
@@ -11,6 +11,7 @@
                        class="w-100 editor-view"></monaco-tree>
         </as-split-area>
         <as-split-area [size]="75" class="editor-view">
+            <div class="monaco-editor monaco-overflow-widgets position-absolute" #monacoOverflowWidgets></div>
           @let editorOptions = editorOptions$ | async;
           @if (editorOptions) {
             <ngx-monaco-editor class="h-100 position-relative"

--- a/apps/showcase/src/components/training/code-editor-view/code-editor-view.component.scss
+++ b/apps/showcase/src/components/training/code-editor-view/code-editor-view.component.scss
@@ -26,3 +26,7 @@ ngx-monaco-editor {
 .editor-view {
   background: #1d1d1d;
 }
+
+.monaco-overflow-widgets {
+  z-index: var(--o3r-header-zindex);
+}

--- a/apps/showcase/src/components/training/code-editor-view/code-editor-view.component.ts
+++ b/apps/showcase/src/components/training/code-editor-view/code-editor-view.component.ts
@@ -2,11 +2,13 @@ import {AsyncPipe, JsonPipe} from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   inject,
   Input,
   OnChanges,
   OnDestroy,
   SimpleChanges,
+  ViewChild,
   ViewEncapsulation
 } from '@angular/core';
 import {FormBuilder, FormControl, FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
@@ -87,6 +89,9 @@ export class CodeEditorViewComponent implements OnDestroy, OnChanges {
    */
   private readonly cwd$ = new BehaviorSubject('');
 
+  @ViewChild('monacoOverflowWidgets')
+  private readonly monacoOverflowWidgets!: ElementRef;
+
   /**
    * Allow to edit the code in the monaco editor
    */
@@ -134,7 +139,8 @@ export class CodeEditorViewComponent implements OnDestroy, OnChanges {
       language: editorOptionsLanguage[filePath.split('.').pop() || 'ts'] || editorOptionsLanguage.ts,
       readOnly: (this.editorMode === 'readonly'),
       automaticLayout: true,
-      scrollBeyondLastLine: false
+      scrollBeyondLastLine: false,
+      overflowWidgetsDomNode: this.monacoOverflowWidgets.nativeElement
     }))
   );
 

--- a/apps/showcase/src/components/utilities/scroll-back-top/scroll-back-top-pres.style.scss
+++ b/apps/showcase/src/components/utilities/scroll-back-top/scroll-back-top-pres.style.scss
@@ -3,7 +3,7 @@ o3r-scroll-back-top-pres {
   bottom: 0;
   right: 0;
   opacity: .5;
-  z-index: 1021;
+  z-index: var(--o3r-header-zindex);
 
   .btn {
     color: #000;

--- a/apps/showcase/src/styles.scss
+++ b/apps/showcase/src/styles.scss
@@ -2,6 +2,10 @@
 @import "highlight.js/styles/github.css";
 @import "./style/theme.scss";
 
+:root {
+  --o3r-header-zindex: 1021;
+}
+
 code {
   font-family: 'Consolas', monospace;
 }


### PR DESCRIPTION
## Proposed change

https://fpaul-1a.github.io/otter/#/sdk-training#1

![image](https://github.com/user-attachments/assets/69c07401-ae76-4d19-830e-e30e98735095)


Before:
![image](https://github.com/user-attachments/assets/274098fb-2339-4be5-878c-f477b5925c22)


## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
