### PR TITLE
feat: group and highlight components by tag name

### DIFF
--- a/packages/@o3r/components/src/devkit/components-devkit.interface.ts
+++ b/packages/@o3r/components/src/devkit/components-devkit.interface.ts
@@ -8,6 +8,9 @@ import type {
 import type {
   PlaceholderMode,
 } from '../stores';
+import type {
+  GroupInfo,
+} from './highlight/models';
 import {
   OtterLikeComponentInfo,
 } from './inspector';
@@ -33,6 +36,48 @@ export interface ToggleInspectorMessage extends OtterMessageContent<'toggleInspe
 }
 
 /**
+ * Message to toggle the highlight
+ */
+export interface ToggleHighlightMessage extends OtterMessageContent<'toggleHighlight'> {
+  /** Is the highlight displayed */
+  isRunning: boolean;
+}
+
+/**
+ * Message the change the configuration of the `HighlightService`
+ */
+export interface ChangeHighlightConfiguration extends OtterMessageContent<'changeHighlightConfiguration'> {
+  /**
+   * Minimum width of HTMLElement to be considered
+   */
+  elementMinWidth?: number;
+  /**
+   * Minimum height of HTMLElement to be considered
+   */
+  elementMinHeight?: number;
+  /**
+   * Throttle interval
+   */
+  throttleInterval?: number;
+  /**
+   * Group information to detect elements
+   */
+  groupsInfo?: Record<string, GroupInfo>;
+  /**
+   * Maximum number of ancestors
+   */
+  maxDepth?: number;
+  /**
+   * Opacity of the chips
+   */
+  chipsOpacity?: number;
+  /**
+   * Auto refresh
+   */
+  autoRefresh?: boolean;
+}
+
+/**
  * Message to toggle the placeholder mode
  */
 export interface PlaceholderModeMessage extends OtterMessageContent<'placeholderMode'> {
@@ -51,6 +96,8 @@ type ComponentsMessageContents =
   | IsComponentSelectionAvailableMessage
   | SelectedComponentInfoMessage
   | ToggleInspectorMessage
+  | ToggleHighlightMessage
+  | ChangeHighlightConfiguration
   | PlaceholderModeMessage;
 
 /** List of possible DataTypes for Components messages */
@@ -74,5 +121,7 @@ export const isComponentsMessage = (message: any): message is AvailableComponent
     || message.dataType === 'isComponentSelectionAvailable'
     || message.dataType === 'placeholderMode'
     || message.dataType === 'toggleInspector'
+    || message.dataType === 'toggleHighlight'
+    || message.dataType === 'changeHighlightConfiguration'
   );
 };

--- a/packages/@o3r/components/src/devkit/components-devtools.message.service.ts
+++ b/packages/@o3r/components/src/devkit/components-devtools.message.service.ts
@@ -41,6 +41,9 @@ import {
   OTTER_COMPONENTS_DEVTOOLS_OPTIONS,
 } from './components-devtools.token';
 import {
+  HighlightService,
+} from './highlight/highlight.service';
+import {
   OtterInspectorService,
   OtterLikeComponentInfo,
 } from './inspector';
@@ -52,7 +55,9 @@ export class ComponentsDevtoolsMessageService implements DevtoolsServiceInterfac
   private readonly options: ComponentsDevtoolsServiceOptions;
   private readonly inspectorService: OtterInspectorService;
   private readonly sendMessage = sendOtterMessage<AvailableComponentsMessageContents>;
+
   private readonly destroyRef = inject(DestroyRef);
+  private readonly highlightService = inject(HighlightService);
 
   constructor(
     private readonly logger: LoggerService,
@@ -65,6 +70,7 @@ export class ComponentsDevtoolsMessageService implements DevtoolsServiceInterfac
     };
 
     this.inspectorService = new OtterInspectorService();
+
     if (this.options.isActivatedOnBootstrap) {
       this.activate();
     }
