### PR TITLE
feat(ama-mfe): make the host application id available for embedded module

### DIFF
--- a/packages/@ama-mfe/ng-utils/README.md
+++ b/packages/@ama-mfe/ng-utils/README.md
@@ -254,3 +254,36 @@ export class CustomService implements MessageProducer<CustomMessageVersions> {
   }
 }
 ```
+### Host information
+
+#### Host application
+
+A host application can send information to the embedded applications using parameters in the URL.
+
+```html
+<iframe [src]="'myModuleUrl' | hostInfo: 'host-app-id'"></iframe>
+```
+
+This will add the `location.origin` and the application id of the host to the URL of the embedded application.
+
+#### Embedded application
+
+The embedded application can access the data sent in the previous section using an injection token:
+```typescript
+import {inject} from '@angular/core';
+import {MFE_HOST_INFO_TOKEN} from '@ama-mfe/ng-utils';
+
+export class SomeClass {
+  private readonly hostInfo = inject(MFE_HOST_INFO_TOKEN);
+  
+  doSomething() {
+    if (this.hostInfo.applicationId === 'app1') {
+      // Do something when embedded in app1
+    } else {
+      // Do something else
+    }
+  }
+}
+```
+
+The host information is stored in session storage so it won't be lost when navigating inside the iframe.

--- a/packages/@ama-mfe/ng-utils/src/connect/connect.providers.ts
+++ b/packages/@ama-mfe/ng-utils/src/connect/connect.providers.ts
@@ -8,6 +8,9 @@ import {
   makeEnvironmentProviders,
 } from '@angular/core';
 import {
+  provideHostInfo,
+} from '../host-info';
+import {
   getDefaultClientEndpointStartOptions,
   KNOWN_MESSAGES,
 } from '../utils';
@@ -23,6 +26,7 @@ import {
 export function provideConnection(connectionConfig: ConnectionConfig) {
   const config: MessagePeerConfig = { id: connectionConfig.id, knownMessages: [...KNOWN_MESSAGES, ...(connectionConfig.knownMessages || [])] };
   return makeEnvironmentProviders([
+    provideHostInfo(),
     {
       provide: MESSAGE_PEER_CONFIG, useValue: config
     },
@@ -30,7 +34,7 @@ export function provideConnection(connectionConfig: ConnectionConfig) {
       provide: MESSAGE_PEER_CONNECT_OPTIONS, useValue: getDefaultClientEndpointStartOptions()
     },
     {
-      // in the case of the ConnectionService will extends the base service 'useExisting' should be used
+      // in the case of the ConnectionService will extend the base service 'useExisting' should be used
       provide: MessagePeerService, useClass: ConnectionService, deps: [MESSAGE_PEER_CONFIG]
     }
   ]);

--- a/packages/@ama-mfe/ng-utils/src/host-info/host-info.pipe.spec.ts
+++ b/packages/@ama-mfe/ng-utils/src/host-info/host-info.pipe.spec.ts
@@ -1,0 +1,68 @@
+import {
+  SecurityContext,
+} from '@angular/core';
+import {
+  TestBed,
+} from '@angular/core/testing';
+import {
+  DomSanitizer,
+  SafeResourceUrl,
+} from '@angular/platform-browser';
+import {
+  MFE_HOST_APPLICATION_ID_PARAM,
+  MFE_HOST_URL_PARAM,
+} from './host-info';
+import {
+  HostInfoPipe,
+} from './host-info.pipe';
+
+describe('HostInfoPipe', () => {
+  let pipe: HostInfoPipe;
+  let sanitizer: DomSanitizer;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        HostInfoPipe,
+        { provide: DomSanitizer, useValue: { sanitize: jest.fn(() => 'sanitizedUrl'), bypassSecurityTrustResourceUrl: jest.fn((url: string) => url) } }
+      ]
+    });
+
+    pipe = TestBed.inject(HostInfoPipe);
+    sanitizer = TestBed.inject(DomSanitizer);
+  });
+
+  it('should return undefined if url is undefined', () => {
+    expect(pipe.transform(undefined, '')).toBeUndefined();
+  });
+
+  it('should not sanitize and return the url computed if it is a string', () => {
+    const url = 'http://example.com';
+    const result = pipe.transform(url, '');
+    expect(sanitizer.sanitize).not.toHaveBeenCalled();
+    expect(sanitizer.bypassSecurityTrustResourceUrl).not.toHaveBeenCalled();
+    expect(result).toMatch(new RegExp(`^${url}.*`));
+  });
+
+  it('should handle SafeResourceUrl input', () => {
+    const url = 'http://safe-url/';
+    const safeUrl: SafeResourceUrl = { mock: url };
+    jest.spyOn(sanitizer, 'sanitize').mockReturnValue(url);
+
+    const result = pipe.transform(safeUrl, '');
+
+    expect(sanitizer.sanitize).toHaveBeenCalledWith(SecurityContext.RESOURCE_URL, safeUrl);
+    expect(sanitizer.bypassSecurityTrustResourceUrl).toHaveBeenCalledWith(result);
+    expect(result).toMatch(new RegExp(`^${url}.*`));
+  });
+
+  it('should add query parameters to the URL', () => {
+    const url = 'http://example.com';
+    const hostUrl = encodeURIComponent('http://localhost');
+    const applicationId = 'my-app-id';
+
+    const result = pipe.transform(url, applicationId);
+
+    expect(result).toBe(`${url}/?${MFE_HOST_URL_PARAM}=${hostUrl}&${MFE_HOST_APPLICATION_ID_PARAM}=${applicationId}`);
+  });
+});

--- a/packages/@ama-mfe/ng-utils/src/host-info/host-info.pipe.ts
+++ b/packages/@ama-mfe/ng-utils/src/host-info/host-info.pipe.ts
@@ -1,0 +1,52 @@
+import {
+  inject,
+  Pipe,
+  PipeTransform,
+  SecurityContext,
+} from '@angular/core';
+import {
+  DomSanitizer,
+  type SafeResourceUrl,
+} from '@angular/platform-browser';
+import {
+  MFE_HOST_APPLICATION_ID_PARAM,
+  MFE_HOST_URL_PARAM,
+} from './host-info';
+
+/**
+ * A pipe that adds the host information in the URL of an iframe,
+ */
+@Pipe({
+  name: 'hostInfo'
+})
+export class HostInfoPipe implements PipeTransform {
+  private readonly domSanitizer = inject(DomSanitizer);
+
+  /**
+   * Transforms the given URL or SafeResourceUrl by appending query parameters.
+   * @param url - The URL or SafeResourceUrl to be transformed.
+   * @param applicationId - The unique identifier of the host application
+   * @returns - The transformed SafeResourceUrl or undefined if the input URL is invalid.
+   */
+  public transform(url: string, applicationId: string): string;
+  public transform(url: SafeResourceUrl, applicationId: string): SafeResourceUrl;
+  public transform(url: undefined, applicationId: string): undefined;
+  public transform(url: string | SafeResourceUrl | undefined, applicationId: string): string | SafeResourceUrl | undefined {
+    const urlString = typeof url === 'string'
+      ? url
+      : this.domSanitizer.sanitize(SecurityContext.RESOURCE_URL, url || null);
+
+    if (!url) {
+      return undefined;
+    }
+
+    if (urlString) {
+      const moduleUrl = new URL(urlString);
+      moduleUrl.searchParams.set(MFE_HOST_URL_PARAM, window.location.origin);
+      moduleUrl.searchParams.set(MFE_HOST_APPLICATION_ID_PARAM, applicationId);
+
+      const moduleUrlStringyfied = moduleUrl.toString();
+      return typeof url === 'string' ? moduleUrlStringyfied : this.domSanitizer.bypassSecurityTrustResourceUrl(moduleUrlStringyfied);
+    }
+  }
+}

--- a/packages/@ama-mfe/ng-utils/src/host-info/host-info.spec.ts
+++ b/packages/@ama-mfe/ng-utils/src/host-info/host-info.spec.ts
@@ -1,0 +1,63 @@
+import {
+  getHostInfo,
+  MFE_HOST_APPLICATION_ID_PARAM,
+  MFE_HOST_URL_PARAM,
+  MFEHostInformation,
+} from './host-info';
+
+describe('HostInfo', () => {
+  const expectedHostInfo = {
+    hostURL: 'expected-url',
+    hostApplicationId: 'expected-application-id'
+  } as const satisfies MFEHostInformation;
+
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'location', { value: {
+      search: '',
+      ancestorOrigins: ['unexpected-url']
+    }, writable: true });
+    Object.defineProperty(globalThis.document, 'referrer', { value: 'unexpected-url', writable: true });
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('getHostInfo', () => {
+    it('should get host info from search parameters', () => {
+      globalThis.location.search = new URLSearchParams({
+        [MFE_HOST_APPLICATION_ID_PARAM]: expectedHostInfo.hostApplicationId,
+        [MFE_HOST_URL_PARAM]: expectedHostInfo.hostURL
+      }).toString();
+      const hostInfo = getHostInfo();
+      expect(hostInfo.hostApplicationId).toBe(expectedHostInfo.hostApplicationId);
+      expect(hostInfo.hostURL).toBe(expectedHostInfo.hostURL);
+    });
+
+    it('should get host info from session storage', () => {
+      const getItemSpy = jest.spyOn(Object.getPrototypeOf(globalThis.sessionStorage), 'getItem').mockReturnValue(JSON.stringify(expectedHostInfo));
+      const hostInfo = getHostInfo();
+      expect(getItemSpy).toHaveBeenCalled();
+      expect(hostInfo.hostApplicationId).toBe(expectedHostInfo.hostApplicationId);
+      expect(hostInfo.hostURL).toBe(expectedHostInfo.hostURL);
+    });
+
+    it('should get host url from location ancestorOrigins', () => {
+      Object.defineProperty(globalThis, 'location', { value: {
+        search: '',
+        ancestorOrigins: [expectedHostInfo.hostURL]
+      } });
+      const hostInfo = getHostInfo();
+      expect(hostInfo.hostURL).toBe(expectedHostInfo.hostURL);
+    });
+
+    it('should get host url from document referrer', () => {
+      Object.defineProperty(globalThis, 'location', { value: {
+        search: '',
+        ancestorOrigins: []
+      } });
+      Object.defineProperty(globalThis.document, 'referrer', { value: expectedHostInfo.hostURL });
+      const hostInfo = getHostInfo();
+      expect(hostInfo.hostURL).toBe(expectedHostInfo.hostURL);
+    });
+  });
+});

--- a/packages/@ama-mfe/ng-utils/src/host-info/host-info.ts
+++ b/packages/@ama-mfe/ng-utils/src/host-info/host-info.ts
@@ -1,0 +1,65 @@
+import {
+  InjectionToken,
+} from '@angular/core';
+
+const SESSION_STORAGE_KEY = 'ama-mfe-host-info';
+
+/**
+ * Search parameter to add to the URL when embedding an iframe containing the URL of the host.
+ * This is needed to support Firefox (on which {@link https://developer.mozilla.org/docs/Web/API/Location/ancestorOrigins | location.ancestorOrigins} is not currently supported)
+ * in case of redirection inside the iframe.
+ */
+export const MFE_HOST_URL_PARAM = 'ama-mfe-host-url';
+
+/**
+ * Search parameter to add to the URL to let a module know on which application it's embedded
+ */
+export const MFE_HOST_APPLICATION_ID_PARAM = 'ama-mfe-host-app-id';
+
+/**
+ * Information about the host in embedded context
+ */
+export interface MFEHostInformation {
+  /**
+   * URL of the host application
+   */
+  hostURL?: string;
+  /**
+   * ID of the host application
+   */
+  hostApplicationId?: string;
+}
+
+/**
+ * Injectable used to get the host information
+ */
+export const MFE_HOST_INFO_TOKEN = new InjectionToken<MFEHostInformation>('MFE_HOST_INFO');
+
+/**
+ * Gather the host information from the url parameters
+ * The host url will use the first found among:
+ * - look for the search parameter {@link MFE_HOST_URL_PARAM} in the URL of the iframe
+ * - use the first item in `location.ancestorOrigins` (currently not supported on Firefox)
+ * - use `document.referrer` (will only work if called before any redirection in the iframe)
+ * The application ID is taken from the search parameter {@link MFE_HOST_APPLICATION_ID_PARAM} in the URL of the iframe
+ */
+export function getHostInfo(): MFEHostInformation {
+  const searchParams = new URLSearchParams(location.search);
+  const storedHostInfo = JSON.parse(sessionStorage.getItem(SESSION_STORAGE_KEY) || '{}') as MFEHostInformation;
+  return {
+    hostURL: searchParams.get(MFE_HOST_URL_PARAM) || storedHostInfo.hostURL || location.ancestorOrigins?.[0] || document.referrer,
+    hostApplicationId: searchParams.get(MFE_HOST_APPLICATION_ID_PARAM) || storedHostInfo.hostApplicationId
+  };
+}
+
+/**
+ * Provider used to gather the host information from the url parameters and handle the persistence in session storage.
+ */
+export function provideHostInfo() {
+  const hostInfo = getHostInfo();
+  sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(hostInfo));
+
+  return [
+    { provide: MFE_HOST_INFO_TOKEN, useValue: hostInfo }
+  ];
+}

--- a/packages/@ama-mfe/ng-utils/src/host-info/index.ts
+++ b/packages/@ama-mfe/ng-utils/src/host-info/index.ts
@@ -1,0 +1,2 @@
+export * from './host-info';
+export * from './host-info.pipe';

--- a/packages/@ama-mfe/ng-utils/src/navigation/navigation.consumer.service.ts
+++ b/packages/@ama-mfe/ng-utils/src/navigation/navigation.consumer.service.ts
@@ -21,12 +21,13 @@ import {
   Subject,
 } from 'rxjs';
 import {
+  MFE_HOST_APPLICATION_ID_PARAM,
+  MFE_HOST_URL_PARAM,
+} from '../host-info';
+import {
   ConsumerManagerService,
   type MessageConsumer,
 } from '../managers/index';
-import {
-  MFE_HOST_URL_PARAM,
-} from '../utils';
 
 /**
  * A service that handles navigation messages and routing.
@@ -93,8 +94,8 @@ export class NavigationConsumerService implements MessageConsumer<NavigationMess
    */
   private navigate(url: string, channelId?: string) {
     const { paths, queryParams } = this.parseUrl(url);
-    // No need to keep this in the URL
-    delete queryParams[MFE_HOST_URL_PARAM];
+    // No need to keep these in the URL
+    [MFE_HOST_URL_PARAM, MFE_HOST_APPLICATION_ID_PARAM].forEach((key) => delete queryParams[key]);
     void this.router.navigate(paths, { relativeTo: this.activeRoute.children.at(-1), queryParams, state: { channelId }, replaceUrl: true });
   }
 

--- a/packages/@ama-mfe/ng-utils/src/public_api.ts
+++ b/packages/@ama-mfe/ng-utils/src/public_api.ts
@@ -5,3 +5,4 @@ export * from './navigation/index';
 export * from './theme/index';
 export * from './connect/index';
 export * from './utils';
+export * from './host-info';

--- a/packages/@ama-mfe/ng-utils/src/theme/theme.helpers.ts
+++ b/packages/@ama-mfe/ng-utils/src/theme/theme.helpers.ts
@@ -1,6 +1,9 @@
 import {
   type Logger,
 } from '@o3r/logger';
+import {
+  getHostInfo,
+} from '../host-info';
 
 /** Default suffix for an url containing a theme css file */
 export const THEME_URL_SUFFIX = '-theme.css';
@@ -72,8 +75,9 @@ export async function applyInitialTheme(options?: StyleHelperOptions): Promise<P
   if (theme) {
     const themeRequest: Promise<void>[] = [];
     themeRequest.push(downloadApplicationThemeCss(theme, options).then((styleToApply) => applyTheme(styleToApply, false)));
-    if (document.referrer) {
-      const url = new URL(document.referrer);
+    const hostInfo = getHostInfo();
+    if (hostInfo.hostURL) {
+      const url = new URL(hostInfo.hostURL);
       url.pathname += `${url.pathname.endsWith('/') ? '' : '/'}${theme}`;
       themeRequest.unshift(getStyle(url.toString(), options).then((styleToApply) => applyTheme(styleToApply, false)));
     }

--- a/packages/@ama-mfe/ng-utils/src/utils.ts
+++ b/packages/@ama-mfe/ng-utils/src/utils.ts
@@ -3,6 +3,9 @@ import type {
   PeerConnectionOptions,
 } from '@amadeus-it-group/microfrontends';
 import {
+  getHostInfo,
+} from './host-info';
+import {
   ERROR_MESSAGE_TYPE,
 } from './messages';
 
@@ -17,26 +20,14 @@ export const KNOWN_MESSAGES = [
 ] as const satisfies Message[];
 
 /**
- * Search parameter to add to the URL when embedding an iframe containing the URL of the host.
- * This is needed to support Firefox (on which {@link https://developer.mozilla.org/docs/Web/API/Location/ancestorOrigins | location.ancestorOrigins} is not currently supported)
- * in case of redirection inside the iframe.
- */
-export const MFE_HOST_URL_PARAM = 'ama-mfe-host-url';
-
-/**
  * Returns the default options for starting a client endpoint peer connection.
- * As `origin`, it will take the parent origin and the `window` will be the parent window.
- * The parent origin will use the first found among:
- * - look for the search parameter {@link MFE_HOST_URL_PARAM} in the URL of the iframe
- * - use the first item in `location.ancestorOrigins` (currently not supported on Firefox)
- * - use `document.referrer` (will only work if called before any redirection in the iframe)
+ * As `origin`, it will take the hostURL from {@link getHostInfo} and the `window` will be the parent window.
  */
 export function getDefaultClientEndpointStartOptions(): PeerConnectionOptions {
-  const searchParams = new URLSearchParams(location.search);
-  const hostURL = searchParams.get(MFE_HOST_URL_PARAM) || location.ancestorOrigins?.[0] || document.referrer;
-  if (hostURL) {
+  const hostInfo = getHostInfo();
+  if (hostInfo.hostURL) {
     return {
-      origin: new URL(hostURL).origin,
+      origin: new URL(hostInfo.hostURL).origin,
       window: window.parent
     };
   }


### PR DESCRIPTION
## Proposed change

### Usage on host side:
Add `ama-mfe-host-app-id=<your id>` as a get parameter of the url of the iframes

### Usage on embedded side:
- Add `provideHostInfo()` in `app.config.ts`
- Call `inject(MFE_HOST_INFO_TOKEN)` whenever needed to get the info about the hosting app

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
