### PR TITLE
feat(config): add support for restrictionKeys

### DIFF
--- a/apps/showcase/eslint.local.config.mjs
+++ b/apps/showcase/eslint.local.config.mjs
@@ -67,6 +67,12 @@ export default [
             }
           }
         }
+      ],
+      '@o3r/o3r-restriction-key-tags': [
+        'error',
+        {
+          supportedKeys: ['api owners']
+        }
       ]
     }
   }

--- a/apps/showcase/src/components/showcase/configuration/configuration-pres.config.ts
+++ b/apps/showcase/src/components/showcase/configuration/configuration-pres.config.ts
@@ -36,6 +36,7 @@ export interface ConfigurationPresConfig extends Configuration {
    * @o3rWidgetParam allDestinationsDifferent true
    * @o3rWidgetParam atLeastOneDestinationAvailable true
    * @o3rWidgetParam destinationPattern "[A-Z][a-zA-Z-' ]+"
+   * @o3rRestrictionKey "api owners"
    */
   destinations: DestinationConfiguration[];
   /**

--- a/docs/ab-testing/AB_TESTING.md
+++ b/docs/ab-testing/AB_TESTING.md
@@ -100,8 +100,9 @@ export class ExperimentFactsService extends FactsService<ExperimentFacts> {
   }
 }
 ```
-**Warning** Your service must be imported only once in the application. A good way to do it is to provide it in root as
-a singleton.
+> [!WARNING]
+> Your service must be imported only once in the application.
+> A good way to do it is to provide it in root as a singleton.
 
 #### The A/B Testing service
 Now, you need to link ``ExperimentFactsService`` and the ``AbTestBridge`` to update the ``experiments`` fact that reflects the

--- a/docs/linter/eslint-plugin/rules/o3r-restriction-key-tags.md
+++ b/docs/linter/eslint-plugin/rules/o3r-restriction-key-tags.md
@@ -1,0 +1,65 @@
+# @o3r/o3r-restriction-key-tags
+
+Ensures that the tags `@o3rRestrictionKey` are used with correct values.
+
+> [!WARNING]
+> This rule must be configured to be used.
+
+## How to use
+
+```json
+{
+  "@o3r/o3r-restriction-key-tags": [
+    "error",
+    {
+      "supportedInterfaceNames": ["NestedConfiguration", "Configuration", "CustomConfigurationInterface"],
+      "supportedKeys": ["restriction", "restriction_with_underscores", "restriction with spaces"]
+    }
+  ]
+}
+```
+
+## Valid code example
+
+```typescript
+export interface ConfigExample extends Configuration {
+  /**
+   * @o3rRestrictionKey restriction_with_underscores
+   */
+  prop1: string;
+  /**
+   * @o3rRestrictionKey restriction
+   * @o3rRestrictionKey "restriction with spaces"
+   */
+  prop2: string;
+}
+```
+
+## Invalid code example
+
+```typescript
+export interface ConfigExample extends Configuration {
+  /**
+   * @o3rRestrictionKey restriction with spaces
+   */
+  prop: string;
+}
+```
+
+```typescript
+export interface ConfigExample extends Configuration {
+  /**
+   * @o3rRestrictionKey unknownRestriction
+   */
+  prop: string | number;
+}
+```
+
+```typescript
+export interface NotAConfigInterface {
+  /**
+   * @o3rRestrictionKey restriction
+   */
+  prop: string;
+}
+```

--- a/docs/linter/eslint-plugin/rules/o3r-widget-tags.md
+++ b/docs/linter/eslint-plugin/rules/o3r-widget-tags.md
@@ -1,9 +1,9 @@
 # @o3r/o3r-widget-tags
 
-Ensures that @o3rWidget and @o3rWidgetParam are used with correct value.
+Ensures that the tags @o3rWidget and @o3rWidgetParam are used with correct values.
 
-
-**Warning** This rule must be configured to be used.
+> [!WARNING]
+> This rule must be configured to be used.
 
 ## How to use
 

--- a/packages/@o3r/components/builders/component-extractor/helpers/component/component-config.extractor.ts
+++ b/packages/@o3r/components/builders/component-extractor/helpers/component/component-config.extractor.ts
@@ -255,6 +255,7 @@ export class ComponentConfigExtractor {
     const res: ConfigProperty = {
       description: configDocInfo?.description || '',
       category: configDocInfo?.category,
+      restrictionKeys: configDocInfo?.restrictionKeys,
       label: configDocInfo?.label || name.replace(/([A-Z])/g, ' $1'),
       name,
       type: 'unknown',

--- a/packages/@o3r/components/src/core/component.output.ts
+++ b/packages/@o3r/components/src/core/component.output.ts
@@ -106,6 +106,8 @@ export interface ConfigProperty {
   widget?: ConfigPropertyWidget;
   /** If true, the CMS user must specify a value for the property */
   required?: boolean;
+  /** Restriction keys */
+  restrictionKeys?: string[];
 }
 
 /**

--- a/packages/@o3r/configuration/schemas/configuration.metadata.schema.json
+++ b/packages/@o3r/configuration/schemas/configuration.metadata.schema.json
@@ -186,6 +186,13 @@
               "items": {
                 "type": "string"
               }
+            },
+            "restrictionKeys": {
+              "type": "array",
+              "description": "Restriction keys to customize the user permissions",
+              "items": {
+                "type": "string"
+              }
             }
           },
           "allOf": [

--- a/packages/@o3r/eslint-config-otter/rules/typescript/jsdoc.cjs
+++ b/packages/@o3r/eslint-config-otter/rules/typescript/jsdoc.cjs
@@ -20,7 +20,7 @@ module.exports = {
     'jsdoc/check-tag-names': [
       'warn',
       {
-        definedTags: ['note', 'title', 'o3rCategory', 'o3rCategories', 'o3rWidget', 'o3rWidgetParam', 'o3rRequired']
+        definedTags: ['note', 'title', 'o3rRestrictionKey', 'o3rCategory', 'o3rCategories', 'o3rWidget', 'o3rWidgetParam', 'o3rRequired']
       }
     ],
     'jsdoc/check-types': 'warn',

--- a/packages/@o3r/eslint-config/src/rules/typescript/jsdoc.cjs
+++ b/packages/@o3r/eslint-config/src/rules/typescript/jsdoc.cjs
@@ -20,7 +20,7 @@ const config = [
       'jsdoc/check-tag-names': [
         'error',
         {
-          definedTags: ['note', 'title', 'o3rCategory', 'o3rCategories', 'o3rWidget', 'o3rWidgetParam', 'o3rRequired']
+          definedTags: ['note', 'title', 'o3rRestrictionKey', 'o3rCategory', 'o3rCategories', 'o3rWidget', 'o3rWidgetParam', 'o3rRequired']
         }
       ],
       'jsdoc/no-defaults': 'off',

--- a/packages/@o3r/eslint-plugin/src/index.ts
+++ b/packages/@o3r/eslint-plugin/src/index.ts
@@ -5,6 +5,7 @@ import matchingConfigurationName from './rules/typescript/matching-configuration
 import noFolderImportForModule from './rules/typescript/no-folder-import-for-module/no-folder-import-for-module';
 import noMultipleTypeConfigurationProperty from './rules/typescript/no-multiple-type-configuration-property/no-multiple-type-configuration-property';
 import o3rCategoriesTags from './rules/typescript/o3r-categories-tags/o3r-categories-tags';
+import o3rRestrictionKeyTags from './rules/typescript/o3r-restriction-key-tags/o3r-restriction-key-tags';
 import o3rWidgetTags from './rules/typescript/o3r-widget-tags/o3r-widget-tags';
 import yarnrcPackageExtensionHarmonize from './rules/yaml/yarnrc-package-extensions-harmonize/yarnrc-package-extensions-harmonize';
 
@@ -18,7 +19,8 @@ module.exports = {
     'matching-configuration-name': matchingConfigurationName,
     'yarnrc-package-extensions-harmonize': yarnrcPackageExtensionHarmonize,
     'no-multiple-type-configuration-property': noMultipleTypeConfigurationProperty,
-    'o3r-categories-tags': o3rCategoriesTags
+    'o3r-categories-tags': o3rCategoriesTags,
+    'o3r-restriction-key-tags': o3rRestrictionKeyTags
   },
   configs: {
     '@o3r/no-folder-import-for-module': 'error',

--- a/packages/@o3r/eslint-plugin/src/rules/typescript/o3r-restriction-key-tags/o3r-restriction-key-tags.spec.ts
+++ b/packages/@o3r/eslint-plugin/src/rules/typescript/o3r-restriction-key-tags/o3r-restriction-key-tags.spec.ts
@@ -1,0 +1,131 @@
+import o3rRestrictionKeyRule, {
+  O3rRestrictionKeyTagsRuleOption,
+} from './o3r-restriction-key-tags';
+const {
+  RuleTester
+} = require('@typescript-eslint/rule-tester');
+
+const ruleTester = new RuleTester();
+
+const code = `
+export interface Config extends Configuration {
+  /**
+   * @o3rRestrictionKey valid
+   * @o3rRestrictionKey valid_with_underscore
+   * @o3rRestrictionKey 'valid with space (single quote)'
+   * @o3rRestrictionKey "valid with space (double quote)"
+   * @o3rRestrictionKey '"valid" with double quote inside'
+   * @o3rRestrictionKey "'valid' with single quote inside"
+   * @o3rRestrictionKey valid_with_number_1
+   */
+  prop: string;
+}
+`;
+
+const supportedKeys = [
+  'valid',
+  'valid_with_underscore',
+  'valid with space',
+  'valid with space (single quote)',
+  'valid with space (double quote)',
+  '"valid" with double quote inside',
+  "'valid' with single quote inside",
+  'valid_with_number_1'
+];
+
+const options = [{ supportedKeys }] as const satisfies Readonly<[O3rRestrictionKeyTagsRuleOption]>;
+
+const unknownKeys = [
+  `unknown_restriction`,
+  `"invalid quote'`,
+  `'another invalid quote"`,
+  `'unknown with single quote'`,
+  `"unknown with double quote"`
+];
+
+const getCodeFor = (key: string) => `
+export interface Config extends Configuration {
+  /**
+   * @o3rRestrictionKey ${key}
+   */
+  prop: string;
+}
+`;
+
+const getSuggestionFor = (actualKey: string) => supportedKeys.map((supportedKey) => ({
+  messageId: 'suggestUseSupportedKey',
+  data: {
+    actualKey,
+    supportedKey
+  },
+  output: getCodeFor(/[^\w]/.test(supportedKey) ? `"${supportedKey}"` : supportedKey)
+}));
+
+ruleTester.run('o3r-restriction-key-tags', o3rRestrictionKeyRule, {
+  valid: [
+    {
+      code,
+      options
+    },
+    {
+      code: `
+export interface Config extends Configuration {
+  /**
+   * Property without restriction
+   */
+  prop: string;
+}`,
+      options
+    }
+  ],
+  invalid: [
+    {
+      code: getCodeFor('"at least one key provided"'),
+      options: [{}],
+      errors: [
+        { messageId: 'noRestrictionKeyProvided' }
+      ]
+    },
+    {
+      code: code.replace(' extends Configuration', ''),
+      options,
+      errors: [
+        {
+          messageId: 'notInConfigurationInterface'
+        }
+      ]
+    },
+    {
+      code: getCodeFor('valid with space'),
+      options,
+      output: getCodeFor(`"valid with space"`),
+      errors: [
+        {
+          messageId: 'notWrapWithQuotes',
+          data: {
+            actualKey: 'valid with space'
+          },
+          suggestions: [{
+            messageId: 'suggestWrapWithQuotes',
+            data: {
+              actualKey: 'valid with space'
+            },
+            output: getCodeFor(`"valid with space"`)
+          }]
+        }
+      ]
+    },
+    ...unknownKeys.map((key) => ({
+      code: getCodeFor(key),
+      options,
+      errors: [{
+        messageId: 'notSupportedKey',
+        data: {
+          actualKey: key,
+          supportedKeys: supportedKeys.join(', ')
+        },
+        suggestions: getSuggestionFor(key)
+      }]
+    }))
+  ]
+});

