### PR TITLE
fix: remove unused and deprecated swagger-gen jar

### DIFF
--- a/packages/@ama-sdk/schematics/package.json
+++ b/packages/@ama-sdk/schematics/package.json
@@ -15,8 +15,7 @@
     "build": "yarn nx build ama-sdk-schematics",
     "postbuild": "patch-package-json-main",
     "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest",
-    "install-swagger-cli": "mvn install:install-file -DgroupId=io.swagger -DartifactId=swagger-codegen-cli -Dversion=2.4.0-AMADEUS -Dpackaging=jar -Dfile=./schematics/resources/swagger-codegen-cli.jar",
-    "build:swagger": "yarn install-swagger-cli && run-p 'build:openapi-*' && yarn cpy 'schematics/**/*.jar' dist/schematics",
+    "build:swagger": "yarn build:openapi-typescript-gen && yarn cpy 'schematics/**/*.jar' dist/schematics",
     "build:openapi-typescript-gen": "mvn clean package -f ./schematics/typescript/core/openapi-codegen-typescript/pom.xml",
     "build:cli": "tsc -b tsconfig.cli.json --pretty && yarn generate-cjs-manifest",
     "prepare:publish": "prepare-publish ./dist"

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/index.js
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/index.js
@@ -1,0 +1,13 @@
+/*
+
+This file is used to allow the use of the builder in the @o3r/framework mono-repository.
+It should not be part of the package.
+
+*/
+
+const { resolve } = require('node:path');
+
+require('ts-node').register({ project: resolve(__dirname, '..', '..', '..', 'tsconfig.builders.json') });
+require('ts-node').register = () => {};
+
+module.exports = require('./index.ts');


### PR DESCRIPTION
## Proposed change

Clean up deprecated jar which was only used for JAVA generation

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
