### PR TITLE
fix(eslint): provide default ignores when adding @o3r/eslint-config

### DIFF
--- a/packages/@o3r/eslint-config/schematics/ng-add/eslint/index.spec.ts
+++ b/packages/@o3r/eslint-config/schematics/ng-add/eslint/index.spec.ts
@@ -63,6 +63,7 @@ describe('update eslint config', () => {
     expect(tree.readText('eslint.local.config.mjs')).toContain(`${monorepoPkgName}/projects`);
     expect(tree.readText('eslint.shared.config.mjs')).toContain(`${monorepoPkgName}/report-unused-disable-directives`);
     expect(tree.readText('eslint.shared.config.mjs')).toContain(`${monorepoPkgName}/eslint-config`);
+    expect(tree.readText('eslint.shared.config.mjs')).toContain(`${monorepoPkgName}/ignores`);
   });
 
   it('should add an eslint config on an application', async () => {
@@ -81,6 +82,7 @@ describe('update eslint config', () => {
     expect(tree.exists(`${libRoot}/tsconfig.eslint.json`)).toBeFalsy();
     expect(tree.readText(`${appRoot}/eslint.config.mjs`)).toContain('import shared from \'../../eslint.shared.config.mjs\'');
     expect(tree.readText(`${appRoot}/eslint.local.config.mjs`)).toContain(`${pckName}/projects`);
+    expect(tree.readText(`${appRoot}/eslint.local.config.mjs`)).toContain(`${pckName}/ignores`);
     expect(tree.readText(`${appRoot}/eslint.local.config.mjs`)).toContain('...globals.browser');
     expect(tree.readJson('angular.json')).toEqual({
       ...angularJsonContent,
@@ -115,6 +117,7 @@ describe('update eslint config', () => {
     expect(tree.exists(`${appRoot}/tsconfig.eslint.json`)).toBeFalsy();
     expect(tree.readText(`${libRoot}/eslint.config.mjs`)).toContain('import shared from \'../../eslint.shared.config.mjs\'');
     expect(tree.readText(`${libRoot}/eslint.local.config.mjs`)).toContain(`${pckName}/projects`);
+    expect(tree.readText(`${libRoot}/eslint.local.config.mjs`)).toContain(`${pckName}/ignores`);
     expect(tree.readText(`${libRoot}/eslint.local.config.mjs`)).not.toContain('...globals.browser');
     expect(tree.readJson('angular.json')).toEqual({
       ...angularJsonContent,

--- a/packages/@o3r/eslint-config/schematics/ng-add/eslint/templates/project/eslint.local.config.__extension__.template
+++ b/packages/@o3r/eslint-config/schematics/ng-add/eslint/templates/project/eslint.local.config.__extension__.template
@@ -23,5 +23,9 @@ const __dirname = dirname(__filename);
         ...globals.browser
       }<% } %>
     }
+  },
+  {
+    name: '<%= packageName %>/ignores',
+    ignores: []
   }
 ];

--- a/packages/@o3r/eslint-config/schematics/ng-add/eslint/templates/workspace/eslint.shared.config.__extension__.template
+++ b/packages/@o3r/eslint-config/schematics/ng-add/eslint/templates/workspace/eslint.shared.config.__extension__.template
@@ -14,6 +14,10 @@ const o3rTemplate = require('@o3r/eslint-config/template');
     }
   },
   {
+    name: '<%= packageName %>/ignores',
+    ignores: []
+  },
+  {
     name: '<%= packageName %>/settings',
     settings: {
       'import/resolver': {


### PR DESCRIPTION
## Proposed change
Ease the usage of ESLint by providing default ignores when adding `@o3r/eslint-config`

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
