### PR TITLE
fix: exports the pipe that was previously standalone to avoid introducing a breaking change

### DIFF
--- a/.yarn/sdks/eslint/package.json
+++ b/.yarn/sdks/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint",
-  "version": "9.22.0-sdk",
+  "version": "9.23.0-sdk",
   "main": "./lib/api.js",
   "type": "commonjs",
   "bin": {

--- a/packages/@ama-sdk/schematics/package.json
+++ b/packages/@ama-sdk/schematics/package.json
@@ -145,7 +145,7 @@
     "@swc/helpers": "~0.5.0",
     "@commitlint/cli": "^19.0.0",
     "@commitlint/config-conventional": "^19.0.0",
-    "@typescript-eslint/eslint-plugin": "~8.26.0",
+    "@typescript-eslint/eslint-plugin": "~8.27.0",
     "jest-junit": "~16.0.0",
     "lint-staged": "^15.0.0",
     "minimist": "^1.2.6",

--- a/packages/@o3r/core/package.json
+++ b/packages/@o3r/core/package.json
@@ -170,11 +170,11 @@
     "@o3r/store-sync": "workspace:^",
     "@stylistic/eslint-plugin": "~3.1.0",
     "@types/jest": "~29.5.2",
-    "@typescript-eslint/eslint-plugin": "~8.26.0",
-    "@typescript-eslint/parser": "~8.26.0",
+    "@typescript-eslint/eslint-plugin": "~8.27.0",
+    "@typescript-eslint/parser": "~8.27.0",
     "angular-eslint": "~19.2.0",
     "cpy-cli": "^5.0.0",
-    "eslint": "~9.22.0",
+    "eslint": "~9.23.0",
     "eslint-import-resolver-node": "~0.3.9",
     "eslint-import-resolver-typescript": "~3.9.0",
     "eslint-plugin-import": "~2.31.0",
@@ -190,7 +190,7 @@
     "jest-preset-angular": "~14.5.0",
     "jsonc-eslint-parser": "~2.4.0",
     "nx": "~20.6.0",
-    "typescript-eslint": "~8.26.0",
+    "typescript-eslint": "~8.27.0",
     "zone.js": "~0.15.0"
   },
   "engines": {

--- a/packages/@o3r/dynamic-content/src/services/dynamic-content/dynamic-content.module.ts
+++ b/packages/@o3r/dynamic-content/src/services/dynamic-content/dynamic-content.module.ts
@@ -47,7 +47,8 @@ export function getCmsAssets() {
     },
     DynamicContentService
   ],
-  imports: [O3rDynamicContentPipe]
+  imports: [O3rDynamicContentPipe],
+  exports: [O3rDynamicContentPipe]
 })
 export class DynamicContentModule {
   /**

--- a/packages/@o3r/eslint-config-otter/package.json
+++ b/packages/@o3r/eslint-config-otter/package.json
@@ -60,10 +60,10 @@
     "typescript": "^5.5.4"
   },
   "generatorDependencies": {
-    "@typescript-eslint/eslint-plugin": "~8.26.0",
-    "@typescript-eslint/parser": "~8.26.0",
-    "@typescript-eslint/utils": "~8.26.0",
-    "eslint": "~9.22.0",
+    "@typescript-eslint/eslint-plugin": "~8.27.0",
+    "@typescript-eslint/parser": "~8.27.0",
+    "@typescript-eslint/utils": "~8.27.0",
+    "eslint": "~9.23.0",
     "eslint-plugin-jsdoc": "~50.6.0",
     "eslint-plugin-unicorn": "~56.0.0"
   },


### PR DESCRIPTION
## Proposed change

Fix the breaking change introduce by https://github.com/AmadeusITGroup/otter/pull/3000
As the pipe was not exported anymore by the module 
 

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->
https://github.com/AmadeusITGroup/otter/pull/3000

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
