### PR TITLE
ci: prevent pull requests to write cache for it tests

### DIFF
--- a/.github/workflows/it-tests.yml
+++ b/.github/workflows/it-tests.yml
@@ -97,6 +97,7 @@ jobs:
         if: inputs.ref == ''
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
+          lookup-only: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
           path: |
             .cache/test-app
             !.cache/test-app/cache/@ama-sdk*


### PR DESCRIPTION
## Proposed change

The `*-test-app` cache should only be written on main/releases branches once a month.
PR were never meant to create these caches.

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
