### PR TITLE
ci: speed up execution of unit tests

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -76,7 +76,7 @@ jobs:
           NX_BASE: ${{ format('remotes/origin/{0}', github.base_ref || github.ref_name) }}
           testCmd: ${{ inputs.affected && 'test:affected' || 'test'}}
           NODE_OPTIONS: ${{ runner.os == 'Windows' && '--max_old_space_size=4096' || '' }}
-        run: yarn ${{ env.testCmd }} --collectCoverage
+        run: yarn ${{ env.testCmd }} --collectCoverage --configuration=ci
       - name: Upload results to Codecov
         uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:

--- a/nx.json
+++ b/nx.json
@@ -198,7 +198,8 @@
       "configurations": {
         "ci": {
           "ci": true,
-          "codeCoverage": true
+          "codeCoverage": true,
+          "maxWorkers": 2
         }
       },
       "cache": true


### PR DESCRIPTION
## Proposed change

Jest tries to parallelize the execution of tests by using all the available number of cores minus 1 (https://jestjs.io/docs/cli#--maxworkersnumstring)
However, Nx is already parallelizing the execution of tests (we've set it to 3 in parallel for the CI)

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
