### PR TITLE
fix(core): add support for "null" type

### DIFF
--- a/packages/@o3r/core/src/utils/deep-fill/deep-fill.spec.ts
+++ b/packages/@o3r/core/src/utils/deep-fill/deep-fill.spec.ts
@@ -12,6 +12,20 @@ describe('Deep fill function', () => {
     expect(deepFill(base, source)).toEqual(base);
   });
 
+  it('should support "null" value in source', () => {
+    const base = { selection: { field: 'test-field' }, a: 'string' };
+    const source = { selection: null } as any;
+
+    expect(deepFill(base, source)).toEqual({ selection: null, a: 'string' });
+  });
+
+  it('should support "null" value in base', () => {
+    const base = { selection: null, a: 'string' } as any;
+    const source = { selection: { field: 'test-field' } };
+
+    expect(deepFill(base, source)).toEqual({ selection: { field: 'test-field' }, a: 'string' });
+  });
+
   it('should keep properties from base not present in the source', () => {
     const base = Object.freeze({a: 1, b: '2', c: true});
     const source = Object.freeze({c: false, a: 3});

--- a/packages/@o3r/core/src/utils/deep-fill/deep-fill.ts
+++ b/packages/@o3r/core/src/utils/deep-fill/deep-fill.ts
@@ -66,9 +66,11 @@ export function deepFill<T extends { [x: string]: any }>(base: T, source?: { [x:
   }
   const newObj = {...base};
   for (const key in base) {
-    if (key in source && typeof base[key] === typeof source[key]) {
+    if (source[key] === null) {
+      newObj[key] = immutablePrimitive(null, additionalMappers);
+    } else if (key in source && typeof base[key] === typeof source[key]) {
       const keyOfSource = source[key];
-      newObj[key] = typeof keyOfSource === 'undefined' ? immutablePrimitive(base[key], additionalMappers) : deepFill(base[key], source[key], additionalMappers);
+      newObj[key] = typeof keyOfSource === 'undefined' ? immutablePrimitive(base[key], additionalMappers) : deepFill(base[key], keyOfSource, additionalMappers);
     } else {
       newObj[key] = immutablePrimitive(base[key], additionalMappers);
     }


### PR DESCRIPTION
## Proposed change

Add the support of the `null` as deepFill object field value

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

<!-- * :bug: Fix #issue -->
* :bug: Fix resolves #2601
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
