### PR TITLE
feat(training): file navigation inside code editor

### DIFF
--- a/apps/showcase/package.json
+++ b/apps/showcase/package.json
@@ -83,7 +83,7 @@
     "monaco-editor": "~0.50.0",
     "ngx-markdown": "^18.1.0",
     "ngx-monaco-editor-v2": "^18.0.0",
-    "ngx-monaco-tree": "^18.1.0",
+    "ngx-monaco-tree": "^18.4.0",
     "pixelmatch": "^5.2.1",
     "pngjs": "^7.0.0",
     "prism-themes": "^1.9.0",

--- a/apps/showcase/src/components/training/code-editor-view/code-editor-view.component.html
+++ b/apps/showcase/src/components/training/code-editor-view/code-editor-view.component.html
@@ -5,7 +5,7 @@
         <as-split-area [size]="25">
           <monaco-tree (clickFile)="onClickFile($event)"
                        [tree]="(cwdTree$ | async) || []"
-                       [currentFile]="project?.startingFile"
+                       [currentFile]="form.controls.file.value"
                        [width]="'auto'"
                        [height]="'auto'"
                        class="w-100 editor-view"></monaco-tree>
@@ -16,7 +16,9 @@
           @if (editorOptions) {
             <ngx-monaco-editor class="h-100 position-relative"
                                [options]="editorOptions"
+                               [model]="model()"
                                (keydown)="onEditorKeyDown($event)"
+                               (onInit)="newMonacoEditorCreated.next()"
                                formControlName="code">
             </ngx-monaco-editor>
           }
@@ -24,7 +26,7 @@
       </as-split>
     </form>
   </as-split-area>
