### PR TITLE
ci: speed up execution of lighthouse tests

### DIFF
--- a/apps/showcase/e2e-playwright/sanity/lighthouse-sanity.e2e.ts
+++ b/apps/showcase/e2e-playwright/sanity/lighthouse-sanity.e2e.ts
@@ -22,6 +22,7 @@ const lighthouseConfig = {
   config: {
     extends: 'lighthouse:default',
     settings: {
+      maxWaitForLoad: 1000,
       onlyCategories: ['accessibility', 'best-practices']
     }
   },


### PR DESCRIPTION
## Proposed change

Currently, lighthouse is waiting 45s for the page to load but never detects it (on every test)
It doesn't seem to impact us since we are not using the `performance` audits, so I propose to reduce the timeout to 1s

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
