### PR TITLE
fix: typos in URLS in v12 migration guide

### DIFF
--- a/migration-guides/12.0.md
+++ b/migration-guides/12.0.md
@@ -76,7 +76,7 @@ Some deprecated code has been removed in version 12.
 
 The following items are **deprecated** and **will be removed** in the version **13**:
 
-### From [@ama-sdk\core](https://npmjs.com/package/@ama-sdk\core)
+### From [@ama-sdk/core](https://npmjs.com/package/@ama-sdk/core)
 
 - `AbortCallback` is deprecated.</br>Note: *Use the one exposed by [@ama-sdk/client-fetch](https://npmjs.com/package/@ama-sdk/client-fetch)*
 - `angularPlugins` is deprecated.</br>Note: *Use the one exposed by [@ama-sdk/client-angular](https://npmjs.com/package/@ama-sdk/client-angular)*
@@ -109,11 +109,11 @@ The following items are **deprecated** and **will be removed** in the version **
 - `TimeoutStatus` is deprecated.</br>Note: *Use the one exposed by [@ama-sdk/client-fetch](https://npmjs.com/package/@ama-sdk/client-fetch)*
 - `WaitForFetch` is deprecated.</br>Note: *Use the one exposed by [@ama-sdk/client-fetch](https://npmjs.com/package/@ama-sdk/client-fetch)*
 
-### From [@o3r\core](https://npmjs.com/package/@o3r\core)
+### From [@o3r/core](https://npmjs.com/package/@o3r/core)
 
 - `keep` is deprecated.</br>Note: *please use `Keep` instead*
 
-### From [@o3r\design](https://npmjs.com/package/@o3r\design)
+### From [@o3r/design](https://npmjs.com/package/@o3r/design)
 
 - `compareVariableByName` is deprecated.</br>Note: *use `getTokenSorterByName` instead.*
 - `computeFileToUpdatePath` is deprecated.</br>Note: *Use `getFileToUpdatePath` instead.*
@@ -121,15 +121,15 @@ The following items are **deprecated** and **will be removed** in the version **
 - `UnregisteredTokenReferenceRender` is deprecated.</br>Note: *duplicate of `UnregisteredTokenReferenceRender`, will be removed on v13*
 - `variableSortComparator` is deprecated.</br>Note: *Use `tokenListTransform` instead.*
 
-### From [@o3r\rules-engine](https://npmjs.com/package/@o3r\rules-engine)
+### From [@o3r/rules-engine](https://npmjs.com/package/@o3r/rules-engine)
 
 - `actionHandlers` is deprecated.</br>Note: *will become protected in Otter v13, instead use `registerActionHandlers`*
 
-### From [@o3r\testing](https://npmjs.com/package/@o3r\testing)
+### From [@o3r/testing](https://npmjs.com/package/@o3r/testing)
 
 The following items from `@o3r/testing/src/core/protractor` are deprecated and will be removed in v13: 
 - `convertPromise` is deprecated.</br>Note: *please use Playwright instead*
-- `ComponentFixtureProfile`, `Constructable`, `FixtureWithCustom` are deprecated.</br>Note: *please use Playwright instead*
+- `ComponentFixtureProfile`, `Constructable`, and `FixtureWithCustom` are deprecated.</br>Note: *please use Playwright instead*
 - `MatAutocomplete` is deprecated.</br>Note: *please use Playwright instead*
 - `MatSelect` is deprecated.</br>Note: *please use Playwright instead*
 - `O3rCheckboxElement` is deprecated.</br>Note: *please use Playwright instead*


### PR DESCRIPTION
## Proposed change

Fix the typo of the backslash in the URLs generated by the deprecated items script. 

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
