### PR TITLE
feat: support exploded syntax in sdk

### DIFF
--- a/packages/@ama-sdk/client-angular/src/api-angular-client.ts
+++ b/packages/@ama-sdk/client-angular/src/api-angular-client.ts
@@ -2,10 +2,12 @@ import type {
   ApiClient,
   ApiTypes,
   BaseApiClientOptions,
+  ParamSerialization,
   PartialExcept,
   RequestOptions,
   RequestOptionsParameters,
   ReviverType,
+  SupportedParamType,
   TokenizedOptions,
 } from '@ama-sdk/core';
 import {
@@ -13,10 +15,15 @@ import {
   ExceptionReply,
   extractQueryParams,
   filterUndefinedValues,
+  getPropertiesFromData,
   getResponseReviver,
   prepareUrl,
+  prepareUrlWithQueryParams,
   processFormData,
   ReviverReply,
+  serializePathParams,
+  serializeQueryParams,
+  stringifyQueryParams,
   tokenizeRequestOptions,
 } from '@ama-sdk/core';
 import type {
@@ -71,6 +78,16 @@ export class ApiAngularClient implements ApiClient {
   }
 
   /** @inheritdoc */
+  public getPropertiesFromData<T, K extends keyof T>(data: T, keys: K[]): Pick<T, K> {
+    return getPropertiesFromData(data, keys);
+  }
+
+  /** @inheritdoc */
+  public stringifyQueryParams<T extends { [key: string]: SupportedParamType }>(queryParams: T): { [p in keyof T]: string; } {
+    return stringifyQueryParams(queryParams);
+  }
+
+  /** @inheritdoc */
   public async getRequestOptions(requestOptionsParameters: RequestOptionsParameters): Promise<RequestOptions> {
     let opts: RequestOptions = {
       ...requestOptionsParameters,
@@ -90,8 +107,29 @@ export class ApiAngularClient implements ApiClient {
   }
 
   /** @inheritdoc */
+  public serializeQueryParams<T extends { [key: string]: SupportedParamType }>(queryParams: T, queryParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string } {
+    if (this.options.serializeQueryParams) {
+      return this.options.serializeQueryParams(queryParams, queryParamSerialization);
+    }
+    return serializeQueryParams(queryParams, queryParamSerialization);
+  }
+
+  /** @inheritdoc */
+  public serializePathParams<T extends { [key: string]: SupportedParamType }>(pathParams: T, pathParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string } {
+    if (this.options.serializePathParams) {
+      return serializePathParams(pathParams, pathParamSerialization);
+    }
+    return serializePathParams(pathParams, pathParamSerialization);
+  }
+
+  /** @inheritdoc */
   public prepareUrl(url: string, queryParameters: { [key: string]: string | undefined } = {}) {
     return prepareUrl(url, queryParameters);
+  }
+
+  /** @inheritdoc */
+  public prepareUrlWithQueryParams(url: string, serializedQueryParams: { [key: string]: string }): string {
+    return prepareUrlWithQueryParams(url, serializedQueryParams);
   }
 
   /** @inheritdoc */

--- a/packages/@ama-sdk/client-beacon/src/api-beacon-client.ts
+++ b/packages/@ama-sdk/client-beacon/src/api-beacon-client.ts
@@ -2,16 +2,23 @@ import type {
   ApiClient,
   ApiTypes,
   BaseApiClientOptions,
+  ParamSerialization,
   PartialExcept,
   RequestOptions,
   RequestOptionsParameters,
+  SupportedParamType,
   TokenizedOptions,
 } from '@ama-sdk/core';
 import {
   extractQueryParams,
   filterUndefinedValues,
+  getPropertiesFromData,
   prepareUrl,
+  prepareUrlWithQueryParams,
   processFormData,
+  serializePathParams,
+  serializeQueryParams,
+  stringifyQueryParams,
   tokenizeRequestOptions,
 } from '@ama-sdk/core';
 
@@ -67,6 +74,16 @@ export class ApiBeaconClient implements ApiClient {
   }
 
   /** @inheritdoc */
+  public getPropertiesFromData<T, K extends keyof T>(data: T, keys: K[]): Pick<T, K> {
+    return getPropertiesFromData(data, keys);
+  }
+
+  /** @inheritdoc */
+  public stringifyQueryParams<T extends { [key: string]: SupportedParamType }>(queryParams: T): { [p in keyof T]: string; } {
+    return stringifyQueryParams(queryParams);
+  }
+
+  /** @inheritdoc */
   public getRequestOptions(options: RequestOptionsParameters): Promise<RequestOptions> {
     if (options.method.toUpperCase() !== 'POST') {
       throw new Error(`Unsupported method: ${options.method}. The beacon API only supports POST.`);
@@ -92,8 +109,29 @@ export class ApiBeaconClient implements ApiClient {
   }
 
   /** @inheritdoc */
+  public serializeQueryParams<T extends { [key: string]: SupportedParamType }>(queryParams: T, queryParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string } {
+    if (this.options.serializeQueryParams) {
+      return this.options.serializeQueryParams(queryParams, queryParamSerialization);
+    }
+    return serializeQueryParams(queryParams, queryParamSerialization);
+  }
+
+  /** @inheritdoc */
+  public serializePathParams<T extends { [key: string]: SupportedParamType }>(pathParams: T, pathParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string } {
+    if (this.options.serializePathParams) {
+      return serializePathParams(pathParams, pathParamSerialization);
+    }
+    return serializePathParams(pathParams, pathParamSerialization);
+  }
+
+  /** @inheritdoc */
   public prepareUrl(url: string, queryParameters?: { [key: string]: string }): string {
     return prepareUrl(url, queryParameters);
+  }
+
+  /** @inheritdoc */
+  public prepareUrlWithQueryParams(url: string, serializedQueryParams: { [key: string]: string }): string {
+    return prepareUrlWithQueryParams(url, serializedQueryParams);
   }
 
   /** @inheritdoc */

--- a/packages/@ama-sdk/client-fetch/src/api-fetch-client.ts
+++ b/packages/@ama-sdk/client-fetch/src/api-fetch-client.ts
@@ -2,11 +2,13 @@ import type {
   ApiClient,
   ApiTypes,
   BaseApiClientOptions,
+  ParamSerialization,
   PartialExcept,
   PluginAsyncRunner,
   RequestOptions,
   RequestOptionsParameters,
   ReviverType,
+  SupportedParamType,
   TokenizedOptions,
 } from '@ama-sdk/core';
 import {
@@ -15,11 +17,16 @@ import {
   ExceptionReply,
   extractQueryParams,
   filterUndefinedValues,
+  getPropertiesFromData,
   getResponseReviver,
   prepareUrl,
+  prepareUrlWithQueryParams,
   processFormData,
   ResponseJSONParseError,
   ReviverReply,
+  serializePathParams,
+  serializeQueryParams,
+  stringifyQueryParams,
   tokenizeRequestOptions,
 } from '@ama-sdk/core';
 import type {
@@ -68,6 +75,16 @@ export class ApiFetchClient implements ApiClient {
   }
 
   /** @inheritdoc */
+  public getPropertiesFromData<T, K extends keyof T>(data: T, keys: K[]): Pick<T, K> {
+    return getPropertiesFromData(data, keys);
+  }
+
+  /** @inheritdoc */
+  public stringifyQueryParams<T extends { [key: string]: SupportedParamType }>(queryParams: T): { [p in keyof T]: string; } {
+    return stringifyQueryParams(queryParams);
+  }
+
+  /** @inheritdoc */
   public tokenizeRequestOptions(url: string, queryParameters: { [key: string]: string }, piiParamTokens: { [key: string]: string }, data: any): TokenizedOptions | undefined {
     return this.options.enableTokenization ? tokenizeRequestOptions(url, queryParameters, piiParamTokens, data) : undefined;
   }
@@ -92,8 +109,29 @@ export class ApiFetchClient implements ApiClient {
   }
 
   /** @inheritdoc */
+  public serializeQueryParams<T extends { [key: string]: SupportedParamType }>(queryParams: T, queryParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string } {
+    if (this.options.serializeQueryParams) {
+      return this.options.serializeQueryParams(queryParams, queryParamSerialization);
+    }
+    return serializeQueryParams(queryParams, queryParamSerialization);
+  }
+
+  /** @inheritdoc */
+  public serializePathParams<T extends { [key: string]: SupportedParamType }>(pathParams: T, pathParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string } {
+    if (this.options.serializePathParams) {
+      return serializePathParams(pathParams, pathParamSerialization);
+    }
+    return serializePathParams(pathParams, pathParamSerialization);
+  }
+
+  /** @inheritdoc */
   public prepareUrl(url: string, queryParameters: { [key: string]: string | undefined } = {}) {
     return prepareUrl(url, queryParameters);
+  }
+
+  /** @inheritdoc */
+  public prepareUrlWithQueryParams(url: string, serializedQueryParams: { [key: string]: string }): string {
+    return prepareUrlWithQueryParams(url, serializedQueryParams);
   }
 
   /** @inheritdoc */

--- a/packages/@ama-sdk/core/src/clients/api-angular-client.ts
+++ b/packages/@ama-sdk/core/src/clients/api-angular-client.ts
@@ -8,9 +8,12 @@ import {
 import {
   extractQueryParams,
   filterUndefinedValues,
+  getPropertiesFromData,
   getResponseReviver,
   prepareUrl,
+  prepareUrlWithQueryParams,
   processFormData,
+  stringifyQueryParams,
   tokenizeRequestOptions,
 } from '../fwk/api.helpers';
 import type {
@@ -26,6 +29,12 @@ import {
 import {
   EmptyResponseError,
 } from '../fwk/errors';
+import {
+  type ParamSerialization,
+  serializePathParams,
+  serializeQueryParams,
+  type SupportedParamType,
+} from '../fwk/param-serialization';
 import {
   ReviverType,
 } from '../fwk/reviver';
@@ -99,6 +108,16 @@ export class ApiAngularClient implements ApiClient {
   }
 
   /** @inheritdoc */
+  public getPropertiesFromData<T, K extends keyof T>(data: T, keys: K[]): Pick<T, K> {
+    return getPropertiesFromData(data, keys);
+  }
+
+  /** @inheritdoc */
+  public stringifyQueryParams<T extends { [key: string]: SupportedParamType }>(queryParams: T): { [p in keyof T]: string; } {
+    return stringifyQueryParams(queryParams);
+  }
+
+  /** @inheritdoc */
   public async getRequestOptions(requestOptionsParameters: RequestOptionsParameters): Promise<RequestOptions> {
     let opts: RequestOptions = {
       ...requestOptionsParameters,
@@ -118,8 +137,29 @@ export class ApiAngularClient implements ApiClient {
   }
 
   /** @inheritdoc */
+  public serializeQueryParams<T extends { [key: string]: SupportedParamType }>(queryParams: T, queryParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string } {
+    if (this.options.serializeQueryParams) {
+      return this.options.serializeQueryParams(queryParams, queryParamSerialization);
+    }
+    return serializeQueryParams(queryParams, queryParamSerialization);
+  }
+
+  /** @inheritdoc */
+  public serializePathParams<T extends { [key: string]: SupportedParamType }>(pathParams: T, pathParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string } {
+    if (this.options.serializePathParams) {
+      return this.options.serializePathParams(pathParams, pathParamSerialization);
+    }
+    return serializePathParams(pathParams, pathParamSerialization);
+  }
+
+  /** @inheritdoc */
   public prepareUrl(url: string, queryParameters: { [key: string]: string | undefined } = {}) {
     return prepareUrl(url, queryParameters);
+  }
+
+  /** @inheritdoc */
+  public prepareUrlWithQueryParams(url: string, serializedQueryParams: { [key: string]: string }): string {
+    return prepareUrlWithQueryParams(url, serializedQueryParams);
   }
 
   /** @inheritdoc */

--- a/packages/@ama-sdk/core/src/clients/api-beacon-client.ts
+++ b/packages/@ama-sdk/core/src/clients/api-beacon-client.ts
@@ -4,8 +4,11 @@ import type {
 import {
   extractQueryParams,
   filterUndefinedValues,
+  getPropertiesFromData,
   prepareUrl,
+  prepareUrlWithQueryParams,
   processFormData,
+  stringifyQueryParams,
   tokenizeRequestOptions,
 } from '../fwk/api.helpers';
 import type {
@@ -18,6 +21,12 @@ import type {
 import type {
   BaseApiClientOptions,
 } from '../fwk/core/base-api-constructor';
+import {
+  type ParamSerialization,
+  serializePathParams,
+  serializeQueryParams,
+  type SupportedParamType,
+} from '../fwk/param-serialization';
 import type {
   RequestBody,
   RequestOptions,
@@ -83,6 +92,16 @@ export class ApiBeaconClient implements ApiClient {
   }
 
   /** @inheritdoc */
+  public getPropertiesFromData<T, K extends keyof T>(data: T, keys: K[]): Pick<T, K> {
+    return getPropertiesFromData(data, keys);
+  }
+
+  /** @inheritdoc */
+  public stringifyQueryParams<T extends { [key: string]: SupportedParamType }>(queryParams: T): { [p in keyof T]: string; } {
+    return stringifyQueryParams(queryParams);
+  }
+
+  /** @inheritdoc */
   public getRequestOptions(options: RequestOptionsParameters): Promise<RequestOptions> {
     if (options.method.toUpperCase() !== 'POST') {
       throw new Error(`Unsupported method: ${options.method}. The beacon API only supports POST.`);
@@ -108,8 +127,29 @@ export class ApiBeaconClient implements ApiClient {
   }
 
   /** @inheritdoc */
+  public serializeQueryParams<T extends { [key: string]: SupportedParamType }>(queryParams: T, queryParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string } {
+    if (this.options.serializeQueryParams) {
+      return this.options.serializeQueryParams(queryParams, queryParamSerialization);
+    }
+    return serializeQueryParams(queryParams, queryParamSerialization);
+  }
+
+  /** @inheritdoc */
+  public serializePathParams<T extends { [key: string]: SupportedParamType }>(pathParams: T, pathParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string } {
+    if (this.options.serializePathParams) {
+      return serializePathParams(pathParams, pathParamSerialization);
+    }
+    return serializePathParams(pathParams, pathParamSerialization);
+  }
+
+  /** @inheritdoc */
   public prepareUrl(url: string, queryParameters?: { [key: string]: string }): string {
     return prepareUrl(url, queryParameters);
+  }
+
+  /** @inheritdoc */
+  public prepareUrlWithQueryParams(url: string, serializedQueryParams: { [key: string]: string }): string {
+    return prepareUrlWithQueryParams(url, serializedQueryParams);
   }
 
   /** @inheritdoc */

--- a/packages/@ama-sdk/core/src/clients/api-fetch-client.ts
+++ b/packages/@ama-sdk/core/src/clients/api-fetch-client.ts
@@ -4,9 +4,12 @@ import {
 import {
   extractQueryParams,
   filterUndefinedValues,
+  getPropertiesFromData,
   getResponseReviver,
   prepareUrl,
+  prepareUrlWithQueryParams,
   processFormData,
+  stringifyQueryParams,
   tokenizeRequestOptions,
 } from '../fwk/api.helpers';
 import type {
@@ -24,6 +27,12 @@ import {
   EmptyResponseError,
   ResponseJSONParseError,
 } from '../fwk/errors';
+import {
+  type ParamSerialization,
+  serializePathParams,
+  serializeQueryParams,
+  type SupportedParamType,
+} from '../fwk/param-serialization';
 import {
   ReviverType,
 } from '../fwk/reviver';
@@ -91,6 +100,16 @@ export class ApiFetchClient implements ApiClient {
   }
 
   /** @inheritdoc */
+  public getPropertiesFromData<T, K extends keyof T>(data: T, keys: K[]): Pick<T, K> {
+    return getPropertiesFromData(data, keys);
+  }
+
+  /** @inheritdoc */
+  public stringifyQueryParams<T extends { [key: string]: SupportedParamType }>(queryParams: T): { [p in keyof T]: string; } {
+    return stringifyQueryParams(queryParams);
+  }
+
+  /** @inheritdoc */
   public tokenizeRequestOptions(url: string, queryParameters: { [key: string]: string }, piiParamTokens: { [key: string]: string }, data: any): TokenizedOptions | undefined {
     return this.options.enableTokenization ? tokenizeRequestOptions(url, queryParameters, piiParamTokens, data) : undefined;
   }
@@ -115,8 +134,29 @@ export class ApiFetchClient implements ApiClient {
   }
 
   /** @inheritdoc */
+  public serializeQueryParams<T extends { [key: string]: SupportedParamType }>(queryParams: T, queryParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string } {
+    if (this.options.serializeQueryParams) {
+      return this.options.serializeQueryParams(queryParams, queryParamSerialization);
+    }
+    return serializeQueryParams(queryParams, queryParamSerialization);
+  }
+
+  /** @inheritdoc */
+  public serializePathParams<T extends { [key: string]: SupportedParamType }>(pathParams: T, pathParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string } {
+    if (this.options.serializePathParams) {
+      return serializePathParams(pathParams, pathParamSerialization);
+    }
+    return serializePathParams(pathParams, pathParamSerialization);
+  }
+
+  /** @inheritdoc */
   public prepareUrl(url: string, queryParameters: { [key: string]: string | undefined } = {}) {
     return prepareUrl(url, queryParameters);
+  }
+
+  /** @inheritdoc */
+  public prepareUrlWithQueryParams(url: string, serializedQueryParams: { [key: string]: string }): string {
+    return prepareUrlWithQueryParams(url, serializedQueryParams);
   }
 
   /** @inheritdoc */

--- a/packages/@ama-sdk/core/src/fwk/api.helper.spec.ts
+++ b/packages/@ama-sdk/core/src/fwk/api.helper.spec.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-console -- only using the reference */
 import {
   getResponseReviver,
+  prepareUrl,
+  prepareUrlWithQueryParams,
   ReviverType,
 } from '@ama-sdk/core';
 
@@ -63,5 +65,27 @@ describe('getResponseReviver - reviver as function', () => {
   it('should only return the reviver if the endpoint reviver is a function or an undefined object', () => {
     expect(getResponseReviver(reviver, { status: 200, ok: true })).toBe(reviver);
     expect(getResponseReviver(undefined, { status: 200, ok: true })).toBe(undefined);
+  });
+});
+
+describe('Prepare URL', () => {
+  it('should correctly prepare url with query parameters of deprecated type', () => {
+    // primitive value
+    expect(prepareUrl('https://sampleUrl/samplePath/sampleOperation', { id: '5' })).toEqual('https://sampleUrl/samplePath/sampleOperation?id=5');
+    // array value
+    expect(prepareUrl('https://sampleUrl/samplePath/sampleOperation', { id: '3,4,5' })).toEqual('https://sampleUrl/samplePath/sampleOperation?id=3,4,5');
+  });
+
+  it('should correctly prepare url with serialized query parameters', () => {
+    // one parameter
+    expect(prepareUrlWithQueryParams('https://sampleUrl/samplePath/sampleOperation', { id: 'id=5' }))
+      .toEqual('https://sampleUrl/samplePath/sampleOperation?id=5');
+
+    // no parameters
+    expect(prepareUrlWithQueryParams('https://sampleUrl/samplePath/sampleOperation', {})).toEqual('https://sampleUrl/samplePath/sampleOperation');
+
+    // multiple parameters
+    expect(prepareUrlWithQueryParams('https://sampleUrl/samplePath/sampleOperation', { id1: 'id1=3,4,5', id2: 'id2=5' }))
+      .toEqual('https://sampleUrl/samplePath/sampleOperation?id1=3,4,5&id2=5');
   });
 });

--- a/packages/@ama-sdk/core/src/fwk/core/api-client.ts
+++ b/packages/@ama-sdk/core/src/fwk/core/api-client.ts
@@ -11,6 +11,10 @@ import type {
   Api,
 } from '../api.interface';
 import type {
+  ParamSerialization,
+  SupportedParamType,
+} from '../param-serialization';
+import type {
   ReviverType,
 } from '../reviver';
 import type {
@@ -52,8 +56,22 @@ export interface ApiClient {
    * Returns a map containing the query parameters
    * @param data
    * @param names
+   * @deprecated use {@link stringifyQueryParams} which accepts only supported types, will be removed in v14.
    */
   extractQueryParams<T extends { [key: string]: any }>(data: T, names: (keyof T)[]): { [p in keyof T]: string; };
+
+  /**
+   * Get requested properties from data
+   * @param data Data to get properties from
+   * @param keys Keys of properties to retrieve
+   */
+  getPropertiesFromData<T, K extends keyof T>(data: T, keys: K[]): Pick<T, K>;
+
+  /**
+   * Returns a map containing the query parameters
+   * @param queryParams Query parameters of supported parameter types
+   */
+  stringifyQueryParams<T extends { [key: string]: SupportedParamType }>(queryParams: T): { [p in keyof T]: string; };
 
   /**
    * Retrieve the option to process the HTTP Call
@@ -61,11 +79,34 @@ export interface ApiClient {
   getRequestOptions(requestOptionsParameters: RequestOptionsParameters): Promise<RequestOptions>;
 
   /**
-   * prepares the url to be called
-   * @param url base url to be used
-   * @param queryParameters key value pair with the parameters. If the value is undefined, the key is dropped
+   * Prepares the url to be called
+   * @param url Base url to be used
+   * @param queryParameters Key value pair with the parameters. If the value is undefined, the key is dropped
+   * @deprecated use {@link prepareUrlWithQueryParams} with query parameter serialization, will be removed in v14.
    */
   prepareUrl(url: string, queryParameters?: { [key: string]: string | undefined }): string;
+
+  /**
+   * Prepares the url to be called with the query parameters
+   * @param url Base url to be used
+   * @param serializedQueryParams Key value pairs of query parameter names and their serialized values
+   */
+  prepareUrlWithQueryParams(url: string, serializedQueryParams: { [key: string]: string }): string;
+
+  /**
+   * Serialize query parameters based on the values of exploded and style
+   * OpenAPI Parameter Serialization {@link https://swagger.io/specification | documentation}
+   * @param queryParams
+   * @param queryParamSerialization
+   */
+  serializeQueryParams<T extends { [key: string]: SupportedParamType }>(queryParams: T, queryParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string };
+
+  /**
+   * Prepares the path parameters for the URL to be called
+   * @param pathParams
+   * @param pathParamSerialization key value pair with the parameters. If the value is undefined, the key is dropped
+   */
+  serializePathParams<T extends { [key: string]: SupportedParamType }>(pathParams: T, pathParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string };
 
   /**
    * Returns tokenized request options:

--- a/packages/@ama-sdk/core/src/fwk/core/base-api-constructor.ts
+++ b/packages/@ama-sdk/core/src/fwk/core/base-api-constructor.ts
@@ -5,6 +5,10 @@ import {
 import type {
   Logger,
 } from '../logger';
+import {
+  ParamSerialization,
+  SupportedParamType,
+} from '../param-serialization';
 
 /** Interface of the constructor configuration object */
 export interface BaseApiClientOptions {
@@ -23,6 +27,10 @@ export interface BaseApiClientOptions {
   disableFallback?: boolean;
   /** Logger (optional, fallback to console logger if undefined) */
   logger?: Logger;
+  /** Custom query parameter serialization method */
+  serializeQueryParams?<T extends { [key: string]: SupportedParamType }>(queryParams: T, queryParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string };
+  /** Custom query parameter serialization method */
+  serializePathParams?<T extends { [key: string]: SupportedParamType }>(pathParams: T, pathParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string };
 }
 
 /** Interface of the constructor configuration object */

--- a/packages/@ama-sdk/core/src/fwk/index.ts
+++ b/packages/@ama-sdk/core/src/fwk/index.ts
@@ -7,4 +7,5 @@ export * from './errors';
 export * from './ignore-enum.type';
 export * from './logger';
 export * from './mocks/index';
+export * from './param-serialization';
 export * from './reviver';

--- a/packages/@ama-sdk/core/src/fwk/param-serialization.spec.ts
+++ b/packages/@ama-sdk/core/src/fwk/param-serialization.spec.ts
@@ -1,0 +1,194 @@
+import {
+  getPropertiesFromData,
+} from './api.helpers';
+import {
+  serializePathParams,
+  serializeQueryParams,
+} from './param-serialization';
+
+describe('Serialize parameters', () => {
+  const mockData = {
+    idPrimitive: '5',
+    idArray: ['3', '4', '5'],
+    idObject: { role: 'admin', firstName: 'Alex' }
+  };
+
+  it('should correctly serialize query parameters', () => {
+    const mockPrimitiveQueryParams = getPropertiesFromData(mockData, ['idPrimitive']);
+    const mockArrayQueryParams = getPropertiesFromData(mockData, ['idArray']);
+    const mockObjectQueryParams = getPropertiesFromData(mockData, ['idObject']);
+    const mockMultipleQueryParams = getPropertiesFromData(mockData, ['idArray', 'idPrimitive']);
+
+    // value = primitive, explode = true, style = form
+    expect(serializeQueryParams(mockPrimitiveQueryParams, { idPrimitive: { explode: true, style: 'form' } })).toEqual({ idPrimitive: 'idPrimitive=5' });
+    // value = primitive, explode = false, style = form
+    expect(serializeQueryParams(mockPrimitiveQueryParams, { idPrimitive: { explode: false, style: 'form' } })).toEqual({ idPrimitive: 'idPrimitive=5' });
+    // value = array, explode = true, style = form
+    expect(serializeQueryParams(mockArrayQueryParams, { idArray: { explode: true, style: 'form' } })).toEqual({ idArray: 'idArray=3&idArray=4&idArray=5' });
+    // value = array, explode = false, style = form
+    expect(serializeQueryParams(mockArrayQueryParams, { idArray: { explode: false, style: 'form' } })).toEqual({ idArray: 'idArray=3,4,5' });
+    // value = array, explode = true, style = spaceDelimited --> not supported
+    expect(serializeQueryParams(mockArrayQueryParams, { idArray: { explode: true, style: 'spaceDelimited' } })).toEqual({ idArray: undefined });
+    // value = array, explode = false, style = spaceDelimited
+    expect(serializeQueryParams(mockArrayQueryParams, { idArray: { explode: false, style: 'spaceDelimited' } })).toEqual({ idArray: 'idArray=3%204%205' });
+    // value = array, explode = true, style = pipeDelimited --> not supported
+    expect(serializeQueryParams(mockArrayQueryParams, { idArray: { explode: true, style: 'pipeDelimited' } })).toEqual({ idArray: undefined });
+    // value = array, explode = false, style = pipeDelimited
+    expect(serializeQueryParams(mockArrayQueryParams, { idArray: { explode: false, style: 'pipeDelimited' } })).toEqual({ idArray: 'idArray=3%7C4%7C5' });
+    // value = object, explode = true, style = form
+    expect(serializeQueryParams(mockObjectQueryParams, { idObject: { explode: true, style: 'form' } })).toEqual({ idObject: 'role=admin&firstName=Alex' });
+    // value = object, explode = false, style = form
+    expect(serializeQueryParams(mockObjectQueryParams, { idObject: { explode: false, style: 'form' } })).toEqual({ idObject: 'idObject=role,admin,firstName,Alex' });
+    // value = object, explode = true, style = spaceDelimited --> not supported
+    expect(serializeQueryParams(mockObjectQueryParams, { idObject: { explode: true, style: 'spaceDelimited' } })).toEqual({ idObject: undefined });
+    // value = object, explode = false, style = spaceDelimited
+    expect(serializeQueryParams(mockObjectQueryParams, { idObject: { explode: false, style: 'spaceDelimited' } })).toEqual({ idObject: 'idObject=role%20admin%20firstName%20Alex' });
+    // value = object, explode = true, style = pipeDelimited --> not supported
+    expect(serializeQueryParams(mockObjectQueryParams, { idObject: { explode: true, style: 'pipeDelimited' } })).toEqual({ idObject: undefined });
+    // value = object, explode = false, style = pipeDelimited
+    expect(serializeQueryParams(mockObjectQueryParams, { idObject: { explode: false, style: 'pipeDelimited' } })).toEqual({ idObject: 'idObject=role%7Cadmin%7CfirstName%7CAlex' });
+    // value = object, explode = true, style = deepObject
+    expect(serializeQueryParams(mockObjectQueryParams, { idObject: { explode: true, style: 'deepObject' } })).toEqual({ idObject: 'idObject%5Brole%5D=admin&idObject%5BfirstName%5D=Alex' });
+    // value = object, explode = false, style = deepObject --> not supported
+    expect(serializeQueryParams(mockObjectQueryParams, { idObject: { explode: false, style: 'deepObject' } })).toEqual({ idObject: undefined });
+    // multiple parameters
+    expect(serializeQueryParams(mockMultipleQueryParams, { idArray: { explode: false, style: 'form' }, idPrimitive: { explode: true, style: 'form' } }))
+      .toEqual({ idArray: 'idArray=3,4,5', idPrimitive: 'idPrimitive=5' });
+  });
+
+  it('should correctly serialize query parameters with undefined or null values', () => {
+    // empty array
+    expect(serializeQueryParams({ idEmptyArray: [] }, { idEmptyArray: { explode: true, style: 'form' } })).toEqual({ idEmptyArray: 'idEmptyArray=' });
+    expect(serializeQueryParams({ idEmptyArray: [] }, { idEmptyArray: { explode: false, style: 'form' } })).toEqual({ idEmptyArray: 'idEmptyArray=' });
+    expect(serializeQueryParams({ idEmptyArray: [] }, { idEmptyArray: { explode: true, style: 'spaceDelimited' } })).toEqual({ idEmptyArray: undefined });
+    expect(serializeQueryParams({ idEmptyArray: [] }, { idEmptyArray: { explode: false, style: 'spaceDelimited' } })).toEqual({ idEmptyArray: undefined });
+    expect(serializeQueryParams({ idEmptyArray: [] }, { idEmptyArray: { explode: true, style: 'pipeDelimited' } })).toEqual({ idEmptyArray: undefined });
+    expect(serializeQueryParams({ idEmptyArray: [] }, { idEmptyArray: { explode: false, style: 'pipeDelimited' } })).toEqual({ idEmptyArray: undefined });
+    expect(serializeQueryParams({ idEmptyArray: [] }, { idEmptyArray: { explode: false, style: 'deepObject' } })).toEqual({ idEmptyArray: undefined });
+    expect(serializeQueryParams({ idEmptyArray: [] }, { idEmptyArray: { explode: false, style: 'deepObject' } })).toEqual({ idEmptyArray: undefined });
+    // array with undefined values
+    expect(serializeQueryParams({ idArrayUndefinedValues: ['value1', undefined, null, 'value2'] }, { idArrayUndefinedValues: { explode: true, style: 'form' } }))
+      .toEqual({ idArrayUndefinedValues: 'idArrayUndefinedValues=value1&idArrayUndefinedValues=value2' });
+    expect(serializeQueryParams({ idArrayUndefinedValues: ['value1', undefined, null, 'value2'] }, { idArrayUndefinedValues: { explode: false, style: 'form' } }))
+      .toEqual({ idArrayUndefinedValues: 'idArrayUndefinedValues=value1,value2' });
+    // empty object
+    expect(serializeQueryParams({ idEmptyObject: {} }, { idEmptyObject: { explode: true, style: 'form' } })).toEqual({ idEmptyObject: 'idEmptyObject=' });
+    expect(serializeQueryParams({ idEmptyObject: {} }, { idEmptyObject: { explode: false, style: 'form' } })).toEqual({ idEmptyObject: 'idEmptyObject=' });
+    expect(serializeQueryParams({ idEmptyObject: {} }, { idEmptyObject: { explode: true, style: 'spaceDelimited' } })).toEqual({ idEmptyObject: undefined });
+    expect(serializeQueryParams({ idEmptyObject: {} }, { idEmptyObject: { explode: false, style: 'spaceDelimited' } })).toEqual({ idEmptyObject: undefined });
+    expect(serializeQueryParams({ idEmptyObject: {} }, { idEmptyObject: { explode: true, style: 'pipeDelimited' } })).toEqual({ idEmptyObject: undefined });
+    expect(serializeQueryParams({ idEmptyObject: {} }, { idEmptyObject: { explode: false, style: 'pipeDelimited' } })).toEqual({ idEmptyObject: undefined });
+    expect(serializeQueryParams({ idEmptyObject: {} }, { idEmptyObject: { explode: true, style: 'deepObject' } })).toEqual({ idEmptyObject: undefined });
+    expect(serializeQueryParams({ idEmptyObject: {} }, { idEmptyObject: { explode: false, style: 'deepObject' } })).toEqual({ idEmptyObject: undefined });
+    // object with undefined values
+    expect(serializeQueryParams({ idObjectUndefinedValues: { property1: undefined, property2: 'value2' } }, { idObjectUndefinedValues: { explode: true, style: 'form' } }))
+      .toEqual({ idObjectUndefinedValues: 'property2=value2' });
+    expect(serializeQueryParams({ idObjectUndefinedValues: { property1: undefined, property2: 'value2' } }, { idObjectUndefinedValues: { explode: false, style: 'form' } }))
+      .toEqual({ idObjectUndefinedValues: 'idObjectUndefinedValues=property2,value2' });
+  });
+
+  it('should correctly serialize path parameters', () => {
+    const pathParametersSimpleExplode = serializePathParams(mockData, {
+      idPrimitive: { explode: true, style: 'simple' },
+      idArray: { explode: true, style: 'simple' },
+      idObject: { explode: true, style: 'simple' }
+    });
+    expect(pathParametersSimpleExplode.idPrimitive).toEqual('5');
+    expect(pathParametersSimpleExplode.idArray).toEqual('3,4,5');
+    expect(pathParametersSimpleExplode.idObject).toEqual('role=admin,firstName=Alex');
+
+    const pathParametersSimple = serializePathParams(mockData, {
+      idPrimitive: { explode: false, style: 'simple' },
+      idArray: { explode: false, style: 'simple' },
+      idObject: { explode: false, style: 'simple' }
+    });
+    expect(pathParametersSimple.idPrimitive).toEqual('5');
+    expect(pathParametersSimple.idArray).toEqual('3,4,5');
+    expect(pathParametersSimple.idObject).toEqual('role,admin,firstName,Alex');
+
+    const pathParametersLabelExplode = serializePathParams(mockData, {
+      idPrimitive: { explode: true, style: 'label' },
+      idArray: { explode: true, style: 'label' },
+      idObject: { explode: true, style: 'label' }
+    });
+    expect(pathParametersLabelExplode.idPrimitive).toEqual('.5');
+    expect(pathParametersLabelExplode.idArray).toEqual('.3.4.5');
+    expect(pathParametersLabelExplode.idObject).toEqual('.role=admin.firstName=Alex');
+
+    const pathParametersLabel = serializePathParams(mockData, {
+      idPrimitive: { explode: false, style: 'label' },
+      idArray: { explode: false, style: 'label' },
+      idObject: { explode: false, style: 'label' }
+    });
+    expect(pathParametersLabel.idPrimitive).toEqual('.5');
+    expect(pathParametersLabel.idArray).toEqual('.3,4,5');
+    expect(pathParametersLabel.idObject).toEqual('.role,admin,firstName,Alex');
+
+    const pathParametersMatrixExplode = serializePathParams(mockData, {
+      idPrimitive: { explode: true, style: 'matrix' },
+      idArray: { explode: true, style: 'matrix' },
+      idObject: { explode: true, style: 'matrix' }
+    });
+    expect(pathParametersMatrixExplode.idPrimitive).toEqual(';idPrimitive=5');
+    expect(pathParametersMatrixExplode.idArray).toEqual(';idArray=3;idArray=4;idArray=5');
+    expect(pathParametersMatrixExplode.idObject).toEqual(';role=admin;firstName=Alex');
+
+    const pathParametersMatrix = serializePathParams(mockData, {
+      idPrimitive: { explode: false, style: 'matrix' },
+      idArray: { explode: false, style: 'matrix' },
+      idObject: { explode: false, style: 'matrix' }
+    });
+    expect(pathParametersMatrix.idPrimitive).toEqual(';idPrimitive=5');
+    expect(pathParametersMatrix.idArray).toEqual(';idArray=3,4,5');
+    expect(pathParametersMatrix.idObject).toEqual(';idObject=role,admin,firstName,Alex');
+  });
+
+  it('should correctly serialize path parameters with undefined or null values', () => {
+    const mockArrayData = {
+      idEmptyArray: [],
+      idArrayToFilter: ['value1', undefined, null, 'value2']
+    };
+
+    const emptyArrayPathParametersSimpleExplode = serializePathParams(mockArrayData, {
+      idEmptyArray: { explode: true, style: 'simple' },
+      idArrayToFilter: { explode: true, style: 'simple' }
+    });
+    expect(emptyArrayPathParametersSimpleExplode.idEmptyArray).toEqual(undefined);
+    expect(emptyArrayPathParametersSimpleExplode.idArrayToFilter).toEqual('value1,value2');
+
+    const emptyArrayPathParametersSimple = serializePathParams(mockArrayData, {
+      idEmptyArray: { explode: false, style: 'simple' },
+      idArrayToFilter: { explode: false, style: 'simple' }
+    });
+    expect(emptyArrayPathParametersSimple.idEmptyArray).toEqual(undefined);
+    expect(emptyArrayPathParametersSimple.idArrayToFilter).toEqual('value1,value2');
+
+    const emptyArrayPathParametersLabelExplode = serializePathParams(mockArrayData, {
+      idEmptyArray: { explode: true, style: 'label' },
+      idArrayToFilter: { explode: true, style: 'label' }
+    });
+    expect(emptyArrayPathParametersLabelExplode.idEmptyArray).toEqual('.');
+    expect(emptyArrayPathParametersLabelExplode.idArrayToFilter).toEqual('.value1.value2');
+
+    const emptyArrayPathParametersLabel = serializePathParams(mockArrayData, {
+      idEmptyArray: { explode: false, style: 'label' },
+      idArrayToFilter: { explode: false, style: 'label' }
+    });
+    expect(emptyArrayPathParametersLabel.idEmptyArray).toEqual('.');
+    expect(emptyArrayPathParametersLabel.idArrayToFilter).toEqual('.value1,value2');
+
+    const emptyArrayPathParametersMatrixExplode = serializePathParams(mockArrayData, {
+      idEmptyArray: { explode: true, style: 'matrix' },
+      idArrayToFilter: { explode: true, style: 'matrix' }
+    });
+    expect(emptyArrayPathParametersMatrixExplode.idEmptyArray).toEqual(';idEmptyArray');
+    expect(emptyArrayPathParametersMatrixExplode.idArrayToFilter).toEqual(';idArrayToFilter=value1;idArrayToFilter=value2');
+
+    const emptyArrayPathParametersMatrix = serializePathParams(mockArrayData, {
+      idEmptyArray: { explode: false, style: 'matrix' },
+      idArrayToFilter: { explode: false, style: 'matrix' }
+    });
+    expect(emptyArrayPathParametersMatrix.idEmptyArray).toEqual(';idEmptyArray');
+    expect(emptyArrayPathParametersMatrix.idArrayToFilter).toEqual(';idArrayToFilter=value1,value2');
+  });
+});

--- a/packages/@ama-sdk/core/src/fwk/param-serialization.ts
+++ b/packages/@ama-sdk/core/src/fwk/param-serialization.ts
@@ -1,0 +1,229 @@
+/** OpenAPI parameter serialization syntax */
+export interface ParamSerialization {
+  /** Parameter is of exploded syntax */
+  explode: boolean;
+  /** Style of the parameter */
+  style: string;
+}
+
+/** Primitive types for the operation parameters */
+export type PrimitiveType = string | number | boolean | undefined | null;
+/** Supported types for the operation parameters - primitives, primitive arrays, and simple non-nested objects */
+export type SupportedParamType = PrimitiveType | PrimitiveType[] | { [key: string]: PrimitiveType };
+
+/**
+ * Serialize query parameters of type array
+ * OpenAPI Parameter Serialization {@link https://swagger.io/specification | documentation}
+ * @param queryParamName
+ * @param queryParamValue
+ * @param paramSerialization
+ */
+function serializeArrayQueryParams(queryParamName: string, queryParamValue: PrimitiveType[], paramSerialization: ParamSerialization) {
+  const filteredArray = queryParamValue.filter((v) => typeof v !== 'undefined' && v !== null);
+  const emptyArray = filteredArray.length === 0;
+  if (paramSerialization.explode && paramSerialization.style === 'form') {
+    return emptyArray
+      ? encodeURIComponent(queryParamName) + '='
+      : filteredArray.map((v) => encodeURIComponent(queryParamName) + '=' + encodeURIComponent(v.toString())).join('&');
+  } else if (!paramSerialization.explode) {
+    switch (paramSerialization.style) {
+      case 'form': {
+        return encodeURIComponent(queryParamName) + '=' + (emptyArray ? '' : filteredArray.map((v) => encodeURIComponent(v.toString())).join(','));
+      }
+      case 'spaceDelimited': {
+        if (emptyArray) {
+          break;
+        }
+        return encodeURIComponent(queryParamName) + '=' + filteredArray.map((v) => encodeURIComponent(v.toString())).join('%20');
+      }
+      case 'pipeDelimited': {
+        if (emptyArray) {
+          break;
+        }
+        return encodeURIComponent(queryParamName) + '=' + filteredArray.map((v) => encodeURIComponent(v.toString())).join('%7C');
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Serialize query parameters of type object
+ * OpenAPI Parameter Serialization {@link https://swagger.io/specification | documentation}
+ * @param queryParamName
+ * @param queryParamValue
+ * @param paramSerialization
+ */
+function serializeObjectQueryParams(queryParamName: string, queryParamValue: { [key: string]: PrimitiveType }, paramSerialization: ParamSerialization) {
+  const filteredObject = Object.fromEntries(
+    Object.entries(queryParamValue).filter((property): property is [string, string | boolean | number] => typeof property[1] !== 'undefined' && property[1] !== null)
+  );
+  const emptyObject = Object.keys(filteredObject).length === 0;
+  if (paramSerialization.style === 'form') {
+    if (emptyObject) {
+      return encodeURIComponent(queryParamName) + '=';
+    }
+    return paramSerialization.explode
+      ? Object.entries(filteredObject).map(([propName, propValue]) => encodeURIComponent(propName) + '=' + encodeURIComponent(propValue.toString())).join('&')
+      : encodeURIComponent(queryParamName) + '='
+        + Object.entries(filteredObject).map(([propName, propValue]) => encodeURIComponent(propName) + ',' + encodeURIComponent(propValue.toString())).join(',');
+  } else if (paramSerialization.style === 'spaceDelimited' && !paramSerialization.explode && !emptyObject) {
+    return encodeURIComponent(queryParamName) + '=' + Object.entries(filteredObject).map(([propName, propValue]) =>
+      encodeURIComponent(propName) + '%20' + encodeURIComponent(propValue.toString())
+    ).join('%20');
+  } else if (paramSerialization.style === 'pipeDelimited' && !paramSerialization.explode && !emptyObject) {
+    return encodeURIComponent(queryParamName) + '=' + Object.entries(filteredObject).map(([propName, propValue]) =>
+      encodeURIComponent(propName) + '%7C' + encodeURIComponent(propValue.toString())
+    ).join('%7C');
+  } else if (paramSerialization.style === 'deepObject' && paramSerialization.explode && !emptyObject) {
+    return Object.entries(filteredObject).map(([propName, propValue]) =>
+      encodeURIComponent(queryParamName) + '%5B' + encodeURIComponent(propName) + '%5D=' + encodeURIComponent(propValue.toString())
+    ).join('&');
+  }
+}
+
+/**
+ * Serialize query parameters based on the values of exploded and style
+ * OpenAPI Parameter Serialization {@link https://swagger.io/specification | documentation}
+ * @param queryParams
+ * @param queryParamSerialization
+ */
+export function serializeQueryParams<T extends { [key: string]: SupportedParamType }>(queryParams: T, queryParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string } {
+  return Object.entries(queryParamSerialization).reduce((acc, [queryParamName, paramSerialization]) => {
+    const queryParamValue = queryParams[queryParamName];
+    if (typeof queryParamValue !== 'undefined' && queryParamValue !== null && !!paramSerialization) {
+      let serializedValue: string | undefined;
+      if (Array.isArray(queryParamValue)) {
+        serializedValue = serializeArrayQueryParams(queryParamName, queryParamValue, paramSerialization);
+      } else if (typeof queryParamValue === 'object') {
+        serializedValue = serializeObjectQueryParams(queryParamName, queryParamValue, paramSerialization);
+      } else {
+        if (paramSerialization.style === 'form') {
+          serializedValue = encodeURIComponent(queryParamName) + '=' + encodeURIComponent(queryParamValue.toString());
+        }
+      }
+      if (serializedValue) {
+        acc[queryParamName as keyof T] = serializedValue;
+      }
+    }
+    return acc;
+  }, {} as { [p in keyof T]: string });
+}
+
+/**
+ * Serialize path parameters of type array
+ * OpenAPI Parameter Serialization {@link https://swagger.io/specification | documentation}
+ * @param pathParamName
+ * @param pathParamValue
+ * @param paramSerialization
+ */
+function serializeArrayPathParams(pathParamName: string, pathParamValue: PrimitiveType[], paramSerialization: ParamSerialization) {
+  const filteredArray = pathParamValue.filter((v) => typeof v !== 'undefined' && v !== null);
+  const emptyArray = filteredArray.length === 0;
+  switch (paramSerialization.style) {
+    case 'simple': {
+      if (emptyArray) {
+        break;
+      }
+      return filteredArray.map((v) => encodeURIComponent(v.toString())).join(',');
+    }
+    case 'label': {
+      return '.' + (emptyArray ? '' : filteredArray.map((v) => encodeURIComponent(v.toString())).join(paramSerialization.explode ? '.' : ','));
+    }
+    case 'matrix': {
+      return paramSerialization.explode
+        ? ';' + (emptyArray ? encodeURIComponent(pathParamName) : filteredArray.map((v) => encodeURIComponent(pathParamName) + '=' + encodeURIComponent(v.toString())).join(';'))
+        : ';' + encodeURIComponent(pathParamName) + (emptyArray ? '' : '=' + filteredArray.map((v) => encodeURIComponent(v.toString())).join(','));
+    }
+  }
+}
+
+/**
+ * Serialize path parameters of type object
+ * OpenAPI Parameter Serialization {@link https://swagger.io/specification | documentation}
+ * @param pathParamName
+ * @param pathParamValue
+ * @param paramSerialization
+ */
+function serializeObjectPathParams(pathParamName: string, pathParamValue: { [key: string]: PrimitiveType }, paramSerialization: ParamSerialization) {
+  const filteredObject = Object.fromEntries(
+    Object.entries(pathParamValue).filter((property): property is [string, string | boolean | number] => typeof property[1] !== 'undefined' && property[1] !== null)
+  );
+  const emptyObject = Object.keys(filteredObject).length === 0;
+  switch (paramSerialization.style) {
+    case 'simple': {
+      if (emptyObject) {
+        break;
+      }
+      return paramSerialization.explode
+        ? Object.entries(filteredObject).map(([propName, propValue]) => encodeURIComponent(propName) + '=' + encodeURIComponent(propValue.toString())).join(',')
+        : Object.entries(filteredObject).map(([propName, propValue]) => encodeURIComponent(propName) + ',' + encodeURIComponent(propValue.toString())).join(',');
+    }
+    case 'label': {
+      if (emptyObject) {
+        return '.';
+      }
+      return paramSerialization.explode
+        ? '.' + Object.entries(filteredObject).map(([propName, propValue]) => encodeURIComponent(propName) + '=' + encodeURIComponent(propValue.toString())).join('.')
+        : '.' + Object.entries(filteredObject).map(([propName, propValue]) => encodeURIComponent(propName) + ',' + encodeURIComponent(propValue.toString())).join(',');
+    }
+    case 'matrix': {
+      if (emptyObject) {
+        return ';' + encodeURIComponent(pathParamName);
+      }
+      return paramSerialization.explode
+        ? ';' + Object.entries(filteredObject).map(([propName, propValue]) => encodeURIComponent(propName) + '=' + encodeURIComponent(propValue.toString())).join(';')
+        : ';' + encodeURIComponent(pathParamName) + '='
+          + Object.entries(filteredObject).map(([propName, propValue]) => encodeURIComponent(propName) + ',' + encodeURIComponent(propValue.toString())).join(',');
+    }
+  }
+}
+
+/**
+ * Serialize path parameters of type primitive
+ * OpenAPI Parameter Serialization {@link https://swagger.io/specification | documentation}
+ * @param pathParamName
+ * @param pathParamValue
+ * @param paramSerialization
+ */
+function serializePrimitivePathParams(pathParamName: string, pathParamValue: PrimitiveType, paramSerialization: ParamSerialization) {
+  if (typeof pathParamValue !== 'undefined' && pathParamValue !== null && !!paramSerialization) {
+    switch (paramSerialization.style) {
+      case 'simple': {
+        return encodeURIComponent(pathParamValue);
+      }
+      case 'label': {
+        return '.' + encodeURIComponent(pathParamValue);
+      }
+      case 'matrix': {
+        return ';' + encodeURIComponent(pathParamName) + '=' + encodeURIComponent(pathParamValue);
+      }
+    }
+  }
+}
+
+/**
+ * Serialize path parameters based on the values of exploded and style, which prepares the path parameters for the URL to be called
+ * OpenAPI Parameter Serialization {@link https://swagger.io/specification | documentation}
+ * @param pathParams
+ * @param pathParamSerialization key value pair with the parameters. If the value is undefined, the key is dropped
+ */
+export function serializePathParams<T extends { [key: string]: SupportedParamType }>(pathParams: T, pathParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string } {
+  return Object.entries(pathParamSerialization).reduce((acc, [pathParamName, paramSerialization]) => {
+    const pathParamValue = pathParams[pathParamName];
+    if (typeof pathParamValue !== 'undefined' && pathParamValue !== null) {
+      let serializedValue: string | undefined;
+      if (Array.isArray(pathParamValue)) {
+        serializedValue = serializeArrayPathParams(pathParamName, pathParamValue, paramSerialization);
+      } else if (typeof pathParamValue === 'object') {
+        serializedValue = serializeObjectPathParams(pathParamName, pathParamValue, paramSerialization);
+      } else {
+        serializedValue = serializePrimitivePathParams(pathParamName, pathParamValue, paramSerialization);
+      }
+      if (serializedValue) {
+        acc[pathParamName as keyof T] = serializedValue;
+      }
+    }
+    return acc;
+  }, {} as { [p in keyof T]: string });
+}

--- a/packages/@ama-sdk/schematics/README.md
+++ b/packages/@ama-sdk/schematics/README.md
@@ -63,7 +63,7 @@ npx -p @angular/cli ng add @ama-sdk/core
 The typescript generator provides 3 generators:
 
 - **shell**: To generate the "shell" of an SDK package
-- **core**: To (re)generate the SDK based on a specified OpenApi specification
+- **core**: To (re)generate the SDK based on a specified OpenAPI specification
 - **create**: To create a new SDK from scratch (i.e. chain **shell** and **core**)
 
 You can generate the `shell` in an existing monorepo with the command:
@@ -87,17 +87,18 @@ The generated package comes with the following script in the package.json:
 ```json5
 {
   // ...
-  "generate": "yarn schematics @ama-sdk/schematics:typescript-core --spec-path ./openapi-spec.yaml",
+  "generate": "yarn schematics @ama-sdk/schematics:typescript-core --spec-path ./open-api.yaml",
   "upgrade:repository": "yarn schematics @ama-sdk/schematics:typescript-shell"
 }
 ```
 
 > [!NOTE]
-> Use `generate` to (re)generate your SDK based on the content of `./openapi-spec.yaml` (make sure you have this file at the root of your project) and `upgrade:repository` to regenerate the structure of your project.
+> Use `generate` to (re)generate your SDK based on the content of `./open-api.yaml` (make sure you have this file at the root of your project) and `upgrade:repository` to regenerate the structure of your project.
 
 > [!TIP]
 > The `--spec-path` parameter supports YAML and JSON file formats based on the file system path or remote URL.
-> The `--spec-package-name` parameter can be used as an alternative to `--spec-path` if you want to generate an SDK with specs from an npm package.  It comes with the optional parameters `--spec-package-registry` and `--spec-package-path` to be able to retrieve the npm package and the specs file from it. By default, the generator expects the `package.json` file inside the npm module containing the specs, to have an export with the key `./openapi.[yaml|yml|json]` and the value will be the relative path to the spec file inside the package.
+> The `--spec-package-name` parameter can be used as an alternative to `--spec-path` if you want to generate an SDK with specs from an npm package.It comes with the optional parameters `--spec-package-registry` and `--spec-package-path` to be able to retrieve the npm package and the specs file from it.
+> By default, the generator expects the `package.json` file inside the npm module containing the specs, to have an export with the key `./open-api.[yaml|yml|json]` and the value will be the relative path to the spec file inside the package.
 
 If you use `Yarn2+` with PnP, you can modify the following `scripts` in `package.json` to generate the SDK based on specifications in a dependency package:
 
@@ -108,6 +109,19 @@ If you use `Yarn2+` with PnP, you can modify the following `scripts` in `package
   "generate": "yarn schematics @ama-sdk/schematics:typescript-core --spec-path $(yarn resolve @my/dep/spec-file.yaml)",
 }
 ```
+
+#### Parameter Serialization
+
+To align ourselves with OpenAPI 3.1, we now support arrays and objects in path and query parameters along with their serialization.
+Based on the values of the keywords `style` and `explode` within the specification file, the parameters are serialized accordingly in the URLs of the APIs.
+For more information, check out OpenAPI's documentation on [parameter serialization](https://swagger.io/specification/).
+
+It is important to note that, as in OpenAPI 3.1, we only support simple arrays and simple non-nested objects in path and query parameters. 
+The parameter types that we support are stored in `SupportedParamType` in the package `@ama-sdk/core`.
+
+> [!NOTE]
+> We provide the methods `serializeQueryParams` and `serializePathParams` to serialize the values of query and path parameters. However, it is also possible to pass
+> your own serialization methods if the ones provided do not meet your requirements. These custom methods can be passed as a parameter to the API client constructor.
 
 #### Light SDK
 
@@ -212,7 +226,7 @@ described global properties `stringifyDate` and  `allowModelExtension`:
       "example-sdk": {
         "generatorName": "typescriptFetch",
         "output": ".",
-        "inputSpec": "./openapi-spec.yaml", // or "./openapi-spec.json" according to the specification format
+        "inputSpec": "./open-api.yaml", // or "./open-api.json" according to the specification format
         "globalProperty": {
           "stringifyDate": false,
           "allowModelExtension": true
@@ -269,7 +283,7 @@ You can use global property options to pass one or both of the following options
 Example:
 
 ```shell
-yarn schematics @ama-sdk/schematics:typescript-core --spec-path ./openapi-spec.yaml --global-property debugModels,debugOperations
+yarn schematics @ama-sdk/schematics:typescript-core --spec-path ./open-api.yaml --global-property debugModels,debugOperations
 ```
 
 You can also use npx instead of yarn in the command.

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/java/com/amadeus/codegen/ts/LambdaHelper.java
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/java/com/amadeus/codegen/ts/LambdaHelper.java
@@ -59,7 +59,7 @@ public class LambdaHelper {
    * Replaces placeholders in the URL such as
    * /carts/{cartId}/travelers
    * to
-   * /carts/${data['cartId']}/travelers
+   * /carts/${serializedPathParams['cartId']}/travelers
    */
   public static class UrlParamReplacerLambda extends CustomLambda {
 
@@ -67,7 +67,7 @@ public class LambdaHelper {
 
       @Override
       public String formatFragment(String fragment) {
-          return fragment.replaceAll("\\{([\\w_-]+)\\}", "\\${data['$1']}");
+          return fragment.replaceAll("\\{([\\w_-]+)\\}", "\\${serializedPathParams['$1']}");
       }
 
   }
@@ -76,7 +76,7 @@ public class LambdaHelper {
    * Replaces placeholders in the URL such as
    * /carts/{cartId}/travelers
    * to
-   * /carts/${this.piiParamTokens['$1'] || data['$1']}/travelers
+   * /carts/${this.piiParamTokens['$1'] || serializedPathParams['$1']}/travelers
    */
   public static class TokenizedUrlParamReplacerLambda extends CustomLambda {
 
@@ -84,7 +84,7 @@ public class LambdaHelper {
 
       @Override
       public String formatFragment(String fragment) {
-          return fragment.replaceAll("\\{([\\w_-]+)\\}", "\\${this.piiParamTokens['$1'] || data['$1']}");
+          return fragment.replaceAll("\\{([\\w_-]+)\\}", "\\${this.piiParamTokens['$1'] || serializedPathParams['$1']}");
       }
   }
 

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/api.mustache
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/api.mustache
@@ -70,7 +70,8 @@ export class {{classname}} implements Api {
     data['{{baseName}}'] = data['{{baseName}}'] !== undefined ? data['{{baseName}}'] : {{#isString}}'{{/isString}}{{defaultValue}}{{#isString}}'{{/isString}};
       {{/defaultValue}}
     {{/allParams}}
-    const queryParams = this.client.extractQueryParams<{{classname}}{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}RequestData>(data, [{{#trimComma}}{{#queryParams}}'{{baseName}}', {{/queryParams}}{{/trimComma}}]{{^queryParams}} as never[]{{/queryParams}});
+    const queryParamsProperties = {{#hasQueryParams}}this.client.getPropertiesFromData(data, [{{#trimComma}}{{#queryParams}}'{{baseName}}', {{/queryParams}}{{/trimComma}}]){{/hasQueryParams}}{{^hasQueryParams}}{}{{/hasQueryParams}};
+    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || '{{#headerJsonMimeType}}{{#produces}}{{mediaType}}{{^-last}}, {{/-last}}{{/produces}}{{/headerJsonMimeType}}';
     const headers: { [key: string]: string | undefined } = {
   {{#trimComma}}    'Content-Type': metadata?.headerContentType || '{{#headerJsonMimeType}}{{#consumes}}{{mediaType}}{{^-last}}, {{/-last}}{{/consumes}}{{/headerJsonMimeType}}',
@@ -99,6 +100,10 @@ export class {{classname}} implements Api {
       body = data['{{baseName}}'] as any;
     }
     {{/bodyParam}}
+    {{#hasPathParams}}
+    const pathParamsProperties = this.client.getPropertiesFromData(data, [{{#trimComma}}{{#pathParams}}'{{baseName}}', {{/pathParams}}{{/trimComma}}]);
+    const serializedPathParams = this.client.serializePathParams(pathParamsProperties, { {{#trimComma}}{{#pathParams}}{{baseName}}: { explode: {{isExplode}}, style: '{{style}}' }, {{/pathParams}}{{/trimComma}} });
+    {{/hasPathParams}}
     const basePath = `${this.client.options.basePath}{{#urlParamReplacer}}{{path}}{{/urlParamReplacer}}`;
     const tokenizedUrl = `${this.client.options.basePath}{{#tokenizedUrlParamReplacer}}{{path}}{{/tokenizedUrlParamReplacer}}`;
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
@@ -115,7 +120,13 @@ export class {{classname}} implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.prepareUrl(options.basePath, options.queryParams);
+    {{#hasQueryParams}}
+    const serializedQueryParams = this.client.serializeQueryParams(queryParamsProperties, { {{#trimComma}}{{#queryParams}}{{baseName}}: { explode: {{isExplode}}, style: '{{style}}' }, {{/queryParams}}{{/trimComma}} });
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, serializedQueryParams);
+    {{/hasQueryParams}}
+    {{^hasQueryParams}}
+    const url = options.basePath;
+    {{/hasQueryParams}}
 
     const ret = this.client.processCall<{{#vendorExtensions}}{{#responses2xxReturnTypes}}{{.}}{{^-last}} | {{/-last}}{{/responses2xxReturnTypes}}{{^responses2xxReturnTypes}}never{{/responses2xxReturnTypes}}{{/vendorExtensions}}>(url, options, {{#tags.0.extensions.x-api-type}}ApiTypes.{{tags.0.extensions.x-api-type}}{{/tags.0.extensions.x-api-type}}{{^tags.0.extensions.x-api-type}}ApiTypes.DEFAULT{{/tags.0.extensions.x-api-type}}, {{classname}}.apiName,{{#keepRevivers}}{{#vendorExtensions}}{{#responses2xx}}{{#-first}} { {{/-first}}{{code}}: {{^primitiveType}}revive{{baseType}}{{/primitiveType}}{{#primitiveType}}undefined{{/primitiveType}}{{^-last}}, {{/-last}}{{#-last}} } {{/-last}}{{/responses2xx}}{{^responses2xx}} undefined{{/responses2xx}}{{/vendorExtensions}}{{/keepRevivers}}{{^keepRevivers}} undefined{{/keepRevivers}}, '{{nickname}}');
     return ret;

--- a/packages/@o3r-training/showcase-sdk/src/api/pet/pet-api.ts
+++ b/packages/@o3r-training/showcase-sdk/src/api/pet/pet-api.ts
@@ -85,7 +85,8 @@ export class PetApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async addPet(data: PetApiAddPetRequestData, metadata?: RequestMetadata<'application/json' | 'application/xml' | 'application/x-www-form-urlencoded', 'application/xml' | 'application/json'>): Promise<Pet> {
-    const queryParams = this.client.extractQueryParams<PetApiAddPetRequestData>(data, [] as never[]);
+    const queryParamsProperties = {};
+    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -114,7 +115,7 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = options.basePath;
 
     const ret = this.client.processCall<Pet>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'addPet');
     return ret;
@@ -127,7 +128,8 @@ export class PetApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async deletePet(data: PetApiDeletePetRequestData, metadata?: RequestMetadata<string, 'application/xml' | 'application/json'>): Promise<string> {
-    const queryParams = this.client.extractQueryParams<PetApiDeletePetRequestData>(data, [] as never[]);
+    const queryParamsProperties = {};
+    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -136,8 +138,10 @@ export class PetApi implements Api {
     };
 
     let body: RequestBody = '';
-    const basePath = `${this.client.options.basePath}/pet/${data['petId']}`;
-    const tokenizedUrl = `${this.client.options.basePath}/pet/${this.piiParamTokens['petId'] || data['petId']}`;
+    const pathParamsProperties = this.client.getPropertiesFromData(data, ['petId']);
+    const serializedPathParams = this.client.serializePathParams(pathParamsProperties, { petId: { explode: false, style: 'simple' } });
+    const basePath = `${this.client.options.basePath}/pet/${serializedPathParams['petId']}`;
+    const tokenizedUrl = `${this.client.options.basePath}/pet/${this.piiParamTokens['petId'] || serializedPathParams['petId']}`;
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
 
     const requestOptions = {
@@ -152,7 +156,7 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = options.basePath;
 
     const ret = this.client.processCall<string>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'deletePet');
     return ret;
@@ -166,7 +170,8 @@ export class PetApi implements Api {
    */
   public async findPetsByStatus(data: PetApiFindPetsByStatusRequestData, metadata?: RequestMetadata<string, 'application/xml' | 'application/json'>): Promise<Pet[]> {
     data['status'] = data['status'] !== undefined ? data['status'] : 'available';
-    const queryParams = this.client.extractQueryParams<PetApiFindPetsByStatusRequestData>(data, ['status']);
+    const queryParamsProperties = this.client.getPropertiesFromData(data, ['status']);
+    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -190,7 +195,8 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.prepareUrl(options.basePath, options.queryParams);
+    const serializedQueryParams = this.client.serializeQueryParams(queryParamsProperties, { status: { explode: true, style: 'form' } });
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, serializedQueryParams);
 
     const ret = this.client.processCall<Pet[]>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'findPetsByStatus');
     return ret;
@@ -203,7 +209,8 @@ export class PetApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async findPetsByTags(data: PetApiFindPetsByTagsRequestData, metadata?: RequestMetadata<string, 'application/xml' | 'application/json'>): Promise<Pet[]> {
-    const queryParams = this.client.extractQueryParams<PetApiFindPetsByTagsRequestData>(data, ['tags']);
+    const queryParamsProperties = this.client.getPropertiesFromData(data, ['tags']);
+    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -227,7 +234,8 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.prepareUrl(options.basePath, options.queryParams);
+    const serializedQueryParams = this.client.serializeQueryParams(queryParamsProperties, { tags: { explode: true, style: 'form' } });
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, serializedQueryParams);
 
     const ret = this.client.processCall<Pet[]>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'findPetsByTags');
     return ret;
@@ -240,7 +248,8 @@ export class PetApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async getPetById(data: PetApiGetPetByIdRequestData, metadata?: RequestMetadata<string, 'application/xml' | 'application/json'>): Promise<Pet> {
-    const queryParams = this.client.extractQueryParams<PetApiGetPetByIdRequestData>(data, [] as never[]);
+    const queryParamsProperties = {};
+    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -248,8 +257,10 @@ export class PetApi implements Api {
     };
 
     let body: RequestBody = '';
-    const basePath = `${this.client.options.basePath}/pet/${data['petId']}`;
-    const tokenizedUrl = `${this.client.options.basePath}/pet/${this.piiParamTokens['petId'] || data['petId']}`;
+    const pathParamsProperties = this.client.getPropertiesFromData(data, ['petId']);
+    const serializedPathParams = this.client.serializePathParams(pathParamsProperties, { petId: { explode: false, style: 'simple' } });
+    const basePath = `${this.client.options.basePath}/pet/${serializedPathParams['petId']}`;
+    const tokenizedUrl = `${this.client.options.basePath}/pet/${this.piiParamTokens['petId'] || serializedPathParams['petId']}`;
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
 
     const requestOptions = {
@@ -264,7 +275,7 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = options.basePath;
 
     const ret = this.client.processCall<Pet>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'getPetById');
     return ret;
@@ -277,7 +288,8 @@ export class PetApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async updatePet(data: PetApiUpdatePetRequestData, metadata?: RequestMetadata<'application/json' | 'application/xml' | 'application/x-www-form-urlencoded', 'application/xml' | 'application/json'>): Promise<Pet> {
-    const queryParams = this.client.extractQueryParams<PetApiUpdatePetRequestData>(data, [] as never[]);
+    const queryParamsProperties = {};
+    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -306,7 +318,7 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = options.basePath;
 
     const ret = this.client.processCall<Pet>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'updatePet');
     return ret;
@@ -319,7 +331,8 @@ export class PetApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async updatePetWithForm(data: PetApiUpdatePetWithFormRequestData, metadata?: RequestMetadata<string, string>): Promise<never> {
-    const queryParams = this.client.extractQueryParams<PetApiUpdatePetWithFormRequestData>(data, ['name', 'status']);
+    const queryParamsProperties = this.client.getPropertiesFromData(data, ['name', 'status']);
+    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -327,8 +340,10 @@ export class PetApi implements Api {
     };
 
     let body: RequestBody = '';
-    const basePath = `${this.client.options.basePath}/pet/${data['petId']}`;
-    const tokenizedUrl = `${this.client.options.basePath}/pet/${this.piiParamTokens['petId'] || data['petId']}`;
+    const pathParamsProperties = this.client.getPropertiesFromData(data, ['petId']);
+    const serializedPathParams = this.client.serializePathParams(pathParamsProperties, { petId: { explode: false, style: 'simple' } });
+    const basePath = `${this.client.options.basePath}/pet/${serializedPathParams['petId']}`;
+    const tokenizedUrl = `${this.client.options.basePath}/pet/${this.piiParamTokens['petId'] || serializedPathParams['petId']}`;
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
 
     const requestOptions = {
@@ -343,7 +358,8 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.prepareUrl(options.basePath, options.queryParams);
+    const serializedQueryParams = this.client.serializeQueryParams(queryParamsProperties, { name: { explode: true, style: 'form' }, status: { explode: true, style: 'form' } });
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, serializedQueryParams);
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'updatePetWithForm');
     return ret;
@@ -356,7 +372,8 @@ export class PetApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async uploadFile(data: PetApiUploadFileRequestData, metadata?: RequestMetadata<'application/octet-stream', 'application/json'>): Promise<ApiResponse> {
-    const queryParams = this.client.extractQueryParams<PetApiUploadFileRequestData>(data, ['additionalMetadata']);
+    const queryParamsProperties = this.client.getPropertiesFromData(data, ['additionalMetadata']);
+    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/octet-stream',
@@ -369,8 +386,10 @@ export class PetApi implements Api {
     } else {
       body = data['body'] as any;
     }
-    const basePath = `${this.client.options.basePath}/pet/${data['petId']}/uploadImage`;
-    const tokenizedUrl = `${this.client.options.basePath}/pet/${this.piiParamTokens['petId'] || data['petId']}/uploadImage`;
+    const pathParamsProperties = this.client.getPropertiesFromData(data, ['petId']);
+    const serializedPathParams = this.client.serializePathParams(pathParamsProperties, { petId: { explode: false, style: 'simple' } });
+    const basePath = `${this.client.options.basePath}/pet/${serializedPathParams['petId']}/uploadImage`;
+    const tokenizedUrl = `${this.client.options.basePath}/pet/${this.piiParamTokens['petId'] || serializedPathParams['petId']}/uploadImage`;
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
 
     const requestOptions = {
@@ -385,7 +404,8 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.prepareUrl(options.basePath, options.queryParams);
+    const serializedQueryParams = this.client.serializeQueryParams(queryParamsProperties, { additionalMetadata: { explode: true, style: 'form' } });
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, serializedQueryParams);
 
     const ret = this.client.processCall<ApiResponse>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'uploadFile');
     return ret;

--- a/packages/@o3r-training/showcase-sdk/src/api/store/store-api.ts
+++ b/packages/@o3r-training/showcase-sdk/src/api/store/store-api.ts
@@ -49,7 +49,8 @@ export class StoreApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async deleteOrder(data: StoreApiDeleteOrderRequestData, metadata?: RequestMetadata<string, string>): Promise<never> {
-    const queryParams = this.client.extractQueryParams<StoreApiDeleteOrderRequestData>(data, [] as never[]);
+    const queryParamsProperties = {};
+    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -57,8 +58,10 @@ export class StoreApi implements Api {
     };
 
     let body: RequestBody = '';
-    const basePath = `${this.client.options.basePath}/store/order/${data['orderId']}`;
-    const tokenizedUrl = `${this.client.options.basePath}/store/order/${this.piiParamTokens['orderId'] || data['orderId']}`;
+    const pathParamsProperties = this.client.getPropertiesFromData(data, ['orderId']);
+    const serializedPathParams = this.client.serializePathParams(pathParamsProperties, { orderId: { explode: false, style: 'simple' } });
+    const basePath = `${this.client.options.basePath}/store/order/${serializedPathParams['orderId']}`;
+    const tokenizedUrl = `${this.client.options.basePath}/store/order/${this.piiParamTokens['orderId'] || serializedPathParams['orderId']}`;
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
 
     const requestOptions = {
@@ -73,7 +76,7 @@ export class StoreApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = options.basePath;
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, StoreApi.apiName, undefined, 'deleteOrder');
     return ret;
@@ -86,7 +89,8 @@ export class StoreApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async getInventory(data: StoreApiGetInventoryRequestData, metadata?: RequestMetadata<string, 'application/json'>): Promise<{ [key: string]: number; }> {
-    const queryParams = this.client.extractQueryParams<StoreApiGetInventoryRequestData>(data, [] as never[]);
+    const queryParamsProperties = {};
+    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -110,7 +114,7 @@ export class StoreApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = options.basePath;
 
     const ret = this.client.processCall<{ [key: string]: number; }>(url, options, ApiTypes.DEFAULT, StoreApi.apiName, undefined, 'getInventory');
     return ret;
@@ -123,7 +127,8 @@ export class StoreApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async getOrderById(data: StoreApiGetOrderByIdRequestData, metadata?: RequestMetadata<string, 'application/xml' | 'application/json'>): Promise<Order> {
-    const queryParams = this.client.extractQueryParams<StoreApiGetOrderByIdRequestData>(data, [] as never[]);
+    const queryParamsProperties = {};
+    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -131,8 +136,10 @@ export class StoreApi implements Api {
     };
 
     let body: RequestBody = '';
-    const basePath = `${this.client.options.basePath}/store/order/${data['orderId']}`;
-    const tokenizedUrl = `${this.client.options.basePath}/store/order/${this.piiParamTokens['orderId'] || data['orderId']}`;
+    const pathParamsProperties = this.client.getPropertiesFromData(data, ['orderId']);
+    const serializedPathParams = this.client.serializePathParams(pathParamsProperties, { orderId: { explode: false, style: 'simple' } });
+    const basePath = `${this.client.options.basePath}/store/order/${serializedPathParams['orderId']}`;
+    const tokenizedUrl = `${this.client.options.basePath}/store/order/${this.piiParamTokens['orderId'] || serializedPathParams['orderId']}`;
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
 
     const requestOptions = {
@@ -147,7 +154,7 @@ export class StoreApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = options.basePath;
 
     const ret = this.client.processCall<Order>(url, options, ApiTypes.DEFAULT, StoreApi.apiName, undefined, 'getOrderById');
     return ret;
@@ -160,7 +167,8 @@ export class StoreApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async placeOrder(data: StoreApiPlaceOrderRequestData, metadata?: RequestMetadata<'application/json' | 'application/xml' | 'application/x-www-form-urlencoded', 'application/json'>): Promise<Order> {
-    const queryParams = this.client.extractQueryParams<StoreApiPlaceOrderRequestData>(data, [] as never[]);
+    const queryParamsProperties = {};
+    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -189,7 +197,7 @@ export class StoreApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = options.basePath;
 
     const ret = this.client.processCall<Order>(url, options, ApiTypes.DEFAULT, StoreApi.apiName, undefined, 'placeOrder');
     return ret;

--- a/packages/@o3r-training/showcase-sdk/src/api/user/user-api.ts
+++ b/packages/@o3r-training/showcase-sdk/src/api/user/user-api.ts
@@ -68,7 +68,8 @@ export class UserApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async createUser(data: UserApiCreateUserRequestData, metadata?: RequestMetadata<'application/json' | 'application/xml' | 'application/x-www-form-urlencoded', 'application/json' | 'application/xml'>): Promise<never> {
-    const queryParams = this.client.extractQueryParams<UserApiCreateUserRequestData>(data, [] as never[]);
+    const queryParamsProperties = {};
+    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -97,7 +98,7 @@ export class UserApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = options.basePath;
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'createUser');
     return ret;
@@ -110,7 +111,8 @@ export class UserApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async createUsersWithListInput(data: UserApiCreateUsersWithListInputRequestData, metadata?: RequestMetadata<'application/json', 'application/xml' | 'application/json'>): Promise<User> {
-    const queryParams = this.client.extractQueryParams<UserApiCreateUsersWithListInputRequestData>(data, [] as never[]);
+    const queryParamsProperties = {};
+    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -139,7 +141,7 @@ export class UserApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = options.basePath;
 
     const ret = this.client.processCall<User>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'createUsersWithListInput');
     return ret;
@@ -152,7 +154,8 @@ export class UserApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async deleteUser(data: UserApiDeleteUserRequestData, metadata?: RequestMetadata<string, string>): Promise<never> {
-    const queryParams = this.client.extractQueryParams<UserApiDeleteUserRequestData>(data, [] as never[]);
+    const queryParamsProperties = {};
+    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -160,8 +163,10 @@ export class UserApi implements Api {
     };
 
     let body: RequestBody = '';
-    const basePath = `${this.client.options.basePath}/user/${data['username']}`;
-    const tokenizedUrl = `${this.client.options.basePath}/user/${this.piiParamTokens['username'] || data['username']}`;
+    const pathParamsProperties = this.client.getPropertiesFromData(data, ['username']);
+    const serializedPathParams = this.client.serializePathParams(pathParamsProperties, { username: { explode: false, style: 'simple' } });
+    const basePath = `${this.client.options.basePath}/user/${serializedPathParams['username']}`;
+    const tokenizedUrl = `${this.client.options.basePath}/user/${this.piiParamTokens['username'] || serializedPathParams['username']}`;
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
 
     const requestOptions = {
@@ -176,7 +181,7 @@ export class UserApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = options.basePath;
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'deleteUser');
     return ret;
@@ -189,7 +194,8 @@ export class UserApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async getUserByName(data: UserApiGetUserByNameRequestData, metadata?: RequestMetadata<string, 'application/xml' | 'application/json'>): Promise<User> {
-    const queryParams = this.client.extractQueryParams<UserApiGetUserByNameRequestData>(data, [] as never[]);
+    const queryParamsProperties = {};
+    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -197,8 +203,10 @@ export class UserApi implements Api {
     };
 
     let body: RequestBody = '';
-    const basePath = `${this.client.options.basePath}/user/${data['username']}`;
-    const tokenizedUrl = `${this.client.options.basePath}/user/${this.piiParamTokens['username'] || data['username']}`;
+    const pathParamsProperties = this.client.getPropertiesFromData(data, ['username']);
+    const serializedPathParams = this.client.serializePathParams(pathParamsProperties, { username: { explode: false, style: 'simple' } });
+    const basePath = `${this.client.options.basePath}/user/${serializedPathParams['username']}`;
+    const tokenizedUrl = `${this.client.options.basePath}/user/${this.piiParamTokens['username'] || serializedPathParams['username']}`;
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
 
     const requestOptions = {
@@ -213,7 +221,7 @@ export class UserApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = options.basePath;
 
     const ret = this.client.processCall<User>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'getUserByName');
     return ret;
@@ -226,7 +234,8 @@ export class UserApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async loginUser(data: UserApiLoginUserRequestData, metadata?: RequestMetadata<string, 'application/xml' | 'application/json'>): Promise<string> {
-    const queryParams = this.client.extractQueryParams<UserApiLoginUserRequestData>(data, ['username', 'password']);
+    const queryParamsProperties = this.client.getPropertiesFromData(data, ['username', 'password']);
+    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -250,7 +259,8 @@ export class UserApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.prepareUrl(options.basePath, options.queryParams);
+    const serializedQueryParams = this.client.serializeQueryParams(queryParamsProperties, { username: { explode: true, style: 'form' }, password: { explode: true, style: 'form' } });
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, serializedQueryParams);
 
     const ret = this.client.processCall<string>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'loginUser');
     return ret;
@@ -263,7 +273,8 @@ export class UserApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async logoutUser(data: UserApiLogoutUserRequestData, metadata?: RequestMetadata<string, string>): Promise<never> {
-    const queryParams = this.client.extractQueryParams<UserApiLogoutUserRequestData>(data, [] as never[]);
+    const queryParamsProperties = {};
+    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -287,7 +298,7 @@ export class UserApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = options.basePath;
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'logoutUser');
     return ret;
@@ -300,7 +311,8 @@ export class UserApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async updateUser(data: UserApiUpdateUserRequestData, metadata?: RequestMetadata<'application/json' | 'application/xml' | 'application/x-www-form-urlencoded', string>): Promise<never> {
-    const queryParams = this.client.extractQueryParams<UserApiUpdateUserRequestData>(data, [] as never[]);
+    const queryParamsProperties = {};
+    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -313,8 +325,10 @@ export class UserApi implements Api {
     } else {
       body = data['User'] as any;
     }
-    const basePath = `${this.client.options.basePath}/user/${data['username']}`;
-    const tokenizedUrl = `${this.client.options.basePath}/user/${this.piiParamTokens['username'] || data['username']}`;
+    const pathParamsProperties = this.client.getPropertiesFromData(data, ['username']);
+    const serializedPathParams = this.client.serializePathParams(pathParamsProperties, { username: { explode: false, style: 'simple' } });
+    const basePath = `${this.client.options.basePath}/user/${serializedPathParams['username']}`;
+    const tokenizedUrl = `${this.client.options.basePath}/user/${this.piiParamTokens['username'] || serializedPathParams['username']}`;
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
 
     const requestOptions = {
@@ -329,7 +343,7 @@ export class UserApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = options.basePath;
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'updateUser');
     return ret;

--- a/packages/@o3r-training/showcase-sdk/src/spec/api-mock.ts
+++ b/packages/@o3r-training/showcase-sdk/src/spec/api-mock.ts
@@ -16,22 +16,6 @@ export interface Api {
 }
 
 /**
- * Mock APIs
- * @deprecated use `getMockedApi` with {@link ApiClient} instead, will be removed in v12.
- */
-export const myApi: Api = {
-  petApi: new api.PetApi(MOCK_SERVER),
-  storeApi: new api.StoreApi(MOCK_SERVER),
-  userApi: new api.UserApi(MOCK_SERVER)
-};
-
-/**
- * Retrieve mocked SDK Apis
- * @param config configuration of the Api Client
- * @deprecated use `getMockedApi` with {@link ApiClient} instead, will be removed in v12.
- */
-export function getMockedApi(config?: string | BaseApiFetchClientConstructor): Api;
-/**
  * Retrieve mocked SDK Apis
  * @param apiClient Api Client instance
  * @example Default Mocked API usage
@@ -41,23 +25,10 @@ export function getMockedApi(config?: string | BaseApiFetchClientConstructor): A
  * const mocks = getMockedApi(new ApiFetchClient({ basePath: MOCK_SERVER_BASE_PATH }));
  * ```
  */
-export function getMockedApi(apiClient: ApiClient): Api;
-/**
- * Retrieve mocked SDK Apis
- * @param config configuration of the Api Client
- */
-export function getMockedApi(config?: string | BaseApiFetchClientConstructor | ApiClient): Api {
-  let apiConfigObj: ApiClient = MOCK_SERVER;
-  if (typeof config === 'string') {
-    apiConfigObj = new ApiFetchClient({basePath: config});
-  } else if (isApiClient(config)) {
-    apiConfigObj = config;
-  } else if (config) {
-    apiConfigObj = new ApiFetchClient(config);
-  }
+export function getMockedApi(apiClient: ApiClient): Api {
   return {
-    petApi: new api.PetApi(apiConfigObj),
-    storeApi: new api.StoreApi(apiConfigObj),
-    userApi: new api.UserApi(apiConfigObj)
+    petApi: new api.PetApi(apiClient),
+    storeApi: new api.StoreApi(apiClient),
+    userApi: new api.UserApi(apiClient)
   };
 }

--- a/packages/@o3r-training/training-sdk/open-api.yaml
+++ b/packages/@o3r-training/training-sdk/open-api.yaml
@@ -14,6 +14,8 @@ paths:
     get:
       tags:
         - "dummy"
+      summary: Dummy get
+      description: Dummy get
       operationId: dummyGet
       responses:
         200:

--- a/packages/@o3r-training/training-sdk/src/api/dummy/dummy-api.ts
+++ b/packages/@o3r-training/training-sdk/src/api/dummy/dummy-api.ts
@@ -29,13 +29,14 @@ export class DummyApi implements Api {
   }
 
   /**
-   * 
-   * 
+   * Dummy get
+   * Dummy get
    * @param data Data to provide to the API call
    * @param metadata Metadata to pass to the API call
    */
   public async dummyGet(data: DummyApiDummyGetRequestData, metadata?: RequestMetadata<string, 'application/json'>): Promise<Flight> {
-    const queryParams = this.client.extractQueryParams<DummyApiDummyGetRequestData>(data, [] as never[]);
+    const queryParamsProperties = {};
+    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -59,7 +60,7 @@ export class DummyApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = options.basePath;
 
     const ret = this.client.processCall<Flight>(url, options, ApiTypes.DEFAULT, DummyApi.apiName, { 200: reviveFlight } , 'dummyGet');
     return ret;

--- a/packages/@o3r-training/training-sdk/src/spec/api-mock.ts
+++ b/packages/@o3r-training/training-sdk/src/spec/api-mock.ts
@@ -14,20 +14,6 @@ export interface Api {
 }
 
 /**
- * Mock APIs
- * @deprecated use `getMockedApi` with {@link ApiClient} instead, will be removed in v12.
- */
-export const myApi: Api = {
-  dummyApi: new api.DummyApi(MOCK_SERVER)
-};
-
-/**
- * Retrieve mocked SDK Apis
- * @param config configuration of the Api Client
- * @deprecated use `getMockedApi` with {@link ApiClient} instead, will be removed in v12.
- */
-export function getMockedApi(config?: string | BaseApiFetchClientConstructor): Api;
-/**
  * Retrieve mocked SDK Apis
  * @param apiClient Api Client instance
  * @example Default Mocked API usage
@@ -37,21 +23,8 @@ export function getMockedApi(config?: string | BaseApiFetchClientConstructor): A
  * const mocks = getMockedApi(new ApiFetchClient({ basePath: MOCK_SERVER_BASE_PATH }));
  * ```
  */
-export function getMockedApi(apiClient: ApiClient): Api;
-/**
- * Retrieve mocked SDK Apis
- * @param config configuration of the Api Client
- */
-export function getMockedApi(config?: string | BaseApiFetchClientConstructor | ApiClient): Api {
-  let apiConfigObj: ApiClient = MOCK_SERVER;
-  if (typeof config === 'string') {
-    apiConfigObj = new ApiFetchClient({basePath: config});
-  } else if (isApiClient(config)) {
-    apiConfigObj = config;
-  } else if (config) {
-    apiConfigObj = new ApiFetchClient(config);
-  }
+export function getMockedApi(apiClient: ApiClient): Api {
   return {
-    dummyApi: new api.DummyApi(apiConfigObj)
+    dummyApi: new api.DummyApi(apiClient)
   };
 }


### PR DESCRIPTION
## Proposed change

Support of exploded syntax for query and path parameters: https://swagger.io/docs/specification/v3_0/serialization/ 
This is an alternate solution to the existing PR https://github.com/AmadeusITGroup/otter/pull/2865 to avoid breaking changes.

**UPDATE:** I added a second commit that limits the path and query parameters to be of supported types (primitve, simple array of primitive values, and simple non-nested objects). If this is approved, I will squash the second commit into the first one.

## Related issues

#640 

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
