### PR TITLE
fix: enforce install if dependencies have ng add

### DIFF
--- a/packages/@o3r/schematics/src/rule-factories/ng-add/dependencies.ts
+++ b/packages/@o3r/schematics/src/rule-factories/ng-add/dependencies.ts
@@ -30,6 +30,7 @@ import {
 } from '../../utility/loaders';
 import {
   getPackageManager,
+  isPackageInstalled,
 } from '../../utility/package-manager-runner';
 
 /**
@@ -170,7 +171,10 @@ export const setupDependencies = (options: SetupDependenciesOptions): Rule => {
     const ngAddToRun = new Set(Object.keys(options.dependencies)
       .filter((dep) => options.ngAddToRun?.some((pattern) => typeof pattern === 'string' ? pattern === dep : pattern.test(dep))));
     const requiringInstallList = new Set(Object.entries(options.dependencies).filter(([, { requireInstall }]) => requireInstall).map(([dep]) => dep));
-    const isInstallNeeded = () => options.skipInstall === undefined ? (ngAddToRun.size > 0 || requiringInstallList.size > 0) : !options.skipInstall;
+    const isInstallNeeded = () => {
+      const needsInstall = Array.from(ngAddToRun).some((packageName) => !isPackageInstalled(packageName));
+      return needsInstall || (options.skipInstall === undefined ? (ngAddToRun.size > 0 || requiringInstallList.size > 0) : !options.skipInstall);
+    };
 
     const editPackageJson = (packageJsonPath: string, packageToInstall: string, dependency: DependencyToAdd, updateLists: boolean): Rule => {
       return (tree, context) => {


### PR DESCRIPTION
## Proposed change

Perform the install if a dependency has an `ng-add` schematics *and* is not installed yet, even if the parent schematics has `skipInstall` to `true` (which is the default value).

## Related issues

<!-- * :bug: Fix #issue -->
* :bug: Fix resolves #2766 
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
