### PR TITLE
fix: adjust path replacement script to work with node 20.19.0

### DIFF
--- a/packages/@o3r/testing/src/tools/path-replacement/path-replacement.ts
+++ b/packages/@o3r/testing/src/tools/path-replacement/path-replacement.ts
@@ -10,6 +10,9 @@ import {
 import {
   requireFromString,
 } from 'module-from-string';
+
+type ModuleType = 'ESM' | 'CJS' | 'unknown';
+
 /**
  * Switch to the needed implementation of core testing, when running e2e tests
  * transforms ESM into CJS when needed
@@ -17,52 +20,137 @@ import {
  * @param customTransformOptions
  */
 export function adjustPath(frameworkName: 'playwright' | 'protractor', customTransformOptions: TransformOptions = {}) {
-  const modulesCache: Record<string, any> = {};
+  const cjsModulesCache: Record<string, any> = {};
+  const moduleTypesCache: Record<string, ModuleType> = {};
   // eslint-disable-next-line @typescript-eslint/unbound-method -- No need to bind the method, we are using `apply`
   const originalRequire = Module.prototype.require;
   const regex = new RegExp(`@o3r/testing/core(?!/${frameworkName})(.*)`);
   Module.prototype.require = function (this: NodeJS.Module, id: string) {
     const newId = id.replace(regex, `@o3r/testing/core/${frameworkName}$1`);
+    const paths = [
+      ...this.paths,
+      ...this.paths.map((i) => i.replace(/[/\\]node_modules$/, ''))
+    ];
 
+    const filePath = require.resolve(newId, { paths });
+
+    const moduleType = checkModuleType(filePath, moduleTypesCache);
+    if (moduleType === 'ESM') {
+      return convertESMToCJS(newId, filePath, cjsModulesCache, customTransformOptions);
+    }
+
+    return Reflect.apply(originalRequire, this, [newId]);
+  } as NodeJS.Require;
+}
+
+/**
+ * Convert ESM to CJS using esbuild
+ * @param moduleId
+ * @param filePath
+ * @param cjsModulesCache
+ * @param customTransformOptions
+ */
+function convertESMToCJS(moduleId: string, filePath: string, cjsModulesCache: Record<string, any>, customTransformOptions: TransformOptions = {}): any {
+  if (!cjsModulesCache[moduleId]) {
+    const fileContent = fs.readFileSync(filePath);
+    const cwd = path.resolve(process.cwd(), 'src');
+    // we use ESBUILD to transform it into CJS
+    const trans = transformSync(fileContent.toString(), {
+      loader: 'js',
+      format: 'cjs',
+      target: 'es2016',
+      sourcesContent: true,
+      sourceRoot: cwd,
+      ...customTransformOptions
+    });
+
+    /*
+     * requireFromString will execute the file apart from just returning a module
+     * It can throw an exception which will prevent stop the execution
+     *
+     * That main blocker includes IVY-compatible libraries which have
+     * no compiler facade in a global scope.
+     */
     try {
-      return Reflect.apply(originalRequire, this, [newId]);
-    } catch {
-      const paths = ([] as string[])
-        .concat(this.paths, this.paths.map((i) => i.replace(/[/\\]node_modules$/, '')));
+      cjsModulesCache[moduleId] = requireFromString(trans.code, {
+        dirname: path.dirname(filePath),
+        useCurrentGlobal: true
+      });
+    } catch (ex) {
+      // eslint-disable-next-line no-console -- no other logger available
+      console.error(ex);
+    }
+  }
 
-      const filePath = require.resolve(newId, { paths });
-      if (!modulesCache[filePath]) {
-        const fileContent = fs.readFileSync(filePath);
-        const cwd = path.resolve(process.cwd(), 'src');
-        // we use ESBUILD to transform it into CJS
-        const trans = transformSync(fileContent.toString(), {
-          loader: 'js',
-          format: 'cjs',
-          target: 'es2016',
-          sourcesContent: true,
-          sourceRoot: cwd,
-          ...customTransformOptions
-        });
+  return cjsModulesCache[moduleId];
+}
 
-        /**
-         * requireFromString will execute the file apart from just returning a module
-         * It can throw an exception which will prevent stop the execution
-         *
-         * That main blocker includes IVY-compatible libraries which have
-         * no compiler facade in a global scope.
-         */
-        try {
-          modulesCache[filePath] = requireFromString(trans.code, {
-            dirname: path.dirname(filePath),
-            useCurrentGlobal: true
-          });
-        } catch (ex) {
-          // eslint-disable-next-line no-console -- no other logger available
-          console.error(ex);
-        }
+/**
+ * Check the module type of the given module path.
+ * @param modulePath
+ * @param cache
+ */
+function checkModuleType(modulePath: string, cache: Record<string, ModuleType>): ModuleType {
+  if (cache[modulePath]) {
+    return cache[modulePath];
+  }
+
+  let type: ModuleType = 'unknown';
+  const ext = path.extname(modulePath);
+  switch (ext) {
+    case '.mjs': {
+      type = 'ESM';
+
+      break;
+    }
+    case '.cjs': {
+      type = 'CJS';
+
+      break;
+    }
+    case '.js': {
+      // Find recursively the package.json file to check if it is an ESM module
+      const packageJsonPath = findPackageJson(modulePath);
+      if (packageJsonPath !== null) {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports -- Needed to require the package.json file
+        const packageJson = require(packageJsonPath);
+        type = packageJson.type === 'module' ? 'ESM' : 'CJS';
       }
 
-      return modulesCache[filePath];
+      break;
     }
-  } as NodeJS.Require;
+    default: {
+      type = 'unknown';
+    }
+  }
+
+  cache[modulePath] = type;
+  return type;
+}
+
+/**
+ * Returns the path to the package.json file in the directory path given as argument.
+ * The method is called recursively to find the package.json in the parent directories.
+ * @param dirPath
+ */
+function findPackageJson(dirPath: string): string | null {
+  const packageJsonPath = path.join(dirPath, 'package.json');
+  const packageJsonExists = (() => {
+    try {
+      require.resolve(packageJsonPath);
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
+  if (packageJsonExists) {
+    return packageJsonPath;
+  }
+
+  const parentDir = path.dirname(dirPath);
+  if (parentDir === dirPath) {
+    return null;
+  }
+  return findPackageJson(parentDir);
 }


### PR DESCRIPTION
## Proposed change

adjustPath method relies on the fact that node throws an error when requiring an ESM module. In the catch block, the code module is transformed to CJS.

This method works until Node 20.18.3.
With Node 20.19.0, [require(esm) is now enabled by default](https://nodejs.org/fr/blog/release/v20.19.0#requireesm-is-now-enabled-by-default) and therefore, no errors are thrown and ESM module are not transformed to CJS anymore.

This PR is a candidate fix for this issue.
Before requiring the module, the type will be inferred. If ESM is detected, the module will be converted to CJS.

## Related issues

Fixes 🐛 #3047 