--- a/packages/@o3r/eslint-plugin/src/rules/typescript/o3r-restriction-key-tags/o3r-restriction-key-tags.ts
+++ b/packages/@o3r/eslint-plugin/src/rules/typescript/o3r-restriction-key-tags/o3r-restriction-key-tags.ts
@@ -1,0 +1,163 @@
+import {
+  TSESLint,
+  type TSESTree,
+} from '@typescript-eslint/utils';
+import {
+  createCommentString,
+  createRule,
+  defaultSupportedInterfaceNames,
+  getNodeComment,
+  isExtendingConfiguration,
+} from '../../utils';
+
+export interface O3rRestrictionKeyTagsRuleOption {
+  supportedInterfaceNames?: string[];
+  supportedKeys?: string[];
+}
+
+type O3rWidgetRuleErrorId =
+  | 'notSupportedKey'
+  | 'notWrapWithQuotes'
+  | 'suggestWrapWithQuotes'
+  | 'suggestUseSupportedKey'
+  | 'noRestrictionKeyProvided'
+  | 'notInConfigurationInterface';
+
+const defaultOptions: [Required<O3rRestrictionKeyTagsRuleOption>] = [{
+  supportedInterfaceNames: defaultSupportedInterfaceNames,
+  supportedKeys: []
+}];
+
+export default createRule<[Readonly<O3rRestrictionKeyTagsRuleOption>, ...any], O3rWidgetRuleErrorId>({
+  name: 'o3r-restriction-key-tags',
+  meta: {
+    hasSuggestions: true,
+    fixable: 'code',
+    type: 'problem',
+    docs: {
+      description: 'Ensures that @o3rRestrictionKey is used with a correct value'
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          supportedInterfaceNames: {
+            type: 'array',
+            items: {
+              type: 'string'
+            }
+          },
+          supportedKeys: {
+            type: 'array',
+            items: {
+              type: 'string'
+            },
+            minItems: 1
+          }
+        }
+      }
+    ],
+    messages: {
+      notSupportedKey: '{{ actualKey }} is not supported. Supported restriction keys: {{ supportedKeys }}.',
+      suggestUseSupportedKey: '{{ actualKey }} is not supported. Replace with {{ supportedKey }}.',
+      notWrapWithQuotes: '`{{ actualKey }}` is not wrapped with quotes.',
+      suggestWrapWithQuotes: 'Wrap `{{ actualKey }}` with quotes.',
+      notInConfigurationInterface: '@o3rRestrictionKey can only be used in a `Configuration` interface.',
+      noRestrictionKeyProvided: 'You must have at least one restriction key.'
+    }
+  },
+  defaultOptions,
+  create: (context, [options]: Readonly<[O3rRestrictionKeyTagsRuleOption, ...any]>) => {
+    const rule = (node: TSESTree.TSPropertySignature) => {
+      const { sourceCode } = context;
+      const comment = getNodeComment(node, sourceCode);
+
+      if (!comment || comment.value.length === 0) {
+        return;
+      }
+
+      const { loc, value: docText } = comment;
+      const supportedKeys = options.supportedKeys || defaultOptions[0].supportedKeys;
+      const supportedKeysSet = new Set(supportedKeys);
+
+      if (supportedKeys.length === 0) {
+        return context.report({
+          messageId: 'noRestrictionKeyProvided',
+          node,
+          loc
+        });
+      }
+
+      const actualKeys = Array.from(docText.matchAll(/@o3rRestrictionKey\s+(.*)/g)).map((match) => match[1]);
+
+      if (actualKeys.length === 0) {
+        return;
+      }
+
+      const interfaceDeclNode = node.parent?.parent;
+      if (!isExtendingConfiguration(interfaceDeclNode, options.supportedInterfaceNames)) {
+        return context.report({
+          messageId: 'notInConfigurationInterface',
+          node,
+          loc
+        });
+      }
+
+      actualKeys.forEach((actualKey) => {
+        if (!supportedKeysSet.has(actualKey)) {
+          if (
+            /((["']).*?\2)/.test(actualKey)
+            && supportedKeysSet.has(actualKey.replace(/(^["']|["']$)/g, ''))
+          ) {
+            return;
+          }
+          const fix: (key: string) => TSESLint.ReportFixFunction = (key) => (fixer) => {
+            return fixer.replaceTextRange(comment.range, createCommentString(comment.value.replace(actualKey, /[^\w]/.test(key) ? `"${key}"` : key)));
+          };
+          return context.report({
+            messageId: 'notSupportedKey',
+            node,
+            loc,
+            data: {
+              actualKey,
+              supportedKeys: supportedKeys.join(', ')
+            },
+            suggest: supportedKeys.map((supportedKey) => ({
+              messageId: 'suggestUseSupportedKey',
+              data: {
+                actualKey,
+                supportedKey
+              },
+              fix: fix(supportedKey)
+            }))
+          });
+        }
+        if (/[^\w]/.test(actualKey)) {
+          const fix: TSESLint.ReportFixFunction = (fixer) => {
+            return fixer.replaceTextRange(comment.range, createCommentString(comment.value.replace(actualKey, `"${actualKey}"`)));
+          };
+          return context.report({
+            messageId: 'notWrapWithQuotes',
+            data: {
+              actualKey
+            },
+            node,
+            loc,
+            fix,
+            suggest: [{
+              messageId: 'suggestWrapWithQuotes',
+              data: {
+                actualKey
+              },
+              fix
+            }]
+          });
+        }
+      });
+    };
+
+    return {
+      TSPropertySignature: rule
+    };
+  }
+});

--- a/packages/@o3r/extractors/src/utils/config-doc.spec.ts
+++ b/packages/@o3r/extractors/src/utils/config-doc.spec.ts
@@ -1,5 +1,6 @@
 import {
   getCategoriesFromDocText,
+  getRestrictionKeysFromDocText,
   getWidgetInformationFromDocComment,
 } from './config-doc';
 
@@ -65,6 +66,27 @@ describe('config doc', () => {
           name: 'test2',
           label: 'Test2'
         }
+      ]);
+    });
+  });
+  describe('getRestrictionKeysFromDocText', () => {
+    it('should get the valid restriction keys', () => {
+      const restrictionKeys = getRestrictionKeysFromDocText(`
+        /**
+         * @o3rRestrictionKey valid
+         * @o3rRestrictionKey valid_1
+         * @o3rRestrictionKey invalid-2
+         * @o3rRestrictionKey "valid-3"
+         * @o3rRestrictionKey 'valid 4'
+         * @o3rRestrictionKey invalid 5
+         * @o3rRestrictionKey "invalid quote'
+         * @o3rRestrictionKey 'another invalid quote"
+         * @o3rRestrictionKey "valid 'quote'"
+         * @o3rRestrictionKey 'another valid "quote"'
+         */
+      `);
+      expect(restrictionKeys).toEqual([
+        'valid', 'valid_1', 'valid-3', 'valid 4', "valid 'quote'", 'another valid "quote"'
       ]);
     });
   });

