### PR TITLE
fix: remove pattern for ref property in localization.metadata.schema.json

### DIFF
--- a/packages/@o3r/localization/schemas/localization.metadata.schema.json
+++ b/packages/@o3r/localization/schemas/localization.metadata.schema.json
@@ -20,8 +20,7 @@
           },
           "ref": {
             "type": "string",
-            "description": "Reference to a local localization",
-            "pattern": "^[^/]*$"
+            "description": "Reference to a local localization"
           },
           "description": {
             "type": "string",


### PR DESCRIPTION
There is no point validating the ref if we don't validate the key.