### PR TITLE
feat(rules-engine): added rule ID for logger error message

### DIFF
--- a/packages/@o3r/rules-engine/src/engine/ruleset-executor.ts
+++ b/packages/@o3r/rules-engine/src/engine/ruleset-executor.ts
@@ -300,7 +300,7 @@ export class RulesetExecutor {
               if (this.rulesEngine.debugMode) {
                 output.evaluation = handleRuleEvaluationDebug(rule, this.ruleset.name, output.actions, output.error, runtimeFactValues, factValues, oldFactValues, inputFacts);
               } else if (output.error) {
-                this.rulesEngine.logger?.error(output.error);
+                this.rulesEngine.logger?.error(`Error while evaluating rule ID: ${rule.id}`, output.error);
                 this.rulesEngine.logger?.warn(`Skipping rule ${rule.name}, and the associated ruleset`);
               }
               return output;


### PR DESCRIPTION
## Proposed change

Added rule ID for the logger error message in rules engine while evaluating a rule. This helps to log the error message with an associated rule ID, instead of just the error text.

## Related issues

https://github.com/AmadeusITGroup/otter/issues/2784