### PR TITLE
feat(ama-mfe): get the url of the host using query parameter

### DIFF
--- a/packages/@ama-mfe/ng-utils/src/navigation/navigation.consumer.service.ts
+++ b/packages/@ama-mfe/ng-utils/src/navigation/navigation.consumer.service.ts
@@ -24,6 +24,9 @@ import {
   ConsumerManagerService,
   type MessageConsumer,
 } from '../managers/index';
+import {
+  MFE_HOST_URL_PARAM,
+} from '../utils';
 
 /**
  * A service that handles navigation messages and routing.
@@ -90,6 +93,8 @@ export class NavigationConsumerService implements MessageConsumer<NavigationMess
    */
   private navigate(url: string, channelId?: string) {
     const { paths, queryParams } = this.parseUrl(url);
+    // No need to keep this in the URL
+    delete queryParams[MFE_HOST_URL_PARAM];
     void this.router.navigate(paths, { relativeTo: this.activeRoute.children.at(-1), queryParams, state: { channelId }, replaceUrl: true });
   }
 

--- a/packages/@ama-mfe/ng-utils/src/navigation/navigation.producer.service.ts
+++ b/packages/@ama-mfe/ng-utils/src/navigation/navigation.producer.service.ts
@@ -99,9 +99,7 @@ export class RoutingService implements MessageProducer<NavigationMessage> {
         url
       } satisfies NavigationV1_0;
       // TODO: sendBest() is not implemented -- https://github.com/AmadeusITGroup/microfrontends/issues/11
-      if (document.referrer) {
-        this.messageService.send(messageV10);
-      } else {
+      if (window.self === window.top) {
         if (channelId === undefined) {
           this.logger.warn('No channelId provided for navigation message');
         } else {
@@ -111,6 +109,8 @@ export class RoutingService implements MessageProducer<NavigationMessage> {
             this.logger.error('Error sending navigation message', error);
           }
         }
+      } else {
+        this.messageService.send(messageV10);
       }
     });
   }

--- a/packages/@ama-mfe/ng-utils/src/utils.ts
+++ b/packages/@ama-mfe/ng-utils/src/utils.ts
@@ -17,13 +17,26 @@ export const KNOWN_MESSAGES = [
 ] as const satisfies Message[];
 
 /**
+ * Search parameter to add to the URL when embedding an iframe containing the URL of the host.
+ * This is needed to support Firefox (on which {@link https://developer.mozilla.org/docs/Web/API/Location/ancestorOrigins | location.ancestorOrigins} is not currently supported)
+ * in case of redirection inside the iframe.
+ */
+export const MFE_HOST_URL_PARAM = 'ama-mfe-host-url';
+
+/**
  * Returns the default options for starting a client endpoint peer connection.
- * As origin it will take the parent origin and the window will be the parent window
+ * As `origin`, it will take the parent origin and the `window` will be the parent window.
+ * The parent origin will use the first found among:
+ * - look for the search parameter {@link MFE_HOST_URL_PARAM} in the URL of the iframe
+ * - use the first item in `location.ancestorOrigins` (currently not supported on Firefox)
+ * - use `document.referrer` (will only work if called before any redirection in the iframe)
  */
 export function getDefaultClientEndpointStartOptions(): PeerConnectionOptions {
-  if (document.referrer) {
+  const searchParams = new URLSearchParams(location.search);
+  const hostURL = searchParams.get(MFE_HOST_URL_PARAM) || location.ancestorOrigins?.[0] || document.referrer;
+  if (hostURL) {
     return {
-      origin: new URL(document.referrer).origin,
+      origin: new URL(hostURL).origin,
       window: window.parent
     };
   }


### PR DESCRIPTION
## Proposed change

We consider 3 ways to get the origin of the host
- `document.referrer` works on all browsers but fails on internal redirection (login for example)
- `location.ancestorOrigins` supports redirections but doesn't work on Firefox
- use a query parameter works in all scenarios but require an additional action to modify the URL of the iframe

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
* :rocket: Feature resolves #2918 
<!-- * :octocat: Pull Request #issue -->
