### PR TITLE
chore(renovate): use matchPackageNames instead of matchPackagePrefixes and matchPackagePatterns

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -85,8 +85,8 @@
     {
       // This rule disable the upgrade of the gaurav-nelson/github-action-markdown-link-check
       // TODO: re-activate the upgrade when the following issue is fixed: gaurav-nelson/github-action-markdown-link-check#200
-      "matchPackagePatterns": [
-        ".*markdown-link-check"
+      "matchPackageNames": [
+        "/.*markdown-link-check/"
       ],
       "enabled": false
     },

--- a/tools/@o3r/workspace-helpers/scripts/create-monorepo-scope.mjs
+++ b/tools/@o3r/workspace-helpers/scripts/create-monorepo-scope.mjs
@@ -69,7 +69,7 @@ const updateRenovateGroup = async (scopeName) => {
 
   const renovateGroup = JSON.parse(await readFile(renovateGroupPath, { encoding: 'utf8' }));
   renovateGroup.packageRules
-    .forEach(({ matchPackagePrefixes }) => matchPackagePrefixes.push(`@${scopeName}`));
+    .forEach(({ matchPackageNames }) => matchPackageNames.push(`/^@${scopeName}/`));
 
   await writeFile(renovateGroupPath, JSON.stringify(renovateGroup, null, 2) + '\n');
 };

--- a/tools/renovate/README.md
+++ b/tools/renovate/README.md
@@ -7,6 +7,11 @@
 
 Otter framework provides a set of Renovate presets to facilitate the setup and reduce the boilerplate in your `.renovaterc.json`
 
+> [!WARNING]
+> Since Otter v12.3, our presets only support Renovate >= 38
+> If you want to use our presets with Renovate < 38,
+> you can lock the version of the presets used thanks to the [#vX.Y.Z suffix](https://docs.renovatebot.com/config-presets/#preset-hosting).
+
 ## Available presets
 
 | Preset                                  | Parameters                         | Description                                                                                        |

--- a/tools/renovate/branching-strategy/release-branches.json
+++ b/tools/renovate/branching-strategy/release-branches.json
@@ -3,7 +3,7 @@
   "description": "Rules to reduce impacted updates on release branches",
   "packageRules": [
     {
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "*"
       ],
       "rangeStrategy": "replace"

--- a/tools/renovate/group/angular.json
+++ b/tools/renovate/group/angular.json
@@ -3,16 +3,16 @@
   "description": "Group all Angular dependencies",
   "packageRules": [
     {
-      "matchPackagePatterns": [
-        "^@angular",
-        "^ng-packagr",
-        "^@schematics",
-        "angular",
-        "^@ngrx",
-        "^zone.js",
-        "^@nrwl",
-        "^@nx",
-        "^nx"
+      "matchPackageNames": [
+        "/^@angular/",
+        "/^ng-packagr/",
+        "/^@schematics/",
+        "/angular/",
+        "/^@ngrx/",
+        "/^zone.js/",
+        "/^@nrwl/",
+        "/^@nx/",
+        "/^nx/"
       ],
       "groupName": "Angular dependencies",
       "groupSlug": "angular-dependencies"

--- a/tools/renovate/group/design-factory.json
+++ b/tools/renovate/group/design-factory.json
@@ -3,13 +3,13 @@
   "description": "Group all design factory dependencies",
   "packageRules": [
     {
-      "matchPackagePatterns": [
-        "bootstrap",
-        "^@ng-select",
-        "^ag-grid-",
-        "^@design-factory",
-        "^@agnos-ui",
-        "^@amadeus-it-group/tansu"
+      "matchPackageNames": [
+        "/bootstrap/",
+        "/^@ng-select/",
+        "/^ag-grid-/",
+        "/^@design-factory/",
+        "/^@agnos-ui/",
+        "/^@amadeus-it-group\/tansu/"
       ],
       "groupName": "Design Factory dependencies",
       "groupSlug": "design-factory-dependencies"

--- a/tools/renovate/group/otter.json
+++ b/tools/renovate/group/otter.json
@@ -5,13 +5,13 @@
     {
       "groupName": "Otter dependencies",
       "groupSlug": "otter-dependencies",
-      "matchPackagePrefixes": [
-        "@otter",
-        "@o3r",
-        "@ama-sdk",
-        "@ama-terasu",
-        "@o3r-training",
-        "@ama-mfe"
+      "matchPackageNames": [
+        "/^@otter/",
+        "/^@o3r/",
+        "/^@ama-sdk/",
+        "/^@ama-terasu/",
+        "/^@o3r-training/",
+        "/^@ama-mfe/"
       ]
     },
     {
@@ -19,13 +19,13 @@
         "main",
         "master"
       ],
-      "matchPackagePrefixes": [
-        "@otter",
-        "@o3r",
-        "@ama-sdk",
-        "@ama-terasu",
-        "@o3r-training",
-        "@ama-mfe"
+      "matchPackageNames": [
+        "/^@otter/",
+        "/^@o3r/",
+        "/^@ama-sdk/",
+        "/^@ama-terasu/",
+        "/^@o3r-training/",
+        "/^@ama-mfe/"
       ],
       "rangeStrategy": "bump"
     },
@@ -33,13 +33,13 @@
       "matchBaseBranches": [
         "/^release/.*/"
       ],
-      "matchPackagePrefixes": [
-        "@otter",
-        "@o3r",
-        "@ama-sdk",
-        "@ama-terasu",
-        "@o3r-training",
-        "@ama-mfe"
+      "matchPackageNames": [
+        "/^@otter/",
+        "/^@o3r/",
+        "/^@ama-sdk/",
+        "/^@ama-terasu/",
+        "/^@o3r-training/",
+        "/^@ama-mfe/"
       ],
       "rangeStrategy": "patch"
     }

--- a/tools/renovate/group/typescript.json
+++ b/tools/renovate/group/typescript.json
@@ -3,9 +3,9 @@
   "description": "Group all Typescript dependencies",
   "packageRules": [
     {
-      "matchPackagePatterns": [
-        "typescript",
-        "tslib"
+      "matchPackageNames": [
+        "/typescript/",
+        "/tslib/"
       ],
       "groupName": "Typescript dependencies",
       "groupSlug": "typescript-dependencies"

--- a/tools/renovate/tasks/sdk-regenerate.json
+++ b/tools/renovate/tasks/sdk-regenerate.json
@@ -3,8 +3,8 @@
   "description": "Trigger SDK regeneration on @ama-sdk update. Need to pass the package manager as a parameter (yarn, npm).",
   "packageRules": [
     {
-      "matchPackagePrefixes": [
-        "@ama-sdk"
+      "matchPackageNames": [
+        "/^@ama-sdk/"
       ],
       "postUpgradeTasks": {
         "commands": [


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
