### PR TITLE
fix(sdk): generation of the SDK in a monorepo

### DIFF
--- a/packages/@ama-sdk/schematics/package.json
+++ b/packages/@ama-sdk/schematics/package.json
@@ -140,18 +140,19 @@
     "typescript-eslint": "~8.29.0"
   },
   "generatorDependencies": {
+    "@angular-eslint/eslint-plugin": "^19.0.0",
+    "@commitlint/cli": "^19.0.0",
+    "@commitlint/config-conventional": "^19.0.0",
     "@swc/cli": "~0.6.0",
     "@swc/core": "~1.11.0",
     "@swc/helpers": "~0.5.0",
-    "@commitlint/cli": "^19.0.0",
-    "@commitlint/config-conventional": "^19.0.0",
     "@typescript-eslint/eslint-plugin": "~8.29.0",
     "jest-junit": "~16.0.0",
     "lint-staged": "^15.0.0",
     "minimist": "^1.2.6",
     "rimraf": "^6.0.1",
-    "typedoc": "~0.28.0",
     "tsc-watch": "^6.0.4",
+    "typedoc": "~0.28.0",
     "yaml-eslint-parser": "^1.2.2"
   },
   "openApiSupportedVersion": "^7.11.0",

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/index.ts
@@ -105,7 +105,7 @@ function ngGenerateTypescriptSDKFn(options: NgGenerateTypescriptSDKShellSchemati
       sdkCoreRange: `${options.exactO3rVersion ? '' : '~'}${amaSdkSchematicsPackageJson.version}`,
       sdkCoreVersion: amaSdkSchematicsPackageJson.version,
       angularVersion: amaSdkSchematicsPackageJson.dependencies!['@angular-devkit/core'],
-      angularEslintVersion: amaSdkSchematicsPackageJson.devDependencies!['@angular-eslint/eslint-plugin'],
+      angularEslintVersion: amaSdkSchematicsPackageJson.generatorDependencies['@angular-eslint/eslint-plugin'],
       versions,
       ...openApiSupportedVersion ? { openApiSupportedVersion } : {},
       engineVersions,

--- a/packages/@o3r/workspace/schematics/sdk/index.ts
+++ b/packages/@o3r/workspace/schematics/sdk/index.ts
@@ -1,5 +1,6 @@
 import {
   existsSync,
+  readFileSync,
 } from 'node:fs';
 import * as path from 'node:path';
 import {
@@ -9,13 +10,11 @@ import {
   MergeStrategy,
   mergeWith,
   move,
-  noop,
   renameTemplateFiles,
   Rule,
-  SchematicContext,
   strings,
+  type TaskId,
   template,
-  Tree,
   url,
 } from '@angular-devkit/schematics';
 import {
@@ -24,13 +23,22 @@ import {
 } from '@angular-devkit/schematics/tasks';
 import {
   createOtterSchematic,
+  type DependencyToAdd,
   getPackageManager,
   getPackagesBaseRootFolder,
   getWorkspaceConfig,
   isNxContext,
+  isPackageInstalled,
   NpmExecTask,
   O3rCliError,
+  setupDependencies,
 } from '@o3r/schematics';
+import {
+  NodeDependencyType,
+} from '@schematics/angular/utility/dependencies';
+import type {
+  PackageJson,
+} from 'type-fest';
 import {
   cleanStandaloneFiles,
 } from './rules/clean-standalone.rule';
@@ -56,6 +64,26 @@ function generateSdkFn(options: NgGenerateSdkSchema): Rule {
   const scope = strings.dasherize(splitName.length > 1 ? splitName[0].replace(/^@/, '') : options.name);
   const projectName = splitName?.length === 2 ? strings.dasherize(splitName[1]) : 'sdk';
   const cleanName = strings.dasherize(options.name).replace(/^@/, '').replaceAll(/\//g, '-');
+  const ownPackageJsonContent = JSON.parse(readFileSync(path.resolve(__dirname, '..', '..', 'package.json'), { encoding: 'utf8' })) as PackageJson;
+
+  const o3rDevPackageToInstall: string[] = [];
+  if (isPackageInstalled('@o3r/eslint-config')) {
+    o3rDevPackageToInstall.push('@o3r/eslint-config');
+  }
+  const dependencies = {
+    ...o3rDevPackageToInstall.reduce((acc, dep) => {
+      acc[dep] = {
+        inManifest: [
+          {
+            range: `${options.exactO3rVersion ? '' : '~'}${ownPackageJsonContent.version!}`,
+            types: [NodeDependencyType.Dev]
+          }
+        ],
+        ngAddOptions: { exactO3rVersion: options.exactO3rVersion }
+      };
+      return acc;
+    }, {} as Record<string, DependencyToAdd>)
+  };
 
   return (tree, context) => {
     const isNx = isNxContext(tree);
@@ -87,6 +115,30 @@ function generateSdkFn(options: NgGenerateSdkSchema): Rule {
       }
     }
     const specPath = options.specPackageName ? `openapi${specExtension}` : options.specPath;
+    const specUpgradeTask: TaskId[] = [];
+    const sdkGenerationTasks: TaskId[] = [];
+    if (specPath) {
+      const installTask = context.addTask(new NodePackageInstallTask());
+      if (options.specPackageName) {
+        specUpgradeTask.push(
+          context.addTask(new NpmExecTask('amasdk-update-spec-from-npm', [
+            options.specPackageName,
+            ...options.specPackagePath ? ['--package-path', options.specPackagePath] : [],
+            '--output', path.join(process.cwd(), targetPath, `openapi${specExtension}`)
+          ], targetPath), [installTask])
+        );
+      }
+      const generationTask = context.addTask(new RunSchematicTask('@ama-sdk/schematics', 'typescript-core', {
+        ...options,
+        specPath,
+        directory: targetPath,
+        packageManager
+      }), [
+        installTask,
+        ...specUpgradeTask
+      ]);
+      sdkGenerationTasks.push(installTask, ...specUpgradeTask, generationTask);
+    }
     return chain([
       externalSchematic('@ama-sdk/schematics', 'typescript-shell', {
         ...options,
@@ -100,29 +152,13 @@ function generateSdkFn(options: NgGenerateSdkSchema): Rule {
       updateTsConfig(targetPath, projectName, scope),
       cleanStandaloneFiles(targetPath),
       addModuleSpecificFiles(),
-      specPath
-        ? (_host: Tree, c: SchematicContext) => {
-          const installTask = c.addTask(new NodePackageInstallTask());
-          const specUpgradeTask = options.specPackageName
-            ? [
-              c.addTask(new NpmExecTask('amasdk-update-spec-from-npm', [
-                options.specPackageName,
-                ...options.specPackagePath ? ['--package-path', options.specPackagePath] : [],
-                '--output', path.join(process.cwd(), targetPath, `openapi${specExtension}`)
-              ], targetPath), [installTask])
-            ]
-            : [];
-          c.addTask(new RunSchematicTask('@ama-sdk/schematics', 'typescript-core', {
-            ...options,
-            specPath,
-            directory: targetPath,
-            packageManager
-          }), [
-            installTask,
-            ...specUpgradeTask
-          ]);
-        }
-        : noop
+      setupDependencies({
+        dependencies,
+        skipInstall: options.skipInstall,
+        ngAddToRun: Object.keys(dependencies),
+        projectName: cleanName,
+        runAfterTasks: sdkGenerationTasks
+      })
     ])(tree, context);
   };
 }

--- a/packages/@o3r/workspace/schematics/sdk/rules/clean-standalone.rule.ts
+++ b/packages/@o3r/workspace/schematics/sdk/rules/clean-standalone.rule.ts
@@ -38,11 +38,12 @@ export function cleanStandaloneFiles(targetPath: string): Rule {
     (tree) => {
       const packageJson = tree.readJson(posix.join(targetPath, 'package.json')) as PackageJson;
       if (packageJson.scripts) {
-        const excludedScripts = ['postinstall', 'set:version'];
+        const excludedScripts = ['postinstall', 'set:version', 'tools:changelog'];
         packageJson.scripts = Object.fromEntries(
           Object.entries(packageJson.scripts).filter(([scriptName]) => !excludedScripts.includes(scriptName))
         );
       }
+      delete packageJson['lint-staged'];
       if (packageJson.devDependencies) {
         packageJson.devDependencies = Object.fromEntries(Object.entries(packageJson.devDependencies).filter(([depName]) => depName !== '@o3r/workspace'));
       }

--- a/packages/@o3r/workspace/schematics/sdk/rules/update-ts-paths.rule.ts
+++ b/packages/@o3r/workspace/schematics/sdk/rules/update-ts-paths.rule.ts
@@ -1,3 +1,6 @@
+import {
+  basename,
+} from 'node:path';
 import type {
   Rule,
 } from '@angular-devkit/schematics';
@@ -33,14 +36,14 @@ export function updateTsConfig(targetPath: string, projectName: string, scope: s
     configWithPath.content.compilerOptions.baseUrl ||= '.';
     configWithPath.content.compilerOptions.paths ||= {};
     configWithPath.content.compilerOptions.paths[`${scope ? `@${scope}/` : ''}${projectName}`] = [
-      `${relativeTargetPath}/dist`,
+      ...(basename(configWithPath.tsconfig) === 'tsconfig.build.json' ? [`${relativeTargetPath}/dist`] : []),
       `${relativeTargetPath}/src/index`
     ];
     configWithPath.content.compilerOptions.paths[`${scope ? `@${scope}/` : ''}${projectName}/fixtures`] = [
       `${relativeTargetPath}/src/fixtures/jest`
     ];
     configWithPath.content.compilerOptions.paths[`${scope ? `@${scope}/` : ''}${projectName}/*`] = [
-      `${relativeTargetPath}/dist/*`,
+      ...(basename(configWithPath.tsconfig) === 'tsconfig.build.json' ? [`${relativeTargetPath}/dist/*`] : []),
       `${relativeTargetPath}/src/*`
     ];
 


### PR DESCRIPTION
## Proposed change

fix(sdk): generation of the SDK in a monorepo

### Includes

- [x] setup-test.ts file not generated and referenced in the 'jest.config.js' generated file
- [x] eslint config generated as standalone (only one file instead of 2 - local + config) - to be checked which rules to add by default
- [x] lint-staged not needed in the package.json of the sdk generated (it exists already at the root)
- [x] paths in tsconfig wrong generated, src paths should be in base tsconfig and dist paths should be in a prod tsconfig file
- [x] wrong versions for dependnecies
"@angular-eslint/eslint-plugin": "",
"@angular-eslint/eslint-plugin-template": "",
"@angular-eslint/utils": "",
- [x] tools:changelog script not needed in the project

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

<!-- * :bug: Fix #issue -->
* :bug: Fix resolves #3094
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
