### PR TITLE
ci: limit it-tests on pull-requests to only ubuntu-npm

### DIFF
--- a/.github/workflows/it-tests.yml
+++ b/.github/workflows/it-tests.yml
@@ -70,6 +70,14 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         packageManager: [yarn, npm]
         testEnvironment: [o3r-project-with-app]
+        fastRun:
+          - ${{ github.event_name == 'pull_request' && github.base_ref == 'main' }}
+        exclude:
+          - fastRun: true
+            os: windows-latest
+          - fastRun: true
+            packageManager: yarn
+    name: it-tests (${{ matrix.os }}, ${{ matrix.packageManager }}, ${{ matrix.testEnvironment }})
     runs-on: ${{ matrix.os }}
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
@@ -152,3 +160,18 @@ jobs:
       - name: Stop verdaccio
         if: always() && runner.os == 'Linux'
         run: yarn verdaccio:stop
+
+  # This job is used to give the final status of the matrix. It can be used as required job for branch security.
+  conclusion:
+    runs-on: ubuntu-latest
+    needs: [it-tests]
+    if: success() || failure()
+    steps:
+      - run: |
+          if [[ $OUTPUT == "success" ]]; then
+            exit 0
+          else
+            exit 1
+          fi
+        env:
+          OUTPUT: ${{ needs.it-tests.result }}


### PR DESCRIPTION
## Proposed change

Only run it-tests on `ubuntu/npm` when a pull-request target `main`

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
