### PR TITLE
fix: condition for using flat config

### DIFF
--- a/packages/@o3r/core/schematics/ng-add/utils/linter/index.spec.ts
+++ b/packages/@o3r/core/schematics/ng-add/utils/linter/index.spec.ts
@@ -1,0 +1,39 @@
+import {
+  Tree,
+} from '@angular-devkit/schematics';
+import {
+  isUsingFlatConfig,
+} from './index';
+
+describe('isUsingFlatConfig', () => {
+  const filenames = [
+    'eslint.config.js',
+    'eslint.config.ts',
+    'eslint.config.mjs',
+    'eslint.config.cjs',
+    'eslint.config.mts',
+    'eslint.config.cts'
+  ];
+
+  filenames.forEach((filename) => {
+    it(`should return true for ${filename}`, () => {
+      const tree = Tree.empty();
+      tree.create(filename, '');
+      expect(isUsingFlatConfig(tree)).toBe(true);
+    });
+  });
+
+  it('should return false if no matching eslint config file is found', () => {
+    const tree = Tree.empty();
+    tree.create('otherfile.txt', '');
+    tree.create('anotherfile.md', '');
+    expect(isUsingFlatConfig(tree)).toBe(false);
+  });
+
+  it('should return false if the eslint config file does not match the pattern', () => {
+    const tree = Tree.empty();
+    tree.create('eslint.config.json', '');
+    tree.create('eslint.config.yaml', '');
+    expect(isUsingFlatConfig(tree)).toBe(false);
+  });
+});

--- a/packages/@o3r/core/schematics/ng-add/utils/linter/index.ts
+++ b/packages/@o3r/core/schematics/ng-add/utils/linter/index.ts
@@ -10,7 +10,7 @@ import {
  * If the ESLint FlatConfig is used in the repository
  * @param tree
  */
-export const isUsingFlatConfig = (tree: Tree) => tree.root.subfiles.find((file) => /eslint\.config\.{m,c,}[jt]s/.test(file));
+export const isUsingFlatConfig = (tree: Tree) => tree.root.subfiles.some((file) => /eslint\.config\.[mc]?[jt]s$/.test(file));
 
 /**
  * Checks if `eslint` package is installed. If so, ask the user for otter linter rules install.

--- a/packages/@o3r/workspace/schematics/rule-factories/linter.spec.ts
+++ b/packages/@o3r/workspace/schematics/rule-factories/linter.spec.ts
@@ -1,0 +1,39 @@
+import {
+  Tree,
+} from '@angular-devkit/schematics';
+import {
+  isUsingFlatConfig,
+} from './linter';
+
+describe('isUsingFlatConfig', () => {
+  const filenames = [
+    'eslint.config.js',
+    'eslint.config.ts',
+    'eslint.config.mjs',
+    'eslint.config.cjs',
+    'eslint.config.mts',
+    'eslint.config.cts'
+  ];
+
+  filenames.forEach((filename) => {
+    it(`should return true for ${filename}`, () => {
+      const tree = Tree.empty();
+      tree.create(filename, '');
+      expect(isUsingFlatConfig(tree)).toBe(true);
+    });
+  });
+
+  it('should return false if no matching eslint config file is found', () => {
+    const tree = Tree.empty();
+    tree.create('otherfile.txt', '');
+    tree.create('anotherfile.md', '');
+    expect(isUsingFlatConfig(tree)).toBe(false);
+  });
+
+  it('should return false if the eslint config file does not match the pattern', () => {
+    const tree = Tree.empty();
+    tree.create('eslint.config.json', '');
+    tree.create('eslint.config.yaml', '');
+    expect(isUsingFlatConfig(tree)).toBe(false);
+  });
+});

--- a/packages/@o3r/workspace/schematics/rule-factories/linter.ts
+++ b/packages/@o3r/workspace/schematics/rule-factories/linter.ts
@@ -10,7 +10,7 @@ import type {
  * If the ESLint FlatConfig is used in the repository
  * @param tree
  */
-export const isUsingFlatConfig = (tree: Tree) => tree.root.subfiles.find((file) => /eslint\.config\.{m,c,}[jt]s/.test(file));
+export const isUsingFlatConfig = (tree: Tree) => tree.root.subfiles.some((file) => /eslint\.config\.[mc]?[jt]s$/.test(file));
 
 /**
  * Checks if `eslint` package is installed. If so, ask the user for otter linter rules install.


### PR DESCRIPTION
## Proposed change

The regex for checking for flat config files was invalid.

This code is currently duplicated in workspace and core, is there a place where we can move it so that it can be reused? In schematics maybe?
