### PR TITLE
chore: deprecate outdate java-sdk generator

### DIFF
--- a/packages/@ama-sdk/schematics/collection.json
+++ b/packages/@ama-sdk/schematics/collection.json
@@ -33,7 +33,7 @@
       "schema": "./schematics/typescript/shell/schema.json"
     },
     "java-client-core": {
-      "description": "Generate a Java SDK source code based on swagger specification",
+      "description": "[Deprecated - Removed in v12] Generate a Java SDK source code based on swagger specification",
       "factory": "./schematics/java/client-core/index#ngGenerateJavaClientCore",
       "schema": "./schematics/java/client-core/schema.json"
     }

--- a/packages/@ama-sdk/schematics/schematics/code-generator/swagger-java-generator/swagger-java.generator.ts
+++ b/packages/@ama-sdk/schematics/schematics/code-generator/swagger-java-generator/swagger-java.generator.ts
@@ -14,6 +14,7 @@ import {
 /**
  * Manage the schematic to generate a sdk using the Swagger 2 Generator
  * Note: a working java setup compatible with Swagger 2 Generator is required to use this class
+ * @deprecated to be removed in v12
  */
 export class SwaggerJavaGenerator extends CodeGenerator<JavaGeneratorTaskOptions> {
   /** @inheritDoc */

--- a/packages/@ama-sdk/schematics/schematics/java/client-core/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/java/client-core/index.ts
@@ -93,6 +93,7 @@ function ngGenerateJavaClientCoreFn(options: NgGenerateJavaClientCoreSchematicsS
 
 /**
  * Generate a Java client SDK source code base on swagger specification
+ * @deprecated Remove in otter v12
  * @param options
  */
 export const ngGenerateJavaClientCore = (options: NgGenerateJavaClientCoreSchematicsSchema) => async () => {

--- a/packages/@ama-sdk/schematics/schematics/java/client-core/swagger-codegen-java-client/README.md
+++ b/packages/@ama-sdk/schematics/schematics/java/client-core/swagger-codegen-java-client/README.md
@@ -1,7 +1,11 @@
-# Swagger Codegen for the javaClient library
+# Swagger Codegen for the javaClient library [Deprecated]
+
+> [!WARN]
+> This project is no longer maintained and is now fully deprecated. We intend to delete it from Otter v12
+> It is based on old version of the SwaggerCodegen tool which is not even compatible with today's standard.
 
 ## Overview
-This is a boiler-plate project to generate your own client library with Swagger.  Its goal is
+This is a boilerplate project to generate your own client library with Swagger.  Its goal is
 to get you started with the basic plumbing so you can put in your own logic.  It won't work without
 your changes applied.
 


### PR DESCRIPTION
## Proposed change

Deprecate the java-sdk generator which is not compatible with OpenApi 3.