### PR TITLE
chore: use Github Type instead of label in task creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-O3R-ISSUE-FORM.yaml
+++ b/.github/ISSUE_TEMPLATE/1-O3R-ISSUE-FORM.yaml
@@ -1,7 +1,8 @@
 name: Bug Report on @o3r
 description: File a bug report on @o3r scope
 title: "[Bug]: "
-labels: ["bug", "o3r", "triage"]
+labels: ["o3r", "triage"]
+type: Bug
 body:
   - type: markdown
     attributes:
@@ -14,7 +15,7 @@ body:
       description: Which package(s) are you facing issue with?
       multiple: true
       options: [
-        '- global -',
+        '*global*',
         amaterasu,
         analytics,
         apis-manager,

--- a/.github/ISSUE_TEMPLATE/2-AMA-SDK-ISSUE-FORM.yaml
+++ b/.github/ISSUE_TEMPLATE/2-AMA-SDK-ISSUE-FORM.yaml
@@ -1,7 +1,8 @@
 name: Bug Report on @ama-sdk
 description: File a bug report on @ama-sdk scope
 title: "[Bug]: "
-labels: ["bug", "ama-sdk", "triage"]
+labels: ["ama-sdk", "triage"]
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/3-AMA-TERASU-ISSUE-FORM.yaml
+++ b/.github/ISSUE_TEMPLATE/3-AMA-TERASU-ISSUE-FORM.yaml
@@ -1,7 +1,8 @@
 name: Bug Report on @ama-terasu
 description: File a bug report on @ama-terasu scope
 title: "[Bug]: "
-labels: ["bug", "ama-terasu", "triage"]
+labels: ["ama-terasu", "triage"]
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/4-APPLICATION-ISSUE-FORM.yaml
+++ b/.github/ISSUE_TEMPLATE/4-APPLICATION-ISSUE-FORM.yaml
@@ -1,7 +1,8 @@
 name: Bug Report to an Application from the Otter project
 description: File a bug report on an Application from the Otter project
 title: "[Bug]: "
-labels: ["bug", "triage"]
+labels: ["triage"]
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/5-FEATURE-FORM.yaml
+++ b/.github/ISSUE_TEMPLATE/5-FEATURE-FORM.yaml
@@ -1,7 +1,8 @@
 name: Feature request
 description: Request or contribute a new feature
 title: "[Feature]: "
-labels: ["enhancement", "triage"]
+labels: ["triage"]
+type: Feature
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Proposed change

chore: use Github Type instead of label in task creation

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
