### PR TITLE
fix: forward options for presets

### DIFF
--- a/packages/@o3r/core/schematics/ng-add/index.ts
+++ b/packages/@o3r/core/schematics/ng-add/index.ts
@@ -85,8 +85,9 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       registerPackageCollectionSchematics(corePackageJsonContent),
       async (t, c) => {
         const { preset, externalPresets, ...forwardOptions } = options;
-        const presetRunner = await presets[preset]({ projectName: forwardOptions.projectName, forwardOptions });
-        const externalPresetRunner = externalPresets ? await getExternalPreset(externalPresets, t, c)({ projectName: forwardOptions.projectName, forwardOptions }) : undefined;
+        const presetOptions = { projectName: forwardOptions.projectName, exactO3rVersion: forwardOptions.exactO3rVersion, forwardOptions };
+        const presetRunner = await presets[preset](presetOptions);
+        const externalPresetRunner = externalPresets ? await getExternalPreset(externalPresets, t, c)(presetOptions) : undefined;
         const modules = [...new Set([...(presetRunner.modules || []), ...(externalPresetRunner?.modules || [])])];
         if (modules.length > 0) {
           c.logger.info(`The following modules will be installed: ${modules.join(', ')}`);

--- a/packages/@o3r/core/schematics/shared/presets/helpers.ts
+++ b/packages/@o3r/core/schematics/shared/presets/helpers.ts
@@ -36,7 +36,7 @@ export function defaultPresetRuleFactory(moduleToInstall: string[], options: Pre
           range: `${options.exactO3rVersion ? '' : '~'}${corePackageJsonContent.version}`,
           types: getProjectNewDependenciesTypes(workspaceProject)
         }],
-        ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
+        ngAddOptions: { ...options.forwardOptions, exactO3rVersion: options.exactO3rVersion }
       };
       return acc;
     }, {} as Record<string, DependencyToAdd>);

--- a/packages/@o3r/create/src/index.it.spec.ts
+++ b/packages/@o3r/create/src/index.it.spec.ts
@@ -106,4 +106,43 @@ describe('Create new otter project command', () => {
       expect(version).toBe(o3rExactVersion);
     });
   });
+
+  test('should generate a project with an application, with --exact-o3r-version and preset cms', async () => {
+    const { workspacePath, packageManagerConfig, o3rExactVersion } = o3rEnvironment.testEnvironment;
+    const inProjectPath = path.join(workspacePath, workspaceProjectName);
+    const execWorkspaceOptions = { ...defaultExecOptions, cwd: workspacePath };
+    const execInAppOptions = { ...defaultExecOptions, cwd: inProjectPath };
+    const packageManager = getPackageManager();
+    const createOptions = [
+      '--package-manager', packageManager,
+      '--skip-confirmation',
+      '--exact-o3r-version',
+      '--preset cms',
+      ...(packageManagerConfig.yarnVersion ? ['--yarn-version', packageManagerConfig.yarnVersion] : [])];
+
+    // TODO: remove it when fixing #1356
+    await fs.mkdir(inProjectPath, { recursive: true });
+    setPackagerManagerConfig(packageManagerConfig, execInAppOptions);
+
+    expect(() => packageManagerCreate({ script: `@o3r@${o3rExactVersion}`, args: [workspaceProjectName, ...createOptions] }, execWorkspaceOptions, 'npm')).not.toThrow();
+    expect(existsSync(path.join(inProjectPath, 'angular.json'))).toBe(true);
+    expect(existsSync(path.join(inProjectPath, 'package.json'))).toBe(true);
+    expect(() => packageManagerInstall(execInAppOptions)).not.toThrow();
+
+    const appName = 'test-application';
+    expect(() => packageManagerExec({ script: 'ng', args: ['g', 'application', appName] }, execInAppOptions)).not.toThrow();
+    expect(existsSync(path.join(inProjectPath, 'project'))).toBe(false);
+    expect(() => packageManagerRunOnProject(appName, true, { script: 'build' }, execInAppOptions)).not.toThrow();
+
+    const rootPackageJson = JSON.parse(await fs.readFile(path.join(inProjectPath, 'package.json'), 'utf8'));
+    const resolutions = packageManager === 'yarn' ? rootPackageJson.resolutions : rootPackageJson.overrides;
+    const appPackageJson = JSON.parse(await fs.readFile(path.join(inProjectPath, 'apps', appName, 'package.json'), 'utf8'));
+    // all otter dependencies in both package.json files must be pinned:
+    [
+      ...Object.entries(rootPackageJson.dependencies), ...Object.entries(rootPackageJson.devDependencies), ...Object.entries(resolutions),
+      ...Object.entries(appPackageJson.dependencies), ...Object.entries(appPackageJson.devDependencies)
+    ].filter(([dep]) => dep.startsWith('@o3r/') || dep.startsWith('@ama-sdk/')).forEach(([,version]) => {
+      expect(version).toBe(o3rExactVersion);
+    });
+  });
 });


### PR DESCRIPTION
## Proposed change

Forward the options to modules when using presets.

How to reproduce:
```shell
npm create @o3r test-preset-cms-exact -- --preset cms --exact-o3r-version
```

Should have all deps fixed and it is not the case today. 