### PR TITLE
fix(workspace): the tsconfig links to generate libraries

### DIFF
--- a/packages/@o3r/workspace/schematics/index.it.spec.ts
+++ b/packages/@o3r/workspace/schematics/index.it.spec.ts
@@ -90,7 +90,7 @@ describe('new otter workspace', () => {
     expect(() => packageManagerRunOnProject('@my-sdk/sdk', isInWorkspace, { script: 'spec:upgrade' }, execAppOptions)).not.toThrow();
   });
 
-  test('should add a library to an existing workspace', () => {
+  test('should add a library to an existing workspace', async () => {
     const { workspacePath } = o3rEnvironment.testEnvironment;
     const execAppOptions = { ...getDefaultExecSyncOptions(), cwd: workspacePath };
     const libName = 'test-library';
@@ -115,6 +115,10 @@ describe('new otter workspace', () => {
     expect(existsSync(path.join(workspacePath, 'project'))).toBe(false);
     generatedLibFiles.forEach((file) => expect(existsSync(path.join(inLibraryPath, file))).toBe(true));
     expect(() => packageManagerRunOnProject(libName, true, { script: 'build' }, execAppOptions)).not.toThrow();
+
+    // check tsconfig.lib.prod.json override
+    const tsconfigLibProd = JSON.parse(await fs.readFile(path.join(inLibraryPath, 'tsconfig.lib.prod.json'), { encoding: 'utf8' }));
+    expect(!!tsconfigLibProd.extends && existsSync(path.resolve(inLibraryPath, tsconfigLibProd.extends))).toBe(true);
   });
 
   test('should generate a monorepo setup', async () => {

--- a/packages/@o3r/workspace/schematics/library/templates/ng/tsconfig.lib.prod.json.template
+++ b/packages/@o3r/workspace/schematics/library/templates/ng/tsconfig.lib.prod.json.template
@@ -1,0 +1,3 @@
+{
+  "extends": "<%= tsconfigBuildPath %>"
+}


### PR DESCRIPTION
## Proposed change

fix(workspace): the tsconfig links to generate libraries

It fixes the following points:
- generate the tsconfig.build.json (mandatory for lib standalone publishing)
- remove the `dist/` path from the `tsconfig.base.json` which is leading to wrong path mapping when the library was locally built
- register properly the lib in both tsconfig files
- update the tsconfig.lib.prod.json to extend the correct tsconfig

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

<!-- * :bug: Fix #issue -->
* :bug: Fix resolves #2665
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
