### PR TITLE
fix(training-sdk): remove the training SDK publishing

### DIFF
--- a/packages/@o3r-training/training-sdk/project.json
+++ b/packages/@o3r-training/training-sdk/project.json
@@ -24,7 +24,6 @@
       }
     },
     "lint": {},
-    "publish": {},
     "extract-folder-structure": {
       "cache": true,
       "executor": "nx:run-script",


### PR DESCRIPTION
## Proposed change

fix(training-sdk): remove the training SDK publishing flagged as `private`

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
