### PR TITLE
fix: placeholder should support rendering the same fact with different json path

### DIFF
--- a/packages/@o3r/components/src/rules-engine/placeholder.rules-engine.effect.spec.ts
+++ b/packages/@o3r/components/src/rules-engine/placeholder.rules-engine.effect.spec.ts
@@ -268,4 +268,34 @@ describe('Rules Engine Effects', () => {
     await jest.runAllTimersAsync();
     expect(effectFn).toHaveBeenCalledWith(expect.objectContaining({entity: expect.objectContaining({renderedTemplate: ''})}));
   });
+
+  it('should support several facts with different path', async () => {
+    const effectFn = jest.fn();
+    subscriptions.push(effect.setPlaceholderRequestEntityFromUrl$.subscribe(effectFn));
+    const response: PlaceholderRequestReply = {
+      vars: {
+        factInTemplateProp1: {
+          type: 'fact',
+          value: 'factInTemplate',
+          path: '$.prop1'
+        },
+        factInTemplateProp2: {
+          type: 'fact',
+          value: 'factInTemplate',
+          path: '$.prop2'
+        }
+      },
+      template: '<%= factInTemplateProp1 %> <%= factInTemplateProp2 %>'
+    };
+    actions.next(setPlaceholderRequestEntityFromUrl({
+      call: Promise.resolve(response),
+      id: 'myPlaceholderUrl',
+      resolvedUrl: 'myPlaceholderResolvedUrl'
+    }));
+
+    effectFn.mockReset();
+    factsStream.factInTemplate.next({ prop1: 'value1', prop2: 'value2' });
+    await jest.runAllTimersAsync();
+    expect(effectFn).toHaveBeenCalledWith(expect.objectContaining({ entity: expect.objectContaining({ renderedTemplate: 'value1 value2' }) }));
+  });
 });

--- a/packages/@o3r/components/src/rules-engine/placeholder.rules-engine.effect.ts
+++ b/packages/@o3r/components/src/rules-engine/placeholder.rules-engine.effect.ts
@@ -118,7 +118,7 @@ export class PlaceholderTemplateResponseEffect {
               break;
             }
             case 'fact': {
-              template = template.replace(ejsVar, factMap[vars[varName].value] ?? '');
+              template = template.replace(ejsVar, factMapFromVars[varName] ?? '');
               break;
             }
             case 'localisation': {


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
