### PR TITLE
fix: jest.config.ut.js not processing array in tsconfig paths correctly

### DIFF
--- a/jest.config.ut.js
+++ b/jest.config.ut.js
@@ -22,8 +22,8 @@ module.exports.getJestProjectConfig = (rootDir, isAngularSetup, options) => {
   ).config;
   const relativePath = relative(rootDir, options?.baseTsconfig ? __dirname(options.baseTsconfig) : __dirname);
   const moduleNameMapper = Object.fromEntries(
-    Object.entries(pathsToModuleNameMapper(compilerOptions.paths))
-      .map(([moduleName, path]) => [moduleName, `<rootDir>/${relativePath}/${path}`])
+    Object.entries(pathsToModuleNameMapper(compilerOptions.paths || {}))
+      .map(([moduleName, paths]) => [moduleName, (Array.isArray(paths) ? paths : [paths]).map(path => `<rootDir>/${relativePath}/${path}`)])
   );
   return {
     preset: 'ts-jest',

--- a/packages/@o3r/testing/schematics/ng-add/templates/workspace/jest.config.ut.js.template
+++ b/packages/@o3r/testing/schematics/ng-add/templates/workspace/jest.config.ut.js.template
@@ -19,10 +19,10 @@ const baseTsconfigPath = resolve(__dirname, './tsconfig.json');
 module.exports.getJestProjectConfig = (rootDir, isAngularSetup) => {
   const { compilerOptions } = ts.parseConfigFileTextToJson(baseTsconfigPath, readFileSync(baseTsconfigPath, { encoding: 'utf-8' })).config;
   const relativePath = relative(rootDir, __dirname);
-  const moduleNameMapper = Object.entries(pathsToModuleNameMapper(compilerOptions.paths || {})).reduce((acc, [moduleName, path]) => {
-    acc[moduleName] = `<rootDir>/${relativePath}/${path}`;
-    return acc;
-  }, {});
+  const moduleNameMapper = Object.fromEntries(
+    Object.entries(pathsToModuleNameMapper(compilerOptions.paths || {}))
+      .map(([moduleName, paths]) => [moduleName, (Array.isArray(paths) ? paths : [paths]).map(path => `<rootDir>/${relativePath}/${path}`)])
+  );
   moduleNameMapper['^@o3r/testing/core$'] = [require.resolve('@o3r/testing/core/angular')];
   moduleNameMapper['^@o3r/testing/core/(.*)'] = [join(require.resolve('@o3r/testing/core/angular'), '$1')];
   return {


### PR DESCRIPTION
## Proposed change

This PR fixes an issue when running tests if tsconfig.json contains more than one item in one of the paths arrays (which is the case when using otter generator for a library).

## Related issue

To reproduce the issue (I did it with Otter 11.5.3):

```sh
npm create @o3r myproject
# (press enter each time a question is asked)
cd myproject
npm exec ng g library
#? Name of the package of the new module? mylib
#? Which preset to use to start your application? BASIC - Minimum plugin list to install for a basic Otter application. (details on https://www.npmjs.com/package/@o3r/core#preset-basic)
npm exec ng g application
#? Name of the new application? myapp
#? Which preset to use to start your application? BASIC - Minimum plugin list to install for a basic Otter application. (details on https://www.npmjs.com/package/@o3r/core#preset-basic)
# You are currently using jasmine. Do you want to setup Jest test framework? You will have to remove jasmine yourself. yes
# Do you want to setup Playwright test framework for E2E? yes
```

Then add a reference to MyLibComponent from `app.component.ts`:

```ts
import { Component } from '@angular/core';
import { RouterOutlet } from '@angular/router';
import { MylibComponent } from 'mylib'; // add this line

@Component({
  selector: 'app-root',
  standalone: true,
  imports: [RouterOutlet, MylibComponent], // add MylibComponent here
  templateUrl: './app.component.html',
  styleUrl: './app.component.scss'
})
export class AppComponent {
  title = 'myapp';
}
```

Then run tests:

```
npm test
```

Tests fail with the following error:
```

> myproject@0.0.0-placeholder test
> lerna run test

(node:58794) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
lerna notice cli v8.1.9

> myapp:test


> myapp@0.0.0-placeholder test
> jest

 FAIL   myapp  src/app/app.component.spec.ts
  ● Test suite failed to run

    Configuration error:
    
    Could not locate module mylib mapped as:
    /home/user/myproject/libs/mylib/dist,libs/mylib/src/public-api.
    
    Please check your configuration for these entries:
    {
      "moduleNameMapper": {
        "/^mylib$/": "/home/user/myproject/libs/mylib/dist,libs/mylib/src/public-api"
      },
      "resolver": undefined
    }

      1 | import { Component } from '@angular/core';
      2 | import { RouterOutlet } from '@angular/router';
    > 3 | import { MylibComponent } from 'mylib';
        | ^
      4 |
      5 | @Component({
      6 |   selector: 'app-root',

      at createNoMappedModuleFoundError (../../node_modules/jest-resolve/build/resolver.js:759:17)
      at Object.<anonymous> (src/app/app.component.ts:3:1)
      at Object.<anonymous> (src/app/app.component.spec.ts:2:1)

(node:59208) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        3.072 s
Ran all test suites.
npm error Lifecycle script `test` failed with error:
npm error code 1
npm error path /home/user/myproject/apps/myapp
npm error workspace myapp@0.0.0-placeholder
npm error location /home/user/myproject/apps/myapp
npm error command failed
npm error command sh -c jest

——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 Lerna (powered by Nx)   Ran target test for project myapp (4s)

   ✖  1/1 failed
   ✔  0/1 succeeded [0 read from cache]

```

Note that `tsconfig.json` contains:

```json5
{
  // ...
  "compilerOptions": {
    // ...
    "paths": {
      "mylib": [
        "libs/mylib/dist",
        "libs/mylib/src/public-api"
      ]
    },
    // ...
  }
  //...
}
```