### PR TITLE
feat(ama-sdk-schematics): ignore editorconfig rules

### DIFF
--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/api/.editorconfig.template
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/api/.editorconfig.template
@@ -1,0 +1,2 @@
+# Exclude folder from project EditorConfig rules
+root = true

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/models/base/.editorconfig.template
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/models/base/.editorconfig.template
@@ -1,0 +1,2 @@
+# Exclude folder from project EditorConfig rules
+root = true

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/spec/.editorconfig.template
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/src/spec/.editorconfig.template
@@ -1,0 +1,2 @@
+# Exclude folder from project EditorConfig rules
+root = true


### PR DESCRIPTION
feat(ama-sdk-schematics): ignore editorconfig rules for generated folders
 
## Proposed change

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
* :rocket: Feature resolves #3106
<!-- * :octocat: Pull Request #issue -->
