### PR TITLE
fix: do not publish training package; not needed

### DIFF
--- a/packages/@o3r-training/showcase-sdk/package.json
+++ b/packages/@o3r-training/showcase-sdk/package.json
@@ -13,9 +13,7 @@
   "types": "index.d.ts",
   "sideEffects": false,
   "deprecated": "This package is intended for testing purposes only.",
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "exports": {
     "./package.json": {
       "default": "./package.json"
@@ -49,7 +47,6 @@
     "spec:regen": "yarn run generate --no-dry-run && amasdk-clear-index",
     "files:pack": "yarn amasdk-files-pack",
     "test": "jest --passWithNoTests",
-    "publish:package": "npm publish ./dist",
     "generate:mock": "schematics ../../@ama-sdk/schematics:mock",
     "doc:generate": "node scripts/override-readme.js && typedoc && node scripts/restore-readme.js",
     "tools:changelog": "commit-and-tag-version"

--- a/packages/@o3r-training/showcase-sdk/project.json
+++ b/packages/@o3r-training/showcase-sdk/project.json
@@ -30,12 +30,6 @@
           "packages/@o3r-training/showcase-sdk/package.json"
         ]
       }
-    },
-    "publish": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "npm publish packages/@o3r-training/showcase-sdk/dist"
-      }
     }
   },
   "tags": ["showcase"]


### PR DESCRIPTION
## Proposed change
Remove the '@o3r-training/showcase-sdk' package from the published packages. It is not needed to be installed during the training and has no value outside the training.
<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
