### PR TITLE
fix: dev install for @o3r/pipeline

### DIFF
--- a/packages/@o3r/extractors/src/core/wrapper.ts
+++ b/packages/@o3r/extractors/src/core/wrapper.ts
@@ -58,7 +58,7 @@ export const createBuilderWithMetricsIfInstalled: BuilderWrapper = (builderFn) =
         message: `
 Would you like to share anonymous data about the usage of Otter builders and schematics with the Otter Team at Amadeus ?
 It will help us to improve our tools.
-For more details and instructions on how to change these settings, see https://github.com/AmadeusITGroup/otter/blob/main/docs/telemetry/PRIVACY_NOTICE.md.
+For more details and instructions on how to change these settings, see https://github.com/AmadeusITGroup/otter/blob/main/docs/telemetry/PRIVACY_NOTICE.md
         `,
         default: false
       } as const satisfies Question;

--- a/packages/@o3r/pipeline/package.json
+++ b/packages/@o3r/pipeline/package.json
@@ -111,5 +111,8 @@
   "schematics": "./collection.json",
   "ng-update": {
     "migrations": "./migration.json"
+  },
+  "ng-add": {
+    "save": "devDependencies"
   }
 }

--- a/packages/@o3r/pipeline/schematics/index.it.spec.ts
+++ b/packages/@o3r/pipeline/schematics/index.it.spec.ts
@@ -8,6 +8,9 @@ const o3rEnvironment = globalThis.o3rEnvironment;
 import {
   execSync,
 } from 'node:child_process';
+import {
+  readFileSync,
+} from 'node:fs';
 import * as path from 'node:path';
 import {
   getDefaultExecSyncOptions,
@@ -15,6 +18,9 @@ import {
   packageManagerExec,
   packageManagerInstall,
 } from '@o3r/test-helpers';
+import type {
+  PackageJson,
+} from 'type-fest';
 
 describe('new otter project', () => {
   test('should add a GitHub pipeline to existing project', () => {
@@ -30,6 +36,11 @@ describe('new otter project', () => {
     expect(diff.deleted.length).toBe(0);
     expect(diff.modified).toContain('package.json');
     expect(diff.modified).toContain(isYarnTest ? 'yarn.lock' : 'package-lock.json');
+
+    const packageJson = JSON.parse(readFileSync(path.join(workspacePath, 'package.json'), { encoding: 'utf8' })) as PackageJson;
+    expect(packageJson.devDependencies).toHaveProperty('@o3r/pipeline');
+    expect(packageJson.dependencies).not.toHaveProperty('@o3r/pipeline');
+
     ['.github/actions/setup/action.yml', '.github/workflows/main.yml'].forEach((yamlFile) => {
       expect(diff.added).toContain(yamlFile);
       execSync(`npx -p @action-validator/cli action-validator ${yamlFile}`, execAppOptions);

--- a/packages/@o3r/schematics/src/utility/wrapper.ts
+++ b/packages/@o3r/schematics/src/utility/wrapper.ts
@@ -91,7 +91,7 @@ export const createSchematicWithMetricsIfInstalled: SchematicWrapper = (schemati
         message: `
 Would you like to share anonymous data about the usage of Otter builders and schematics with the Otter Team at Amadeus ?
 It will help us to improve our tools.
-For more details and instructions on how to change these settings, see https://github.com/AmadeusITGroup/otter/blob/main/docs/telemetry/PRIVACY_NOTICE.md.
+For more details and instructions on how to change these settings, see https://github.com/AmadeusITGroup/otter/blob/main/docs/telemetry/PRIVACY_NOTICE.md
         `,
         default: false
       } as const satisfies Question;


### PR DESCRIPTION
## Proposed change

The `pipeline` package should be added as a dev dependency. 

We should reflect if this is the case for other packages as well.