### PR TITLE
fix: eslint-config eslint-plugin dep

### DIFF
--- a/packages/@o3r/eslint-config/schematics/ng-add/index.ts
+++ b/packages/@o3r/eslint-config/schematics/ng-add/index.ts
@@ -63,7 +63,6 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
     const devDependenciesToInstall = [
       '@eslint-community/eslint-plugin-eslint-comments',
       '@eslint/js',
-      '@o3r/eslint-plugin',
       '@stylistic/eslint-plugin',
       '@typescript-eslint/parser',
       '@typescript-eslint/utils',


### PR DESCRIPTION
## Proposed change

Removing `@o3r/eslint-config` explicit dev dep for `@o3r/eslint-plugin` as it comes from its own package json.

Fixes the following scenario:
- create a new otter project with a fixed version
- add `@o3r/eslint-config` (with fixed otter version) 

Now: version is not fixed for `@o3r/eslint-plugin`
Expected: version is fixed for  `@o3r/eslint-plugin`


