### PR TITLE
fix(#2630): use posix to compute path for outputPath

### DIFF
--- a/packages/@o3r/core/schematics/rule-factories/otter-environment/index.ts
+++ b/packages/@o3r/core/schematics/rule-factories/otter-environment/index.ts
@@ -1,5 +1,4 @@
 import {
-  join,
   posix,
 } from 'node:path';
 import type {
@@ -81,7 +80,7 @@ export function updateOtterEnvironmentAdapter(
 
       // override angular's dist/webapp output path with apps/webapp/dist
       if (workspaceProject.architect?.build?.options?.outputPath) {
-        workspaceProject.architect.build.options.outputPath = join(workspaceProject.root, 'dist');
+        workspaceProject.architect.build.options.outputPath = posix.join(workspaceProject.root, 'dist');
       }
 
       workspace.projects[options.projectName!] = workspaceProject;


### PR DESCRIPTION
## Proposed change
use posix to compute path for `outputPath`

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

<!-- * :bug: Fix #issue -->
 * :bug: Fix resolves #2630
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
