### PR TITLE
fix: remove unnecessary default false in schema

### DIFF
--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/schema.json
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/schema.json
@@ -56,8 +56,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/analytics/schematics/ng-add/schema.json
+++ b/packages/@o3r/analytics/schematics/ng-add/schema.json
@@ -13,8 +13,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/apis-manager/schematics/ng-add/schema.json
+++ b/packages/@o3r/apis-manager/schematics/ng-add/schema.json
@@ -23,13 +23,11 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     },
     "skipCodeSample": {
       "type": "boolean",
-      "description": "Skip the code sample generated in application to register the ApiManager (which is relying on FetchApiClient)",
-      "default": false
+      "description": "Skip the code sample generated in application to register the ApiManager (which is relying on FetchApiClient)"
     }
   },
   "required": [

--- a/packages/@o3r/components/schematics/ng-add/schema.json
+++ b/packages/@o3r/components/schematics/ng-add/schema.json
@@ -18,8 +18,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/configuration/schematics/ng-add/schema.json
+++ b/packages/@o3r/configuration/schematics/ng-add/schema.json
@@ -13,8 +13,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/core/schematics/service/schema.json
+++ b/packages/@o3r/core/schematics/service/schema.json
@@ -34,8 +34,7 @@
     "skipLinter": {
       "type": "boolean",
       "description": "Skip the linter process",
-      "default": false,
-      "x-prompt": "Skip linter process on generated files?"
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/core/schematics/store-action/schema.json
+++ b/packages/@o3r/core/schematics/store-action/schema.json
@@ -57,8 +57,7 @@
     "skipLinter": {
       "type": "boolean",
       "description": "Skip the linter process",
-      "default": false,
-      "x-prompt": "Skip linter process on generated files?"
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/core/schematics/store/entity-async/schema.json
+++ b/packages/@o3r/core/schematics/store/entity-async/schema.json
@@ -46,8 +46,7 @@
     "skipLinter": {
       "type": "boolean",
       "description": "Skip the linter process",
-      "default": false,
-      "x-prompt": "Skip linter process on generated files?"
+      "default": false
     },
     "testFramework": {
       "type": "string",

--- a/packages/@o3r/core/schematics/store/entity-sync/schema.json
+++ b/packages/@o3r/core/schematics/store/entity-sync/schema.json
@@ -46,8 +46,7 @@
     "skipLinter": {
       "type": "boolean",
       "description": "Skip the linter process",
-      "default": false,
-      "x-prompt": "Skip linter process on generated files?"
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/core/schematics/store/schema.json
+++ b/packages/@o3r/core/schematics/store/schema.json
@@ -33,8 +33,7 @@
     "skipLinter": {
       "type": "boolean",
       "description": "Skip the linter process",
-      "default": false,
-      "x-prompt": "Skip linter process on generated files?"
+      "default": false
     },
 
     "storeName": {

--- a/packages/@o3r/core/schematics/store/simple-async/schema.json
+++ b/packages/@o3r/core/schematics/store/simple-async/schema.json
@@ -39,8 +39,7 @@
     "skipLinter": {
       "type": "boolean",
       "description": "Skip the linter process",
-      "default": false,
-      "x-prompt": "Skip linter process on generated files?"
+      "default": false
     },
     "testFramework": {
       "type": "string",

--- a/packages/@o3r/core/schematics/store/simple-sync/schema.json
+++ b/packages/@o3r/core/schematics/store/simple-sync/schema.json
@@ -28,8 +28,7 @@
     "skipLinter": {
       "type": "boolean",
       "description": "Skip the linter process",
-      "default": false,
-      "x-prompt": "Skip linter process on generated files?"
+      "default": false
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/design/builders/generate-css/schema.json
+++ b/packages/@o3r/design/builders/generate-css/schema.json
@@ -42,7 +42,6 @@
     },
     "metadataIgnorePrivate": {
       "type": "boolean",
-      "default": false,
       "description": "Ignore the private variable in the Metadata generation."
     },
     "rootPath": {
@@ -51,12 +50,10 @@
     },
     "watch": {
       "type": "boolean",
-      "default": false,
       "description": "Enable Watch mode"
     },
     "failOnDuplicate": {
       "type": "boolean",
-      "default": false,
       "description": "Determine if the process should stop in case of Token duplication"
     },
     "templateFile": {
@@ -90,7 +87,6 @@
     },
     "failOnMissingReference": {
       "type": "boolean",
-      "default": false,
       "description": "Determine if the builder should fail if a missing Design Token reference is detected"
     }
   },

--- a/packages/@o3r/design/builders/generate-jsonschema/schema.json
+++ b/packages/@o3r/design/builders/generate-jsonschema/schema.json
@@ -21,12 +21,10 @@
     },
     "watch": {
       "type": "boolean",
-      "default": false,
       "description": "Enable Watch mode"
     },
     "failOnDuplicate": {
       "type": "boolean",
-      "default": false,
       "description": "Determine if the process should stop in case of Token duplication"
     },
     "schemaId": {

--- a/packages/@o3r/design/builders/generate-style/schema.json
+++ b/packages/@o3r/design/builders/generate-style/schema.json
@@ -51,7 +51,6 @@
     },
     "metadataIgnorePrivate": {
       "type": "boolean",
-      "default": false,
       "description": "Ignore private variables in the metadata generation."
     },
     "rootPath": {
@@ -60,12 +59,10 @@
     },
     "watch": {
       "type": "boolean",
-      "default": false,
       "description": "Enable watch mode"
     },
     "failOnDuplicate": {
       "type": "boolean",
-      "default": false,
       "description": "Determine if the process should stop in case of Design Token duplication"
     },
     "templateFile": {
@@ -100,7 +97,6 @@
     },
     "failOnMissingReference": {
       "type": "boolean",
-      "default": false,
       "description": "Determine if the builder should fail if a missing Design Token reference is detected"
     },
     "sortOrderPatternsFilePath": {

--- a/packages/@o3r/design/schematics/generate-css/schema.json
+++ b/packages/@o3r/design/schematics/generate-css/schema.json
@@ -32,7 +32,6 @@
     },
     "failOnDuplicate": {
       "type": "boolean",
-      "default": false,
       "description": "Determine if the process should stop in case of Token duplication"
     }
   },

--- a/packages/@o3r/design/schematics/ng-add/schema.json
+++ b/packages/@o3r/design/schematics/ng-add/schema.json
@@ -17,8 +17,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/dynamic-content/schematics/ng-add/schema.json
+++ b/packages/@o3r/dynamic-content/schematics/ng-add/schema.json
@@ -13,8 +13,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/eslint-config-otter/schematics/ng-add/schema.json
+++ b/packages/@o3r/eslint-config-otter/schematics/ng-add/schema.json
@@ -13,8 +13,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/eslint-config/schematics/ng-add/schema.json
+++ b/packages/@o3r/eslint-config/schematics/ng-add/schema.json
@@ -13,13 +13,11 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     },
     "fix": {
       "type": "boolean",
-      "description": "Fix known issues with our ESLint config after Otter application or library generation",
-      "default": false
+      "description": "Fix known issues with our ESLint config after Otter application or library generation"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/extractors/schematics/ng-add/schema.json
+++ b/packages/@o3r/extractors/schematics/ng-add/schema.json
@@ -13,8 +13,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/forms/schematics/ng-add/schema.json
+++ b/packages/@o3r/forms/schematics/ng-add/schema.json
@@ -13,8 +13,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/localization/schematics/add-localization-key/schema.json
+++ b/packages/@o3r/localization/schematics/add-localization-key/schema.json
@@ -34,8 +34,7 @@
     },
     "updateTemplate": {
       "type": "boolean",
-      "description": "Update the template by replacing matching value by the localization key",
-      "default": false
+      "description": "Update the template by replacing matching value by the localization key"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/localization/schematics/ng-add/schema.json
+++ b/packages/@o3r/localization/schematics/ng-add/schema.json
@@ -23,8 +23,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/logger/schematics/ng-add/schema.json
+++ b/packages/@o3r/logger/schematics/ng-add/schema.json
@@ -13,8 +13,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/mobile/schematics/ng-add/schema.json
+++ b/packages/@o3r/mobile/schematics/ng-add/schema.json
@@ -13,8 +13,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/new-version/schematics/ng-add/schema.json
+++ b/packages/@o3r/new-version/schematics/ng-add/schema.json
@@ -13,8 +13,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "additionalProperties": false,

--- a/packages/@o3r/routing/schematics/ng-add/schema.json
+++ b/packages/@o3r/routing/schematics/ng-add/schema.json
@@ -13,8 +13,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/rules-engine/schematics/ng-add/schema.json
+++ b/packages/@o3r/rules-engine/schematics/ng-add/schema.json
@@ -18,8 +18,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/store-sync/schematics/ng-add/schema.json
+++ b/packages/@o3r/store-sync/schematics/ng-add/schema.json
@@ -18,8 +18,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/stylelint-plugin/schematics/ng-add/schema.json
+++ b/packages/@o3r/stylelint-plugin/schematics/ng-add/schema.json
@@ -13,8 +13,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/styling/schematics/ng-add/schema.json
+++ b/packages/@o3r/styling/schematics/ng-add/schema.json
@@ -18,8 +18,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/test-helpers/schematics/ng-add/schema.json
+++ b/packages/@o3r/test-helpers/schematics/ng-add/schema.json
@@ -23,8 +23,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/testing/schematics/ng-add/schema.json
+++ b/packages/@o3r/testing/schematics/ng-add/schema.json
@@ -25,8 +25,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/third-party/schematics/ng-add/schema.json
+++ b/packages/@o3r/third-party/schematics/ng-add/schema.json
@@ -13,8 +13,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "additionalProperties": true,

--- a/packages/@o3r/workspace/schematics/library/schema.json
+++ b/packages/@o3r/workspace/schematics/library/schema.json
@@ -38,8 +38,7 @@
     },
     "exactO3rVersion": {
       "type": "boolean",
-      "description": "Use a pinned version for otter packages",
-      "default": false
+      "description": "Use a pinned version for otter packages"
     }
   },
   "required": ["name"],


### PR DESCRIPTION
## Proposed change

To have the options specified in angular.json taking into account we need to not have "default" in schema.json
I removed the `"default": false` for the properties already flagged as not mandatory as it will not change the behavior

But it raised a question in my mind, should we removed all the "default" in the schema.json of the schematics and handle "default" values in the source code directly ? 
So if some values are specified in the angular.json it will always be taken into account instead of the "default" ones.

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->
https://github.com/AmadeusITGroup/otter/issues/2822

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
