### PR TITLE
fix: typo

### DIFF
--- a/apps/chrome-devtools/src/app-devtools/theming-panel/color.pipe.ts
+++ b/apps/chrome-devtools/src/app-devtools/theming-panel/color.pipe.ts
@@ -32,7 +32,7 @@ export class HexColorPipe implements PipeTransform {
   name: 'contrast',
   standalone: true
 })
-export class ConstrastPipe implements PipeTransform {
+export class ContrastPipe implements PipeTransform {
   public transform(color: string) {
     return getBestColorContrast(color);
   }
@@ -43,10 +43,10 @@ export class ConstrastPipe implements PipeTransform {
  * Compute accessibility score for color contrast
  */
 @Pipe({
-  name: 'accessibilityConstrastScore',
+  name: 'accessibilityContrastScore',
   standalone: true
 })
-export class AccessibilityConstrastScorePipe implements PipeTransform {
+export class AccessibilityContrastScorePipe implements PipeTransform {
   public transform(color1: string, color2: string, textSize: 'small' | 'large') {
     return getAccessibilityContrastScore(color1, color2, textSize);
   }

--- a/apps/chrome-devtools/src/app-devtools/theming-panel/theming-panel-pres.component.ts
+++ b/apps/chrome-devtools/src/app-devtools/theming-panel/theming-panel-pres.component.ts
@@ -53,8 +53,8 @@ import {
   getPaletteColors,
 } from './color.helpers';
 import {
-  AccessibilityConstrastScorePipe,
-  ConstrastPipe,
+  AccessibilityContrastScorePipe,
+  ContrastPipe,
   HexColorPipe,
 } from './color.pipe';
 import {
@@ -112,8 +112,8 @@ export interface VariableGroup {
     ReactiveFormsModule,
     FormsModule,
     HexColorPipe,
-    ConstrastPipe,
-    AccessibilityConstrastScorePipe,
+    ContrastPipe,
+    AccessibilityContrastScorePipe,
     NgbTypeaheadModule,
     VariableLabelPipe,
     DfTooltipModule,

--- a/apps/chrome-devtools/src/app-devtools/theming-panel/theming-panel-pres.template.html
+++ b/apps/chrome-devtools/src/app-devtools/theming-panel/theming-panel-pres.template.html
@@ -60,8 +60,8 @@
                           </label>
                           <span class="my-auto">{{ resolvedColor }}</span>
                           <span class="ms-auto my-auto">
-                            <span ngbTooltip="Accessibility score for small text" [style.fontSize]="'12px'" class="me-2">{{ resolvedColor | accessibilityConstrastScore : (resolvedColor | contrast) : 'small' }}</span>
-                            <span ngbTooltip="Accessibility score for large text" [style.fontSize]="'24px'">{{ resolvedColor | accessibilityConstrastScore : (resolvedColor | contrast) : 'large' }}</span>
+                            <span ngbTooltip="Accessibility score for small text" [style.fontSize]="'12px'" class="me-2">{{ resolvedColor | accessibilityContrastScore : (resolvedColor | contrast) : 'small' }}</span>
+                            <span ngbTooltip="Accessibility score for large text" [style.fontSize]="'24px'">{{ resolvedColor | accessibilityContrastScore : (resolvedColor | contrast) : 'large' }}</span>
                           </span>
                         </li>
                       }

--- a/packages/@o3r/localization/schematics/add-localization-key/index.spec.ts
+++ b/packages/@o3r/localization/schematics/add-localization-key/index.spec.ts
@@ -185,7 +185,7 @@ describe('Add Localization', () => {
           key: 'dummyLoc1',
           description: 'Dummy 1 description',
           value: 'Dummy 1',
-          dictionnary: false
+          dictionary: false
         }), initialTree, { interactive: false }))).rejects.toThrow();
       });
 
@@ -201,7 +201,7 @@ describe('Add Localization', () => {
           key: 'dummyLoc1',
           description: 'Dummy 1 description',
           value: 'Dummy 1',
-          dictionnary: false
+          dictionary: false
         }, initialTree);
 
         expect(spy).toHaveBeenCalledWith('convert-component', expect.anything(), expect.anything());

--- a/packages/@o3r/localization/schematics/add-localization-key/index.ts
+++ b/packages/@o3r/localization/schematics/add-localization-key/index.ts
@@ -149,9 +149,9 @@ export function ngAddLocalizationKeyFn(options: NgAddLocalizationKeySchematicsSc
 
       const updateLocalizationFileRule: Rule = () => {
         (localizationJson as any)[properties.keyValue] = {
-          ...(properties.dictionnary
+          ...(properties.dictionary
             ? {
-              dictionnary: true
+              dictionary: true
             }
             : {
               defaultValue: properties.defaultValue

--- a/packages/@o3r/localization/schematics/add-localization-key/schema.json
+++ b/packages/@o3r/localization/schematics/add-localization-key/schema.json
@@ -26,10 +26,11 @@
       "description": "Default value of the localization",
       "default": ""
     },
-    "dictionnary": {
+    "dictionary": {
       "type": "boolean",
-      "description": "Is a dictionnary key",
-      "default": false
+      "description": "Is a dictionary key (the alias dictionnary will be removed in v13)",
+      "default": false,
+      "alias": "dictionnary"
     },
     "updateTemplate": {
       "type": "boolean",

--- a/packages/@o3r/localization/schematics/add-localization-key/schema.ts
+++ b/packages/@o3r/localization/schematics/add-localization-key/schema.ts
@@ -18,8 +18,8 @@ export interface NgAddLocalizationKeySchematicsSchema extends SchematicOptionObj
   /** Default value of the localization */
   value: string;
 
-  /** Is a dictionnary key */
-  dictionnary: boolean;
+  /** Is a dictionary key */
+  dictionary: boolean;
 
   /** Update the template by replacing matching value by the localization key */
   updateTemplate?: boolean | undefined;

--- a/packages/@o3r/schematics/src/utility/ast.ts
+++ b/packages/@o3r/schematics/src/utility/ast.ts
@@ -272,7 +272,7 @@ export const addInterfaceToClassTransformerFactory = (
 /**
  * Add comment on class properties
  * @param classElements
- * @param comments Dictionnary of comment indexed by properties' name
+ * @param comments Dictionary of comment indexed by properties' name
  */
 export const addCommentsOnClassProperties = (
   classElements: ts.ClassElement[],


### PR DESCRIPTION
## Proposed change
- Rename option `dictionnary` into `dictionary`
- Rename `ConstrastPipe` and `AccessibilityConstrastScorePipe`,
respectively into `ContrastPipe` and `AccessibilityContrastScorePipe`

## Related issues

*- No issue associated -*