### PR TITLE
feat: clean up deprecated items in api-mock of SDKs and protractor testing

### DIFF
--- a/migration-guides/12.0.md
+++ b/migration-guides/12.0.md
@@ -127,9 +127,11 @@ The following items are **deprecated** and **will be removed** in the version **
 
 ### From [@o3r/testing](https://npmjs.com/package/@o3r/testing)
 
-The following items from `@o3r/testing/src/core/protractor` are deprecated and will be removed in v13: 
+The following items from `@o3r/testing/src/core/protractor` are deprecated and will be removed in v13:
+- `ComponentFixtureProfile` is deprecated.</br>Note: *please use Playwright instead*
+- `Constructable` is deprecated.</br>Note: *please use Playwright instead*
 - `convertPromise` is deprecated.</br>Note: *please use Playwright instead*
-- `ComponentFixtureProfile`, `Constructable`, and `FixtureWithCustom` are deprecated.</br>Note: *please use Playwright instead*
+- `FixtureWithCustom` is deprecated.</br>Note: *please use Playwright instead*
 - `MatAutocomplete` is deprecated.</br>Note: *please use Playwright instead*
 - `MatSelect` is deprecated.</br>Note: *please use Playwright instead*
 - `O3rCheckboxElement` is deprecated.</br>Note: *please use Playwright instead*

--- a/packages/@ama-sdk/core/src/clients/api-fetch-client.ts
+++ b/packages/@ama-sdk/core/src/clients/api-fetch-client.ts
@@ -184,8 +184,7 @@ export class ApiFetchClient implements ApiClient {
       exception = new ResponseJSONParseError(e.message || 'Fail to parse response body', (response && response.status) || 0, body, { apiName, operationId, url, origin });
     }
 
