### PR TITLE
fix: reset actions emitted when no rulesets remains activated

### DIFF
--- a/packages/@o3r/rules-engine/src/engine/helpers/filter-ruleset-event.operator.ts
+++ b/packages/@o3r/rules-engine/src/engine/helpers/filter-ruleset-event.operator.ts
@@ -1,4 +1,4 @@
-import { combineLatest, Observable } from 'rxjs';
+import { combineLatest, Observable, of } from 'rxjs';
 import { map, shareReplay, switchMap } from 'rxjs/operators';
 import { RulesetExecutor } from '../ruleset-executor';
 
@@ -14,11 +14,13 @@ export function filterRulesetsEventStream(restrictiveRuleSets?: string[]) {
         Object.values(rulesets).filter((ruleSet) => restrictiveRuleSets.indexOf(ruleSet.id) > -1) :
         Object.values(rulesets);
 
-      return combineLatest(activeRulesets.map((ruleset) => ruleset.rulesResultsSubject$)).pipe(
-        map((item) => item.reduce((acc, currentValue) => {
-          acc.push(...currentValue);
-          return acc;
-        }, [])));
+      return activeRulesets?.length > 0
+        ? combineLatest(activeRulesets.map((ruleset) => ruleset.rulesResultsSubject$)).pipe(
+          map((item) => item.reduce((acc, currentValue) => {
+            acc.push(...currentValue);
+            return acc;
+          }, [])))
+        : of([]);
     }),
     shareReplay(1)
   );

--- a/packages/@o3r/rules-engine/src/services/runner/rules-engine.runner.service.spec.ts
+++ b/packages/@o3r/rules-engine/src/services/runner/rules-engine.runner.service.spec.ts
@@ -273,7 +273,7 @@ describe('Rules engine service', () => {
       next: value => nextFn(value)
     });
     // should output no actions as all rulesets are on demand
-    expect(nextFn).not.toHaveBeenCalled();
+    expect(nextFn).toHaveBeenCalledWith([]);
     sub.unsubscribe();
 
     // activate ruleset 1 via his own linked component


### PR DESCRIPTION
## Proposed change

Emit an empty array of actions to execute when no ruleset remains active during the executions of rules engine. 
Nowadays there is no emission so the already applied actions are not reset.

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

* :bug: Fix #2609 
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
