### PR TITLE
feat(training): persistence of code modifications

### DIFF
--- a/apps/showcase/src/components/training/code-editor-view/code-editor-view.component.html
+++ b/apps/showcase/src/components/training/code-editor-view/code-editor-view.component.html
@@ -1,6 +1,6 @@
 <as-split direction="vertical">
   <as-split-area [size]="editorMode() === 'interactive' ? 50 : 100">
-    <form [formGroup]="form" class="editor h-100">
+    <form [formGroup]="form" class="editor h-100 overflow-hidden position-relative">
       <as-split direction="horizontal">
         <as-split-area [size]="25">
           <monaco-tree (clickFile)="onClickFile($event)"
@@ -11,7 +11,6 @@
                        class="w-100 editor-view"></monaco-tree>
         </as-split-area>
         <as-split-area [size]="75" class="editor-view">
-          <div class="monaco-editor monaco-overflow-widgets position-absolute" #monacoOverflowWidgets></div>
           @let editorOptions = editorOptions$ | async;
           @if (editorOptions) {
             <ngx-monaco-editor class="h-100 position-relative"

--- a/apps/showcase/src/components/training/code-editor-view/code-editor-view.component.scss
+++ b/apps/showcase/src/components/training/code-editor-view/code-editor-view.component.scss
@@ -27,6 +27,10 @@ ngx-monaco-editor {
   background: #1d1d1d;
 }
 
-.monaco-overflow-widgets {
-  z-index: var(--o3r-header-zindex);
+.save-code-dialog-backdrop {
+  position: absolute;
+}
+
+.save-code-dialog-window {
+  position: absolute;
 }

--- a/apps/showcase/src/components/training/save-code-dialog/index.ts
+++ b/apps/showcase/src/components/training/save-code-dialog/index.ts
@@ -1,0 +1,1 @@
+export * from './save-code-dialog.component';

--- a/apps/showcase/src/components/training/save-code-dialog/save-code-dialog.component.spec.ts
+++ b/apps/showcase/src/components/training/save-code-dialog/save-code-dialog.component.spec.ts
@@ -1,0 +1,26 @@
+import {
+  ComponentFixture,
+  TestBed,
+} from '@angular/core/testing';
+import {
+  SaveCodeDialogComponent,
+} from './save-code-dialog.component';
+
+describe('ViewComponent', () => {
+  let component: SaveCodeDialogComponent;
+  let fixture: ComponentFixture<SaveCodeDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SaveCodeDialogComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SaveCodeDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/showcase/src/components/training/save-code-dialog/save-code-dialog.component.ts
+++ b/apps/showcase/src/components/training/save-code-dialog/save-code-dialog.component.ts
@@ -1,0 +1,19 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+} from '@angular/core';
+import {
+  NgbActiveModal,
+} from '@ng-bootstrap/ng-bootstrap';
+
+@Component({
+  selector: 'code-editor-terminal',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [],
+  templateUrl: './save-code-dialog.template.html'
+})
+export class SaveCodeDialogComponent {
+  public readonly activeModal = inject(NgbActiveModal);
+}

--- a/apps/showcase/src/components/training/save-code-dialog/save-code-dialog.template.html
+++ b/apps/showcase/src/components/training/save-code-dialog/save-code-dialog.template.html
@@ -1,0 +1,10 @@
+<div class="modal-header">
+  <h2 class="modal-title">Code modifications detected</h2>
+</div>
+<div class="modal-body">
+  <p>Do you want to resume your training or discard your changes?</p>
+</div>
+<div class="modal-footer">
+  <button type="button" class="btn btn-outline-danger me-5" (click)="activeModal.close(false)">Discard</button>
+  <button type="button" class="btn btn-primary" ngbAutofocus (click)="activeModal.close(true)">Resume</button>
+</div>

--- a/apps/showcase/src/components/training/training-step/training-step-pres.component.html
+++ b/apps/showcase/src/components/training/training-step/training-step-pres.component.html
@@ -1,7 +1,7 @@
 <div class="h-100">
   <as-split direction="horizontal">
     @if (instructions) {
-      <as-split-area [size]="50">
+      <as-split-area [size]="project ? 50 : 100">
         <div class="instructions h-100 overflow-auto pe-6">
           <h2>{{title}}</h2>
           <markdown clipboard [data]="instructions"></markdown>
@@ -9,7 +9,7 @@
       </as-split-area>
     }
     @if (project) {
-      <as-split-area [size]="50">
+      <as-split-area [size]="instructions ? 50 : 100">
         <div class="h-100 overflow-hidden">
           <code-editor-view
             [project]="project"


### PR DESCRIPTION
## Proposed change
Add persistence in `localStorage` of code modifications in a training step.
When the user refresh or come back on the training on which code modifications were made, we prompt a dialog to ask if he wants to keep the changes or discard them.
![image](https://github.com/user-attachments/assets/b55fccc4-97a8-44b4-be69-2bcebf586e55)


With this feature we think also to add a `Reset` or `Discard changes` button, it will be done in another PR, unless someone think it's a must inside this PR.