### PR TITLE
fix: expose number type only for number operators and date in next mi…

### DIFF
--- a/packages/@o3r/rules-engine/src/engine/operator/operators/date-based.operators.ts
+++ b/packages/@o3r/rules-engine/src/engine/operator/operators/date-based.operators.ts
@@ -21,7 +21,7 @@ export const inRangeDate: Operator<Date, [DateInput, DateInput], DateInput> = {
  * @title is in next minutes
  * @returns false for dates before `now` and for dates after `now` + `nextMinutes`, true for dates between `now` and `now` + `nextMinutes`
  */
-export const dateInNextMinutes: Operator<Date, string | number, DateInput> = {
+export const dateInNextMinutes: Operator<Date, number, DateInput, string | number> = {
   name: 'dateInNextMinutes',
   evaluator: (leftDateInput, minutes, operatorFactValues) => {
     if (!operatorFactValues) {
@@ -43,7 +43,7 @@ export const dateInNextMinutes: Operator<Date, string | number, DateInput> = {
  * @title is not in next minutes
  * @returns false for dates before `now` and for dates between `now` and `now` + `nextMinutes`, true for dates after `now` + `nextMinutes`
  */
-export const dateNotInNextMinutes: Operator<Date, string | number, DateInput> = {
+export const dateNotInNextMinutes: Operator<Date, number, DateInput, string | number> = {
   name: 'dateNotInNextMinutes',
   evaluator: (leftDateInput, minutes, operatorFactValues) => {
     if (!operatorFactValues) {

--- a/packages/@o3r/rules-engine/src/engine/operator/operators/number-based.operators.ts
+++ b/packages/@o3r/rules-engine/src/engine/operator/operators/number-based.operators.ts
@@ -5,7 +5,7 @@ import { Operator } from '../operator.interface';
  * Check if the number variable is greater or equal to a specific value
  * @title ≥
  */
-export const greaterThanOrEqual: Operator<number, number | string, number | string> = {
+export const greaterThanOrEqual: Operator<number, number, number | string, number | string> = {
   name: 'greaterThanOrEqual',
   evaluator: (firstNumber, secondNumber) => firstNumber >= secondNumber,
   validateLhs: numberValidator,
@@ -16,7 +16,7 @@ export const greaterThanOrEqual: Operator<number, number | string, number | stri
  * Check if the number variable is greater than a specific value
  * @title >
  */
-export const greaterThan: Operator<number, number | string, number | string> = {
+export const greaterThan: Operator<number, number, number | string, number | string> = {
   name: 'greaterThan',
   evaluator: (firstNumber, secondNumber) => firstNumber > secondNumber,
   validateLhs: numberValidator,
@@ -27,7 +27,7 @@ export const greaterThan: Operator<number, number | string, number | string> = {
  * Check if the number variable is lower or equal to a specific value
  * @title ≤
  */
-export const lessOrEqual: Operator<number, number | string, number | string> = {
+export const lessOrEqual: Operator<number, number, number | string, number | string> = {
   name: 'lessOrEqual',
   evaluator: (firstNumber, secondNumber) => firstNumber <= secondNumber,
   validateLhs: numberValidator,
@@ -38,7 +38,7 @@ export const lessOrEqual: Operator<number, number | string, number | string> = {
  * Check if the number variable is lower than a specific value
  * @title <
  */
-export const lessThan: Operator<number, number | string, number | string> = {
+export const lessThan: Operator<number, number, number | string, number | string> = {
   name: 'lessThan',
   evaluator: (firstNumber, secondNumber) => firstNumber < secondNumber,
   validateLhs: numberValidator,


### PR DESCRIPTION
The dateInNextMinutes operator takes as right operand a `string` or a `number`, but what we want to expose as metadata is only the `number` type. Same thing is happening for the number based operators.
## Proposed change

Expose only the `number` type in the metadata of these operators.

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->
result in operators metadata:
![image](https://github.com/user-attachments/assets/e3aa480a-77bd-406e-a8ff-48ff214c7c00)


<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
