### PR TITLE
feat: exploded syntax in sdk - support dates

### DIFF
--- a/packages/@ama-sdk/core/src/fwk/api.helpers.ts
+++ b/packages/@ama-sdk/core/src/fwk/api.helpers.ts
@@ -1,8 +1,9 @@
 import {
   TokenizedOptions,
 } from '../plugins/core/request-plugin';
-import type {
-  SupportedParamType,
+import {
+  isDateType,
+  type SupportedParamType,
 } from './param-serialization';
 import type {
   ReviverType,
@@ -76,7 +77,9 @@ export function stringifyQueryParams<T extends { [key: string]: SupportedParamTy
     .filter((name) => typeof queryParams[name] !== 'undefined' && queryParams[name] !== null)
     .reduce((acc, name) => {
       const prop = queryParams[name];
-      acc[name] = (typeof prop === 'object' && !Array.isArray(prop)) ? JSON.stringify(prop) : prop!.toString();
+      acc[name] = isDateType(prop)
+        ? prop.toJSON()
+        : ((typeof prop === 'object' && !Array.isArray(prop)) ? JSON.stringify(prop) : prop!.toString());
       return acc;
     }, {} as { [p in keyof T]: string });
 }

--- a/packages/@ama-sdk/core/src/fwk/param-serialization.spec.ts
+++ b/packages/@ama-sdk/core/src/fwk/param-serialization.spec.ts
@@ -2,6 +2,9 @@ import {
   getPropertiesFromData,
 } from './api.helpers';
 import {
+  utils,
+} from './date';
+import {
   serializePathParams,
   serializeQueryParams,
 } from './param-serialization';
@@ -190,5 +193,25 @@ describe('Serialize parameters', () => {
     });
     expect(emptyArrayPathParametersMatrix.idEmptyArray).toEqual(';idEmptyArray');
     expect(emptyArrayPathParametersMatrix.idArrayToFilter).toEqual(';idArrayToFilter=value1,value2');
+  });
+
+  it('should correctly serialize parameters of type date', () => {
+    const currentDate = new Date();
+    const mockDateData = {
+      idDate: currentDate,
+      idUtilsDate: new utils.Date(new Date('2025-01-01T00:00:00')),
+      idUtilsDateTime: new utils.DateTime(new Date('2025-01-01T00:00:00'))
+    };
+    const mockDateParams = getPropertiesFromData(mockDateData, ['idDate']);
+    const mockUtilsDateParams = getPropertiesFromData(mockDateData, ['idUtilsDate']);
+    const mockUtilsDateTimeParams = getPropertiesFromData(mockDateData, ['idUtilsDateTime']);
+
+    expect(serializeQueryParams(mockDateParams, { idDate: { explode: true, style: 'form' } })).toEqual({ idDate: `idDate=${currentDate.toJSON()}` });
+    expect(serializeQueryParams(mockUtilsDateParams, { idUtilsDate: { explode: true, style: 'form' } })).toEqual({ idUtilsDate: 'idUtilsDate=2025-01-01' });
+    expect(serializeQueryParams(mockUtilsDateTimeParams, { idUtilsDateTime: { explode: true, style: 'form' } })).toEqual({ idUtilsDateTime: 'idUtilsDateTime=2025-01-01T00:00:00.000' });
+
+    expect(serializePathParams(mockDateParams, { idDate: { explode: true, style: 'simple' } })).toEqual({ idDate: `${currentDate.toJSON()}` });
+    expect(serializePathParams(mockUtilsDateParams, { idUtilsDate: { explode: true, style: 'simple' } })).toEqual({ idUtilsDate: '2025-01-01' });
+    expect(serializePathParams(mockUtilsDateTimeParams, { idUtilsDateTime: { explode: true, style: 'simple' } })).toEqual({ idUtilsDateTime: '2025-01-01T00:00:00.000' });
   });
 });


### PR DESCRIPTION
## Proposed change

Fix the newly created `PrimitiveType` to support dates (`utils.Date` and `utils.DateTime`)

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
