### PR TITLE
fix(ama-sdk): fallback open api generator version to 7.9.0

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -104,7 +104,9 @@
         "org.openapitools:openapi-generator"
       ],
       "groupName": "Open API updates",
-      "groupSlug": "openapi"
+      "groupSlug": "openapi",
+      // TODO wait for https://github.com/OpenAPITools/openapi-generator/issues/20135 to be fixed before upgrading to 7.10.0
+      "enabled": false
     },
     {
       // We don't want to update this dep as we are still targeting a fork

--- a/packages/@ama-sdk/schematics/package.json
+++ b/packages/@ama-sdk/schematics/package.json
@@ -153,7 +153,7 @@
     "tsc-watch": "^6.0.4",
     "yaml-eslint-parser": "^1.2.2"
   },
-  "openApiSupportedVersion": "~7.10.0",
+  "openApiSupportedVersion": "~7.9.0",
   "engines": {
     "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
   }

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/pom.xml
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/pom.xml
@@ -95,7 +95,9 @@
     <dependency>
       <groupId>org.openapitools</groupId>
       <artifactId>openapi-generator</artifactId>
-      <version>7.10.0</version>
+      <!-- TODO wait for https://github.com/OpenAPITools/openapi-generator/issues/20135 to be fixed before upgrading to 7.10.0 -->
+      <!-- Don't forget to enable the custom manager in .renovaterc.json5  -->
+      <version>7.9.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Proposed change
Fallback open api generator version to 7.9.0
because of this [issue](https://github.com/OpenAPITools/openapi-generator/issues/20135)

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
