### PR TITLE
fix(renovate): add missing `--` in `npm run ng update` command

### DIFF
--- a/tools/renovate/tasks/otter-ng-update.json
+++ b/tools/renovate/tasks/otter-ng-update.json
@@ -11,7 +11,7 @@
       "postUpgradeTasks": {
         "commands": [
           "{{arg0}} install",
-          "{{arg0}} run ng update {{{depName}}} --from={{{currentVersion}}} --to={{{newVersion}}} --migrate-only --allow-dirty --force"
+          "{{arg0}} run ng update {{{depName}}} {{#if (equals '{{arg0}}' 'npm')}}-- {{/if}}--from={{{currentVersion}}} --to={{{newVersion}}} --migrate-only --allow-dirty --force"
         ],
         "fileFilters": [
           "!**/.{npmrc,yarnrc*}"


### PR DESCRIPTION
## Proposed change

Fix an issue in renovate `otter-ng-update` preset when used with npm: 
`--` was missing in the command, so `ng update` options such as `--allow-dirty` were not taken into account.

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
