### PR TITLE
feat: exploded syntax in sdk - otter default values for swagger2

### DIFF
--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/java/com/amadeus/codegen/ts/AbstractTypeScriptClientCodegen.java
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/java/com/amadeus/codegen/ts/AbstractTypeScriptClientCodegen.java
@@ -585,6 +585,17 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
         parameter.isPrimitiveType = false;
       }
     }
+
+    // Set Otter default parameter serialization for Swagger 2.0
+    if (parameter.style == null || "".equals(parameter.style)) {
+      if (parameter.isQueryParam) {
+        parameter.isExplode = false;
+        parameter.style = "form";
+      } else if (parameter.isPathParam) {
+        parameter.isExplode = false;
+        parameter.style = "simple";
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Proposed change

Add default values for specifications of version Swagger 2.0

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
