### PR TITLE
chore(eslint-plugin): rely on base template parser

### DIFF
--- a/packages/@o3r/eslint-plugin/package.json
+++ b/packages/@o3r/eslint-plugin/package.json
@@ -56,6 +56,7 @@
   "devDependencies": {
     "@angular-devkit/core": "~18.2.0",
     "@angular-devkit/schematics": "~18.2.0",
+    "@angular-eslint/template-parser": "~18.4.0",
     "@angular-eslint/test-utils": "~18.4.0",
     "@angular/compiler": "~18.2.0",
     "@babel/core": "~7.26.0",

--- a/packages/@o3r/eslint-plugin/src/rules/template/no-inner-html/no-inner-html.spec.ts
+++ b/packages/@o3r/eslint-plugin/src/rules/template/no-inner-html/no-inner-html.spec.ts
@@ -1,22 +1,26 @@
 import {
+  meta,
+  parseForESLint,
+} from '@angular-eslint/template-parser';
+import {
   RuleTester,
 } from '@angular-eslint/test-utils';
-import {
-  templateParser,
-} from 'angular-eslint';
 import noInnerHTMLRule, {
   name,
 } from './no-inner-html';
 
 const ruleTester = new RuleTester({
   languageOptions: {
-    parser: templateParser
+    parser: {
+      meta,
+      parseForESLint
+    }
   }
 });
 
 const validHTML = '<p innerText="test"></p>';
 
-ruleTester.run(name, noInnerHTMLRule as any /* workaround for 5.9.0 breaking change on interface */, {
+ruleTester.run(name, noInnerHTMLRule, {
   valid: [validHTML],
   invalid: [
     {

--- a/packages/@o3r/eslint-plugin/src/rules/template/template-async-number-limitation/template-async-number-limitation.spec.ts
+++ b/packages/@o3r/eslint-plugin/src/rules/template/template-async-number-limitation/template-async-number-limitation.spec.ts
@@ -1,21 +1,25 @@
 import {
+  meta,
+  parseForESLint,
+} from '@angular-eslint/template-parser';
+import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/test-utils';
-import {
-  templateParser,
-} from 'angular-eslint';
 import templateAsyncNumberLimitation, {
   name,
 } from './template-async-number-limitation';
 
 const ruleTester = new RuleTester({
   languageOptions: {
-    parser: templateParser
+    parser: {
+      meta,
+      parseForESLint
+    }
   }
 });
 
-ruleTester.run(name, templateAsyncNumberLimitation as any /* workaround for 5.9.0 breaking change on interface */, {
+ruleTester.run(name, templateAsyncNumberLimitation, {
   valid: [
     '',
     '<div ngIf="obs$ | async"></div>',

--- a/tools/github-actions/new-version/packaged-action/LICENSE.txt
+++ b/tools/github-actions/new-version/packaged-action/LICENSE.txt
@@ -94,33 +94,6 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 @o3r/new-version
-Copyright Amadeus SAS
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation and/or
-other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors
-may be used to endorse or promote products derived from this software without
-specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 @octokit/auth-token
 MIT

--- a/yarn.lock
+++ b/yarn.lock
@@ -1331,7 +1331,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular-eslint/template-parser@npm:18.4.3":
+"@angular-eslint/template-parser@npm:18.4.3, @angular-eslint/template-parser@npm:~18.4.0":
   version: 18.4.3
   resolution: "@angular-eslint/template-parser@npm:18.4.3"
   dependencies:
@@ -8909,6 +8909,7 @@ __metadata:
   dependencies:
     "@angular-devkit/core": "npm:~18.2.0"
     "@angular-devkit/schematics": "npm:~18.2.0"
+    "@angular-eslint/template-parser": "npm:~18.4.0"
     "@angular-eslint/test-utils": "npm:~18.4.0"
     "@angular/compiler": "npm:~18.2.0"
     "@babel/core": "npm:~7.26.0"


### PR DESCRIPTION
## Proposed change

chore(eslint-plugin): rely on base template parser instead of angular-eslint one

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
