### PR TITLE
Renovate presets: run `otter-ng-update` post upgrade commands in mode executionMode=update

### DIFF
--- a/tools/renovate/tasks/otter-ng-update.json
+++ b/tools/renovate/tasks/otter-ng-update.json
@@ -4,9 +4,7 @@
   "packageRules": [
     {
       "matchPackageNames": [
-        "@o3r/core",
-        "@ama-sdk/core",
-        "@otter/core"
+        "@o3r/core"
       ],
       "postUpgradeTasks": {
         "commands": [
@@ -16,7 +14,7 @@
         "fileFilters": [
           "!**/.{npmrc,yarnrc*}"
         ],
-        "executionMode": "branch"
+        "executionMode": "update"
       }
     }
   ]


### PR DESCRIPTION
## Proposed change

This mode makes the post upgrade command run for each dependency update, rather than once for all the updates in the branch. 
We need to set this mode because `ng update` does not allow the `--from=... --to=... --migrate-only` combination for many packages at the same time.

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
