### PR TITLE
feat: specify renovate Otter preset versions

### DIFF
--- a/packages/@ama-sdk/schematics/package.json
+++ b/packages/@ama-sdk/schematics/package.json
@@ -142,7 +142,7 @@
   },
   "generatorDependencies": {
     "@swc/cli": "~0.6.0",
-    "@swc/core": "~1.10.0",
+    "@swc/core": "~1.11.0",
     "@swc/helpers": "~0.5.0",
     "@commitlint/cli": "^19.0.0",
     "@commitlint/config-conventional": "^19.0.0",

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/.renovaterc.json.template
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/.renovaterc.json.template
@@ -1,14 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>AmadeusITGroup/otter//tools/renovate/base",<% if (packageManager === 'yarn') { %>
-    "github>AmadeusITGroup/otter//tools/renovate/sdk"<% if (specPackageName) { %>,
-    "github>AmadeusITGroup/otter//tools/renovate/sdk-spec-upgrade(<%= specPackageName %>)"<% } %><% } else { %>
-    "github>AmadeusITGroup/otter//tools/renovate/group/otter",
-    "github>AmadeusITGroup/otter//tools/renovate/tasks/base",
-    "github>AmadeusITGroup/otter//tools/renovate/tasks/sdk-regenerate(npm)"<% if (specPackageName) { %>,
-    "github>AmadeusITGroup/otter//tools/renovate/group/sdk-spec(<%= specPackageName %>)",
-    "github>AmadeusITGroup/otter//tools/renovate/tasks/sdk-spec-regenerate(npm, <%= specPackageName %>)"<% } %><% } %>
+    "github>AmadeusITGroup/otter//tools/renovate/base#<%= sdkCoreVersion %>",<% if (packageManager === 'yarn') { %>
+    "github>AmadeusITGroup/otter//tools/renovate/sdk#<%= sdkCoreVersion %>"<% if (specPackageName) { %>,
+    "github>AmadeusITGroup/otter//tools/renovate/sdk-spec-upgrade(<%= specPackageName %>)#<%= sdkCoreVersion %>"<% } %><% } else { %>
+    "github>AmadeusITGroup/otter//tools/renovate/group/otter#<%= sdkCoreVersion %>",
+    "github>AmadeusITGroup/otter//tools/renovate/tasks/base#<%= sdkCoreVersion %>",
+    "github>AmadeusITGroup/otter//tools/renovate/tasks/sdk-regenerate(npm)#<%= sdkCoreVersion %>"<% if (specPackageName) { %>,
+    "github>AmadeusITGroup/otter//tools/renovate/group/sdk-spec(<%= specPackageName %>)#<%= sdkCoreVersion %>",
+    "github>AmadeusITGroup/otter//tools/renovate/tasks/sdk-spec-regenerate(npm, <%= specPackageName %>)#<%= sdkCoreVersion %>"<% } %><% } %>
   ],
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,

--- a/packages/@o3r/workspace/migration.json
+++ b/packages/@o3r/workspace/migration.json
@@ -5,6 +5,11 @@
       "version": "10.1.0-alpha.0",
       "description": "Updates of @o3r/workspace to v10.1.*",
       "factory": "./schematics/ng-update/index#updateV10_1"
+    },
+    "migration-v12_1": {
+      "version": "12.1.0-prerelease.0",
+      "description": "Updates of @o3r/workspace to v12.1.*",
+      "factory": "./schematics/ng-update/index#updateV12_1"
     }
   }
 }

