### PR TITLE
fix: sdk exploded syntax - take into account request plugin options

### DIFF
--- a/packages/@ama-sdk/client-angular/src/api-angular-client.ts
+++ b/packages/@ama-sdk/client-angular/src/api-angular-client.ts
@@ -55,7 +55,8 @@ const DEFAULT_OPTIONS = {
   angularPlugins: [],
   requestPlugins: [],
   enableTokenization: false,
-  disableFallback: false
+  disableFallback: false,
+  enableParameterSerialization: false
 } as const satisfies Omit<BaseApiAngularClientOptions, 'basePath' | 'httpClient'>;
 
 /** Client to process the call to the API using Angular API */
@@ -130,7 +131,7 @@ export class ApiAngularClient implements ApiClient {
   }
 
   /** @inheritdoc */
-  public prepareUrlWithQueryParams(url: string, serializedQueryParams: { [key: string]: string }): string {
+  public prepareUrlWithQueryParams(url: string, serializedQueryParams?: { [key: string]: string }): string {
     return prepareUrlWithQueryParams(url, serializedQueryParams);
   }
 

--- a/packages/@ama-sdk/client-beacon/src/api-beacon-client.ts
+++ b/packages/@ama-sdk/client-beacon/src/api-beacon-client.ts
@@ -35,7 +35,8 @@ export interface BaseApiBeaconClientConstructor extends PartialExcept<Omit<BaseA
 const DEFAULT_OPTIONS = {
   replyPlugins: [] as never[],
   requestPlugins: [],
-  enableTokenization: false
+  enableTokenization: false,
+  enableParameterSerialization: false
 } as const satisfies Omit<BaseApiBeaconClientOptions, 'basePath'>;
 
 /**
@@ -130,7 +131,7 @@ export class ApiBeaconClient implements ApiClient {
   }
 
   /** @inheritdoc */
-  public prepareUrlWithQueryParams(url: string, serializedQueryParams: { [key: string]: string }): string {
+  public prepareUrlWithQueryParams(url: string, serializedQueryParams?: { [key: string]: string }): string {
     return prepareUrlWithQueryParams(url, serializedQueryParams);
   }
 

--- a/packages/@ama-sdk/client-fetch/src/api-fetch-client.ts
+++ b/packages/@ama-sdk/client-fetch/src/api-fetch-client.ts
@@ -51,7 +51,8 @@ const DEFAULT_OPTIONS = {
   fetchPlugins: [],
   requestPlugins: [],
   enableTokenization: false,
-  disableFallback: false
+  disableFallback: false,
+  enableParameterSerialization: false
 } as const satisfies Omit<BaseApiFetchClientOptions, 'basePath'>;
 
 /** Client to process the call to the API using Fetch API */
@@ -131,7 +132,7 @@ export class ApiFetchClient implements ApiClient {
   }
 
   /** @inheritdoc */
-  public prepareUrlWithQueryParams(url: string, serializedQueryParams: { [key: string]: string }): string {
+  public prepareUrlWithQueryParams(url: string, serializedQueryParams?: { [key: string]: string }): string {
     return prepareUrlWithQueryParams(url, serializedQueryParams);
   }
 

--- a/packages/@ama-sdk/core/src/clients/api-angular-client.ts
+++ b/packages/@ama-sdk/core/src/clients/api-angular-client.ts
@@ -82,7 +82,8 @@ const DEFAULT_OPTIONS: Omit<BaseApiAngularClientOptions, 'basePath' | 'httpClien
   angularPlugins: [],
   requestPlugins: [],
   enableTokenization: false,
-  disableFallback: false
+  disableFallback: false,
+  enableParameterSerialization: false
 };
 
 /**
@@ -160,7 +161,7 @@ export class ApiAngularClient implements ApiClient {
   }
 
   /** @inheritdoc */
-  public prepareUrlWithQueryParams(url: string, serializedQueryParams: { [key: string]: string }): string {
+  public prepareUrlWithQueryParams(url: string, serializedQueryParams?: { [key: string]: string }): string {
     return prepareUrlWithQueryParams(url, serializedQueryParams);
   }
 

--- a/packages/@ama-sdk/core/src/clients/api-beacon-client.ts
+++ b/packages/@ama-sdk/core/src/clients/api-beacon-client.ts
@@ -52,7 +52,8 @@ export interface BaseApiBeaconClientConstructor extends PartialExcept<Omit<BaseA
 const DEFAULT_OPTIONS: Omit<BaseApiBeaconClientOptions, 'basePath'> = {
   replyPlugins: [] as never[],
   requestPlugins: [],
-  enableTokenization: false
+  enableTokenization: false,
+  enableParameterSerialization: false
 };
 
 /**
@@ -148,7 +149,7 @@ export class ApiBeaconClient implements ApiClient {
   }
 
   /** @inheritdoc */
-  public prepareUrlWithQueryParams(url: string, serializedQueryParams: { [key: string]: string }): string {
+  public prepareUrlWithQueryParams(url: string, serializedQueryParams?: { [key: string]: string }): string {
     return prepareUrlWithQueryParams(url, serializedQueryParams);
   }
 

--- a/packages/@ama-sdk/core/src/clients/api-fetch-client.ts
+++ b/packages/@ama-sdk/core/src/clients/api-fetch-client.ts
@@ -73,7 +73,8 @@ const DEFAULT_OPTIONS: Omit<BaseApiFetchClientOptions, 'basePath'> = {
   fetchPlugins: [],
   requestPlugins: [],
   enableTokenization: false,
-  disableFallback: false
+  disableFallback: false,
+  enableParameterSerialization: false
 };
 
 /**
@@ -156,7 +157,7 @@ export class ApiFetchClient implements ApiClient {
   }
 
   /** @inheritdoc */
-  public prepareUrlWithQueryParams(url: string, serializedQueryParams: { [key: string]: string }): string {
+  public prepareUrlWithQueryParams(url: string, serializedQueryParams?: { [key: string]: string }): string {
     return prepareUrlWithQueryParams(url, serializedQueryParams);
   }
 

--- a/packages/@ama-sdk/core/src/fwk/api.helpers.ts
+++ b/packages/@ama-sdk/core/src/fwk/api.helpers.ts
@@ -13,7 +13,6 @@ import type {
  * Prepares the url to be called
  * @param url Base url to be used
  * @param queryParameters Key value pair with the parameters. If the value is undefined, the key is dropped
- * @deprecated use {@link prepareUrlWithQueryParams} with query parameter serialization, will be removed in v14.
  */
 export function prepareUrl(url: string, queryParameters: { [key: string]: string | undefined } = {}) {
   const queryPart = Object.keys(queryParameters)
@@ -31,7 +30,7 @@ export function prepareUrl(url: string, queryParameters: { [key: string]: string
  * @param url Base url to be used
  * @param serializedQueryParams Key value pairs of query parameter names and their serialized values
  */
-export function prepareUrlWithQueryParams(url: string, serializedQueryParams: { [key: string]: string }): string {
+export function prepareUrlWithQueryParams(url: string, serializedQueryParams: { [key: string]: string } = {}): string {
   const paramsPrefix = url.includes('?') ? '&' : '?';
   const queryPart = Object.values(serializedQueryParams).join('&');
   return url + (queryPart ? paramsPrefix + queryPart : '');

--- a/packages/@ama-sdk/core/src/fwk/core/api-client.ts
+++ b/packages/@ama-sdk/core/src/fwk/core/api-client.ts
@@ -1,4 +1,5 @@
 import type {
+  ParamSerializationOptions,
   RequestBody,
   RequestMetadata,
   RequestOptions,
@@ -27,6 +28,8 @@ export interface RequestOptionsParameters {
   basePath: string;
   /** Query Parameters */
   queryParams?: { [key: string]: string | undefined };
+  /** Parameter serialization options */
+  paramSerializationOptions?: ParamSerializationOptions;
   /** Force body to string */
   body?: RequestBody;
   /** Force headers to Headers type */
@@ -91,7 +94,7 @@ export interface ApiClient {
    * @param url Base url to be used
    * @param serializedQueryParams Key value pairs of query parameter names and their serialized values
    */
-  prepareUrlWithQueryParams(url: string, serializedQueryParams: { [key: string]: string }): string;
+  prepareUrlWithQueryParams(url: string, serializedQueryParams?: { [key: string]: string }): string;
 
   /**
    * Serialize query parameters based on the values of exploded and style

--- a/packages/@ama-sdk/core/src/fwk/core/base-api-constructor.ts
+++ b/packages/@ama-sdk/core/src/fwk/core/base-api-constructor.ts
@@ -27,6 +27,8 @@ export interface BaseApiClientOptions {
   disableFallback?: boolean;
   /** Logger (optional, fallback to console logger if undefined) */
   logger?: Logger;
+  /** Enable parameter serialization with exploded syntax */
+  enableParameterSerialization?: boolean;
   /** Custom query parameter serialization method */
   serializeQueryParams?<T extends { [key: string]: SupportedParamType }>(queryParams: T, queryParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string };
   /** Custom query parameter serialization method */

--- a/packages/@ama-sdk/core/src/plugins/core/request-plugin.ts
+++ b/packages/@ama-sdk/core/src/plugins/core/request-plugin.ts
@@ -1,5 +1,6 @@
 import type {
   Api,
+  ParamSerialization,
 } from '../../fwk';
 import type {
   Plugin,
@@ -44,9 +45,21 @@ export interface RequestMetadata<C extends string = string, A extends string = s
   signal?: AbortSignal;
 }
 
+/**
+ * Options for the serialization of the parameters
+ */
+export interface ParamSerializationOptions {
+  /** Serialization of the query parameters (style and explode) */
+  queryParamSerialization?: { [key: string]: ParamSerialization };
+  /** Enable parameter serialization with exploded syntax */
+  enableParameterSerialization?: boolean;
+}
+
 export interface RequestOptions extends RequestInit {
   /** Query Parameters */
   queryParams?: { [key: string]: string };
+  /** Parameter serialization options */
+  paramSerializationOptions?: ParamSerializationOptions;
   /** Force body to string */
   body?: RequestBody;
   /** Force headers to Headers type */

--- a/packages/@ama-sdk/core/src/plugins/si-token/si-token.request.ts
+++ b/packages/@ama-sdk/core/src/plugins/si-token/si-token.request.ts
@@ -1,3 +1,6 @@
+import type {
+  QueryParamValueSerialization,
+} from '../../fwk/param-serialization';
 import {
   AdditionalParamsRequest,
 } from '../additional-params';
@@ -24,7 +27,7 @@ export class SiTokenRequest extends AdditionalParamsRequest implements RequestPl
    */
   constructor(siToken?: string, siToken2?: string) {
     super({
-      queryParams: (queryParams?: { [key: string]: string }) => {
+      queryParams: (queryParams?: { [key: string]: string } | { [key: string]: QueryParamValueSerialization }) => {
         const ret = queryParams || {};
         if (this.siToken) {
           ret.SITK = this.siToken;

--- a/packages/@ama-sdk/schematics/README.md
+++ b/packages/@ama-sdk/schematics/README.md
@@ -119,9 +119,27 @@ For more information, check out OpenAPI's documentation on [parameter serializat
 It is important to note that, as in OpenAPI 3.1, we only support simple arrays and simple non-nested objects in path and query parameters. 
 The parameter types that we support are stored in `SupportedParamType` in the package `@ama-sdk/core`.
 
+To enable the parameter serialization within your API, you can set the option `enableParameterSerialization` to `true` (its current default value is `false`) in the constructor. For example:
+```typescript
+const apiConfig: ApiClient = new ApiFetchClient(
+  {
+    basePath: 'https://petstore3.swagger.io/api/v3',
+    enableParameterSerialization: true
+  }
+);
+```
+
+We provide the methods `serializeQueryParams` and `serializePathParams` to serialize the values of query and path parameters. However, it is also possible to pass
+your own serialization methods if the ones provided do not meet your requirements. These custom methods can be passed as a parameter to the API client constructor.
+
 > [!NOTE]
-> We provide the methods `serializeQueryParams` and `serializePathParams` to serialize the values of query and path parameters. However, it is also possible to pass
-> your own serialization methods if the ones provided do not meet your requirements. These custom methods can be passed as a parameter to the API client constructor.
+> If you have enabled the serialization mechanism and want to update the query parameters within a `RequestPlugin`, these must be serialized before being returned to the
+> API to prepare the URL. You can do so by using the serialization method that we provide (`serializeQueryParams`) or your own serialization method. The value of the query
+> parameters returned by the `RequestPlugin` will be forwarded to the next plugin and the last value will be directly added to the URL.
+
+> [!NOTE]
+> It is important to note that special characters have to be encoded, as required by RFC6570 and RFC3986. Please take this into account if you choose to use your own
+> serialization methods.
 
 #### Light SDK
 

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/java/com/amadeus/codegen/ts/AbstractTypeScriptClientCodegen.java
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/java/com/amadeus/codegen/ts/AbstractTypeScriptClientCodegen.java
@@ -146,7 +146,9 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
     additionalProperties.put("parseRegexp", new LambdaHelper.ParseRegexp());
     additionalProperties.put("plurialize", new LambdaHelper.Plurialize());
     additionalProperties.put("urlParamReplacer", new LambdaHelper.UrlParamReplacerLambda());
+    additionalProperties.put("urlSerializedParamReplacer", new LambdaHelper.UrlSerializedParamReplacerLambda());
     additionalProperties.put("tokenizedUrlParamReplacer", new LambdaHelper.TokenizedUrlParamReplacerLambda());
+    additionalProperties.put("tokenizedUrlSerializedParamReplacer", new LambdaHelper.TokenizedUrlSerializedParamReplacerLambda());
     additionalProperties.put("apiFolderName", new LambdaHelper.ApiFolderName());
     additionalProperties.put("removeBrackets", new LambdaHelper.RemoveText("[]"));
     additionalProperties.put("removeFowardslash", new LambdaHelper.RemoveText("/"));

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/java/com/amadeus/codegen/ts/LambdaHelper.java
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/java/com/amadeus/codegen/ts/LambdaHelper.java
@@ -59,11 +59,28 @@ public class LambdaHelper {
    * Replaces placeholders in the URL such as
    * /carts/{cartId}/travelers
    * to
-   * /carts/${serializedPathParams['cartId']}/travelers
+   * /carts/${data['cartId']}/travelers
    */
   public static class UrlParamReplacerLambda extends CustomLambda {
 
       public UrlParamReplacerLambda() {}
+
+      @Override
+      public String formatFragment(String fragment) {
+          return fragment.replaceAll("\\{([\\w_-]+)\\}", "\\${data['$1']}");
+      }
+
+  }
+
+  /**
+   * Replaces placeholders in the URL such as
+   * /carts/{cartId}/travelers
+   * to
+   * /carts/${serializedPathParams['cartId']}/travelers
+   */
+  public static class UrlSerializedParamReplacerLambda extends CustomLambda {
+
+      public UrlSerializedParamReplacerLambda() {}
 
       @Override
       public String formatFragment(String fragment) {
@@ -76,11 +93,27 @@ public class LambdaHelper {
    * Replaces placeholders in the URL such as
    * /carts/{cartId}/travelers
    * to
-   * /carts/${this.piiParamTokens['$1'] || serializedPathParams['$1']}/travelers
+   * /carts/${this.piiParamTokens['$1'] || data['$1']}/travelers
    */
   public static class TokenizedUrlParamReplacerLambda extends CustomLambda {
 
       public TokenizedUrlParamReplacerLambda() {}
+
+      @Override
+      public String formatFragment(String fragment) {
+          return fragment.replaceAll("\\{([\\w_-]+)\\}", "\\${this.piiParamTokens['$1'] || data['$1']}");
+      }
+  }
+
+  /**
+   * Replaces placeholders in the URL such as
+   * /carts/{cartId}/travelers
+   * to
+   * /carts/${this.piiParamTokens['$1'] || serializedPathParams['$1']}/travelers
+   */
+  public static class TokenizedUrlSerializedParamReplacerLambda extends CustomLambda {
+
+      public TokenizedUrlSerializedParamReplacerLambda() {}
 
       @Override
       public String formatFragment(String fragment) {

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/api.mustache
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/api.mustache
@@ -5,7 +5,7 @@ import { {{import}} } from '../../models/base/{{#kebabCase}}{{import}}{{/kebabCa
 import { revive{{import}} } from '../../models/base/{{#kebabCase}}{{import}}{{/kebabCase}}/{{#kebabCase}}{{import}}{{/kebabCase}}.reviver';
 {{/keepRevivers}}
 {{/imports}}
-import { Api, ApiClient, ApiTypes, computePiiParameterTokens, isJsonMimeType, RequestBody, RequestMetadata, utils } from '@ama-sdk/core';
+import { Api, ApiClient, ApiTypes, computePiiParameterTokens, isJsonMimeType, ParamSerializationOptions, RequestBody, RequestMetadata, utils } from '@ama-sdk/core';
 
 {{#operations}}
   {{#operation}}
@@ -70,8 +70,6 @@ export class {{classname}} implements Api {
     data['{{baseName}}'] = data['{{baseName}}'] !== undefined ? data['{{baseName}}'] : {{#isString}}'{{/isString}}{{defaultValue}}{{#isString}}'{{/isString}};
       {{/defaultValue}}
     {{/allParams}}
-    const queryParamsProperties = {{#hasQueryParams}}this.client.getPropertiesFromData(data, [{{#trimComma}}{{#queryParams}}'{{baseName}}', {{/queryParams}}{{/trimComma}}]){{/hasQueryParams}}{{^hasQueryParams}}{}{{/hasQueryParams}};
-    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || '{{#headerJsonMimeType}}{{#produces}}{{mediaType}}{{^-last}}, {{/-last}}{{/produces}}{{/headerJsonMimeType}}';
     const headers: { [key: string]: string | undefined } = {
   {{#trimComma}}    'Content-Type': metadata?.headerContentType || '{{#headerJsonMimeType}}{{#consumes}}{{mediaType}}{{^-last}}, {{/-last}}{{/consumes}}{{/headerJsonMimeType}}',
@@ -100,12 +98,49 @@ export class {{classname}} implements Api {
       body = data['{{baseName}}'] as any;
     }
     {{/bodyParam}}
+
+    let queryParams = {};
+    {{#hasQueryParams}}
+    const queryParamsProperties = this.client.getPropertiesFromData(data, [{{#trimComma}}{{#queryParams}}'{{baseName}}', {{/queryParams}}{{/trimComma}}]);
+    {{/hasQueryParams}}
+    const paramSerializationOptions: ParamSerializationOptions = {
+      enableParameterSerialization: this.client.options.enableParameterSerialization
+    };
     {{#hasPathParams}}
-    const pathParamsProperties = this.client.getPropertiesFromData(data, [{{#trimComma}}{{#pathParams}}'{{baseName}}', {{/pathParams}}{{/trimComma}}]);
-    const serializedPathParams = this.client.serializePathParams(pathParamsProperties, { {{#trimComma}}{{#pathParams}}{{baseName}}: { explode: {{isExplode}}, style: '{{style}}' }, {{/pathParams}}{{/trimComma}} });
+    let basePath;
+    let tokenizedUrl;
+    if (this.client.options.enableParameterSerialization) {
+      {{#hasQueryParams}}
+      const queryParamSerialization = { {{#trimComma}}{{#queryParams}}{{baseName}}: { explode: {{isExplode}}, style: '{{style}}' }, {{/queryParams}}{{/trimComma}} };
+      queryParams = this.client.serializeQueryParams(queryParamsProperties, queryParamSerialization);
+      paramSerializationOptions.queryParamSerialization = queryParamSerialization;
+      {{/hasQueryParams}}
+      const pathParamsProperties = this.client.getPropertiesFromData(data, [{{#trimComma}}{{#pathParams}}'{{baseName}}', {{/pathParams}}{{/trimComma}}]);
+      const pathParamSerialization = { {{#trimComma}}{{#pathParams}}{{baseName}}: { explode: {{isExplode}}, style: '{{style}}' }, {{/pathParams}}{{/trimComma}} }
+      const serializedPathParams = this.client.serializePathParams(pathParamsProperties, pathParamSerialization);
+      basePath = `${this.client.options.basePath}{{#urlSerializedParamReplacer}}{{path}}{{/urlSerializedParamReplacer}}`
+      tokenizedUrl = `${this.client.options.basePath}{{#tokenizedUrlSerializedParamReplacer}}{{path}}{{/tokenizedUrlSerializedParamReplacer}}`
+    } else {
+      {{#hasQueryParams}}
+      queryParams = this.client.stringifyQueryParams(queryParamsProperties);
+      {{/hasQueryParams}}
+      basePath = `${this.client.options.basePath}{{#urlParamReplacer}}{{path}}{{/urlParamReplacer}}`;
+      tokenizedUrl = `${this.client.options.basePath}{{#tokenizedUrlParamReplacer}}{{path}}{{/tokenizedUrlParamReplacer}}`;
+    }
     {{/hasPathParams}}
+    {{^hasPathParams}}
+    {{#hasQueryParams}}
+    if (this.client.options.enableParameterSerialization) {
+      const queryParamSerialization = { {{#trimComma}}{{#queryParams}}{{baseName}}: { explode: {{isExplode}}, style: '{{style}}' }, {{/queryParams}}{{/trimComma}} };
+      queryParams = this.client.serializeQueryParams(queryParamsProperties, queryParamSerialization);
+      paramSerializationOptions.queryParamSerialization = queryParamSerialization;
+    } else {
+      queryParams = this.client.stringifyQueryParams(queryParamsProperties);
+    }
+    {{/hasQueryParams}}
     const basePath = `${this.client.options.basePath}{{#urlParamReplacer}}{{path}}{{/urlParamReplacer}}`;
     const tokenizedUrl = `${this.client.options.basePath}{{#tokenizedUrlParamReplacer}}{{path}}{{/tokenizedUrlParamReplacer}}`;
+    {{/hasPathParams}}
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
 
     const requestOptions = {
@@ -113,6 +148,7 @@ export class {{classname}} implements Api {
       method: '{{httpMethod}}',
       basePath,
       queryParams,
+      paramSerializationOptions,
       body: body || undefined,
       metadata,
       tokenizedOptions,
@@ -120,13 +156,7 @@ export class {{classname}} implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    {{#hasQueryParams}}
-    const serializedQueryParams = this.client.serializeQueryParams(queryParamsProperties, { {{#trimComma}}{{#queryParams}}{{baseName}}: { explode: {{isExplode}}, style: '{{style}}' }, {{/queryParams}}{{/trimComma}} });
-    const url = this.client.prepareUrlWithQueryParams(options.basePath, serializedQueryParams);
-    {{/hasQueryParams}}
-    {{^hasQueryParams}}
-    const url = options.basePath;
-    {{/hasQueryParams}}
+    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<{{#vendorExtensions}}{{#responses2xxReturnTypes}}{{.}}{{^-last}} | {{/-last}}{{/responses2xxReturnTypes}}{{^responses2xxReturnTypes}}never{{/responses2xxReturnTypes}}{{/vendorExtensions}}>(url, options, {{#tags.0.extensions.x-api-type}}ApiTypes.{{tags.0.extensions.x-api-type}}{{/tags.0.extensions.x-api-type}}{{^tags.0.extensions.x-api-type}}ApiTypes.DEFAULT{{/tags.0.extensions.x-api-type}}, {{classname}}.apiName,{{#keepRevivers}}{{#vendorExtensions}}{{#responses2xx}}{{#-first}} { {{/-first}}{{code}}: {{^primitiveType}}revive{{baseType}}{{/primitiveType}}{{#primitiveType}}undefined{{/primitiveType}}{{^-last}}, {{/-last}}{{#-last}} } {{/-last}}{{/responses2xx}}{{^responses2xx}} undefined{{/responses2xx}}{{/vendorExtensions}}{{/keepRevivers}}{{^keepRevivers}} undefined{{/keepRevivers}}, '{{nickname}}');
     return ret;

--- a/packages/@o3r-training/showcase-sdk/src/api/pet/pet-api.ts
+++ b/packages/@o3r-training/showcase-sdk/src/api/pet/pet-api.ts
@@ -1,6 +1,6 @@
 import { ApiResponse } from '../../models/base/api-response/index';
 import { Pet } from '../../models/base/pet/index';
-import { Api, ApiClient, ApiTypes, computePiiParameterTokens, isJsonMimeType, RequestBody, RequestMetadata, } from '@ama-sdk/core';
+import { Api, ApiClient, ApiTypes, computePiiParameterTokens, isJsonMimeType, ParamSerializationOptions, RequestBody, RequestMetadata, } from '@ama-sdk/core';
 
 /** Enum status used in the PetApi's findPetsByStatus function parameter */
 export type PetApiFindPetsByStatusStatusEnum = 'available' | 'pending' | 'sold';
@@ -85,8 +85,6 @@ export class PetApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async addPet(data: PetApiAddPetRequestData, metadata?: RequestMetadata<'application/json' | 'application/xml' | 'application/x-www-form-urlencoded', 'application/xml' | 'application/json'>): Promise<Pet> {
-    const queryParamsProperties = {};
-    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -99,6 +97,11 @@ export class PetApi implements Api {
     } else {
       body = data['Pet'] as any;
     }
+
+    let queryParams = {};
+    const paramSerializationOptions: ParamSerializationOptions = {
+      enableParameterSerialization: this.client.options.enableParameterSerialization
+    };
     const basePath = `${this.client.options.basePath}/pet`;
     const tokenizedUrl = `${this.client.options.basePath}/pet`;
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
@@ -108,6 +111,7 @@ export class PetApi implements Api {
       method: 'POST',
       basePath,
       queryParams,
+      paramSerializationOptions,
       body: body || undefined,
       metadata,
       tokenizedOptions,
@@ -115,7 +119,7 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = options.basePath;
+    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<Pet>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'addPet');
     return ret;
@@ -128,8 +132,6 @@ export class PetApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async deletePet(data: PetApiDeletePetRequestData, metadata?: RequestMetadata<string, 'application/xml' | 'application/json'>): Promise<string> {
-    const queryParamsProperties = {};
-    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -138,10 +140,23 @@ export class PetApi implements Api {
     };
 
     let body: RequestBody = '';
-    const pathParamsProperties = this.client.getPropertiesFromData(data, ['petId']);
-    const serializedPathParams = this.client.serializePathParams(pathParamsProperties, { petId: { explode: false, style: 'simple' } });
-    const basePath = `${this.client.options.basePath}/pet/${serializedPathParams['petId']}`;
-    const tokenizedUrl = `${this.client.options.basePath}/pet/${this.piiParamTokens['petId'] || serializedPathParams['petId']}`;
+
+    let queryParams = {};
+    const paramSerializationOptions: ParamSerializationOptions = {
+      enableParameterSerialization: this.client.options.enableParameterSerialization
+    };
+    let basePath;
+    let tokenizedUrl;
+    if (this.client.options.enableParameterSerialization) {
+      const pathParamsProperties = this.client.getPropertiesFromData(data, ['petId']);
+      const pathParamSerialization = { petId: { explode: false, style: 'simple' } }
+      const serializedPathParams = this.client.serializePathParams(pathParamsProperties, pathParamSerialization);
+      basePath = `${this.client.options.basePath}/pet/${serializedPathParams['petId']}`
+      tokenizedUrl = `${this.client.options.basePath}/pet/${this.piiParamTokens['petId'] || serializedPathParams['petId']}`
+    } else {
+      basePath = `${this.client.options.basePath}/pet/${data['petId']}`;
+      tokenizedUrl = `${this.client.options.basePath}/pet/${this.piiParamTokens['petId'] || data['petId']}`;
+    }
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
 
     const requestOptions = {
@@ -149,6 +164,7 @@ export class PetApi implements Api {
       method: 'DELETE',
       basePath,
       queryParams,
+      paramSerializationOptions,
       body: body || undefined,
       metadata,
       tokenizedOptions,
@@ -156,7 +172,7 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = options.basePath;
+    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<string>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'deletePet');
     return ret;
@@ -170,8 +186,6 @@ export class PetApi implements Api {
    */
   public async findPetsByStatus(data: PetApiFindPetsByStatusRequestData, metadata?: RequestMetadata<string, 'application/xml' | 'application/json'>): Promise<Pet[]> {
     data['status'] = data['status'] !== undefined ? data['status'] : 'available';
-    const queryParamsProperties = this.client.getPropertiesFromData(data, ['status']);
-    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -179,6 +193,19 @@ export class PetApi implements Api {
     };
 
     let body: RequestBody = '';
+
+    let queryParams = {};
+    const queryParamsProperties = this.client.getPropertiesFromData(data, ['status']);
+    const paramSerializationOptions: ParamSerializationOptions = {
+      enableParameterSerialization: this.client.options.enableParameterSerialization
+    };
+    if (this.client.options.enableParameterSerialization) {
+      const queryParamSerialization = { status: { explode: true, style: 'form' } };
+      queryParams = this.client.serializeQueryParams(queryParamsProperties, queryParamSerialization);
+      paramSerializationOptions.queryParamSerialization = queryParamSerialization;
+    } else {
+      queryParams = this.client.stringifyQueryParams(queryParamsProperties);
+    }
     const basePath = `${this.client.options.basePath}/pet/findByStatus`;
     const tokenizedUrl = `${this.client.options.basePath}/pet/findByStatus`;
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
@@ -188,6 +215,7 @@ export class PetApi implements Api {
       method: 'GET',
       basePath,
       queryParams,
+      paramSerializationOptions,
       body: body || undefined,
       metadata,
       tokenizedOptions,
@@ -195,8 +223,7 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const serializedQueryParams = this.client.serializeQueryParams(queryParamsProperties, { status: { explode: true, style: 'form' } });
-    const url = this.client.prepareUrlWithQueryParams(options.basePath, serializedQueryParams);
+    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<Pet[]>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'findPetsByStatus');
     return ret;
@@ -209,8 +236,6 @@ export class PetApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async findPetsByTags(data: PetApiFindPetsByTagsRequestData, metadata?: RequestMetadata<string, 'application/xml' | 'application/json'>): Promise<Pet[]> {
-    const queryParamsProperties = this.client.getPropertiesFromData(data, ['tags']);
-    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -218,6 +243,19 @@ export class PetApi implements Api {
     };
 
     let body: RequestBody = '';
+
+    let queryParams = {};
+    const queryParamsProperties = this.client.getPropertiesFromData(data, ['tags']);
+    const paramSerializationOptions: ParamSerializationOptions = {
+      enableParameterSerialization: this.client.options.enableParameterSerialization
+    };
+    if (this.client.options.enableParameterSerialization) {
+      const queryParamSerialization = { tags: { explode: true, style: 'form' } };
+      queryParams = this.client.serializeQueryParams(queryParamsProperties, queryParamSerialization);
+      paramSerializationOptions.queryParamSerialization = queryParamSerialization;
+    } else {
+      queryParams = this.client.stringifyQueryParams(queryParamsProperties);
+    }
     const basePath = `${this.client.options.basePath}/pet/findByTags`;
     const tokenizedUrl = `${this.client.options.basePath}/pet/findByTags`;
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
@@ -227,6 +265,7 @@ export class PetApi implements Api {
       method: 'GET',
       basePath,
       queryParams,
+      paramSerializationOptions,
       body: body || undefined,
       metadata,
       tokenizedOptions,
@@ -234,8 +273,7 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const serializedQueryParams = this.client.serializeQueryParams(queryParamsProperties, { tags: { explode: true, style: 'form' } });
-    const url = this.client.prepareUrlWithQueryParams(options.basePath, serializedQueryParams);
+    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<Pet[]>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'findPetsByTags');
     return ret;
@@ -248,8 +286,6 @@ export class PetApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async getPetById(data: PetApiGetPetByIdRequestData, metadata?: RequestMetadata<string, 'application/xml' | 'application/json'>): Promise<Pet> {
-    const queryParamsProperties = {};
-    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -257,10 +293,23 @@ export class PetApi implements Api {
     };
 
     let body: RequestBody = '';
-    const pathParamsProperties = this.client.getPropertiesFromData(data, ['petId']);
-    const serializedPathParams = this.client.serializePathParams(pathParamsProperties, { petId: { explode: false, style: 'simple' } });
-    const basePath = `${this.client.options.basePath}/pet/${serializedPathParams['petId']}`;
-    const tokenizedUrl = `${this.client.options.basePath}/pet/${this.piiParamTokens['petId'] || serializedPathParams['petId']}`;
+
+    let queryParams = {};
+    const paramSerializationOptions: ParamSerializationOptions = {
+      enableParameterSerialization: this.client.options.enableParameterSerialization
+    };
+    let basePath;
+    let tokenizedUrl;
+    if (this.client.options.enableParameterSerialization) {
+      const pathParamsProperties = this.client.getPropertiesFromData(data, ['petId']);
+      const pathParamSerialization = { petId: { explode: false, style: 'simple' } }
+      const serializedPathParams = this.client.serializePathParams(pathParamsProperties, pathParamSerialization);
+      basePath = `${this.client.options.basePath}/pet/${serializedPathParams['petId']}`
+      tokenizedUrl = `${this.client.options.basePath}/pet/${this.piiParamTokens['petId'] || serializedPathParams['petId']}`
+    } else {
+      basePath = `${this.client.options.basePath}/pet/${data['petId']}`;
+      tokenizedUrl = `${this.client.options.basePath}/pet/${this.piiParamTokens['petId'] || data['petId']}`;
+    }
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
 
     const requestOptions = {
@@ -268,6 +317,7 @@ export class PetApi implements Api {
       method: 'GET',
       basePath,
       queryParams,
+      paramSerializationOptions,
       body: body || undefined,
       metadata,
       tokenizedOptions,
@@ -275,7 +325,7 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = options.basePath;
+    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<Pet>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'getPetById');
     return ret;
@@ -288,8 +338,6 @@ export class PetApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async updatePet(data: PetApiUpdatePetRequestData, metadata?: RequestMetadata<'application/json' | 'application/xml' | 'application/x-www-form-urlencoded', 'application/xml' | 'application/json'>): Promise<Pet> {
-    const queryParamsProperties = {};
-    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -302,6 +350,11 @@ export class PetApi implements Api {
     } else {
       body = data['Pet'] as any;
     }
+
+    let queryParams = {};
+    const paramSerializationOptions: ParamSerializationOptions = {
+      enableParameterSerialization: this.client.options.enableParameterSerialization
+    };
     const basePath = `${this.client.options.basePath}/pet`;
     const tokenizedUrl = `${this.client.options.basePath}/pet`;
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
@@ -311,6 +364,7 @@ export class PetApi implements Api {
       method: 'PUT',
       basePath,
       queryParams,
+      paramSerializationOptions,
       body: body || undefined,
       metadata,
       tokenizedOptions,
@@ -318,7 +372,7 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = options.basePath;
+    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<Pet>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'updatePet');
     return ret;
@@ -331,8 +385,6 @@ export class PetApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async updatePetWithForm(data: PetApiUpdatePetWithFormRequestData, metadata?: RequestMetadata<string, string>): Promise<never> {
-    const queryParamsProperties = this.client.getPropertiesFromData(data, ['name', 'status']);
-    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -340,10 +392,28 @@ export class PetApi implements Api {
     };
 
     let body: RequestBody = '';
-    const pathParamsProperties = this.client.getPropertiesFromData(data, ['petId']);
-    const serializedPathParams = this.client.serializePathParams(pathParamsProperties, { petId: { explode: false, style: 'simple' } });
-    const basePath = `${this.client.options.basePath}/pet/${serializedPathParams['petId']}`;
-    const tokenizedUrl = `${this.client.options.basePath}/pet/${this.piiParamTokens['petId'] || serializedPathParams['petId']}`;
+
+    let queryParams = {};
+    const queryParamsProperties = this.client.getPropertiesFromData(data, ['name', 'status']);
+    const paramSerializationOptions: ParamSerializationOptions = {
+      enableParameterSerialization: this.client.options.enableParameterSerialization
+    };
+    let basePath;
+    let tokenizedUrl;
+    if (this.client.options.enableParameterSerialization) {
+      const queryParamSerialization = { name: { explode: true, style: 'form' }, status: { explode: true, style: 'form' } };
+      queryParams = this.client.serializeQueryParams(queryParamsProperties, queryParamSerialization);
+      paramSerializationOptions.queryParamSerialization = queryParamSerialization;
+      const pathParamsProperties = this.client.getPropertiesFromData(data, ['petId']);
+      const pathParamSerialization = { petId: { explode: false, style: 'simple' } }
+      const serializedPathParams = this.client.serializePathParams(pathParamsProperties, pathParamSerialization);
+      basePath = `${this.client.options.basePath}/pet/${serializedPathParams['petId']}`
+      tokenizedUrl = `${this.client.options.basePath}/pet/${this.piiParamTokens['petId'] || serializedPathParams['petId']}`
+    } else {
+      queryParams = this.client.stringifyQueryParams(queryParamsProperties);
+      basePath = `${this.client.options.basePath}/pet/${data['petId']}`;
+      tokenizedUrl = `${this.client.options.basePath}/pet/${this.piiParamTokens['petId'] || data['petId']}`;
+    }
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
 
     const requestOptions = {
@@ -351,6 +421,7 @@ export class PetApi implements Api {
       method: 'POST',
       basePath,
       queryParams,
+      paramSerializationOptions,
       body: body || undefined,
       metadata,
       tokenizedOptions,
@@ -358,8 +429,7 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const serializedQueryParams = this.client.serializeQueryParams(queryParamsProperties, { name: { explode: true, style: 'form' }, status: { explode: true, style: 'form' } });
-    const url = this.client.prepareUrlWithQueryParams(options.basePath, serializedQueryParams);
+    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'updatePetWithForm');
     return ret;
@@ -372,8 +442,6 @@ export class PetApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async uploadFile(data: PetApiUploadFileRequestData, metadata?: RequestMetadata<'application/octet-stream', 'application/json'>): Promise<ApiResponse> {
-    const queryParamsProperties = this.client.getPropertiesFromData(data, ['additionalMetadata']);
-    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/octet-stream',
@@ -386,10 +454,28 @@ export class PetApi implements Api {
     } else {
       body = data['body'] as any;
     }
-    const pathParamsProperties = this.client.getPropertiesFromData(data, ['petId']);
-    const serializedPathParams = this.client.serializePathParams(pathParamsProperties, { petId: { explode: false, style: 'simple' } });
-    const basePath = `${this.client.options.basePath}/pet/${serializedPathParams['petId']}/uploadImage`;
-    const tokenizedUrl = `${this.client.options.basePath}/pet/${this.piiParamTokens['petId'] || serializedPathParams['petId']}/uploadImage`;
+
+    let queryParams = {};
+    const queryParamsProperties = this.client.getPropertiesFromData(data, ['additionalMetadata']);
+    const paramSerializationOptions: ParamSerializationOptions = {
+      enableParameterSerialization: this.client.options.enableParameterSerialization
+    };
+    let basePath;
+    let tokenizedUrl;
+    if (this.client.options.enableParameterSerialization) {
+      const queryParamSerialization = { additionalMetadata: { explode: true, style: 'form' } };
+      queryParams = this.client.serializeQueryParams(queryParamsProperties, queryParamSerialization);
+      paramSerializationOptions.queryParamSerialization = queryParamSerialization;
+      const pathParamsProperties = this.client.getPropertiesFromData(data, ['petId']);
+      const pathParamSerialization = { petId: { explode: false, style: 'simple' } }
+      const serializedPathParams = this.client.serializePathParams(pathParamsProperties, pathParamSerialization);
+      basePath = `${this.client.options.basePath}/pet/${serializedPathParams['petId']}/uploadImage`
+      tokenizedUrl = `${this.client.options.basePath}/pet/${this.piiParamTokens['petId'] || serializedPathParams['petId']}/uploadImage`
+    } else {
+      queryParams = this.client.stringifyQueryParams(queryParamsProperties);
+      basePath = `${this.client.options.basePath}/pet/${data['petId']}/uploadImage`;
+      tokenizedUrl = `${this.client.options.basePath}/pet/${this.piiParamTokens['petId'] || data['petId']}/uploadImage`;
+    }
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
 
     const requestOptions = {
@@ -397,6 +483,7 @@ export class PetApi implements Api {
       method: 'POST',
       basePath,
       queryParams,
+      paramSerializationOptions,
       body: body || undefined,
       metadata,
       tokenizedOptions,
@@ -404,8 +491,7 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const serializedQueryParams = this.client.serializeQueryParams(queryParamsProperties, { additionalMetadata: { explode: true, style: 'form' } });
-    const url = this.client.prepareUrlWithQueryParams(options.basePath, serializedQueryParams);
+    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<ApiResponse>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'uploadFile');
     return ret;

--- a/packages/@o3r-training/showcase-sdk/src/api/store/store-api.ts
+++ b/packages/@o3r-training/showcase-sdk/src/api/store/store-api.ts
@@ -1,5 +1,5 @@
 import { Order } from '../../models/base/order/index';
-import { Api, ApiClient, ApiTypes, computePiiParameterTokens, isJsonMimeType, RequestBody, RequestMetadata, } from '@ama-sdk/core';
+import { Api, ApiClient, ApiTypes, computePiiParameterTokens, isJsonMimeType, ParamSerializationOptions, RequestBody, RequestMetadata, } from '@ama-sdk/core';
 
 /** Parameters object to StoreApi's deleteOrder function */
 export interface StoreApiDeleteOrderRequestData {
@@ -49,8 +49,6 @@ export class StoreApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async deleteOrder(data: StoreApiDeleteOrderRequestData, metadata?: RequestMetadata<string, string>): Promise<never> {
-    const queryParamsProperties = {};
-    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -58,10 +56,23 @@ export class StoreApi implements Api {
     };
 
     let body: RequestBody = '';
-    const pathParamsProperties = this.client.getPropertiesFromData(data, ['orderId']);
-    const serializedPathParams = this.client.serializePathParams(pathParamsProperties, { orderId: { explode: false, style: 'simple' } });
-    const basePath = `${this.client.options.basePath}/store/order/${serializedPathParams['orderId']}`;
-    const tokenizedUrl = `${this.client.options.basePath}/store/order/${this.piiParamTokens['orderId'] || serializedPathParams['orderId']}`;
+
+    let queryParams = {};
+    const paramSerializationOptions: ParamSerializationOptions = {
+      enableParameterSerialization: this.client.options.enableParameterSerialization
+    };
+    let basePath;
+    let tokenizedUrl;
+    if (this.client.options.enableParameterSerialization) {
+      const pathParamsProperties = this.client.getPropertiesFromData(data, ['orderId']);
+      const pathParamSerialization = { orderId: { explode: false, style: 'simple' } }
+      const serializedPathParams = this.client.serializePathParams(pathParamsProperties, pathParamSerialization);
+      basePath = `${this.client.options.basePath}/store/order/${serializedPathParams['orderId']}`
+      tokenizedUrl = `${this.client.options.basePath}/store/order/${this.piiParamTokens['orderId'] || serializedPathParams['orderId']}`
+    } else {
+      basePath = `${this.client.options.basePath}/store/order/${data['orderId']}`;
+      tokenizedUrl = `${this.client.options.basePath}/store/order/${this.piiParamTokens['orderId'] || data['orderId']}`;
+    }
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
 
     const requestOptions = {
@@ -69,6 +80,7 @@ export class StoreApi implements Api {
       method: 'DELETE',
       basePath,
       queryParams,
+      paramSerializationOptions,
       body: body || undefined,
       metadata,
       tokenizedOptions,
@@ -76,7 +88,7 @@ export class StoreApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = options.basePath;
+    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, StoreApi.apiName, undefined, 'deleteOrder');
     return ret;
@@ -89,8 +101,6 @@ export class StoreApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async getInventory(data: StoreApiGetInventoryRequestData, metadata?: RequestMetadata<string, 'application/json'>): Promise<{ [key: string]: number; }> {
-    const queryParamsProperties = {};
-    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -98,6 +108,11 @@ export class StoreApi implements Api {
     };
 
     let body: RequestBody = '';
+
+    let queryParams = {};
+    const paramSerializationOptions: ParamSerializationOptions = {
+      enableParameterSerialization: this.client.options.enableParameterSerialization
+    };
     const basePath = `${this.client.options.basePath}/store/inventory`;
     const tokenizedUrl = `${this.client.options.basePath}/store/inventory`;
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
@@ -107,6 +122,7 @@ export class StoreApi implements Api {
       method: 'GET',
       basePath,
       queryParams,
+      paramSerializationOptions,
       body: body || undefined,
       metadata,
       tokenizedOptions,
@@ -114,7 +130,7 @@ export class StoreApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = options.basePath;
+    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<{ [key: string]: number; }>(url, options, ApiTypes.DEFAULT, StoreApi.apiName, undefined, 'getInventory');
     return ret;
@@ -127,8 +143,6 @@ export class StoreApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async getOrderById(data: StoreApiGetOrderByIdRequestData, metadata?: RequestMetadata<string, 'application/xml' | 'application/json'>): Promise<Order> {
-    const queryParamsProperties = {};
-    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -136,10 +150,23 @@ export class StoreApi implements Api {
     };
 
     let body: RequestBody = '';
-    const pathParamsProperties = this.client.getPropertiesFromData(data, ['orderId']);
-    const serializedPathParams = this.client.serializePathParams(pathParamsProperties, { orderId: { explode: false, style: 'simple' } });
-    const basePath = `${this.client.options.basePath}/store/order/${serializedPathParams['orderId']}`;
-    const tokenizedUrl = `${this.client.options.basePath}/store/order/${this.piiParamTokens['orderId'] || serializedPathParams['orderId']}`;
+
+    let queryParams = {};
+    const paramSerializationOptions: ParamSerializationOptions = {
+      enableParameterSerialization: this.client.options.enableParameterSerialization
+    };
+    let basePath;
+    let tokenizedUrl;
+    if (this.client.options.enableParameterSerialization) {
+      const pathParamsProperties = this.client.getPropertiesFromData(data, ['orderId']);
+      const pathParamSerialization = { orderId: { explode: false, style: 'simple' } }
+      const serializedPathParams = this.client.serializePathParams(pathParamsProperties, pathParamSerialization);
+      basePath = `${this.client.options.basePath}/store/order/${serializedPathParams['orderId']}`
+      tokenizedUrl = `${this.client.options.basePath}/store/order/${this.piiParamTokens['orderId'] || serializedPathParams['orderId']}`
+    } else {
+      basePath = `${this.client.options.basePath}/store/order/${data['orderId']}`;
+      tokenizedUrl = `${this.client.options.basePath}/store/order/${this.piiParamTokens['orderId'] || data['orderId']}`;
+    }
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
 
     const requestOptions = {
@@ -147,6 +174,7 @@ export class StoreApi implements Api {
       method: 'GET',
       basePath,
       queryParams,
+      paramSerializationOptions,
       body: body || undefined,
       metadata,
       tokenizedOptions,
@@ -154,7 +182,7 @@ export class StoreApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = options.basePath;
+    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<Order>(url, options, ApiTypes.DEFAULT, StoreApi.apiName, undefined, 'getOrderById');
     return ret;
@@ -167,8 +195,6 @@ export class StoreApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async placeOrder(data: StoreApiPlaceOrderRequestData, metadata?: RequestMetadata<'application/json' | 'application/xml' | 'application/x-www-form-urlencoded', 'application/json'>): Promise<Order> {
-    const queryParamsProperties = {};
-    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -181,6 +207,11 @@ export class StoreApi implements Api {
     } else {
       body = data['Order'] as any;
     }
+
+    let queryParams = {};
+    const paramSerializationOptions: ParamSerializationOptions = {
+      enableParameterSerialization: this.client.options.enableParameterSerialization
+    };
     const basePath = `${this.client.options.basePath}/store/order`;
     const tokenizedUrl = `${this.client.options.basePath}/store/order`;
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
@@ -190,6 +221,7 @@ export class StoreApi implements Api {
       method: 'POST',
       basePath,
       queryParams,
+      paramSerializationOptions,
       body: body || undefined,
       metadata,
       tokenizedOptions,
@@ -197,7 +229,7 @@ export class StoreApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = options.basePath;
+    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<Order>(url, options, ApiTypes.DEFAULT, StoreApi.apiName, undefined, 'placeOrder');
     return ret;

--- a/packages/@o3r-training/showcase-sdk/src/api/user/user-api.ts
+++ b/packages/@o3r-training/showcase-sdk/src/api/user/user-api.ts
@@ -1,5 +1,5 @@
 import { User } from '../../models/base/user/index';
-import { Api, ApiClient, ApiTypes, computePiiParameterTokens, isJsonMimeType, RequestBody, RequestMetadata, } from '@ama-sdk/core';
+import { Api, ApiClient, ApiTypes, computePiiParameterTokens, isJsonMimeType, ParamSerializationOptions, RequestBody, RequestMetadata, } from '@ama-sdk/core';
 
 /** Parameters object to UserApi's createUser function */
 export interface UserApiCreateUserRequestData {
@@ -68,8 +68,6 @@ export class UserApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async createUser(data: UserApiCreateUserRequestData, metadata?: RequestMetadata<'application/json' | 'application/xml' | 'application/x-www-form-urlencoded', 'application/json' | 'application/xml'>): Promise<never> {
-    const queryParamsProperties = {};
-    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -82,6 +80,11 @@ export class UserApi implements Api {
     } else {
       body = data['User'] as any;
     }
+
+    let queryParams = {};
+    const paramSerializationOptions: ParamSerializationOptions = {
+      enableParameterSerialization: this.client.options.enableParameterSerialization
+    };
     const basePath = `${this.client.options.basePath}/user`;
     const tokenizedUrl = `${this.client.options.basePath}/user`;
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
@@ -91,6 +94,7 @@ export class UserApi implements Api {
       method: 'POST',
       basePath,
       queryParams,
+      paramSerializationOptions,
       body: body || undefined,
       metadata,
       tokenizedOptions,
@@ -98,7 +102,7 @@ export class UserApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = options.basePath;
+    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'createUser');
     return ret;
@@ -111,8 +115,6 @@ export class UserApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async createUsersWithListInput(data: UserApiCreateUsersWithListInputRequestData, metadata?: RequestMetadata<'application/json', 'application/xml' | 'application/json'>): Promise<User> {
-    const queryParamsProperties = {};
-    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -125,6 +127,11 @@ export class UserApi implements Api {
     } else {
       body = data['User'] as any;
     }
+
+    let queryParams = {};
+    const paramSerializationOptions: ParamSerializationOptions = {
+      enableParameterSerialization: this.client.options.enableParameterSerialization
+    };
     const basePath = `${this.client.options.basePath}/user/createWithList`;
     const tokenizedUrl = `${this.client.options.basePath}/user/createWithList`;
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
@@ -134,6 +141,7 @@ export class UserApi implements Api {
       method: 'POST',
       basePath,
       queryParams,
+      paramSerializationOptions,
       body: body || undefined,
       metadata,
       tokenizedOptions,
@@ -141,7 +149,7 @@ export class UserApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = options.basePath;
+    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<User>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'createUsersWithListInput');
     return ret;
@@ -154,8 +162,6 @@ export class UserApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async deleteUser(data: UserApiDeleteUserRequestData, metadata?: RequestMetadata<string, string>): Promise<never> {
-    const queryParamsProperties = {};
-    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -163,10 +169,23 @@ export class UserApi implements Api {
     };
 
     let body: RequestBody = '';
-    const pathParamsProperties = this.client.getPropertiesFromData(data, ['username']);
-    const serializedPathParams = this.client.serializePathParams(pathParamsProperties, { username: { explode: false, style: 'simple' } });
-    const basePath = `${this.client.options.basePath}/user/${serializedPathParams['username']}`;
-    const tokenizedUrl = `${this.client.options.basePath}/user/${this.piiParamTokens['username'] || serializedPathParams['username']}`;
+
+    let queryParams = {};
+    const paramSerializationOptions: ParamSerializationOptions = {
+      enableParameterSerialization: this.client.options.enableParameterSerialization
+    };
+    let basePath;
+    let tokenizedUrl;
+    if (this.client.options.enableParameterSerialization) {
+      const pathParamsProperties = this.client.getPropertiesFromData(data, ['username']);
+      const pathParamSerialization = { username: { explode: false, style: 'simple' } }
+      const serializedPathParams = this.client.serializePathParams(pathParamsProperties, pathParamSerialization);
+      basePath = `${this.client.options.basePath}/user/${serializedPathParams['username']}`
+      tokenizedUrl = `${this.client.options.basePath}/user/${this.piiParamTokens['username'] || serializedPathParams['username']}`
+    } else {
+      basePath = `${this.client.options.basePath}/user/${data['username']}`;
+      tokenizedUrl = `${this.client.options.basePath}/user/${this.piiParamTokens['username'] || data['username']}`;
+    }
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
 
     const requestOptions = {
@@ -174,6 +193,7 @@ export class UserApi implements Api {
       method: 'DELETE',
       basePath,
       queryParams,
+      paramSerializationOptions,
       body: body || undefined,
       metadata,
       tokenizedOptions,
@@ -181,7 +201,7 @@ export class UserApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = options.basePath;
+    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'deleteUser');
     return ret;
@@ -194,8 +214,6 @@ export class UserApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async getUserByName(data: UserApiGetUserByNameRequestData, metadata?: RequestMetadata<string, 'application/xml' | 'application/json'>): Promise<User> {
-    const queryParamsProperties = {};
-    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -203,10 +221,23 @@ export class UserApi implements Api {
     };
 
     let body: RequestBody = '';
-    const pathParamsProperties = this.client.getPropertiesFromData(data, ['username']);
-    const serializedPathParams = this.client.serializePathParams(pathParamsProperties, { username: { explode: false, style: 'simple' } });
-    const basePath = `${this.client.options.basePath}/user/${serializedPathParams['username']}`;
-    const tokenizedUrl = `${this.client.options.basePath}/user/${this.piiParamTokens['username'] || serializedPathParams['username']}`;
+
+    let queryParams = {};
+    const paramSerializationOptions: ParamSerializationOptions = {
+      enableParameterSerialization: this.client.options.enableParameterSerialization
+    };
+    let basePath;
+    let tokenizedUrl;
+    if (this.client.options.enableParameterSerialization) {
+      const pathParamsProperties = this.client.getPropertiesFromData(data, ['username']);
+      const pathParamSerialization = { username: { explode: false, style: 'simple' } }
+      const serializedPathParams = this.client.serializePathParams(pathParamsProperties, pathParamSerialization);
+      basePath = `${this.client.options.basePath}/user/${serializedPathParams['username']}`
+      tokenizedUrl = `${this.client.options.basePath}/user/${this.piiParamTokens['username'] || serializedPathParams['username']}`
+    } else {
+      basePath = `${this.client.options.basePath}/user/${data['username']}`;
+      tokenizedUrl = `${this.client.options.basePath}/user/${this.piiParamTokens['username'] || data['username']}`;
+    }
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
 
     const requestOptions = {
@@ -214,6 +245,7 @@ export class UserApi implements Api {
       method: 'GET',
       basePath,
       queryParams,
+      paramSerializationOptions,
       body: body || undefined,
       metadata,
       tokenizedOptions,
@@ -221,7 +253,7 @@ export class UserApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = options.basePath;
+    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<User>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'getUserByName');
     return ret;
@@ -234,8 +266,6 @@ export class UserApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async loginUser(data: UserApiLoginUserRequestData, metadata?: RequestMetadata<string, 'application/xml' | 'application/json'>): Promise<string> {
-    const queryParamsProperties = this.client.getPropertiesFromData(data, ['username', 'password']);
-    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -243,6 +273,19 @@ export class UserApi implements Api {
     };
 
     let body: RequestBody = '';
+
+    let queryParams = {};
+    const queryParamsProperties = this.client.getPropertiesFromData(data, ['username', 'password']);
+    const paramSerializationOptions: ParamSerializationOptions = {
+      enableParameterSerialization: this.client.options.enableParameterSerialization
+    };
+    if (this.client.options.enableParameterSerialization) {
+      const queryParamSerialization = { username: { explode: true, style: 'form' }, password: { explode: true, style: 'form' } };
+      queryParams = this.client.serializeQueryParams(queryParamsProperties, queryParamSerialization);
+      paramSerializationOptions.queryParamSerialization = queryParamSerialization;
+    } else {
+      queryParams = this.client.stringifyQueryParams(queryParamsProperties);
+    }
     const basePath = `${this.client.options.basePath}/user/login`;
     const tokenizedUrl = `${this.client.options.basePath}/user/login`;
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
@@ -252,6 +295,7 @@ export class UserApi implements Api {
       method: 'GET',
       basePath,
       queryParams,
+      paramSerializationOptions,
       body: body || undefined,
       metadata,
       tokenizedOptions,
@@ -259,8 +303,7 @@ export class UserApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const serializedQueryParams = this.client.serializeQueryParams(queryParamsProperties, { username: { explode: true, style: 'form' }, password: { explode: true, style: 'form' } });
-    const url = this.client.prepareUrlWithQueryParams(options.basePath, serializedQueryParams);
+    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<string>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'loginUser');
     return ret;
@@ -273,8 +316,6 @@ export class UserApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async logoutUser(data: UserApiLogoutUserRequestData, metadata?: RequestMetadata<string, string>): Promise<never> {
-    const queryParamsProperties = {};
-    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -282,6 +323,11 @@ export class UserApi implements Api {
     };
 
     let body: RequestBody = '';
+
+    let queryParams = {};
+    const paramSerializationOptions: ParamSerializationOptions = {
+      enableParameterSerialization: this.client.options.enableParameterSerialization
+    };
     const basePath = `${this.client.options.basePath}/user/logout`;
     const tokenizedUrl = `${this.client.options.basePath}/user/logout`;
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
@@ -291,6 +337,7 @@ export class UserApi implements Api {
       method: 'GET',
       basePath,
       queryParams,
+      paramSerializationOptions,
       body: body || undefined,
       metadata,
       tokenizedOptions,
@@ -298,7 +345,7 @@ export class UserApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = options.basePath;
+    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'logoutUser');
     return ret;
@@ -311,8 +358,6 @@ export class UserApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async updateUser(data: UserApiUpdateUserRequestData, metadata?: RequestMetadata<'application/json' | 'application/xml' | 'application/x-www-form-urlencoded', string>): Promise<never> {
-    const queryParamsProperties = {};
-    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -325,10 +370,23 @@ export class UserApi implements Api {
     } else {
       body = data['User'] as any;
     }
-    const pathParamsProperties = this.client.getPropertiesFromData(data, ['username']);
-    const serializedPathParams = this.client.serializePathParams(pathParamsProperties, { username: { explode: false, style: 'simple' } });
-    const basePath = `${this.client.options.basePath}/user/${serializedPathParams['username']}`;
-    const tokenizedUrl = `${this.client.options.basePath}/user/${this.piiParamTokens['username'] || serializedPathParams['username']}`;
+
+    let queryParams = {};
+    const paramSerializationOptions: ParamSerializationOptions = {
+      enableParameterSerialization: this.client.options.enableParameterSerialization
+    };
+    let basePath;
+    let tokenizedUrl;
+    if (this.client.options.enableParameterSerialization) {
+      const pathParamsProperties = this.client.getPropertiesFromData(data, ['username']);
+      const pathParamSerialization = { username: { explode: false, style: 'simple' } }
+      const serializedPathParams = this.client.serializePathParams(pathParamsProperties, pathParamSerialization);
+      basePath = `${this.client.options.basePath}/user/${serializedPathParams['username']}`
+      tokenizedUrl = `${this.client.options.basePath}/user/${this.piiParamTokens['username'] || serializedPathParams['username']}`
+    } else {
+      basePath = `${this.client.options.basePath}/user/${data['username']}`;
+      tokenizedUrl = `${this.client.options.basePath}/user/${this.piiParamTokens['username'] || data['username']}`;
+    }
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
 
     const requestOptions = {
@@ -336,6 +394,7 @@ export class UserApi implements Api {
       method: 'PUT',
       basePath,
       queryParams,
+      paramSerializationOptions,
       body: body || undefined,
       metadata,
       tokenizedOptions,
@@ -343,7 +402,7 @@ export class UserApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = options.basePath;
+    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'updateUser');
     return ret;

--- a/packages/@o3r-training/training-sdk/src/api/dummy/dummy-api.ts
+++ b/packages/@o3r-training/training-sdk/src/api/dummy/dummy-api.ts
@@ -1,6 +1,6 @@
 import { Flight } from '../../models/base/flight/index';
 import { reviveFlight } from '../../models/base/flight/flight.reviver';
-import { Api, ApiClient, ApiTypes, computePiiParameterTokens,  RequestBody, RequestMetadata, } from '@ama-sdk/core';
+import { Api, ApiClient, ApiTypes, computePiiParameterTokens,  ParamSerializationOptions, RequestBody, RequestMetadata, } from '@ama-sdk/core';
 
 /** Parameters object to DummyApi's dummyGet function */
 export interface DummyApiDummyGetRequestData {
@@ -35,8 +35,6 @@ export class DummyApi implements Api {
    * @param metadata Metadata to pass to the API call
    */
   public async dummyGet(data: DummyApiDummyGetRequestData, metadata?: RequestMetadata<string, 'application/json'>): Promise<Flight> {
-    const queryParamsProperties = {};
-    const queryParams = this.client.stringifyQueryParams(queryParamsProperties);
     const metadataHeaderAccept = metadata?.headerAccept || 'application/json';
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': metadata?.headerContentType || 'application/json',
@@ -44,6 +42,11 @@ export class DummyApi implements Api {
     };
 
     let body: RequestBody = '';
+
+    let queryParams = {};
+    const paramSerializationOptions: ParamSerializationOptions = {
+      enableParameterSerialization: this.client.options.enableParameterSerialization
+    };
     const basePath = `${this.client.options.basePath}/dummy`;
     const tokenizedUrl = `${this.client.options.basePath}/dummy`;
     const tokenizedOptions = this.client.tokenizeRequestOptions(tokenizedUrl, queryParams, this.piiParamTokens, data);
@@ -53,6 +56,7 @@ export class DummyApi implements Api {
       method: 'GET',
       basePath,
       queryParams,
+      paramSerializationOptions,
       body: body || undefined,
       metadata,
       tokenizedOptions,
@@ -60,7 +64,7 @@ export class DummyApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = options.basePath;
+    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
 
     const ret = this.client.processCall<Flight>(url, options, ApiTypes.DEFAULT, DummyApi.apiName, { 200: reviveFlight } , 'dummyGet');
     return ret;


### PR DESCRIPTION
## Proposed change

When we previously implemented the exploded syntax for SDK parameter serialization, we removed the possibility of taking into account the query parameters that can be updated in the Request Plugins - which needs to be fixed. Here is a possible fix, which prepares the URL using the request plugins options (which could update the query parameters). 

Also, the parameter `queryParamSerialization` has been added to `RequestOptionsParameters`, which can be used in order to serialize the query parameter modifications that are potentially made. In another PR, I will add a method allowing to deserialize the parameters, which facilitates the modifications in the Request Plugins.

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
