### PR TITLE
fix: enforce listr2 resolution for yarn pnp in o3r/create

### DIFF
--- a/packages/@o3r/create/src/index.ts
+++ b/packages/@o3r/create/src/index.ts
@@ -134,6 +134,7 @@ const ADD_O3R_CORE_ERROR_CODE = 3;
 const NPM_CONFIG_REGISTRY_ERROR_CODE = 4;
 const YARN_CONFIG_REGISTRY_ERROR_CODE = 5;
 const INSTALL_PROCESS_ERROR_CODE = 6;
+const YARN_SET_PACKAGE_EXTENSIONS = 7;
 
 const exitProcessIfErrorInSpawnSync = (exitCode: number, { error, status }: ReturnType<typeof spawnSync>) => {
   if (error || status !== 0) {
@@ -222,6 +223,12 @@ const prepareWorkspace = (relativeDirectory = '.', projectPackageManager = 'npm'
     exitProcessIfErrorInSpawnSync(YARN_SET_VERSION_ERROR_CODE, spawnSync(
       runner,
       ['set', 'version', yarnVersion],
+      spawnSyncOpts
+    ));
+    exitProcessIfErrorInSpawnSync(YARN_SET_PACKAGE_EXTENSIONS, spawnSync(
+      runner,
+      // TODO temporarily fixed until https://github.com/listr2/listr2/pull/719 is merged
+      ['config', 'set', 'packageExtensions["@listr2/prompt-adapter-inquirer@*"].peerDependencies.listr2', '"*"'],
       spawnSyncOpts
     ));
   }


### PR DESCRIPTION
## Proposed change

listr2/prompt-adapter-inquirer is a dependency brought by angular cli.
This package declares incorrectly its listr2 dependency which results in a failure in our o3r create schematic.

This fix should be removed once https://github.com/listr2/listr2/pull/719 is merged


## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
