### PR TITLE
fix(vscode): unlock  vscode extension

### DIFF
--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -1,6 +1,7 @@
 import {
   commands,
-  ExtensionContext, languages } from 'vscode';
+  ExtensionContext, languages,
+  window } from 'vscode';
 import { extractAllToVariable } from './commands/extract/styling/extract-all-to-variable.command';
 import { extractToVariable } from './commands/extract/styling/extract-to-variable.command';
 import { generateComponentGenerateCommand } from './commands/generate/component.command';
@@ -33,10 +34,11 @@ import { designTokenCompletionItemAndHoverProviders } from './intellisense/desig
  * @param context
  */
 export function activate(context: ExtensionContext) {
+  const channel = window.createOutputChannel('Otter');
   const designTokenProviders = designTokenCompletionItemAndHoverProviders();
 
   context.subscriptions.push(
-    languages.registerCompletionItemProvider(['javascript','typescript'], configurationCompletionItemProvider(), configurationCompletionTriggerChar),
+    languages.registerCompletionItemProvider(['javascript','typescript'], configurationCompletionItemProvider({ channel }), configurationCompletionTriggerChar),
     languages.registerCompletionItemProvider(['scss'], stylingCompletionItemProvider(), stylingCompletionTriggerChar),
     languages.registerCompletionItemProvider(['scss', 'css'], designTokenProviders),
     languages.registerHoverProvider(['scss', 'css'], designTokenProviders),

--- a/apps/vscode-extension/src/intellisense/configuration.ts
+++ b/apps/vscode-extension/src/intellisense/configuration.ts
@@ -1,5 +1,4 @@
-import { CompletionItem, CompletionItemKind, CompletionItemProvider, SnippetString } from 'vscode';
-import { ESLint } from 'eslint';
+import { CompletionItem, CompletionItemKind, CompletionItemProvider, SnippetString, type OutputChannel } from 'vscode';
 
 interface ConfigurationTags {
   /** @see CompletionItem.documentation */
@@ -97,8 +96,15 @@ const getConfigurationTagsFromEslintConfig = (eslintConfig: any, comment: string
   };
 };
 
-export const configurationCompletionItemProvider = () : CompletionItemProvider<CompletionItem> => {
-  const eslint = new ESLint();
+export const configurationCompletionItemProvider = (options: { channel: OutputChannel }): CompletionItemProvider<CompletionItem> => {
+  const eslint = import('eslint')
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- External package defined name
+    .then(({ ESLint }) => new ESLint())
+    .catch((err) => {
+      options.channel.appendLine('error during EsLint loading');
+      options.channel.appendLine(JSON.stringify(err));
+      return undefined;
+    });
 
   return {
     provideCompletionItems: async (doc, pos) => {
@@ -132,7 +138,7 @@ export const configurationCompletionItemProvider = () : CompletionItemProvider<C
         return [];
       }
 
-      const config = await eslint.calculateConfigForFile(doc.fileName);
+      const config = await (await eslint)?.calculateConfigForFile(doc.fileName) || {};
       const configurationTags = getConfigurationTagsFromEslintConfig(config, match[0], fileText);
 
       return getCompletionsItemsFromConfigurationTags(configurationTags);


### PR DESCRIPTION
## Proposed change

Allow the VsCode extension to be loaded without espree detection 
This PR **is not** a proper fix of the lack of  espree dependency but unlock the extension run

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

* :bug: Fix (**partial**) #2580
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
