### PR TITLE
test(chrome-devtools): setup e2e tests for chrome extension

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -46,4 +46,6 @@ jobs:
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: e2e-report
-          path: apps/showcase/playwright-reports
+          path: |
+            apps/chrome-devtools/playwright-reports
+            apps/showcase/playwright-reports

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -20,7 +20,7 @@ packageExtensions:
       "@swc/types": "*"
   "@typescript-eslint/rule-tester@*":
     dependencies:
-      "@typescript-eslint/parser": ~8.19.0
+      "@typescript-eslint/parser": ~8.20.0
   "@angular-eslint/eslint-plugin-template@*":
     dependencies:
       "@typescript-eslint/types": "^8.0.0"

--- a/apps/chrome-devtools/.gitignore
+++ b/apps/chrome-devtools/.gitignore
@@ -1,3 +1,9 @@
+# Build
 /dist
 /dist-test
 /chrome-extension.zip
+
+# Playwright
+dist-e2e-playwright
+playwright-reports
+test-results

--- a/apps/chrome-devtools/e2e-playwright/playwright-config.sanity.ts
+++ b/apps/chrome-devtools/e2e-playwright/playwright-config.sanity.ts
@@ -1,0 +1,15 @@
+import * as path from 'node:path';
+import {
+  defineConfig,
+} from '@playwright/test';
+import {
+  default as defaultConfig,
+} from './playwright-config';
+
+const config = defineConfig({
+  ...defaultConfig,
+  testDir: path.join(__dirname, 'sanity'),
+  testMatch: /.*\.e2e\.ts$/
+});
+
+export default config;

--- a/apps/chrome-devtools/e2e-playwright/playwright-config.ts
+++ b/apps/chrome-devtools/e2e-playwright/playwright-config.ts
@@ -1,0 +1,48 @@
+import * as path from 'node:path';
+import {
+  adjustPath,
+} from '@o3r/testing/tools/path-replacement';
+import {
+  defineConfig,
+} from '@playwright/test';
+
+adjustPath('playwright');
+
+const reportsFolder = path.join(__dirname, '..', 'playwright-reports');
+
+const config = defineConfig({
+  testDir: path.join(__dirname, '..', 'e2e-playwright'),
+  testMatch: /.*\.e2e-playwright-spec.ts$/,
+  snapshotPathTemplate: '{testDir}/screenshots/{testFilePath}/{arg}{ext}',
+  reporter: [
+    ['list'],
+    ['junit', { outputFile: path.join(reportsFolder, 'junit', 'reporter.xml') }],
+    ['html', { open: 'never', outputFolder: path.join(reportsFolder, 'html') }]
+  ],
+  retries: process.env.CI ? 3 : 0,
+  forbidOnly: !!process.env.CI,
+  navigationTimeout: 10_000,
+  timeout: 60_000,
+  use: {
+    ignoreHTTPSErrors: true,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+    launchOptions: {}
+  },
+  expect: {
+    toHaveScreenshot: {
+      maxDiffPixelRatio: 0
+    }
+  },
+  projects: [
+    {
+      name: 'Chromium',
+      use: {
+        browserName: 'chromium',
+        channel: 'chromium'
+      }
+    }
+  ]
+});
+
+export default config;

--- a/apps/chrome-devtools/e2e-playwright/sanity/install-sanity.e2e.ts
+++ b/apps/chrome-devtools/e2e-playwright/sanity/install-sanity.e2e.ts
@@ -1,0 +1,15 @@
+import {
+  expect,
+} from '@playwright/test';
+import {
+  test,
+} from '../test-with-extension';
+
+const EXTENSION_ID = 'aejabgendbpckkdnjaphhlifbhepmbne';
+
+test.describe('Install extension to chrome', () => {
+  test('Background service worker', ({ extensionServiceWorker, extensionId }) => {
+    expect(extensionServiceWorker).toBeDefined();
+    expect(extensionId).toBe(EXTENSION_ID);
+  });
+});

