### PR TITLE
fix(ama-mfe-ng-utils): remove useless `isServiceMessage` check

### DIFF
--- a/packages/@ama-mfe/ng-utils/src/managers/consumer.manager.service.spec.ts
+++ b/packages/@ama-mfe/ng-utils/src/managers/consumer.manager.service.spec.ts
@@ -160,16 +160,6 @@ describe('ConsumerManagerService', () => {
     expect(errorHelpers.sendError).toHaveBeenCalledWith(messagePeerService, { reason: 'version_mismatch', source: message.payload });
   });
 
-  it('consume additional messages should do nothing for internal protocol messages', async () => {
-    console.warn = jest.fn();
-    console.error = jest.fn();
-    const message: RoutedMessage<Message> = { payload: { type: 'connect', version: '2.0' }, from: 'a', to: [] };
-    messagesSubjectMock.next(message);
-    await jest.runAllTimersAsync();
-    expect(loggerServiceMock.warn).not.toHaveBeenCalled();
-    expect(loggerServiceMock.error).not.toHaveBeenCalled();
-  });
-
   it('consume additional messages should do nothing for undefined payload', async () => {
     console.warn = jest.fn();
     console.error = jest.fn();

--- a/packages/@ama-mfe/ng-utils/src/managers/consumer.manager.service.ts
+++ b/packages/@ama-mfe/ng-utils/src/managers/consumer.manager.service.ts
@@ -1,5 +1,4 @@
 import {
-  isServiceMessage,
   Message,
   RoutedMessage,
 } from '@amadeus-it-group/microfrontends';
@@ -84,10 +83,7 @@ export class ConsumerManagerService {
       this.logger.warn('Cannot consume a messages with undefined payload.');
       return;
     }
-    // not interested in service messages like 'connect' or 'disconnect'
-    if (isServiceMessage(message.payload)) {
-      return;
-    }
+
     const consumers = this.consumers();
     const typeMatchingConsumers = consumers
       .filter((consumer) => consumer.type === message.payload.type);


### PR DESCRIPTION
## Proposed change

Since `v0.0.3` service messages don't arrive via `.messages$`, but have separate `.serviceMessages$`, so the check is not necessary