### PR TITLE
fix(eslint): use cache for lint-staged + change command to not use no-error-on-unmatched-pattern

### DIFF
--- a/apps/chrome-devtools/project.json
+++ b/apps/chrome-devtools/project.json
@@ -138,7 +138,16 @@
       "dependsOn": ["^build"]
     },
     "lint": {
-      "executor": "nx:run-commands"
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "yarn eslint \"**/*.{m,c,}{j,t}s\" \"**/*.json\" \"**/*.html\""
+      },
+      "configurations": {
+        "ci": {
+          "command": "yarn eslint \"**/*.{m,c,}{j,t}s\" \"**/*.json\" \"**/*.html\" --quiet --cache-location .cache/eslint"
+        }
+      }
     },
     "test": {
       "executor": "@nx/jest:jest",

--- a/apps/showcase/project.json
+++ b/apps/showcase/project.json
@@ -39,7 +39,16 @@
       ]
     },
     "lint": {
-      "executor": "nx:run-commands"
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "yarn eslint \"**/*.{m,c,}{j,t}s\" \"**/*.json\" \"**/*.html\""
+      },
+      "configurations": {
+        "ci": {
+          "command": "yarn eslint \"**/*.{m,c,}{j,t}s\" \"**/*.json\" \"**/*.html\" --quiet --cache-location .cache/eslint"
+        }
+      }
     },
     "compile": {
       "executor": "@angular-devkit/build-angular:application",

--- a/nx.json
+++ b/nx.json
@@ -150,11 +150,11 @@
     "lint": {
       "options": {
         "cwd": "{projectRoot}",
-        "command": "yarn eslint \"**/*.{m,c,}{j,t}s\" \"**/*.html\" \"**/*.json\" --no-error-on-unmatched-pattern"
+        "command": "yarn eslint \"**/*.{m,c,}{j,t}s\" \"**/*.json\""
       },
       "configurations": {
         "ci": {
-          "command": "yarn eslint \"**/*.{m,c,}{j,t}s\" \"**/*.html\" \"**/*.json\" --quiet --cache-location .cache/eslint --no-error-on-unmatched-pattern"
+          "command": "yarn eslint \"**/*.{m,c,}{j,t}s\" \"**/*.json\" --quiet --cache-location .cache/eslint"
         }
       },
       "executor": "nx:run-commands",

--- a/package.json
+++ b/package.json
@@ -51,14 +51,8 @@
     "workspaces:list": "yarn workspaces list --no-private --json | yarn node -e 'let data=\"\"; process.openStdin().on(\"data\", (c) => data+=c).on(\"end\", () => process.stdout.write(data.split(/[\\n\\r]+/).filter((l) => !!l).map((l) => JSON.parse(l).location).join(require(\"node:path\").delimiter)));'"
   },
   "lint-staged": {
-    "*.ts": [
-      "eslint --quiet --fix"
-    ],
-    "**/package.json": [
-      "eslint --quiet --fix"
-    ],
-    "**/.yarnrc.yml": [
-      "eslint --quiet --fix"
+    "**/{package.json,.yarnrc.yml,*.ts,*.mts,*.cts*.js,*.mjs,*.cjs,*.html}": [
+      "eslint --quiet --fix --cache-location .cache/eslint"
     ],
     "*": [
       "editorconfig-checker -exclude \".*[\\\\/]templates[\\\\/].*\" -ignore-defaults --verbose"

--- a/packages/@o3r/components/project.json
+++ b/packages/@o3r/components/project.json
@@ -43,7 +43,16 @@
       }
     },
     "lint": {
-      "executor": "nx:run-commands"
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "yarn eslint \"**/*.{m,c,}{j,t}s\" \"**/*.json\" \"**/*.html\""
+      },
+      "configurations": {
+        "ci": {
+          "command": "yarn eslint \"**/*.{m,c,}{j,t}s\" \"**/*.json\" \"**/*.html\" --quiet --cache-location .cache/eslint"
+        }
+      }
     },
     "test": {
       "executor": "@nx/jest:jest",

--- a/packages/@o3r/rules-engine/project.json
+++ b/packages/@o3r/rules-engine/project.json
@@ -77,7 +77,16 @@
       }
     },
     "lint": {
-      "executor": "nx:run-commands"
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "yarn eslint \"**/*.{m,c,}{j,t}s\" \"**/*.json\" \"**/*.html\""
+      },
+      "configurations": {
+        "ci": {
+          "command": "yarn eslint \"**/*.{m,c,}{j,t}s\" \"**/*.json\" \"**/*.html\" --quiet --cache-location .cache/eslint"
+        }
+      }
     },
     "test": {
       "executor": "@nx/jest:jest",


### PR DESCRIPTION
## Proposed change
Try to improve eslint run via nx and lint-staged

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
