### PR TITLE
feat(design): add support of URL as token file input

### DIFF
--- a/packages/@o3r/design/src/core/design-token/parsers/design-token.parser.ts
+++ b/packages/@o3r/design/src/core/design-token/parsers/design-token.parser.ts
@@ -301,7 +301,16 @@ interface ParseDesignTokenFileOptions {
  * @param options
  */
 export const parseDesignTokenFile = async (specificationFilePath: string, options?: ParseDesignTokenFileOptions) => {
-  const readFile = options?.readFile || (async (filePath: string) => (await import('node:fs/promises')).readFile(filePath, { encoding: 'utf8' }));
+  let isUrl = false;
+  try {
+    isUrl = new URL(specificationFilePath).protocol.startsWith('http');
+  } catch {
+    // not an URL
+  }
+  const readFile = options?.readFile || (isUrl
+    ? async (filePath: string) => (await fetch(filePath)).text()
+    : async (filePath: string) => (await import('node:fs/promises')).readFile(filePath, { encoding: 'utf8' })
+  );
   const context = {
     basePath: dirname(specificationFilePath),
     ...options?.specificationContext


### PR DESCRIPTION
## Proposed change

feat(design): add support of URL as token file input

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
