### PR TITLE
fix: remove deprecated vars for templates

### DIFF
--- a/packages/@o3r/components/schemas/placeholder-template.schema.json
+++ b/packages/@o3r/components/schemas/placeholder-template.schema.json
@@ -40,14 +40,6 @@
             "value": {
               "type": "string"
             },
-            "vars": {
-              "deprecated": true,
-              "description": "Deprecated: will be removed in V12. List of variables that can be used in the localization string",
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
             "parameters": {
               "type": "object",
               "additionalProperties": {

--- a/packages/@o3r/components/src/rules-engine/placeholder.rules-engine.effect.spec.ts
+++ b/packages/@o3r/components/src/rules-engine/placeholder.rules-engine.effect.spec.ts
@@ -109,61 +109,20 @@ describe('Rules Engine Effects', () => {
     expect(effect).toBeDefined();
   });
 
-  it('should resolve vars', async () => {
-    const setPlaceholderEffect$ = effect.setPlaceholderRequestEntityFromUrl$.pipe(shareReplay(1));
-    const response: PlaceholderRequestReply = {
-      vars: {
-        myRelPath: {
-          type: 'relativeUrl',
-          value: 'assets-demo-app/img/logo/logo-positive.png'
-        },
-        test: {
-          type: 'localisation',
-          value: 'localisationKey',
-          vars: ['parameterForLoc']
-        },
-        parameterForLoc: {
-          type: 'fact',
-          value: 'parameter'
-        },
-        factInTemplate: {
-          type: 'fact',
-          value: 'factInTemplate',
-          path: '$.myKey'
-        }
-      },
-      template: '<img src=\'<%= myRelPath %>\'> <div><%= test %></div><span><%= factInTemplate %></span>'
-    };
-    actions.next(setPlaceholderRequestEntityFromUrl({
-      call: Promise.resolve(response),
-      id: 'myPlaceholderUrl',
-      resolvedUrl: 'myPlaceholderResolvedUrl'
-    }));
-    factsStream.myFact.next('ignored');
-    factsStream.parameter.next('success');
-    factsStream.factInTemplate.next({ myKey: 'Outstanding fact' });
-
-    const result = (await firstValueFrom(setPlaceholderEffect$)) as UpdateAsyncStoreItemEntityActionPayloadWithId<PlaceholderRequestModel>
-      & Action<'[PlaceholderRequest] update entity'>;
-    expect(result.type).toBe('[PlaceholderRequest] update entity');
-    expect(result.entity.renderedTemplate).toBe('<img src=\'fakeUrl\'> <div>This is a test with a success</div><span>Outstanding fact</span>');
-    expect(result.entity.unknownTypeFound).toBeFalsy();
-  });
-
-  it('should resolve vars and parameters', async () => {
+  it('should resolve parameters', async () => {
     const setPlaceholderEffect$ = effect.setPlaceholderRequestEntityFromUrl$.pipe(shareReplay(1));
     const response: PlaceholderRequestReply = {
       vars: {
         test: {
           type: 'localisation',
           value: 'locForUser',
-          vars: ['varForLoc'],
           parameters: {
             userEmail: 'email',
-            userPhone: 'phone'
+            userPhone: 'phone',
+            parameter: 'paramForLoc'
           }
         },
-        varForLoc: {
+        paramForLoc: {
           type: 'fact',
           value: 'parameter'
         },

--- a/packages/@o3r/components/src/rules-engine/placeholder.rules-engine.effect.ts
+++ b/packages/@o3r/components/src/rules-engine/placeholder.rules-engine.effect.ts
@@ -152,15 +152,10 @@ export class PlaceholderTemplateResponseEffect {
               break;
             }
             case 'localisation': {
-              const linkedVars = (vars[varName].vars || []).reduce((acc: { [key: string]: any }, parameter) => {
-                const paramName = vars[parameter].value;
-                acc[paramName] = factMap[paramName];
-                return acc;
-              }, {});
               const linkedParams = (Object.entries(vars[varName].parameters || {})).reduce((acc: { [key: string]: any }, [paramKey, paramValue]) => {
                 acc[paramKey] = factMapFromVars[paramValue];
                 return acc;
-              }, linkedVars);
+              }, {});
               replacements$.push(
                 this.translationService
                   ? this.translationService.translate(vars[varName].value, linkedParams).pipe(

--- a/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.state.ts
+++ b/packages/@o3r/components/src/stores/placeholder-request/placeholder-request.state.ts
@@ -11,7 +11,6 @@ import {
 export interface PlaceholderVariable {
   type: 'fact' | 'fullUrl' | 'relativeUrl' | 'localisation';
   value: string;
-  vars?: string[];
   parameters?: Record<string, string>;
   path?: string;
 }


### PR DESCRIPTION
## Proposed change

Follow up for https://github.com/AmadeusITGroup/otter/pull/1587, removing deprecated `vars` used in placeholder templates.
Documentation has been already updated https://github.com/AmadeusITGroup/otter/commit/18470a5f5617e580959ffde5b1147b0ae69bfb46#diff-84b1c82a9c6fd7aaf05809ae0ad3020bdaf415d9b37ad73029fe22999ebfbb26 