### PR TITLE
fix: build and test before release

### DIFF
--- a/packages/@o3r/pipeline/schematics/ng-add/templates/github/__dot__github/workflows/main.yml
+++ b/packages/@o3r/pipeline/schematics/ng-add/templates/github/__dot__github/workflows/main.yml
@@ -41,6 +41,7 @@ jobs:
         run: <%= packageManager %> run lint
 
   release:
+    needs: [build, unit-tests, lint]
     permissions:
       contents: write
     runs-on: <%= runner %>


### PR DESCRIPTION
## Proposed change
The `release` step for a pipeline generated with `@o3r/pipelines` should wait for `build`, `unit-tests` and  `lint`. 