-    // eslint-disable-next-line no-console -- `console.error` is supposed to be the default value if the `options` argument is not provided, can be removed in Otter v12.
-    const reviver = getResponseReviver(revivers, response, operationId, { disableFallback: this.options.disableFallback, log: console.error });
+    const reviver = getResponseReviver(revivers, response, operationId, { disableFallback: this.options.disableFallback });
     const replyPlugins = this.options.replyPlugins
       ? this.options.replyPlugins.map((plugin) => plugin.load<T>({
         dictionaries: root && root.dictionaries,

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/spec/api-mock.mustache
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/spec/api-mock.mustache
@@ -19,24 +19,6 @@ export interface Api {
 }
 
 /**
- * Mock APIs
- * @deprecated use `getMockedApi` with {@link ApiClient} instead, will be removed in v12.
- */
-export const myApi: Api = {
-{{#noEmptyLines}}{{#trimComma}}{{#apis}}
-{{#operations}}
-  {{#camelize}}{{classname}}{{/camelize}}: new api.{{classname}}(MOCK_SERVER),
-{{/operations}}
-{{/apis}}{{/trimComma}}{{/noEmptyLines}}
-};
-
-/**
- * Retrieve mocked SDK Apis
- * @param config configuration of the Api Client
- * @deprecated use `getMockedApi` with {@link ApiClient} instead, will be removed in v12.
- */
-export function getMockedApi(config?: string | BaseApiFetchClientConstructor): Api;
-/**
  * Retrieve mocked SDK Apis
  * @param apiClient Api Client instance
  * @example Default Mocked API usage
@@ -46,24 +28,11 @@ export function getMockedApi(config?: string | BaseApiFetchClientConstructor): A
  * const mocks = getMockedApi(new ApiFetchClient({ basePath: MOCK_SERVER_BASE_PATH }));
  * ```
  */
-export function getMockedApi(apiClient: ApiClient): Api;
-/**
- * Retrieve mocked SDK Apis
- * @param config configuration of the Api Client
- */
-export function getMockedApi(config?: string | BaseApiFetchClientConstructor | ApiClient): Api {
-  let apiConfigObj: ApiClient = MOCK_SERVER;
-  if (typeof config === 'string') {
-    apiConfigObj = new ApiFetchClient({basePath: config});
-  } else if (isApiClient(config)) {
-    apiConfigObj = config;
-  } else if (config) {
-    apiConfigObj = new ApiFetchClient(config);
-  }
+export function getMockedApi(apiClient: ApiClient): Api {
   return {
 {{#noEmptyLines}}{{#trimComma}}{{#apis}}
 {{#operations}}
-    {{#camelize}}{{classname}}{{/camelize}}: new api.{{classname}}(apiConfigObj),
+    {{#camelize}}{{classname}}{{/camelize}}: new api.{{classname}}(apiClient),
 {{/operations}}
 {{/apis}}{{/trimComma}}{{/noEmptyLines}}
   };

--- a/packages/@o3r-training/showcase-sdk/src/spec/api-mock.ts
+++ b/packages/@o3r-training/showcase-sdk/src/spec/api-mock.ts
@@ -3,7 +3,6 @@ import {
 } from '@ama-sdk/client-fetch';
 import {
   ApiClient,
-  isApiClient,
 } from '@ama-sdk/core';
 import * as api from '../api';
 

--- a/packages/@o3r-training/training-sdk/package.json
+++ b/packages/@o3r-training/training-sdk/package.json
@@ -21,7 +21,7 @@
       "default": "./structure/src.json"
     },
     "./structure/spec.json": {
-      "default": "./structure/src.json"
+      "default": "./structure/spec.json"
     },
     ".": {
       "main": "./cjs/index.js",
@@ -63,11 +63,15 @@
     "tslib": "^2.6.2"
   },
   "peerDependenciesMeta": {
+    "@ama-sdk/client-fetch": {
+      "optional": true
+    },
     "isomorphic-fetch": {
       "optional": true
     }
   },
   "devDependencies": {
+    "@ama-sdk/client-fetch": "workspace:^",
     "@ama-sdk/core": "workspace:^",
     "@ama-sdk/schematics": "workspace:^",
     "@angular-devkit/core": "~19.0.0",
@@ -119,6 +123,7 @@
     "yaml-eslint-parser": "^1.2.2"
   },
   "peerDependencies": {
+    "@ama-sdk/client-fetch": "workspace:^",
     "@ama-sdk/core": "workspace:^",
     "isomorphic-fetch": "~3.0.0"
   },

--- a/packages/@o3r-training/training-sdk/src/spec/api-mock.ts
+++ b/packages/@o3r-training/training-sdk/src/spec/api-mock.ts
@@ -1,6 +1,9 @@
-import { type ApiClient, isApiClient } from '@ama-sdk/core';
-import { ApiFetchClient, type BaseApiFetchClientConstructor } from '@ama-sdk/core';
-
+import {
+  ApiFetchClient,
+} from '@ama-sdk/client-fetch';
+import type {
+  ApiClient,
+} from '@ama-sdk/core';
 import * as api from '../api';
 
 /**
@@ -14,20 +17,6 @@ export interface Api {
 }
 
 /**
- * Mock APIs
- * @deprecated use `getMockedApi` with {@link ApiClient} instead, will be removed in v12.
- */
-export const myApi: Api = {
-  dummyApi: new api.DummyApi(MOCK_SERVER)
-};
-
-/**
- * Retrieve mocked SDK Apis
- * @param config configuration of the Api Client
- * @deprecated use `getMockedApi` with {@link ApiClient} instead, will be removed in v12.
- */
-export function getMockedApi(config?: string | BaseApiFetchClientConstructor): Api;
-/**
  * Retrieve mocked SDK Apis
  * @param apiClient Api Client instance
  * @example Default Mocked API usage
@@ -37,21 +26,8 @@ export function getMockedApi(config?: string | BaseApiFetchClientConstructor): A
  * const mocks = getMockedApi(new ApiFetchClient({ basePath: MOCK_SERVER_BASE_PATH }));
  * ```
  */
-export function getMockedApi(apiClient: ApiClient): Api;
-/**
- * Retrieve mocked SDK Apis
- * @param config configuration of the Api Client
- */
-export function getMockedApi(config?: string | BaseApiFetchClientConstructor | ApiClient): Api {
-  let apiConfigObj: ApiClient = MOCK_SERVER;
-  if (typeof config === 'string') {
-    apiConfigObj = new ApiFetchClient({basePath: config});
-  } else if (isApiClient(config)) {
-    apiConfigObj = config;
-  } else if (config) {
-    apiConfigObj = new ApiFetchClient(config);
-  }
+export function getMockedApi(apiClient: ApiClient): Api {
   return {
-    dummyApi: new api.DummyApi(apiConfigObj)
+    dummyApi: new api.DummyApi(apiClient)
   };
 }

--- a/packages/@o3r/testing/src/core/protractor/component-fixture.ts
+++ b/packages/@o3r/testing/src/core/protractor/component-fixture.ts
@@ -8,12 +8,15 @@ import {
   FixtureUsageError,
 } from '../../errors/index';
 import type {
-  ComponentFixtureProfile,
+  ComponentFixtureProfile as ComponentFixtureProfileCore,
+  Constructable as ConstructableCore,
+  FixtureWithCustom as FixtureWithCustomCore,
 } from '../component-fixture';
 import {
   withTimeout,
 } from '../helpers';
 import {
+  ElementProfile,
   O3rElement,
   O3rElementConstructor,
 } from './element';
@@ -28,7 +31,17 @@ import {
 /**
  * @deprecated Will be removed in v13, please use Playwright instead
  */
-export type { ComponentFixtureProfile, Constructable, FixtureWithCustom } from '../component-fixture';
+export interface ComponentFixtureProfile<V extends ElementProfile = ElementProfile> extends ComponentFixtureProfileCore<V> {}
+
+/**
+ * @deprecated Will be removed in v13, please use Playwright instead
+ */
+export interface FixtureWithCustom extends FixtureWithCustomCore {}
+
+/**
+ * @deprecated Will be removed in v13, please use Playwright instead
+ */
+export interface Constructable<T extends ComponentFixtureProfile, U extends FixtureWithCustom = FixtureWithCustom> extends ConstructableCore<T, U> {}
 
 /**
  * Implementation of the fixture dedicated to protractor, hence using the webdriver to interact with the dom.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6938,6 +6938,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@o3r-training/training-sdk@workspace:packages/@o3r-training/training-sdk"
   dependencies:
+    "@ama-sdk/client-fetch": "workspace:^"
     "@ama-sdk/core": "workspace:^"
     "@ama-sdk/schematics": "workspace:^"
     "@angular-devkit/core": "npm:~19.0.0"
@@ -6990,9 +6991,12 @@ __metadata:
     typescript-eslint: "npm:~8.21.0"
     yaml-eslint-parser: "npm:^1.2.2"
   peerDependencies:
+    "@ama-sdk/client-fetch": "workspace:^"
     "@ama-sdk/core": "workspace:^"
     isomorphic-fetch: ~3.0.0
   peerDependenciesMeta:
+    "@ama-sdk/client-fetch":
+      optional: true
     isomorphic-fetch:
       optional: true
   languageName: unknown


### PR DESCRIPTION
## Proposed change

Cleanup of deprecated items in api-mock of showcase SDK and training SDK (and mustache file in @ama-sdk/schematics)

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
