### PR TITLE
feat(sdk): extract compare date function from utils.date

### DIFF
--- a/packages/@ama-sdk/core/src/fwk/date.spec.ts
+++ b/packages/@ama-sdk/core/src/fwk/date.spec.ts
@@ -1,4 +1,5 @@
 import {
+  compareDates,
   utils,
 } from './date';
 
@@ -132,5 +133,21 @@ describe('Date', () => {
     // The day should be correct and not 27
     expect(dateUtils.toJSON()).toEqual('1972-05-28');
     expect(dateUtils.getDate()).toBe(28);
+  });
+});
+
+describe('Compare utils.Date', () => {
+  it('should return 0 for same date', () => {
+    expect(compareDates(new utils.Date(2020, 2, 2), new utils.Date(2020, 2, 2))).toBe(0);
+  });
+  it('should return negative when date1 is sooner', () => {
+    expect(compareDates(new utils.Date(2019, 3, 3), new utils.Date(2020, 2, 2))).toBeLessThan(0);
+    expect(compareDates(new utils.Date(2020, 1, 3), new utils.Date(2020, 2, 2))).toBeLessThan(0);
+    expect(compareDates(new utils.Date(2020, 2, 1), new utils.Date(2020, 2, 2))).toBeLessThan(0);
+  });
+  it('should return positive when date1 is later', () => {
+    expect(compareDates(new utils.Date(2021, 1, 1), new utils.Date(2020, 2, 2))).toBeGreaterThan(0);
+    expect(compareDates(new utils.Date(2020, 3, 1), new utils.Date(2020, 2, 2))).toBeGreaterThan(0);
+    expect(compareDates(new utils.Date(2020, 2, 3), new utils.Date(2020, 2, 2))).toBeGreaterThan(0);
   });
 });

--- a/packages/@ama-sdk/core/src/fwk/date.ts
+++ b/packages/@ama-sdk/core/src/fwk/date.ts
@@ -26,6 +26,16 @@ function getNewTimeZoneWithOffset(dateArgs: any[], timezoneOffset: number) {
 }
 
 /**
+ * Compare 2 utils.Date, return negative if date1 is sooner, 0 if dates are equals, positive if date1 is later
+ * This function is meant to be used with utils.Date and only compares Year, Month and Date, the time part is fully ignored.
+ * @param date1
+ * @param date2
+ */
+export function compareDates(date1: utils.Date, date2: utils.Date) {
+  return date1.getFullYear() - date2.getFullYear() || date1.getMonth() - date2.getMonth() || date1.getDate() - date2.getDate();
+}
+
+/**
  * Removes timezone information from ISO8601 strings
  */
 export class CommonDate extends Date {
@@ -62,7 +72,7 @@ export class CommonDate extends Date {
   /**
    * Overrides the JSON conversion to remove any timezone information.
    */
-  public toJSON(): string {
+  public override toJSON(): string {
     return `${this.getFullYear()}-${pad(this.getMonth() + 1)}-${pad(this.getDate())}T${pad(this.getHours())}:${pad(this.getMinutes())}:${pad(this.getSeconds())}.${pad(this.getMilliseconds(), 3)}`;
   }
 }
@@ -98,12 +108,13 @@ export namespace utils {
     /**
      * Overrides the JSON conversion to remove any time information.
      */
-    public toJSON(): string {
+    public override toJSON(): string {
       return (`${this.getFullYear()}-${pad(this.getMonth() + 1)}-${pad(this.getDate())}`);
     }
 
     /**
      * Compare if two dates are equals.
+     * @deprecated this will be removed in v14, please use {@link compareDates} instead
      * @param  {Date}    date the date to compare
      * @returns {boolean}      true if the dates are equals.
      */


### PR DESCRIPTION
## Proposed change

In `utils.Date` class, we expose a method `equals` to compare 2 dates.
Using this method when mocking the clock in Playwright will make the test fail due to the change in prototype.
The issue has been raised in Playwright https://github.com/microsoft/playwright/issues/35314, but it will probably not be fixed anytime soon.

I suggest to extract the method to a helper that can be used even with fake Dates

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