-  @if (editorMode === 'interactive') {
+  @if (editorMode() === 'interactive') {
     <as-split-area [size]="50">
       <code-editor-control class="d-flex flex-column h-100"></code-editor-control>
     </as-split-area>

--- a/apps/showcase/src/components/training/code-editor-view/code-editor-view.component.ts
+++ b/apps/showcase/src/components/training/code-editor-view/code-editor-view.component.ts
@@ -1,21 +1,22 @@
 import {
   AsyncPipe,
-  JsonPipe,
 } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
+  effect,
   ElementRef,
   inject,
-  Input,
-  OnChanges,
+  input,
   OnDestroy,
-  SimpleChanges,
+  untracked,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
 import {
   takeUntilDestroyed,
+  toSignal,
 } from '@angular/core/rxjs-interop';
 import {
   FormBuilder,
@@ -33,6 +34,7 @@ import {
 import {
   AngularSplitModule,
 } from 'angular-split';
+import type * as Monaco from 'monaco-editor';
 import {
   MonacoEditorModule,
 } from 'ngx-monaco-editor-v2';
@@ -46,6 +48,7 @@ import {
   debounceTime,
   distinctUntilChanged,
   filter,
+  firstValueFrom,
   from,
   map,
   Observable,
@@ -53,17 +56,25 @@ import {
   share,
   skip,
   startWith,
+  Subject,
   switchMap,
 } from 'rxjs';
 import {
   checkIfPathInMonacoTree,
 } from '../../../helpers/monaco-tree.helper';
 import {
+  flattenTree,
   WebContainerService,
 } from '../../../services';
 import {
   CodeEditorControlComponent,
 } from '../code-editor-control';
+
+declare global {
+  interface Window {
+    monaco: typeof Monaco;
+  }
+}
 
 /** ngx-monaco-editor options language - determined based on file extension */
 const editorOptionsLanguage: Record<string, string> = {
@@ -96,7 +107,6 @@ export interface TrainingProject {
     AsyncPipe,
     CodeEditorControlComponent,
     FormsModule,
-    JsonPipe,
     MonacoEditorModule,
     NgxMonacoTreeComponent,
     ReactiveFormsModule,
@@ -107,7 +117,7 @@ export interface TrainingProject {
   templateUrl: './code-editor-view.component.html',
   styleUrl: './code-editor-view.component.scss'
 })
-export class CodeEditorViewComponent implements OnDestroy, OnChanges {
+export class CodeEditorViewComponent implements OnDestroy {
   /**
    * @see {FormBuilder}
    */
@@ -130,13 +140,13 @@ export class CodeEditorViewComponent implements OnDestroy, OnChanges {
   /**
    * Allow to edit the code in the monaco editor
    */
-  @Input() public editorMode: EditorMode = 'readonly';
+  public editorMode = input<EditorMode>('readonly');
   /**
    * Project to load in the code editor.
    * It should describe the files to load, the starting file, the folder dedicated to the project as well as the
    * commands to initialize the project
    */
-  @Input() public project?: TrainingProject;
+  public project = input.required<TrainingProject>();
   /**
    * Service to load files and run commands in the application instance of the webcontainer.
    */
@@ -168,22 +178,70 @@ export class CodeEditorViewComponent implements OnDestroy, OnChanges {
     });
 
   /**
+   * Subject used to notify when a new monaco editor has been created
+   */
+  public readonly newMonacoEditorCreated = new Subject<void>();
+
+  /**
+   * Promise resolved with the global monaco instance
+   */
+  private readonly monacoPromise = firstValueFrom(this.newMonacoEditorCreated.pipe(
+    map(() => window.monaco)
+  ));
+
+  /**
    * Configuration for the Monaco Editor
    */
   public editorOptions$ = this.form.controls.file.valueChanges.pipe(
     startWith(''),
     filter((filePath): filePath is string => !!filePath),
-    map((filePath) => ({
+    map(() => ({
       theme: 'vs-dark',
-      language: editorOptionsLanguage[filePath.split('.').pop() || 'ts'] || editorOptionsLanguage.ts,
-      readOnly: (this.editorMode === 'readonly'),
+      readOnly: (this.editorMode() === 'readonly'),
       automaticLayout: true,
       scrollBeyondLastLine: false,
-      overflowWidgetsDomNode: this.monacoOverflowWidgets.nativeElement
+      overflowWidgetsDomNode: this.monacoOverflowWidgets.nativeElement,
+      model: this.model()
     }))
   );
 
+  private readonly fileContentLoaded$ = this.form.controls.file.valueChanges.pipe(
+    takeUntilDestroyed(),
+    combineLatestWith(this.cwdTree$),
+    filter(([path, monacoTree]) => !!path && checkIfPathInMonacoTree(monacoTree, path.split('/'))),
+    switchMap(([path]) => from(this.webContainerService.readFile(`${this.project().cwd}/${path}`).catch(() => ''))),
+    share()
+  );
+
+  private readonly fileContent = toSignal(this.fileContentLoaded$);
+
+  /**
+   * Model used for monaco editor for the currently selected file.
+   * We need that to associate the opened file to a URI which is necessary to resolve relative paths on imports.
+   */
+  public model = computed(() => {
+    const value = this.fileContent();
+    const fileName = this.form.controls.file.value!;
+    const fileExtension = fileName.split('.').at(-1);
+    return {
+      value,
+      language: editorOptionsLanguage[fileExtension || ''] || '',
+      uri: `file:///${fileName}`
+    };
+  });
+
   constructor() {
+    effect(async () => {
+      const project = this.project();
+      await untracked(async () => {
+        if (project.files) {
+          // Remove link between launch project and terminals
+          await this.webContainerService.loadProject(project.files, project.commands, project.cwd);
+        }
+        await this.loadNewProject();
+        this.cwd$.next(project?.cwd || '');
+      });
+    });
     this.form.controls.code.valueChanges.pipe(
       distinctUntilChanged(),
       skip(1),
@@ -195,16 +253,115 @@ export class CodeEditorViewComponent implements OnDestroy, OnChanges {
         this.loggerService.error('No project found');
         return;
       }
-      const path = `${this.project.cwd}/${this.form.controls.file.value}`;
+      const path = `${this.project().cwd}/${this.form.controls.file.value}`;
       this.loggerService.log('Writing file', path);
       void this.webContainerService.writeFile(path, text);
     });
-    this.form.controls.file.valueChanges.pipe(
-      combineLatestWith(this.cwdTree$),
-      filter(([path, monacoTree]) => !!path && checkIfPathInMonacoTree(monacoTree, path.split('/'))),
-      switchMap(([path]) => from(this.webContainerService.readFile(`${this.project!.cwd}/${path}`).catch(() => ''))),
+    this.fileContentLoaded$.subscribe((content) => this.form.controls.code.setValue(content));
+
+    // Reload definition types when finishing install
+    this.webContainerService.runner.dependenciesLoaded$.pipe(
       takeUntilDestroyed()
-    ).subscribe((content) => this.form.controls.code.setValue(content));
+    ).subscribe(async () => {
+      await this.reloadDeclarationTypes();
+    });
+    const revealCodeInEditorRequest = new Subject<Monaco.IPosition | Monaco.IRange>();
+    revealCodeInEditorRequest.pipe(
+      takeUntilDestroyed(),
+      switchMap((selectionOrPosition) => this.newMonacoEditorCreated.pipe(map(() => selectionOrPosition)))
+    ).subscribe((selectionOrPosition) => {
+      if (window.monaco.Position.isIPosition(selectionOrPosition)) {
+        window.monaco.editor.getEditors()[0].revealPositionNearTop(selectionOrPosition);
+      } else {
+        window.monaco.editor.getEditors()[0].revealRangeNearTop(selectionOrPosition);
+      }
+    });
+    void this.monacoPromise.then((monaco) => {
+      monaco.editor.registerEditorOpener({
+        openCodeEditor: (_source: Monaco.editor.ICodeEditor, resource: Monaco.Uri, selectionOrPosition?: Monaco.IRange | Monaco.IPosition) => {
+          if (resource && this.project().files) {
+            const filePath = resource.path.slice(1);
+            // TODO write a proper function to search in the tree
+            const flatFiles = flattenTree(this.project().files);
+            if (flatFiles.some((projectFile) => projectFile.filePath === resource.path)) {
+              this.form.controls.file.setValue(filePath);
+              if (selectionOrPosition) {
+                revealCodeInEditorRequest.next(selectionOrPosition);
+                return true;
+              }
+            }
+          }
+          return false;
+        }
+      });
+      monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
+        allowNonTsExtensions: true,
+        target: monaco.languages.typescript.ScriptTarget.Latest,
+        module: monaco.languages.typescript.ModuleKind.ESNext,
+        moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,
+        paths: {
+          sdk: [
+            'file:///libs/sdk/src/index'
+          ],
+          'sdk/*': [
+            'file:///libs/sdk/src/*'
+          ]
+        }
+      });
+    });
+  }
+
+  /**
+   * Unload ahh the files from the global monaco editor
+   */
+  private async cleanAllModelsFromMonaco() {
+    const monaco = await this.monacoPromise;
+    monaco.editor.getModels().forEach((m) => m.dispose());
+  }
+
+  /**
+   * Load all the files from `this.project` as Models in the global monaco editor.
+   */
+  private async loadAllProjectFilesToMonaco() {
+    const monaco = await this.monacoPromise;
+    const flatFiles = flattenTree(this.project().files);
+    flatFiles.forEach(({ filePath, content }) => {
+      const language = editorOptionsLanguage[filePath.split('.').at(-1) || ''] || '';
+      monaco.editor.createModel(content, language, monaco.Uri.from({ scheme: 'file', path: filePath }));
+    });
+    // Refresh tsconfig paths mapping
+    monaco.languages.typescript.typescriptDefaults.setCompilerOptions(
+      monaco.languages.typescript.typescriptDefaults.getCompilerOptions()
+    );
+  }
+
+  /**
+   * Load a new project in global monaco editor and update local form accordingly
+   */
+  private async loadNewProject() {
+    if (this.project()?.startingFile) {
+      this.form.controls.file.setValue(this.project().startingFile);
+    } else {
+      this.form.controls.file.setValue('');
+      this.form.controls.code.setValue('');
+    }
+    await this.cleanAllModelsFromMonaco();
+    await this.loadAllProjectFilesToMonaco();
+  }
+
+  /**
+   * Reload declaration types from web-container
+   */
+  public async reloadDeclarationTypes() {
+    if (this.project().cwd) {
+      const declarationTypes = [
+        ...await this.webContainerService.getDeclarationTypes(this.project().cwd),
+        { filePath: 'file:///node_modules/@ama-sdk/core/index.d.ts', content: 'export * from "./src/public_api.d.ts";' },
+        { filePath: 'file:///node_modules/@ama-sdk/client-fetch/index.d.ts', content: 'export * from "./src/public_api.d.ts";' }
+      ];
+      const monaco = await this.monacoPromise;
+      monaco.languages.typescript.typescriptDefaults.setExtraLibs(declarationTypes);
+    }
   }
 
   public onEditorKeyDown(event: KeyboardEvent) {
@@ -219,32 +376,9 @@ export class CodeEditorViewComponent implements OnDestroy, OnChanges {
    * @inheritDoc
    */
   public async onClickFile(filePath: string) {
-    if (!this.project) {
-      return;
-    }
-    const path = `${this.project.cwd}/${filePath}`;
-    if (this.project && await this.webContainerService.isFile(path)) {
+    const path = `${this.project().cwd}/${filePath}`;
+    if (await this.webContainerService.isFile(path)) {
       this.form.controls.file.setValue(filePath);
-    }
-  }
-
-  /**
-   * @inheritDoc
-   */
-  public ngOnChanges(changes: SimpleChanges) {
-    if ('project' in changes) {
-      if (this.project?.files) {
-        // Remove link between launch project and terminals
-        void this.webContainerService.loadProject(this.project.files, this.project.commands, this.project.cwd);
-      }
-
-      if (this.project?.startingFile) {
-        this.form.controls.file.setValue(this.project.startingFile);
-      } else {
-        this.form.controls.file.setValue('');
-        this.form.controls.code.setValue('');
-      }
-      this.cwd$.next(this.project?.cwd || '');
     }
   }
 

--- a/apps/showcase/src/helpers/monaco-tree.helper.ts
+++ b/apps/showcase/src/helpers/monaco-tree.helper.ts
@@ -6,6 +6,9 @@ import type {
 import type {
   MonacoTreeElement,
 } from 'ngx-monaco-tree';
+import {
+  isDirectoryNode,
+} from '../services/webcontainer/webcontainer.helpers';
 
 /**
  * Check if the monaco tree contains the path in parameters
@@ -31,9 +34,8 @@ export function checkIfPathInMonacoTree(tree: MonacoTreeElement[], path: string[
 export function convertTreeRec(path: string, node: DirectoryNode | FileNode | SymlinkNode): MonacoTreeElement {
   return {
     name: path,
-    content: (node as DirectoryNode).directory
-      ? Object.entries((node as DirectoryNode).directory)
-        .map(([p, n]) => convertTreeRec(p, n))
+    content: isDirectoryNode(node)
+      ? Object.entries(node.directory).map(([p, n]) => convertTreeRec(p, n))
       : undefined
   };
 }

--- a/apps/showcase/src/services/webcontainer/webcontainer.helpers.ts
+++ b/apps/showcase/src/services/webcontainer/webcontainer.helpers.ts
@@ -3,6 +3,10 @@ import {
   getFilesTree,
 } from '@o3r-training/training-tools';
 import {
+  type DirectoryNode,
+  type FileNode,
+  type FileSystemTree,
+  type SymlinkNode,
   WebContainer,
   WebContainerProcess,
 } from '@webcontainer/api';
@@ -60,4 +64,80 @@ export const makeProcessWritable = (process: WebContainerProcess, terminal: Term
   const input = process.input.getWriter();
   terminal.onData((data) => input.write(data));
   return input;
+};
+
+/**
+ * Ensure that node input node is a DirectoryNode
+ * @param node
+ */
+export const isDirectoryNode = (node: DirectoryNode | FileNode | SymlinkNode): node is DirectoryNode => !!(node as DirectoryNode).directory;
+
+/**
+ * Ensure that node input node is a FileNode
+ * @param node
+ */
+export const isFileNode = (node: DirectoryNode | FileNode | SymlinkNode): node is FileNode => !!(node as FileNode).file;
+
+/**
+ * Deep merge of directories
+ * @param dirBase Base directory
+ * @param dirOverride Directory to override base
+ */
+export const mergeDirectories = (dirBase: DirectoryNode, dirOverride: DirectoryNode): DirectoryNode => {
+  const merge = structuredClone(dirBase);
+  Object.entries(dirOverride.directory).forEach(([path, node]) => {
+    const baseNode = merge.directory[path];
+    if (!baseNode || (isFileNode(node) && isFileNode(baseNode))) {
+      // Not present in base directory
+      // Or present in both as file
+      merge.directory[path] = node;
+    } else if (isDirectoryNode(node) && isDirectoryNode(baseNode)) {
+      // Present in both as directory
+      merge.directory[path] = mergeDirectories(baseNode, node);
+    } else {
+      throw new Error('Cannot merge file and directory together');
+    }
+  });
+  return merge;
+};
+
+/**
+ * Merge a sub file system into another
+ * @param fileSystemTree Original file system.
+ * @param fileSystemOverride File system that should be merged with the original. Its files take precedence over the original one.
+ * @param path Location in mergeFolder where fileSystemOverride should be merged.
+ */
+export function overrideFileSystemTree(fileSystemTree: FileSystemTree, fileSystemOverride: FileSystemTree, path: string[]): FileSystemTree {
+  const key = path.shift() as string;
+  const target = fileSystemTree[key] || { directory: {} };
+  if (path.length === 0 && isDirectoryNode(target)) {
+    // Exploration of file system is done, we can merge the directories
+    fileSystemTree[key] = mergeDirectories(target, { directory: fileSystemOverride });
+  } else if (isDirectoryNode(target)) {
+    fileSystemTree[key] = {
+      directory: {
+        ...target.directory,
+        ...overrideFileSystemTree(target.directory, fileSystemOverride, path)
+      }
+    };
+  } else {
+    throw new Error(`Cannot override the file ${key} with a folder`);
+  }
+  return fileSystemTree;
+}
+
+/**
+ * Flatten a tree to an array of objects with filePath and content
+ * @param tree
+ * @param basePath
+ */
+export const flattenTree = (tree: FileSystemTree, basePath = ''): { filePath: string; content: string }[] => {
+  return Object.entries(tree).reduce((out, [path, node]) => {
+    if (isDirectoryNode(node)) {
+      out.push(...flattenTree(node.directory, `${basePath}/${path}`));
+    } else if (isFileNode(node)) {
+      out.push({ filePath: `${basePath}/${path}`, content: (node.file as any).contents });
+    }
+    return out;
+  }, [] as { filePath: string; content: string }[]);
 };

--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
     "ng-packagr": "~18.2.0",
     "ngx-markdown": "^18.1.0",
     "ngx-monaco-editor-v2": "^18.0.0",
-    "ngx-monaco-tree": "^18.1.0",
+    "ngx-monaco-tree": "^18.4.0",
     "npm-run-all2": "^6.0.0",
     "nx": "~19.5.0",
     "nx-cloud": "^19.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9346,7 +9346,7 @@ __metadata:
     ng-packagr: "npm:~18.2.0"
     ngx-markdown: "npm:^18.1.0"
     ngx-monaco-editor-v2: "npm:^18.0.0"
-    ngx-monaco-tree: "npm:^18.1.0"
+    ngx-monaco-tree: "npm:^18.4.0"
     npm-run-all2: "npm:^6.0.0"
     nx: "npm:~19.5.0"
     nx-cloud: "npm:^19.1.0"
@@ -10331,7 +10331,7 @@ __metadata:
     monaco-editor: "npm:~0.50.0"
     ngx-markdown: "npm:^18.1.0"
     ngx-monaco-editor-v2: "npm:^18.0.0"
-    ngx-monaco-tree: "npm:^18.1.0"
+    ngx-monaco-tree: "npm:^18.4.0"
     pixelmatch: "npm:^5.2.1"
     playwright-lighthouse: "npm:~4.0.0"
     pngjs: "npm:^7.0.0"
@@ -29107,9 +29107,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ngx-monaco-tree@npm:^18.1.0":
-  version: 18.3.0
-  resolution: "ngx-monaco-tree@npm:18.3.0"
+"ngx-monaco-tree@npm:^18.4.0":
+  version: 18.4.0
+  resolution: "ngx-monaco-tree@npm:18.4.0"
   dependencies:
     tslib: "npm:^2.7.0"
   peerDependencies:
@@ -29117,7 +29117,7 @@ __metadata:
     "@angular/common": ^18.2.2
     "@angular/core": ^18.2.2
     "@vscode/codicons": ^0.0.32
-  checksum: 10/ee369bc9b313ab6cafa12c58d9502dbeb4f33df61cc2c09e5e59dfec0e87c766889ed329f01566731d84fc8fc4193c74e6b4e8b6b331ce5fff1505b531ca2154
+  checksum: 10/f17f60a374069dc80a3eff730b94c22cadbfcbadd36c6343a180ddcc460ecd185175f18975247d595f5335335ea632a13427db307dfc077997165e7e296570d1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed change

Enable `Go to Definition` feature (Ctrl+click), auto complete and avoid errors on imports.
https://fpaul-1a.github.io/otter/#/sdk-training#1

![image](https://github.com/user-attachments/assets/02527b55-e049-49bd-a586-895001799363)

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
