### PR TITLE
fix: renovate exception 

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -83,7 +83,7 @@ jobs:
           flags: unittests
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test results to Codecov
-        uses: codecov/test-results-action@9739113ad922ea0a9abb4b2c0f8bf6a4aa8ef820 # 1.0.1
+        uses: codecov/test-results-action@4e79e65778be1cecd5df25e14af1eafb6df80ea9 # 1.0.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Publish tests reports

--- a/tools/renovate/managers/github-node-version.json5
+++ b/tools/renovate/managers/github-node-version.json5
@@ -1,8 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Upgrade Node LTS version dependencies in Github Pipeline",
   "customManagers": [
     {
+      "description": "Upgrade Node to LTS version in Github Pipeline Environment",
       "customType": "regex",
       // TODO: To be removed when Renovate will support fileMatch reference or Manager extension
       "fileMatch": [
@@ -13,11 +13,32 @@
         "(^|/)action\\.ya?ml$"
       ],
       "matchStrings": [
-        "node-version: (?<currentValue>.+?)"
+        "node-version: (?<currentValue>.+?)\\s"
       ],
       "depNameTemplate": "node",
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "docker"
+      "datasourceTemplate": "node-version",
+      "versioningTemplate": "node"
+    }
+  ],
+  "packageRules": [
+    {
+      // TODO: replace the following matchers to `matchManagers` when https://github.com/renovatebot/renovate/issues/21760 is fixed
+      "matchDatasources": [
+        "node-version"
+      ],
+      "matchFileNames": [
+        "**/.github/workflows/**/*.y{a,}ml",
+        "**/__dot__github/workflows/**/*.y{a,}ml",
+        "**/__empty__.github/workflows/**/*.y{a,}ml",
+        "**/action.y{a,}ml"
+      ],
+
+      "matchBaseBranches": [
+        "main",
+        "master",
+        "develop"
+      ],
+      "enable": true
     }
   ]
 }


### PR DESCRIPTION


## Proposed change

fix: codecov version raising an exception on mend.io (see [mend.io dashboard](https://developer.mend.io/github/AmadeusITGroup/otter))
fix: renovate node version rule to activate on main branches

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