--- a/apps/chrome-devtools/e2e-playwright/scenarios/dummy-scenario.e2e-playwright-spec.ts
+++ b/apps/chrome-devtools/e2e-playwright/scenarios/dummy-scenario.e2e-playwright-spec.ts
@@ -1,0 +1,12 @@
+import {
+  expect,
+} from '@playwright/test';
+import {
+  test,
+} from '../test-with-extension';
+
+test.describe('Dummy scenario', () => {
+  test('Dummy test', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/apps/chrome-devtools/e2e-playwright/test-with-extension.ts
+++ b/apps/chrome-devtools/e2e-playwright/test-with-extension.ts
@@ -1,0 +1,42 @@
+import path from 'node:path';
+import {
+  test as base,
+  type BrowserContext,
+  chromium,
+  type Worker,
+} from '@playwright/test';
+
+const pathToExtension = path.resolve(__dirname, '..', 'dist');
+
+/**
+ * Extends playwright test to add extension access
+ */
+export const test = base.extend<{
+  context: BrowserContext;
+  extensionServiceWorker: Worker;
+  extensionId: string;
+}>({
+  // eslint-disable-next-line no-empty-pattern -- Required for dependency injection
+  context: async ({}, use) => {
+    const context = await chromium.launchPersistentContext('', {
+      channel: 'chromium',
+      args: [
+        `--disable-extensions-except=${pathToExtension}`,
+        `--load-extension=${pathToExtension}`
+      ]
+    });
+    await use(context);
+    await context.close();
+  },
+  extensionServiceWorker: async ({ context }, use) => {
+    let [background] = context.serviceWorkers();
+    if (!background) {
+      background = await context.waitForEvent('serviceworker');
+    }
+    await use(background);
+  },
+  extensionId: async ({ extensionServiceWorker }, use) => {
+    const extensionId = extensionServiceWorker.url().split('/')[2];
+    await use(extensionId);
+  }
+});

--- a/apps/chrome-devtools/eslint.local.config.mjs
+++ b/apps/chrome-devtools/eslint.local.config.mjs
@@ -12,6 +12,13 @@ const __dirname = dirname(__filename);
 
 export default [
   {
+    name: '@o3r/chrome-devtools/ignores',
+    ignores: [
+      'playwright-reports/**/*',
+      'test-results/**/*'
+    ]
+  },
+  {
     name: '@o3r/chrome-devtools/projects',
     languageOptions: {
       sourceType: 'module',
@@ -40,6 +47,15 @@ export default [
     rules: {
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off'
+    }
+  },
+  {
+    name: '@o3r/chrome-devtools/playwright',
+    files: ['**/e2e-playwright/**'],
+    languageOptions: {
+      globals: {
+        ...globals.node
+      }
     }
   }
 ];

--- a/apps/chrome-devtools/package.json
+++ b/apps/chrome-devtools/package.json
@@ -22,7 +22,10 @@
     "start": "concurrently 'yarn:watch:*'",
     "watch:manifest": "yarn patch:manifest --watch",
     "watch:extension": "tsc-watch -b tsconfig.extension.json --noClear --onSuccess 'yarn patch:extension'",
-    "publish-to-market": "node ./scripts/publish-to-market.mjs"
+    "publish-to-market": "node ./scripts/publish-to-market.mjs",
+    "test:playwright": "concurrently -m 1 -P 'yarn run test:playwright:* {*}' --",
+    "test:playwright:scenario": "playwright test --config=e2e-playwright/playwright-config.ts",
+    "test:playwright:sanity": "playwright test --config=e2e-playwright/playwright-config.sanity.ts"
   },
   "files": [
     "dist/"
@@ -42,6 +45,7 @@
     "@o3r/localization": "workspace:^",
     "@o3r/logger": "workspace:^",
     "@o3r/rules-engine": "workspace:^",
+    "@playwright/test": "~1.49.0",
     "@schematics/angular": "~18.2.0",
     "@stylistic/eslint-plugin": "~2.7.0",
     "@types/chrome": "^0.0.283",
@@ -71,8 +75,10 @@
     "jest-junit": "~16.0.0",
     "jest-preset-angular": "~14.2.0",
     "jsonc-eslint-parser": "~2.4.0",
+    "lighthouse": "~12.2.0",
     "minimist": "^1.2.6",
     "nx": "~19.8.0",
+    "playwright-lighthouse": "~4.0.0",
     "rimraf": "^5.0.1",
     "tsc-watch": "^6.0.4",
     "typescript": "~5.5.4",

--- a/apps/chrome-devtools/project.json
+++ b/apps/chrome-devtools/project.json
@@ -131,7 +131,11 @@
     },
     "build-extension": {
       "executor": "nx:run-script",
-      "outputs": ["{projectRoot}/dist/extension"],
+      "outputs": [
+        "{projectRoot}/dist/extension/**/*.js",
+        "{projectRoot}/dist/extension/**/*.ts",
+        "{projectRoot}/dist/extension/**/*.map"
+      ],
       "options": {
         "script": "build:extension"
       },
@@ -150,13 +154,19 @@
       }
     },
     "test": {},
+    "test-e2e": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "test:playwright"
+      }
+    },
     "copy-assets": {
       "executor": "nx:run-script",
       "options": {
         "script": "copy:assets"
       },
       "outputs": [
-        "{projectRoot}/dist/assets/**",
+        "{projectRoot}/dist/extension/icons/**",
         "{projectRoot}/dist/manifest.json",
         "{projectRoot}/dist/devtools.html",
         "{projectRoot}/dist/options.html"

--- a/apps/chrome-devtools/scripts/set-manifest-version.cjs
+++ b/apps/chrome-devtools/scripts/set-manifest-version.cjs
@@ -5,12 +5,13 @@ const manifestPath = join(__dirname, '..', 'dist', 'manifest.json');
 const { version } = require(join(__dirname, '..', 'dist', 'package.json'));
 
 /**
- * align the manifest version with the package.json version
+ * Align the manifest version with the package.json version.
+ * Prerelease versions are not supported in manifest.
  * @param {string} file path to manifest.json
  */
 const updateVersion = async (file) => {
   const content = JSON.parse(await readFile(file, { encoding: 'utf8' }));
-  content.version = version;
+  content.version = version.replace(/-.*$/, '');
   await writeFile(file, JSON.stringify(content, null, 2));
 };
 

--- a/apps/chrome-devtools/src/manifest.json
+++ b/apps/chrome-devtools/src/manifest.json
@@ -28,5 +28,6 @@
   "host_permissions": [
     "https://*/*",
     "http://*/*"
-  ]
+  ],
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxaVpZJkemn3FLmdB6cMqZxa46zGaLo8YC6KxD/Me5jC9mFrgzuybPYzb3OqJ4/66NhXaFV76a6V1aKPez5ZNN2Qm1s4HBIR25u4w8+qwxEOFrjL6t6SvPwZxZ+aN0DG33TjbStm2vgd3ElRrsjpRC5STxLz/ru+ldbiPlri7FZVQ4qCtsR+NheLgop82x52Joy3YyB/dFKyZpTGETfpd+6BNgo/8egOLH4XZkWZZ5hE2CDvazuZY6AqgQTNIiRuhhaW2iNxir09RVF6Ey6IiQUCvmQvek3lmCyqRD/bUdJwIEYeVUgjUJ7dCOBfE10siex9mzGHTVlKqZPYwI9Pq8wIDAQAB"
 }

--- a/apps/chrome-devtools/tsconfig.eslint.json
+++ b/apps/chrome-devtools/tsconfig.eslint.json
@@ -3,6 +3,7 @@
   "include": [
     "eslint*.config.mjs",
     "jest.config.js",
+    "e2e-playwright/**/*",
     "testing/setup-jest.ts",
     "scripts/**/*.cjs"
   ]

--- a/apps/chrome-devtools/tsconfig.extension.json
+++ b/apps/chrome-devtools/tsconfig.extension.json
@@ -6,6 +6,7 @@
     "lib": ["es2021", "dom"],
     "types": ["chrome"],
     "outDir": "dist",
+    "rootDir": "./src",
     "module": "ES2020",
     "moduleResolution": "Node",
     "tsBuildInfoFile": "build/extension.tsbuildinfo",

--- a/apps/showcase/.gitignore
+++ b/apps/showcase/.gitignore
@@ -1,3 +1,4 @@
+# Build
 /*.metadata.json
 /dev-resources
 
@@ -5,6 +6,8 @@
 dist-e2e-playwright
 playwright-reports
 test-results
+
+# Training
 training-assets
 src/assets/trainings/**/exercise.json
 src/assets/trainings/**/solution.json

--- a/apps/showcase/tsconfig.eslint.json
+++ b/apps/showcase/tsconfig.eslint.json
@@ -3,7 +3,7 @@
   "include": [
     "eslint*.config.mjs",
     "jest.config.js",
-    "e2e*playwright/**/*",
+    "e2e-playwright/**/*",
     "testing/setup-jest.ts"
   ]
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,26 +15,34 @@ coverage:
 
 ignore:
   # Package Manager files
-  - '.yarn/**/*'
+  - '.yarn'
   - '.pnp.*'
-  - '.cache/**/*'
-  - 'tmp/**/*'
-  - '**/node_modules/**/*'
+  - '.cache'
+  - 'tmp'
+  - '**/node_modules'
 
   # Distribution folders
-  - 'packages/@*/*/dist/**/*'
-  - 'tools/@*/*/dist/**/*'
-  - 'apps/@*/*/dist/**/*'
+  - 'packages/@*/*/dist'
+  - 'tools/@*/*/dist'
+  - 'apps/@*/*/dist'
 
   # Generated files
-  - 'packages/@o3r-training/showcase-sdk/src/api/**/*'
-  - 'packages/@o3r-training/showcase-sdk/src/models/base/**/*'
-  - 'packages/@o3r-training/showcase-sdk/src/spec/**/*'
-  - 'tools/github-actions/*/packaged-action/**/*'
+  - 'apps/showcase/dev-resources'
+  - 'apps/showcase/training-assets'
+  - 'packages/@o3r-training/showcase-sdk/src/api'
+  - 'packages/@o3r-training/showcase-sdk/src/models/base'
+  - 'packages/@o3r-training/showcase-sdk/src/spec'
+  - 'tools/github-actions/*/packaged-action'
 
   # Templates
   - '**/*.template'
-  - '**/schematics/**/templates/**/*'
+  - '**/schematics/**/templates'
+
+  # Tests
+  - '**/dist-test'
+  - '**/dist-e2e-playwright'
+  - '**/playwright-reports'
+  - '**/test-results'
 
 comment:
   layout: "condensed_header, condensed_files, condensed_footer"

--- a/packages/@ama-sdk/schematics/package.json
+++ b/packages/@ama-sdk/schematics/package.json
@@ -143,7 +143,7 @@
     "@swc/helpers": "~0.5.0",
     "@commitlint/cli": "^19.0.0",
     "@commitlint/config-conventional": "^19.0.0",
-    "@typescript-eslint/eslint-plugin": "~8.19.0",
+    "@typescript-eslint/eslint-plugin": "~8.20.0",
     "jest-junit": "~16.0.0",
     "lint-staged": "^15.0.0",
     "minimist": "^1.2.6",

--- a/packages/@o3r/core/package.json
+++ b/packages/@o3r/core/package.json
@@ -155,8 +155,8 @@
     "@o3r/store-sync": "workspace:^",
     "@stylistic/eslint-plugin": "~2.7.0",
     "@types/jest": "~29.5.2",
-    "@typescript-eslint/eslint-plugin": "~8.19.0",
-    "@typescript-eslint/parser": "~8.19.0",
+    "@typescript-eslint/eslint-plugin": "~8.20.0",
+    "@typescript-eslint/parser": "~8.20.0",
     "angular-eslint": "~18.4.0",
     "cpy-cli": "^5.0.0",
     "eslint": "~9.14.0",
@@ -175,7 +175,7 @@
     "jest-preset-angular": "~14.2.0",
     "jsonc-eslint-parser": "~2.4.0",
     "nx": "~19.8.0",
-    "typescript-eslint": "~8.19.0",
+    "typescript-eslint": "~8.20.0",
     "zone.js": "~0.14.2"
   },
   "engines": {

--- a/packages/@o3r/eslint-config-otter/package.json
+++ b/packages/@o3r/eslint-config-otter/package.json
@@ -73,9 +73,9 @@
     "typescript": "^5.5.4"
   },
   "generatorDependencies": {
-    "@typescript-eslint/eslint-plugin": "~8.19.0",
-    "@typescript-eslint/parser": "~8.19.0",
-    "@typescript-eslint/utils": "~8.19.0",
+    "@typescript-eslint/eslint-plugin": "~8.20.0",
+    "@typescript-eslint/parser": "~8.20.0",
+    "@typescript-eslint/utils": "~8.20.0",
     "eslint": "~9.14.0",
     "eslint-plugin-jsdoc": "~50.2.0",
     "eslint-plugin-unicorn": "^56.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8111,6 +8111,7 @@ __metadata:
     "@o3r/logger": "workspace:^"
     "@o3r/rules-engine": "workspace:^"
     "@o3r/styling": "workspace:^"
+    "@playwright/test": "npm:~1.49.0"
     "@popperjs/core": "npm:^2.11.5"
     "@schematics/angular": "npm:~18.2.0"
     "@stylistic/eslint-plugin": "npm:~2.7.0"
@@ -8145,8 +8146,10 @@ __metadata:
     jest-junit: "npm:~16.0.0"
     jest-preset-angular: "npm:~14.2.0"
     jsonc-eslint-parser: "npm:~2.4.0"
+    lighthouse: "npm:~12.2.0"
     minimist: "npm:^1.2.6"
     nx: "npm:~19.8.0"
+    playwright-lighthouse: "npm:~4.0.0"
     rimraf: "npm:^5.0.1"
     rxjs: "npm:^7.8.1"
     tinycolor2: "npm:^1.6.0"
@@ -15053,22 +15056,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:~8.19.0":
-  version: 8.19.1
-  resolution: "@typescript-eslint/parser@npm:8.19.1"
-  dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.19.1"
-    "@typescript-eslint/types": "npm:8.19.1"
-    "@typescript-eslint/typescript-estree": "npm:8.19.1"
-    "@typescript-eslint/visitor-keys": "npm:8.19.1"
-    debug: "npm:^4.3.4"
-  peerDependencies:
-    eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.8.0"
-  checksum: 10/da3db63ff655cf0fb91745ba8e52d853386f601cf6106d36f4541efcb9e2c6c3b82c6743b15680eff9eafeccaf31c9b26191a955e66ae19de9172f67335463ab
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/rule-tester@npm:~8.20.0":
   version: 8.20.0
   resolution: "@typescript-eslint/rule-tester@npm:8.20.0"
@@ -15082,16 +15069,6 @@ __metadata:
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
   checksum: 10/000375c16c0d9fc7118378ccd7d2ba041d3441bd23f3eead348caf8a481ff99e27994b8dfd512fd270a865cdbf45566f37ae53e82ea5f8cae51026f00370e024
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/scope-manager@npm:8.19.1":
-  version: 8.19.1
-  resolution: "@typescript-eslint/scope-manager@npm:8.19.1"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.19.1"
-    "@typescript-eslint/visitor-keys": "npm:8.19.1"
-  checksum: 10/6ffc78b15367f211eb6650459ca2bb6bfe4c1fa95a3474adc08ee9a20c250b2e0e02fd99be36bd3dad74967ecd9349e792b5d818d85735cba40f1b5c236074d1
   languageName: node
   linkType: hard
 
@@ -15120,35 +15097,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.19.1":
-  version: 8.19.1
-  resolution: "@typescript-eslint/types@npm:8.19.1"
-  checksum: 10/5833a5f8fdac4a490dd3906a0243a0713fbf138fabb451870c70b0b089c539a9624b467b0913ddc0a225a8284342e7fd31cd506dec53c1a6d8f3c8c8902b9cae
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/types@npm:8.20.0, @typescript-eslint/types@npm:^8.0.0":
   version: 8.20.0
   resolution: "@typescript-eslint/types@npm:8.20.0"
   checksum: 10/434859226136ea9e439e8abf5dcf813ea3b55b7e4af6ecc8d290a2f925e3baad0579765ac32d21005b0caedaac38b8624131f87b572c84ca92ac3e742a52e149
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/typescript-estree@npm:8.19.1":
-  version: 8.19.1
-  resolution: "@typescript-eslint/typescript-estree@npm:8.19.1"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.19.1"
-    "@typescript-eslint/visitor-keys": "npm:8.19.1"
-    debug: "npm:^4.3.4"
-    fast-glob: "npm:^3.3.2"
-    is-glob: "npm:^4.0.3"
-    minimatch: "npm:^9.0.4"
-    semver: "npm:^7.6.0"
-    ts-api-utils: "npm:^2.0.0"
-  peerDependencies:
-    typescript: ">=4.8.4 <5.8.0"
-  checksum: 10/5de467452d5ef1a380d441b06cd0134652a0c98cdb4ce31b93eb589f7dc75ef60364d03fd80ca0a48d0c8b268f7258d4f6528b16fe1b89442d60a4bc960fe5f5
   languageName: node
   linkType: hard
 
@@ -15182,16 +15134,6 @@ __metadata:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.8.0"
   checksum: 10/d4369f3e535d5c75eedce2b8f4ea1e857b75ac2ea73f2c707ba3fa3533053f63d8c22f085e58573a2d035d61ed69f6fef4ba0bc7c7df173d26b3adce73bf6aed
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/visitor-keys@npm:8.19.1":
-  version: 8.19.1
-  resolution: "@typescript-eslint/visitor-keys@npm:8.19.1"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.19.1"
-    eslint-visitor-keys: "npm:^4.2.0"
-  checksum: 10/510eb196e7b7d59d3981d672a75454615159e931fe78e2a64b09607c3cfa45110709b0eb5ac3dd271d757a0d98cf4868ad2f45bf9193f96e9efec3efa92a19c1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed change

Set up e2e tests for chrome extensions.
For now, it just ensure that the installation of the extension on chrome is successful.
The goal would be to have visual testing with mocks on the extension panel to avoid regressions.

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