@@ -128,6 +134,42 @@ export class ComponentsDevtoolsMessageService implements DevtoolsServiceInterfac
       }
       case 'toggleInspector': {
         this.inspectorService.toggleInspector(message.isRunning);
+        break;
+      }
+      case 'toggleHighlight': {
+        if (message.isRunning) {
+          this.highlightService.start();
+        } else {
+          this.highlightService.stop();
+        }
+        break;
+      }
+      case 'changeHighlightConfiguration': {
+        if (message.elementMinWidth) {
+          this.highlightService.elementMinWidth = message.elementMinWidth;
+        }
+        if (message.elementMinHeight) {
+          this.highlightService.elementMinHeight = message.elementMinHeight;
+        }
+        if (message.throttleInterval) {
+          this.highlightService.throttleInterval = message.throttleInterval;
+        }
+        if (message.groupsInfo) {
+          this.highlightService.groupsInfo = message.groupsInfo;
+        }
+        if (message.maxDepth) {
+          this.highlightService.maxDepth = message.maxDepth;
+        }
+        if (message.chipsOpacity) {
+          this.highlightService.chipsOpacity = message.chipsOpacity;
+        }
+        if (message.autoRefresh !== undefined) {
+          this.highlightService.autoRefresh = message.autoRefresh;
+        }
+        if (this.highlightService.isRunning()) {
+          // Re-start to recompute the highlight with the new configuration
+          this.highlightService.start();
+        }
         break;
       }
       case 'placeholderMode': {

--- a/packages/@o3r/components/src/devkit/highlight/constants.ts
+++ b/packages/@o3r/components/src/devkit/highlight/constants.ts
@@ -1,0 +1,40 @@
+/**
+ * Class applied on the wrapper of highlight elements
+ */
+export const HIGHLIGHT_WRAPPER_CLASS = 'highlight-wrapper';
+
+/**
+ * Class applied on the overlay elements
+ */
+export const HIGHLIGHT_OVERLAY_CLASS = 'highlight-overlay';
+
+/**
+ * Class applied on the chip elements
+ */
+export const HIGHLIGHT_CHIP_CLASS = 'highlight-chip';
+
+/**
+ * Default value for maximum number of ancestors
+ */
+export const DEFAULT_MAX_DEPTH = 10;
+
+/**
+ * Default value for element min height
+ */
+export const DEFAULT_ELEMENT_MIN_HEIGHT = 30;
+/**
+ * Default value for element min width
+ */
+export const DEFAULT_ELEMENT_MIN_WIDTH = 60;
+/**
+ * Default value for throttle interval
+ */
+export const DEFAULT_THROTTLE_INTERVAL = 500;
+/**
+ * Default value for chips opacity
+ */
+export const DEFAULT_CHIPS_OPACITY = 1;
+/**
+ * Default value for auto refresh activation
+ */
+export const DEFAULT_AUTO_REFRESH = true;

--- a/packages/@o3r/components/src/devkit/highlight/helpers.spec.ts
+++ b/packages/@o3r/components/src/devkit/highlight/helpers.spec.ts
@@ -1,0 +1,445 @@
+import {
+  HIGHLIGHT_CHIP_CLASS,
+  HIGHLIGHT_OVERLAY_CLASS,
+} from './constants';
+import {
+  computeNumberOfAncestors,
+  createChip,
+  CreateChipOptions,
+  createOverlay,
+  CreateOverlayOptions,
+  filterElementsWithInfo,
+  getIdentifier,
+  throttle,
+} from './helpers';
+import {
+  ElementWithGroupInfo,
+  GroupInfo,
+} from './models';
+
+describe('Highlight helpers', () => {
+  describe('getIdentifier', () => {
+    it('should return the tagName', () => {
+      const element = {
+        htmlElement: {
+          tagName: 'prefix-selector'
+        } as HTMLElement,
+        regexp: '^prefix',
+        backgroundColor: 'blue',
+        displayName: 'prefix'
+      } satisfies ElementWithGroupInfo;
+      expect(getIdentifier(element)).toBe('prefix-selector');
+    });
+
+    it('should return the first attributeName matching', () => {
+      const element = {
+        htmlElement: {
+          tagName: 'custom-selector',
+          attributes: [
+            { name: 'custom-attribute' },
+            { name: 'prefix-attribute' },
+            { name: 'prefix-attribute-2' }
+          ] as any as NamedNodeMap
+        } as HTMLElement,
+        regexp: '^prefix',
+        backgroundColor: 'blue',
+        displayName: 'prefix'
+      } satisfies ElementWithGroupInfo;
+      expect(getIdentifier(element)).toBe('prefix-attribute');
+    });
+
+    it('should return the first attributeName matching with its value', () => {
+      const element = {
+        htmlElement: {
+          tagName: 'custom-selector',
+          attributes: [{ name: 'prefix-attribute', value: 'value' }] as any as NamedNodeMap
+        } as HTMLElement,
+        regexp: '^prefix',
+        backgroundColor: 'blue',
+        displayName: 'prefix'
+      } satisfies ElementWithGroupInfo;
+      expect(getIdentifier(element)).toBe('prefix-attribute="value"');
+    });
+
+    it('should return the first className matching', () => {
+      const element = {
+        htmlElement: {
+          tagName: 'custom-selector',
+          attributes: [] as any as NamedNodeMap,
+          classList: ['custom-class', 'prefix-class', 'prefix-class-2'] as any as DOMTokenList
+        } as HTMLElement,
+        regexp: '^prefix',
+        backgroundColor: 'blue',
+        displayName: 'prefix'
+      } satisfies ElementWithGroupInfo;
+      expect(getIdentifier(element)).toBe('prefix-class');
+    });
+  });
+
+  describe('computeNumberOfAncestors', () => {
+    let parentElement: HTMLElement;
+    let childElement: HTMLElement;
+    let siblingElement: HTMLElement;
+    let grandparentElement: HTMLElement;
+
+    beforeEach(() => {
+      grandparentElement = document.createElement('div');
+      parentElement = document.createElement('div');
+      childElement = document.createElement('div');
+      siblingElement = document.createElement('div');
+
+      grandparentElement.append(parentElement);
+      parentElement.append(childElement);
+      grandparentElement.append(siblingElement);
+
+      document.body.innerHTML = '';
+      document.body.append(grandparentElement);
+    });
+
+    afterEach(() => {
+      document.body.innerHTML = '';
+    });
+
+    it('should return the correct number of ancestors for a child element', () => {
+      const elementList = [grandparentElement, parentElement, siblingElement];
+      const result = computeNumberOfAncestors(childElement, elementList);
+
+      expect(result).toBe(2); // grandparentElement and parentElement are ancestors
+    });
+
+    it('should return 0 if the element has no ancestors in the list', () => {
+      const elementList = [siblingElement];
+      const result = computeNumberOfAncestors(childElement, elementList);
+
+      expect(result).toBe(0); // siblingElement is not an ancestor
+    });
+
+    it('should return 1 if the element has one ancestor in the list', () => {
+      const elementList = [parentElement];
+      const result = computeNumberOfAncestors(childElement, elementList);
+
+      expect(result).toBe(1); // parentElement is the only ancestor
+    });
+
+    it('should return 0 if the element list is empty', () => {
+      const elementList: HTMLElement[] = [];
+      const result = computeNumberOfAncestors(childElement, elementList);
+
+      expect(result).toBe(0); // No ancestors in an empty list
+    });
+
+    it('should return 0 if the element is not contained in any ancestor', () => {
+      const unrelatedElement = document.createElement('div');
+      const elementList = [unrelatedElement];
+      const result = computeNumberOfAncestors(childElement, elementList);
+
+      expect(result).toBe(0); // unrelatedElement is not an ancestor
+    });
+  });
+
+  describe('filterElementsWithInfo', () => {
+    let grandparentElement: HTMLElement;
+    let parentElement: HTMLElement;
+    let childElement: HTMLElement;
+    let siblingElement: HTMLElement;
+    let elements: HTMLElement[];
+
+    const elementMinHeight = 20;
+    const elementMinWidth = 20;
+    const groupsInfo: Record<string, GroupInfo> = {
+      'Group 1': {
+        regexp: '^div',
+        backgroundColor: 'blue',
+        displayName: 'Group 1'
+      },
+      'Group 2': {
+        regexp: '^span',
+        backgroundColor: 'red',
+        displayName: 'Group 2'
+      }
+    };
+
+    beforeEach(() => {
+      // Create a mock DOM structure using createElement
+      grandparentElement = document.createElement('div');
+      parentElement = document.createElement('span');
+      childElement = document.createElement('div');
+      siblingElement = document.createElement('div');
+
+      // Set spy to simulate dimensions
+      jest.spyOn(grandparentElement, 'getBoundingClientRect').mockReturnValue({
+        height: 200,
+        width: 200
+      } as DOMRect);
+      jest.spyOn(parentElement, 'getBoundingClientRect').mockReturnValue({
+        height: 100,
+        width: 100
+      } as DOMRect);
+      jest.spyOn(childElement, 'getBoundingClientRect').mockReturnValue({
+        height: 50,
+        width: 50
+      } as DOMRect);
+      jest.spyOn(siblingElement, 'getBoundingClientRect').mockReturnValue({
+        height: 10,
+        width: 10
+      } as DOMRect);
+
+      grandparentElement.append(parentElement);
+      parentElement.append(childElement);
+      parentElement.append(siblingElement);
+
+      elements = [grandparentElement, parentElement, childElement, siblingElement];
+    });
+
+    it('should filter the only element that does not match the criteria', () => {
+      const result: ElementWithGroupInfo[] = filterElementsWithInfo(elements, elementMinHeight, elementMinWidth, groupsInfo);
+
+      expect(result).toHaveLength(3); // No elements match the criteria
+    });
+
+    it('should return an empty array if the element list is empty', () => {
+      const result: ElementWithGroupInfo[] = filterElementsWithInfo([], elementMinHeight, elementMinWidth, groupsInfo);
+
+      expect(result).toHaveLength(0); // No elements in the list
+    });
+
+    it('should filter elements based on size and group info', () => {
+      const result: ElementWithGroupInfo[] = filterElementsWithInfo(elements, elementMinHeight, elementMinWidth, groupsInfo);
+
+      expect(result).toHaveLength(3); // Two elements match the criteria
+      expect(result[0].displayName).toBe('Group 1'); // First element matches group1
+      expect(result[1].displayName).toBe('Group 2'); // Second element matches group2
+      expect(result[2].displayName).toBe('Group 1'); // Third element matches group1
+    });
+
+    it('should correctly match elements based on tag name, attributes, or class names', () => {
+      // Add attributes and classes to test matching
+      grandparentElement.classList.add('test-class');
+      parentElement.dataset.test = 'test-attr';
+
+      const result: ElementWithGroupInfo[] = filterElementsWithInfo(elements, elementMinHeight, elementMinWidth, groupsInfo);
+
+      expect(result.some((el) => el.htmlElement.tagName.toLowerCase() === 'div')).toBe(true); // Matches tag name
+      expect(result.some((el) => el.htmlElement.dataset.test === 'test-attr')).toBe(true); // Matches attribute
+      expect(result.some((el) => el.htmlElement.classList.contains('test-class'))).toBe(true); // Matches class name
+    });
+  });
+
+  describe('createOverlay', () => {
+    let mockDocument: Document;
+
+    beforeEach(() => {
+      // Create a mock document
+      mockDocument = document.implementation.createHTMLDocument('Test Document');
+    });
+
+    it('should create an overlay element with the correct class and styles', () => {
+      const opts: CreateOverlayOptions = {
+        top: '10px',
+        left: '20px',
+        width: '100px',
+        height: '50px',
+        backgroundColor: 'red',
+        position: 'absolute'
+      };
+
+      const overlay = createOverlay(mockDocument, opts, 2);
+
+      expect(overlay).toBeInstanceOf(HTMLDivElement);
+      expect(overlay.classList.contains(HIGHLIGHT_OVERLAY_CLASS)).toBe(true);
+      expect(overlay.style.top).toBe('10px');
+      expect(overlay.style.left).toBe('20px');
+      expect(overlay.style.width).toBe('100px');
+      expect(overlay.style.height).toBe('50px');
+      expect(overlay.style.border).toBe('2px solid red');
+      expect(overlay.style.zIndex).toBe('10000');
+      expect(overlay.style.position).toBe('absolute');
+      expect(overlay.style.pointerEvents).toBe('none');
+      expect(overlay.style.zIndex).toBe('10000');
+    });
+
+    it('should alternate border style between solid and dotted based on depth', () => {
+      const opts: CreateOverlayOptions = {
+        top: '0px',
+        left: '0px',
+        width: '50px',
+        height: '50px',
+        backgroundColor: 'green',
+        position: 'absolute'
+      };
+
+      const overlayDepthEven = createOverlay(mockDocument, opts, 2);
+      const overlayDepthOdd = createOverlay(mockDocument, opts, 3);
+
+      expect(overlayDepthEven.style.border).toBe('2px solid green');
+      expect(overlayDepthOdd.style.border).toBe('2px dotted green');
+    });
+  });
+
+  describe('createChip', () => {
+    let mockDocument: Document;
+    let mockOverlay: HTMLDivElement;
+
+    beforeEach(() => {
+      // Create a mock document
+      mockDocument = document.implementation.createHTMLDocument('Test Document');
+
+      // Create a mock overlay element
+      mockOverlay = mockDocument.createElement('div');
+      mockOverlay.style.boxShadow = 'none';
+    });
+
+    it('should create a chip element with the correct class and text content', () => {
+      const opts: CreateChipOptions = {
+        top: '10px',
+        left: '20px',
+        backgroundColor: 'blue',
+        position: 'absolute',
+        displayName: 'Test Chip',
+        depth: 3,
+        name: 'Test Name'
+      };
+
+      const chip = createChip(mockDocument, opts, mockOverlay);
+
+      expect(chip).toBeInstanceOf(HTMLDivElement);
+      expect(chip.classList.contains(HIGHLIGHT_CHIP_CLASS)).toBe(true);
+      expect(chip.textContent).toBe('Test Chip 3');
+      expect(chip.title).toBe('Test Name');
+    });
+
+    it('should set the correct styles on the chip element', () => {
+      const opts: CreateChipOptions = {
+        top: '10px',
+        left: '20px',
+        backgroundColor: 'red',
+        color: '#000',
+        position: 'fixed',
+        displayName: 'Styled Chip',
+        depth: 1,
+        name: 'Styled Name',
+        opacity: 0.8
+      };
+
+      const chip = createChip(mockDocument, opts, mockOverlay);
+
+      expect(chip.style.top).toBe('10px');
+      expect(chip.style.left).toBe('20px');
+      expect(chip.style.backgroundColor).toBe('red');
+      expect(chip.style.color).toBe('rgb(0, 0, 0)');
+      expect(chip.style.position).toBe('fixed');
+      expect(chip.style.display).toBe('inline-block');
+      expect(chip.style.padding).toBe('2px 4px');
+      expect(chip.style.borderRadius).toBe('0 0 4px');
+      expect(chip.style.cursor).toBe('pointer');
+      expect(chip.style.zIndex).toBe('10000');
+      expect(chip.style.textWrap).toBe('no-wrap');
+      expect(chip.style.opacity).toBe('0.8');
+    });
+
+    it('should copy the chip name to the clipboard on click', () => {
+      const opts: CreateChipOptions = {
+        top: '10px',
+        left: '20px',
+        backgroundColor: 'green',
+        position: 'absolute',
+        displayName: 'Clickable Chip',
+        depth: 2,
+        name: 'Chip Name'
+      };
+
+      // Mock the clipboard API
+      Object.assign(navigator, {
+        clipboard: {
+          writeText: jest.fn().mockResolvedValue(undefined)
+        }
+      });
+
+      const chip = createChip(mockDocument, opts, mockOverlay);
+      chip.click();
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Chip Name');
+    });
+
+    it('should handle mouseover and mouseout events correctly', () => {
+      const opts: CreateChipOptions = {
+        top: '10px',
+        left: '20px',
+        backgroundColor: 'purple',
+        position: 'absolute',
+        displayName: 'Hoverable Chip',
+        depth: 1,
+        name: 'Hover Name',
+        opacity: 0.5
+      };
+
+      const chip = createChip(mockDocument, opts, mockOverlay);
+
+      // Simulate mouseover
+      chip.dispatchEvent(new Event('mouseover'));
+      expect(chip.style.opacity).toBe('1');
+      expect(mockOverlay.style.boxShadow).toBe('0 0 10px 3px purple');
+
+      // Simulate mouseout
+      chip.dispatchEvent(new Event('mouseout'));
+      expect(chip.style.opacity).toBe('0.5');
+      expect(mockOverlay.style.boxShadow).toBe('none');
+    });
+
+    describe('throttle', () => {
+      beforeEach(() => {
+        jest.useFakeTimers();
+      });
+
+      afterEach(() => {
+        jest.useRealTimers();
+      });
+
+      it('should call the function immediately on first call', () => {
+        const fn = jest.fn();
+        const throttled = throttle(fn, 100);
+        throttled('arg1', 'arg2');
+        expect(fn).toHaveBeenCalledTimes(1);
+        expect(fn).toHaveBeenCalledWith('arg1', 'arg2');
+      });
+
+      it('should not call the function again before the delay', () => {
+        const fn = jest.fn();
+        const throttled = throttle(fn, 100);
+        throttled();
+        throttled();
+        throttled();
+        expect(fn).toHaveBeenCalledTimes(1);
+      });
+
+      it('should call the function again after the delay', () => {
+        const fn = jest.fn();
+        const throttled = throttle(fn, 100);
+        throttled();
+        jest.advanceTimersByTime(100);
+        throttled();
+        expect(fn).toHaveBeenCalledTimes(2);
+      });
+
+      it('should pass all arguments to the throttled function', () => {
+        const fn = jest.fn();
+        const throttled = throttle(fn, 50);
+        throttled(1, 2, 3);
+        expect(fn).toHaveBeenCalledWith(1, 2, 3);
+      });
+
+      it('should not call the function if called multiple times within the delay', () => {
+        const fn = jest.fn();
+        const throttled = throttle(fn, 200);
+        throttled();
+        jest.advanceTimersByTime(100);
+        throttled();
+        throttled();
+        expect(fn).toHaveBeenCalledTimes(1);
+        jest.advanceTimersByTime(100);
+        throttled();
+        expect(fn).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+});

--- a/packages/@o3r/components/src/devkit/highlight/helpers.ts
+++ b/packages/@o3r/components/src/devkit/highlight/helpers.ts
@@ -1,0 +1,201 @@
+import {
+  HIGHLIGHT_CHIP_CLASS,
+  HIGHLIGHT_OVERLAY_CLASS,
+  HIGHLIGHT_WRAPPER_CLASS,
+} from './constants';
+import type {
+  ElementWithGroupInfo,
+  GroupInfo,
+} from './models';
+
+/**
+ * Retrieve the identifier of the element
+ * @param element
+ */
+export function getIdentifier(element: ElementWithGroupInfo): string {
+  const { tagName, attributes, classList } = element.htmlElement;
+  const regexp = new RegExp(element.regexp, 'i');
+  if (!regexp.test(tagName)) {
+    const attribute = Array.from(attributes).find((attr) => regexp.test(attr.name));
+    if (attribute) {
+      return `${attribute.name}${attribute.value ? `="${attribute.value}"` : ''}`;
+    }
+    const className = Array.from(classList).find((cName) => regexp.test(cName));
+    if (className) {
+      return className;
+    }
+  }
+  return tagName;
+}
+
+/**
+ * Filters a list of HTML elements and returns those that match specific group information.
+ *
+ * Each element is checked against a set of criteria:
+ * - The element's dimensions must meet the minimum height and width requirements.
+ * - The element's tag name, attributes, or class names must match a regular expression defined in the group information.
+ * @param elements An array of HTML elements to filter.
+ * @param elementMinHeight The min height required for each element to be considered in the computation
+ * @param elementMinWidth The min width required for each element to be considered in the computation
+ * @param groupsInfo The config that describes the HTML tags to check
+ * @returns An array of objects containing the matching elements and their associated group information
+ */
+export function filterElementsWithInfo(elements: HTMLElement[], elementMinHeight: number, elementMinWidth: number, groupsInfo: Record<string, GroupInfo>): ElementWithGroupInfo[] {
+  return elements.reduce((acc: ElementWithGroupInfo[], element) => {
+    const { height, width } = element.getBoundingClientRect();
+
+    if (height < elementMinHeight || width < elementMinWidth) {
+      return acc;
+    }
+    const elementInfo = Object.values(groupsInfo).find((info) => {
+      const regexp = new RegExp(info.regexp, 'i');
+
+      return regexp.test(element.tagName)
+        || Array.from(element.attributes).some((attr) => regexp.test(attr.name))
+        || Array.from(element.classList).some((cName) => regexp.test(cName));
+    });
+    if (elementInfo) {
+      return acc.concat({ ...elementInfo, htmlElement: element });
+    }
+    return acc;
+  }, []);
+}
+
+/**
+ * Compute the number of ancestors of a given element based on a list of elements
+ * @param element
+ * @param elementList
+ */
+export function computeNumberOfAncestors(element: HTMLElement, elementList: HTMLElement[]) {
+  return elementList.filter((el: HTMLElement) => el.contains(element)).length;
+}
+
+/**
+ * Throttle {@link fn} with a {@link delay}
+ * @param fn method to run
+ * @param delay given in ms
+ */
+export function throttle<T extends (...args: any[]) => any>(fn: T, delay: number): (...args: Parameters<T>) => void {
+  let timerFlag: ReturnType<typeof setTimeout> | null = null;
+
+  const throttleFn = (...args: Parameters<T>) => {
+    if (timerFlag === null) {
+      fn(...args);
+      timerFlag = setTimeout(() => {
+        timerFlag = null;
+      }, delay);
+    }
+  };
+  return throttleFn;
+}
+
+/**
+ * Run {@link refreshFn} if {@link mutations} implies to refresh elements inside {@link highlightWrapper}
+ * @param mutations
+ * @param highlightWrapper
+ * @param refreshFn
+ */
+export function runRefreshIfNeeded(mutations: MutationRecord[], highlightWrapper: Element | null, refreshFn: () => void) {
+  if (
+    mutations.some((mutation) =>
+      mutation.target !== highlightWrapper
+      || (
+        mutation.target === document.body
+        && Array.from<HTMLElement>(mutation.addedNodes.values() as any)
+          .concat(...mutation.removedNodes.values() as any)
+          .some((node) => !node.classList.contains(HIGHLIGHT_WRAPPER_CLASS))
+      )
+    )
+  ) {
+    refreshFn();
+  }
+}
+
+/**
+ * Options to create an overlay element
+ */
+export interface CreateOverlayOptions {
+  top: string;
+  left: string;
+  position: string;
+  width: string;
+  height: string;
+  backgroundColor: string;
+}
+
+/**
+ * Create an overlay element
+ * @param doc HTML Document
+ * @param opts
+ * @param depth
+ */
+export function createOverlay(doc: Document, opts: CreateOverlayOptions, depth: number) {
+  const overlay = doc.createElement('div');
+  overlay.classList.add(HIGHLIGHT_OVERLAY_CLASS);
+  // All static style could be moved in a <style>
+  overlay.style.top = opts.top;
+  overlay.style.left = opts.left;
+  overlay.style.width = opts.width;
+  overlay.style.height = opts.height;
+  overlay.style.border = `2px ${depth % 2 === 0 ? 'solid' : 'dotted'} ${opts.backgroundColor}`;
+  overlay.style.zIndex = '10000';
+  overlay.style.position = opts.position;
+  overlay.style.pointerEvents = 'none';
+  return overlay;
+}
+
+/**
+ * Options to create a chip element
+ */
+export interface CreateChipOptions {
+  displayName: string;
+  depth: number;
+  top: string;
+  left: string;
+  position: string;
+  backgroundColor: string;
+  color?: string;
+  name: string;
+  opacity?: number;
+}
+
+/**
+ * Create a chip element
+ * @param doc HTML Document
+ * @param opts
+ * @param overlay
+ */
+export function createChip(doc: Document, opts: CreateChipOptions, overlay: HTMLDivElement) {
+  const chip = doc.createElement('div');
+  chip.classList.add(HIGHLIGHT_CHIP_CLASS);
+  chip.textContent = `${opts.displayName} ${opts.depth}`;
+  // All static style could be moved in a <style>
+  chip.style.top = opts.top;
+  chip.style.left = opts.left;
+  chip.style.backgroundColor = opts.backgroundColor;
+  chip.style.color = opts.color ?? '#FFF';
+  chip.style.position = opts.position;
+  chip.style.display = 'inline-block';
+  chip.style.padding = '2px 4px';
+  chip.style.borderRadius = '0 0 4px';
+  chip.style.cursor = 'pointer';
+  chip.style.zIndex = '10000';
+  chip.style.textWrap = 'no-wrap';
+  chip.style.opacity = opts.opacity?.toString() ?? '1';
+  chip.title = opts.name;
+  chip.addEventListener('click', () => {
+    // Should we log in the console as well ?
+    void navigator.clipboard.writeText(opts.name);
+  });
+  chip.addEventListener('mouseover', () => {
+    chip.style.opacity = '1';
+    overlay.style.boxShadow = `0 0 10px 3px ${opts.backgroundColor}`;
+  });
+  chip.addEventListener('mouseout', () => {
+    chip.style.opacity = opts.opacity?.toString() ?? '1';
+    overlay.style.boxShadow = 'none';
+  });
+  overlay.style.transition = 'box-shadow 0.3s ease-in-out';
+
+  return chip;
+}

--- a/packages/@o3r/components/src/devkit/highlight/highlight.service.ts
+++ b/packages/@o3r/components/src/devkit/highlight/highlight.service.ts
@@ -1,0 +1,230 @@
+import {
+  DOCUMENT,
+} from '@angular/common';
+import {
+  DestroyRef,
+  inject,
+  Injectable,
+} from '@angular/core';
+import {
+  DEFAULT_AUTO_REFRESH,
+  DEFAULT_CHIPS_OPACITY,
+  DEFAULT_ELEMENT_MIN_HEIGHT,
+  DEFAULT_ELEMENT_MIN_WIDTH,
+  DEFAULT_MAX_DEPTH,
+  DEFAULT_THROTTLE_INTERVAL,
+  HIGHLIGHT_WRAPPER_CLASS,
+} from './constants';
+import {
+  computeNumberOfAncestors,
+  createChip,
+  createOverlay,
+  filterElementsWithInfo,
+  getIdentifier,
+  runRefreshIfNeeded,
+  throttle,
+} from './helpers';
+import type {
+  ElementWithGroupInfo,
+  ElementWithGroupInfoAndDepth,
+  GroupInfo,
+} from './models';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class HighlightService {
+  /**
+   * Group information
+   * Value could be changed through chrome extension options
+   */
+  public groupsInfo: Record<string, GroupInfo> = {};
+
+  /**
+   * Maximum number of components ancestor
+   * Value could be changed through chrome extension view
+   */
+  public maxDepth = DEFAULT_MAX_DEPTH;
+
+  /**
+   * Element min height to be considered
+   * Value could be changed through chrome extension options
+   */
+  public elementMinHeight = DEFAULT_ELEMENT_MIN_HEIGHT;
+
+  /**
+   * Element min width to be considered
+   * Value could be changed through chrome extension options
+   */
+  public elementMinWidth = DEFAULT_ELEMENT_MIN_WIDTH;
+
+  /**
+   * Throttle interval to refresh the highlight elements
+   * Value could be changed through chrome extension options
+   */
+  public throttleInterval = DEFAULT_THROTTLE_INTERVAL;
+
+  /**
+   * Opacity of the chips
+   * Value could be changed through chrome extension options
+   */
+  public chipsOpacity = DEFAULT_CHIPS_OPACITY;
+
+  /**
+   * Whether to activate the auto refresh of the highlight
+   * Value could be changed through chrome extension view
+   */
+  public autoRefresh = DEFAULT_AUTO_REFRESH;
+
+  private throttleRun: (() => void) | undefined;
+  private singleRun = false;
+
+  private readonly document = inject(DOCUMENT);
+
+  private readonly mutationObserver = new MutationObserver((mutations) =>
+    runRefreshIfNeeded(
+      mutations,
+      this.getHighlightWrapper(),
+      () => this.throttleRun?.()
+    )
+  );
+
+  private readonly resizeObserver = new ResizeObserver(() => this.throttleRun?.());
+
+  constructor() {
+    inject(DestroyRef).onDestroy(() => this.stop());
+  }
+
+  private getHighlightWrapper() {
+    return this.document.body.querySelector(`.${HIGHLIGHT_WRAPPER_CLASS}`);
+  }
+
+  private cleanHighlightWrapper() {
+    this.getHighlightWrapper()?.querySelectorAll('*').forEach((node) => node.remove());
+  }
+
+  private initializeHighlightWrapper() {
+    let wrapper = this.getHighlightWrapper();
+    if (!wrapper) {
+      wrapper = this.document.createElement('div');
+      wrapper.classList.add(HIGHLIGHT_WRAPPER_CLASS);
+      this.document.body.append(wrapper);
+    }
+    this.cleanHighlightWrapper();
+  }
+
+  private run() {
+    this.initializeHighlightWrapper();
+    const wrapper = this.getHighlightWrapper()!;
+
+    // We have to select all elements from document because
+    // with CSS Selector it's impossible to select element
+    // by regex on their `tagName`, attribute name or attribute value.
+    const allHTMLElements: HTMLElement[] = Array.from(this.document.body.querySelectorAll<HTMLElement>('*'));
+    const elementsWithInfo: ElementWithGroupInfo[] = filterElementsWithInfo(allHTMLElements, this.elementMinHeight, this.elementMinWidth, this.groupsInfo);
+
+    const elementsWithInfoAndDepth = elementsWithInfo
+      .reduce((acc: ElementWithGroupInfoAndDepth[], elementWithInfo, _, array) => {
+        const depth = computeNumberOfAncestors(elementWithInfo.htmlElement, array.map((e) => e.htmlElement));
+        if (depth <= this.maxDepth) {
+          return acc.concat({
+            ...elementWithInfo,
+            depth
+          });
+        }
+        return acc;
+      }, []);
+
+    const overlayData: Record<string, { chip: HTMLElement; overlay: HTMLElement; depth: number }[]> = {};
+
+    elementsWithInfoAndDepth.forEach((item) => {
+      const { htmlElement: element, backgroundColor, color, displayName, depth } = item;
+      const rect = element.getBoundingClientRect();
+      const position = element.computedStyleMap().get('position')?.toString() === 'fixed' ? 'fixed' : 'absolute';
+      const top = `${position === 'fixed' ? rect.top : (rect.top + window.scrollY)}px`;
+      const left = `${position === 'fixed' ? rect.left : (rect.left + window.scrollX)}px`;
+
+      const overlay = createOverlay(this.document, {
+        top, left, width: `${rect.width}px`, height: `${rect.height}px`, position, backgroundColor
+      }, depth);
+
+      const chip = createChip(this.document, {
+        displayName,
+        depth,
+        top,
+        left,
+        backgroundColor,
+        color,
+        position,
+        name: getIdentifier(item),
+        opacity: this.chipsOpacity
+      }, overlay);
+
+      wrapper.append(overlay);
+      wrapper.append(chip);
+
+      const positionKey = `${top};${left}`;
+      if (!overlayData[positionKey]) {
+        overlayData[positionKey] = [];
+      }
+      overlayData[positionKey].push({ chip, overlay, depth });
+    });
+
+    Object.values(overlayData).forEach((chips) => {
+      chips
+        .sort(({ depth: depthA }, { depth: depthB }) => depthA - depthB)
+        .forEach(({ chip, overlay }, index, array) => {
+          if (index !== 0) {
+            // In case of overlap,
+            // we should translate the chip to have it visible
+            // and reduce the size of the overlay.
+            const translateX = array.slice(0, index).reduce((sum, e) => sum + e.chip.getBoundingClientRect().width, 0);
+            chip.style.transform = `translateX(${translateX}px)`;
+            overlay.style.margin = `${index}px 0 0 ${index}px`;
+            overlay.style.width = `${+overlay.style.width.replace('px', '') - 2 * index}px`;
+            overlay.style.height = `${+overlay.style.height.replace('px', '') - 2 * index}px`;
+            overlay.style.zIndex = `${+overlay.style.zIndex - index}`;
+          }
+        });
+    });
+  }
+
+  /**
+   * Returns true if the highlight is displayed
+   */
+  public isRunning() {
+    return !!this.throttleRun || this.singleRun;
+  }
+
+  /**
+   * Start the highlight of elements
+   */
+  public start() {
+    this.stop();
+    if (!this.autoRefresh) {
+      this.run();
+      this.singleRun = true;
+      return;
+    }
+
+    this.throttleRun = throttle(() => this.run(), this.throttleInterval);
+    this.throttleRun();
+    this.document.addEventListener('scroll', this.throttleRun, true);
+    this.resizeObserver.observe(this.document.body);
+    this.mutationObserver.observe(this.document.body, { childList: true, subtree: true });
+  }
+
+  /**
+   * Stop the highlight of elements
+   */
+  public stop() {
+    this.cleanHighlightWrapper();
+    if (this.throttleRun) {
+      this.document.removeEventListener('scroll', this.throttleRun, true);
+      this.resizeObserver.disconnect();
+      this.mutationObserver.disconnect();
+      this.throttleRun = undefined;
+      this.singleRun = false;
+    }
+  }
+}

--- a/packages/@o3r/components/src/devkit/highlight/models.ts
+++ b/packages/@o3r/components/src/devkit/highlight/models.ts
@@ -1,0 +1,39 @@
+/**
+ * Model to describe a group of elements
+ */
+export interface GroupInfo {
+  /**
+   * Text color for the {@link displayName}
+   */
+  color?: string;
+  /**
+   * Color of the border of the element once highlighted
+   */
+  backgroundColor: string;
+  /**
+   * Name of the group display
+   */
+  displayName: string;
+  /**
+   * Regexp to detect the elements part of the group
+   */
+  regexp: string;
+}
+
+/**
+ * Element associated to his group information
+ */
+export interface ElementWithGroupInfo extends GroupInfo {
+  /** HTML element */
+  htmlElement: HTMLElement;
+}
+
+/**
+ * Element associated to his group information and depth
+ */
+export interface ElementWithGroupInfoAndDepth extends ElementWithGroupInfo {
+  /**
+   * Number of ancestors
+   */
+  depth: number;
+}


### PR DESCRIPTION
### Related issues
🚀 Feature https://github.com/AmadeusITGroup/otter/issues/2532

### Use `postMessage` to play with the configs (chrome extension part is not done yet)

- Set up groups (same message for the following configurations elementMinWidth, elementMinHeight, throttleInterval, maxDepth, chipsOpacity and autoRefresh)

```
window.postMessage({
  type: 'otter',
  to: 'app',
  content: {
    dataType: 'changeHighlightConfiguration',
    groupsInfo: {
      otter: {
        backgroundColor: '#f4dac6',
        color: 'black',
        regexp: '^o3r',
        displayName: 'o3r'
      },
      designFactory: {
        backgroundColor: '#000835',
        regexp: '^df',
        displayName: 'df'
      },
      ngBootstrap: {
        backgroundColor: '#0d6efd',
        regexp: '^ngb',
        displayName: 'ngb'
      }
    },
    maxDepth: 6,
    chipsOpacity: 0.8,
    autoRefresh: true
  }
});
```

- Activate highlight

```
window.postMessage({
  type: 'otter',
  to: 'app',
  content: {
    dataType: 'toggleHighlight',
    isRunning: true
  }
});
```
- You can also try to hover the chips and play with the opacity to have a better view on the highlighted elements