--- a/packages/@o3r/extractors/src/utils/config-doc.ts
+++ b/packages/@o3r/extractors/src/utils/config-doc.ts
@@ -31,6 +31,9 @@ export interface ConfigDocInformation {
   /** Tags (taken from `@tags` tag) */
   tags?: string[];
 
+  /** Restriction keys (taken from `@o3rRestrictionKey` tag) */
+  restrictionKeys?: string[];
+
   /** Category (taken from `@o3rCategory` tag) */
   category?: string;
 
@@ -139,6 +142,17 @@ export function isO3rRequiredTagPresent(docText: string): boolean {
 }
 
 /**
+ * Get restriction keys from a given DocComment.
+ *
+ * The restriction keys extracted from @o3rRestrictionKey tag.
+ * @param docComment The DocComment to get restriction keys from
+ */
+export function getRestrictionKeysFromDocText(docComment: string): string[] {
+  return Array.from(docComment.matchAll(/@o3rRestrictionKey\s+(\w+|"[^"\n]*"|'[^'\n]*')$/gm))
+    .map((match) => match[1].replaceAll(/(^["']|["']$)/g, ''));
+}
+
+/**
  * Get category from a given DocComment.
  *
  * The category is extracted from @o3rCategory tag.
@@ -221,6 +235,7 @@ export class ConfigDocParser {
         tags: getTagsFromDocComment(docComment),
         category: getCategoryFromDocText(docText),
         categories: getCategoriesFromDocText(docText),
+        restrictionKeys: getRestrictionKeysFromDocText(docText),
         widget: getWidgetInformationFromDocComment(docText),
         required: isO3rRequiredTagPresent(docText)
       };

--- a/tools/github-actions/cascading/readme.md
+++ b/tools/github-actions/cascading/readme.md
@@ -28,7 +28,10 @@ If the plugin finds a branch candidate for cascading, it will try a git merge an
   * if conflictsIgnoredPackages input is not empty, there are only conflicts in package.json and yarn.lock files and the conflict is only related to those packages, a pull request will be automatically created resolving the conflict by discarding those changes
   * else a pull request will be automatically created (409 error will be thrown if the pull request already exists). If assignCommitter is true, the first person with a "Merge" commit in the list will be assigned as required approval
 
-**Warning**: The action requires to be run in a job with `contents: write` permission or the provided token needs to have the permission to create a pull request, write and trigger builds on release branches.
+> [!WARNING]
+> The action requires to be run in a job with `contents: write` permission
+> or the provided token needs to have the permission to create a pull request,
+> write and trigger builds on release branches.
 
 The cascading task is logging a lot of information, don't hesitate to have a look to have more precisions about what exactly is executed.
 


### PR DESCRIPTION
## Proposed change
As a developer I want to be able to flag a configuration property as sensitive.
It was decided to have an array of restriction, named `restrictionKeys` for each property, to support potential future use case with different level of restriction based on the role of the user configuring the property value.
This PR includes:
- the update of the metadata schema
- the extraction of `restrictionKeys` from the jsdoc tags `@o3rRestrictionKeys`
- a linter to limit the possible keys used with `@o3rRestrictionKeys`

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
