### PR TITLE
fix: fix ng lint for generated packages

### DIFF
--- a/packages/@o3r/workspace/schematics/library/templates/ng/jest/tsconfig.spec.json.template
+++ b/packages/@o3r/workspace/schematics/library/templates/ng/jest/tsconfig.spec.json.template
@@ -1,17 +1,11 @@
 {
   "extends": "<%= tsconfigSpecPath %>",
   "compilerOptions": {
-    "composite": true,
     "outDir": "test",
     "rootDir": "."
   },
   "include": [
     "./src/**/*.spec.ts"
   ],
-  "exclude": [],
-  "references": [
-    {
-      "path": "./tsconfig.build.composite.json"
-    }
-  ]
+  "exclude": []
 }


### PR DESCRIPTION
## Proposed change

The angular lint builder does not support references and composite.
IDE supports navigation for spec files thanks to the project tsconfig.json
We do not need these references anymore

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
