### PR TITLE
fix(vscode): allow VsCode extension without espree detection

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -372,6 +372,7 @@
     "@types/node": "^20.0.0",
     "@types/vscode": "^1.67.0",
     "@typescript-eslint/parser": "~8.19.0",
+    "@typescript-eslint/utils": "~8.19.0",
     "@vscode/vsce": "^2.16.0",
     "angular-eslint": "~18.4.0",
     "cpy-cli": "^5.0.0",

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -2,6 +2,7 @@ import {
   commands,
   ExtensionContext,
   languages,
+  window,
 } from 'vscode';
 import {
   extractAllToVariable,
@@ -60,10 +61,11 @@ import {
  * @param context
  */
 export function activate(context: ExtensionContext) {
+  const channel = window.createOutputChannel('Otter');
   const designTokenProviders = designTokenCompletionItemAndHoverProviders();
 
   context.subscriptions.push(
-    languages.registerCompletionItemProvider(['javascript', 'typescript'], configurationCompletionItemProvider(), configurationCompletionTriggerChar),
+    languages.registerCompletionItemProvider(['javascript', 'typescript'], configurationCompletionItemProvider({ channel }), configurationCompletionTriggerChar),
     languages.registerCompletionItemProvider(['scss'], stylingCompletionItemProvider(), stylingCompletionTriggerChar),
     languages.registerCompletionItemProvider(['scss', 'css'], designTokenProviders),
     languages.registerHoverProvider(['scss', 'css'], designTokenProviders),

--- a/yarn.lock
+++ b/yarn.lock
@@ -29961,6 +29961,7 @@ __metadata:
     "@types/node": "npm:^20.0.0"
     "@types/vscode": "npm:^1.67.0"
     "@typescript-eslint/parser": "npm:~8.19.0"
+    "@typescript-eslint/utils": "npm:~8.19.0"
     "@vscode/vsce": "npm:^2.16.0"
     angular-eslint: "npm:~18.4.0"
     cpy-cli: "npm:^5.0.0"


### PR DESCRIPTION
## Proposed change

Allow the VsCode extension to be loaded without espree detection 
This PR **is not** a proper fix of the lack of  espree dependency but unlock the extension run

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

* :bug: Fix (**partial**) #2580
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