--- a/packages/@o3r/workspace/schematics/ng-add/helpers/renovate/index.ts
+++ b/packages/@o3r/workspace/schematics/ng-add/helpers/renovate/index.ts
@@ -1,3 +1,5 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import {
   apply,
   MergeStrategy,
@@ -13,12 +15,17 @@ import {
   getPackageManager,
   getTemplateFolder,
 } from '@o3r/schematics';
+import type {
+  PackageJson,
+} from 'type-fest';
 
 /**
  * Add renovate configuration to Otter application
  * @param rootPath @see RuleFactory.rootPath
  */
 export function generateRenovateConfig(rootPath: string): Rule {
+  const ownPackageJsonContent = JSON.parse(fs.readFileSync(path.resolve(__dirname, '..', '..', '..', '..', 'package.json'), { encoding: 'utf8' })) as PackageJson;
+
   return (tree: Tree, context: SchematicContext) => {
     if (tree.exists('.renovaterc.json')) {
       return tree;
@@ -26,6 +33,7 @@ export function generateRenovateConfig(rootPath: string): Rule {
     const templateSource = apply(url(getTemplateFolder(rootPath, __dirname)), [
       template({
         dot: '.',
+        version: ownPackageJsonContent.version,
         packageManager: getPackageManager()
       }),
       renameTemplateFiles()

--- a/packages/@o3r/workspace/schematics/ng-add/helpers/renovate/templates/__dot__renovaterc.json.template
+++ b/packages/@o3r/workspace/schematics/ng-add/helpers/renovate/templates/__dot__renovaterc.json.template
@@ -1,10 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>AmadeusITGroup/otter//tools/renovate/base",<% if (packageManager == 'yarn') { %>
-    "github>AmadeusITGroup/otter//tools/renovate/otter-project"<% } else { %>
-    "github>AmadeusITGroup/otter//tools/renovate/group/otter",
-    "github>AmadeusITGroup/otter//tools/renovate/tasks/base",
-    "github>AmadeusITGroup/otter//tools/renovate/tasks/otter-ng-update(npm)"<% } %>
+    "github>AmadeusITGroup/otter//tools/renovate/base#<%= version %>",<% if (packageManager == 'yarn') { %>
+    "github>AmadeusITGroup/otter//tools/renovate/otter-project#<%= version %>"<% } else { %>
+    "github>AmadeusITGroup/otter//tools/renovate/group/otter#<%= version %>",
+    "github>AmadeusITGroup/otter//tools/renovate/tasks/base#<%= version %>",
+    "github>AmadeusITGroup/otter//tools/renovate/tasks/otter-ng-update(npm)#<%= version %>"<% } %>
   ]
 }

--- a/packages/@o3r/workspace/schematics/ng-update/index.ts
+++ b/packages/@o3r/workspace/schematics/ng-update/index.ts
@@ -8,6 +8,9 @@ import {
 import {
   addPresetsRenovate,
 } from './v10.1/add-presets-renovate';
+import {
+  updateRenovateVersion,
+} from './v12.1/renovate-version';
 
 /**
  * Update of Otter Workspace V10.1
@@ -25,3 +28,20 @@ function updateV10_1Fn(): Rule {
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention -- function name contains the version number
 export const updateV10_1 = createOtterSchematic(updateV10_1Fn);
+
+/**
+ * Update of Otter Workspace V12.1
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention -- function name contains the version number
+function updateV12_1Fn(): Rule {
+  const updateRules: Rule[] = [
+    updateRenovateVersion()
+  ];
+  return chain(updateRules);
+}
+
+/**
+ * Update of Otter Workspace V12.1
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention -- function name contains the version number
+export const updateV12_1 = createOtterSchematic(updateV12_1Fn);

--- a/packages/@o3r/workspace/schematics/ng-update/v12.1/renovate-version.ts
+++ b/packages/@o3r/workspace/schematics/ng-update/v12.1/renovate-version.ts
@@ -1,0 +1,37 @@
+import {
+  readFileSync,
+} from 'node:fs';
+import {
+  resolve,
+} from 'node:path';
+import type {
+  Rule,
+} from '@angular-devkit/schematics';
+
+const otterRenovatePathPrefix = 'github>AmadeusITGroup/otter//';
+const withVersionPattern = /#[0-9.]+(?:-.+)?$/;
+const supportedRenovateFiles = ['.renovaterc.json', 'renovaterc.json', 'renovate.json'];
+
+export const updateRenovateVersion = (): Rule => {
+  const version: string | undefined = JSON.parse(readFileSync(resolve(__dirname, '..', '..', '..', 'package.json'), { encoding: 'utf8' })).version;
+  return (tree, context) => {
+    if (!version) {
+      context.logger.warn('No Otter version detected');
+      return tree;
+    }
+    supportedRenovateFiles
+      .filter((renovateFile) => tree.exists(renovateFile))
+      .forEach((renovateFile) => {
+        const renovateConfig = tree.readJson(renovateFile) as any;
+        renovateConfig.extends = renovateConfig.extends?.map((extensionPath: string) => {
+          if (!extensionPath.startsWith(otterRenovatePathPrefix) || withVersionPattern.test(extensionPath)) {
+            return extensionPath;
+          }
+
+          return `${extensionPath}#${version}`;
+        });
+        tree.overwrite(renovateFile, JSON.stringify(renovateConfig, null, 2));
+      });
+    return tree;
+  };
+};

--- a/tools/renovate/managers/renovate-otter-presets.json5
+++ b/tools/renovate/managers/renovate-otter-presets.json5
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "^renovate\\.json5?$",
+        "^\\.github/renovate\\.json5?$",
+        "^\\.gitlab/renovate\\.json5?$",
+        "^\\.renovaterc\\.json$",
+        "^\\.renovaterc$"
+      ],
+      "matchStrings": [
+        "\"github>AmadeusITGroup/otter//.*#(?<currentValue>[^\" \\n\\(]+)"
+      ],
+
+      "datasourceTemplate": "npm",
+      "depNameTemplate": "@o3r/core",
+      "depTypeTemplate": "renovate-preset"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDepTypes": [
+        "renovate-preset"
+      ],
+      "matchBaseBranches": [
+        "main",
+        "master",
+        "develop",
+        "/^release/"
+      ],
+      "enable": true
+    }
+  ]
+}

--- a/tools/renovate/otter-project.json
+++ b/tools/renovate/otter-project.json
@@ -5,6 +5,7 @@
     "github>AmadeusITGroup/otter//tools/renovate/group/otter",
     "github>AmadeusITGroup/otter//tools/renovate/tasks/base",
     "github>AmadeusITGroup/otter//tools/renovate/tasks/otter-ng-update(yarn)",
-    "github>AmadeusITGroup/otter//tools/renovate/tasks/yarn-pnp"
+    "github>AmadeusITGroup/otter//tools/renovate/tasks/yarn-pnp",
+    "github>AmadeusITGroup/otter//tools/renovate/managers/renovate-otter-presets.json5"
   ]
 }


### PR DESCRIPTION
## Proposed change

feat: specify renovate Otter preset versions

Missing:
- [x] Rule to upgrade locked version with Otter
- [x] `ng-update` schematics rule

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

<!-- * :bug: Fix #issue -->
* :rocket: Feature resolves #1829
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
