### PR TITLE
fix: renovate to use chore instead of fix

### DIFF
--- a/tools/renovate/base.json
+++ b/tools/renovate/base.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended",
     ":dependencyDashboard",
+    ":semanticCommitTypeAll(chore)",
     "group:allNonMajor",
     "group:monorepos",
     "group:recommended",


### PR DESCRIPTION
## Proposed change

Renovate should use `chore` when bumping deps rather than `fix`. 
