### PR TITLE
feat(ama-mfe-utils): download application local CSS

### DIFF
--- a/packages/@ama-mfe/ng-utils/src/theme/theme.consumer.service.ts
+++ b/packages/@ama-mfe/ng-utils/src/theme/theme.consumer.service.ts
@@ -23,6 +23,7 @@ import {
 } from '../managers/index';
 import {
   applyTheme,
+  downloadApplicationThemeCss,
 } from './theme.helpers';
 
 /**
@@ -47,10 +48,18 @@ export class ThemeConsumerService implements MessageConsumer<ThemeMessage> {
      * Use the message paylod to get the theme and apply it
      * @param message message to consume
      */
-    '1.0': (message: RoutedMessage<ThemeV1_0>) => {
+    '1.0': async (message: RoutedMessage<ThemeV1_0>) => {
       const sanitizedCss = this.domSanitizer.sanitize(SecurityContext.STYLE, message.payload.css);
       if (sanitizedCss !== null) {
         applyTheme(sanitizedCss);
+      }
+      try {
+        const css = await downloadApplicationThemeCss(message.payload.name);
+        applyTheme(css, false);
+      } catch (e) {
+        // TODO https://github.com/AmadeusITGroup/otter/issues/2887 - proper logger
+        // eslint-disable-next-line no-console -- log the error - replace this with a proper logger
+        console.warn(`no CSS variable for the theme ${message.payload.name}`, e);
       }
     }
   };

--- a/packages/@ama-mfe/ng-utils/src/theme/theme.helpers.spec.ts
+++ b/packages/@ama-mfe/ng-utils/src/theme/theme.helpers.spec.ts
@@ -1,7 +1,9 @@
 import {
   applyInitialTheme,
   applyTheme,
+  downloadApplicationThemeCss,
   getStyle,
+  THEME_URL_SUFFIX,
 } from './theme.helpers';
 
 describe('theme helpers', () => {
@@ -127,6 +129,18 @@ describe('theme helpers', () => {
       await applyInitialTheme();
       expect(getStyleSpy).toHaveBeenCalledTimes(2);
       expect(document.adoptedStyleSheets.length).toBe(2);
+    });
+  });
+
+  describe('downloadApplicationThemeCss', () => {
+    it('should add suffix to CSS file', async () => {
+      await downloadApplicationThemeCss('test-css-file');
+      expect(global.Request).toHaveBeenCalledWith(`test-css-file${THEME_URL_SUFFIX}`);
+    });
+
+    it('should keep suffix when specified', async () => {
+      await downloadApplicationThemeCss('test-css-file.css');
+      expect(global.Request).toHaveBeenCalledWith(`test-css-file.css`);
     });
   });
 });

--- a/packages/@ama-mfe/ng-utils/src/theme/theme.helpers.ts
+++ b/packages/@ama-mfe/ng-utils/src/theme/theme.helpers.ts
@@ -38,6 +38,15 @@ export function applyTheme(themeValue?: string, cleanPrevious = true): void {
 }
 
 /**
+ * Download the application additional theme
+ * @param theme Name of the theme to download from the current application
+ */
+export function downloadApplicationThemeCss(theme: string) {
+  const cssHref = `${theme.endsWith('.css') ? theme : theme + THEME_URL_SUFFIX}`;
+  return getStyle(cssHref);
+}
+
+/**
  * Applies the initial theme based on the URL query parameters.
  *
  * This function fetches the CSS theme specified in the URL query parameters and applies it as a stylesheet.
@@ -45,16 +54,15 @@ export function applyTheme(themeValue?: string, cleanPrevious = true): void {
  */
 export async function applyInitialTheme(): Promise<PromiseSettledResult<void>[] | undefined> {
   const searchParams = new URLSearchParams(window.location.search);
-  let cssHref = searchParams.get(THEME_QUERY_PARAM_NAME);
+  const theme = searchParams.get(THEME_QUERY_PARAM_NAME);
   document.adoptedStyleSheets = [];
-  if (cssHref) {
-    cssHref = `${cssHref.endsWith('.css') ? cssHref : cssHref + THEME_URL_SUFFIX}`;
+  if (theme) {
     const themeRequest: Promise<void>[] = [];
-    themeRequest.push(getStyle(cssHref).then((styleToApply) => applyTheme(styleToApply, false)));
+    themeRequest.push(downloadApplicationThemeCss(theme).then((styleToApply) => applyTheme(styleToApply, false)));
     if (document.referrer) {
       const url = new URL(document.referrer);
-      url.pathname += `${url.pathname.endsWith('/') ? '' : '/'}${cssHref}`;
-      themeRequest.push(getStyle(url.toString()).then((styleToApply) => applyTheme(styleToApply, false)));
+      url.pathname += `${url.pathname.endsWith('/') ? '' : '/'}${theme}`;
+      themeRequest.unshift(getStyle(url.toString()).then((styleToApply) => applyTheme(styleToApply, false)));
     }
 
     return Promise.allSettled(themeRequest);


### PR DESCRIPTION
## Proposed change

feat(ama-mfe-utils): download application local CSS when receiving message from host 

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
* :rocket: Feature resolves #2919
<!-- * :octocat: Pull Request #issue -->
