### PR TITLE
chore: install with no scripts after postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:affected": "yarn nx affected --target=test",
     "test-e2e": "yarn nx run-many --target=test-e2e",
     "test-int": "yarn nx run-many --target=test-int",
-    "postinstall": "husky && yarn build:lint && yarn harmonize:version && yarn update-yarn-sdks",
+    "postinstall": "husky && yarn build:lint && yarn harmonize:version && yarn update-yarn-sdks && yarn install --mode=skip-build",
     "update-yarn-sdks": "node -e \"'pnp' !== '$(yarn config get nodeLinker)' || process.exit(1)\" || yarn sdks",
     "clear": "rimraf -g './{packages,tools,apps}/{@*/,}{amaterasu/,}*/{dist,build,dist-*}/'",
     "set:version": "yarn o3r-set-version --placeholder 0.0.0-placeholder --include '{apps,packages}/**/dist/{package,manifest}.json'",

--- a/packages/@o3r/core/package.json
+++ b/packages/@o3r/core/package.json
@@ -166,7 +166,7 @@
     "@ngrx/router-store": "~19.1.0",
     "@ngrx/store": "~19.1.0",
     "@ngrx/store-devtools": "~19.1.0",
-    "@nx/eslint-plugin": "~20.6.0",
+    "@nx/eslint-plugin": "~20.7.0",
     "@o3r/store-sync": "workspace:^",
     "@stylistic/eslint-plugin": "~3.1.0",
     "@types/jest": "~29.5.2",
@@ -189,7 +189,7 @@
     "jest-junit": "~16.0.0",
     "jest-preset-angular": "~14.5.0",
     "jsonc-eslint-parser": "~2.4.0",
-    "nx": "~20.6.0",
+    "nx": "~20.7.0",
     "typescript-eslint": "~8.29.0",
     "zone.js": "~0.15.0"
   },


### PR DESCRIPTION
## Proposed change

Run `yarn install` after the `postinstall` scripts.
