### PR TITLE
docs: markdown link check exception for Figma plugins

### DIFF
--- a/.github/markdown-external-links.config.json
+++ b/.github/markdown-external-links.config.json
@@ -17,6 +17,9 @@
     },
     {
       "pattern": "https://petstore3.swagger.io/api/v3"
+    },
+    {
+      "pattern": "^https://figma.com/community/*"
     }
   ],
   "replacementPatterns": [


### PR DESCRIPTION
## Proposed change

Adding an exception for markdown link checker for Figma plugins as they use a bot protection returning 403 for non-human users.

```shell
curl -I https://www.figma.com/community/plugin/929607085343688745/color-shades
HTTP/2 403 
server: CloudFront
date: Mon, 03 Mar 2025 15:03:31 GMT
content-type: text/html
content-length: 919
x-cache: Error from cloudfront
via: 1.1 f41688bac877227b82b3347b2428d266.cloudfront.net (CloudFront)
x-amz-cf-pop: FRA56-P12
alt-svc: h3=":443"; ma=86400
x-amz-cf-id: BEkxjBUsVFyzSVEuDhJb_GHpcdp58fmWSQ5Y97UodcSjwpWsBPrZjQ==
x-content-type-options: nosniff
strict-transport-security: max-age=31536000; includeSubDomains; preload
```

Bot protection doesn't affect other Figma links (i.e. https://help.figma.com/hc/en-us/articles/14506821864087-Overview-of-variables-collections-and-modes) so adding the exception just for plugins.
## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

<!-- * :bug: Fix #issue -->
* :bug: Fix resolves #2925 
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
