### PR TITLE
chore: add codeowners for CMS specifications

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,15 +9,14 @@
 ## Default reviewers for Anayltics build metrics webpack plugin
 # /packages/@o3r/analytics/plugins/webpack/build-metrics @rglearns
 
-## Default reviewers for AEM Plugin JSON Schemas
-# /packages/@o3r/application/schemas/ @guillaume-goulet
-# /packages/@o3r/localization/schemas/ @guillaume-goulet
-# /packages/@o3r/configuration/schemas/ @guillaume-goulet
-# /packages/@o3r/components/schemas/ @guillaume-goulet
-# /packages/@o3r/dynamic-content/schemas/ @guillaume-goulet
-# /packages/@o3r/extractors/schemas/ @guillaume-goulet
-# /packages/@o3r/rules-engine/schemas/ @guillaume-goulet
-
+# Default reviewers for CMS Plugin JSON Schemas
+/packages/@o3r/application/schemas/ @AmadeusITGroup/otter_cms
+/packages/@o3r/localization/schemas/ @AmadeusITGroup/otter_cms
+/packages/@o3r/configuration/schemas/ @AmadeusITGroup/otter_cms
+/packages/@o3r/components/schemas/ @AmadeusITGroup/otter_cms
+/packages/@o3r/dynamic-content/schemas/ @AmadeusITGroup/otter_cms
+/packages/@o3r/extractors/schemas/ @AmadeusITGroup/otter_cms
+/packages/@o3r/rules-engine/schemas/ @AmadeusITGroup/otter_cms
 
 # Default reviewers for Intellij extension
 /apps/intellij-extension/ @OxyFlax

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ dist-lint/
 tmp/
 .acache/
 *.tsbuildinfo
+/bin
 
 # Documentations
 /documentation.json


### PR DESCRIPTION
## Proposed change

chore: add codeowners for CMS specifications
chore: add /bin folder to gitignore

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
