### PR TITLE
Bump `@amadeus-it-group/microfrontends` to `0.0.7`

### DIFF
--- a/packages/@ama-mfe/messages/package.json
+++ b/packages/@ama-mfe/messages/package.json
@@ -32,7 +32,7 @@
     "tslib": "^2.6.2"
   },
   "peerDependencies": {
-    "@amadeus-it-group/microfrontends": "0.0.5"
+    "@amadeus-it-group/microfrontends": "0.0.7"
   },
   "peerDependenciesMeta": {
     "@amadeus-it-group/microfrontends": {
@@ -40,7 +40,7 @@
     }
   },
   "devDependencies": {
-    "@amadeus-it-group/microfrontends": "0.0.5",
+    "@amadeus-it-group/microfrontends": "0.0.7",
     "@compodoc/compodoc": "^1.1.19",
     "@eslint-community/eslint-plugin-eslint-comments": "^4.4.0",
     "@nx/eslint-plugin": "~20.7.0",

--- a/packages/@ama-mfe/messages/src/messages/navigation/navigation.versions.ts
+++ b/packages/@ama-mfe/messages/src/messages/navigation/navigation.versions.ts
@@ -1,5 +1,5 @@
 import type {
-  Message,
+  VersionedMessage,
 } from '@amadeus-it-group/microfrontends';
 import type {
   NAVIGATION_MESSAGE_TYPE,
@@ -10,7 +10,7 @@ import type {
  * Used in microfrontend architecture based on iframes where an iframe change its url and notify its parent with the url change
  * The parent should update its own url with the information received in order to allow the refresh and the deep link share
  */
-export interface NavigationV1_0 extends Message {
+export interface NavigationV1_0 extends VersionedMessage {
   /** @inheritdoc */
   type: typeof NAVIGATION_MESSAGE_TYPE;
   /** @inheritdoc */

--- a/packages/@ama-mfe/messages/src/messages/resize/resize.versions.ts
+++ b/packages/@ama-mfe/messages/src/messages/resize/resize.versions.ts
@@ -1,5 +1,5 @@
 import type {
-  Message,
+  VersionedMessage,
 } from '@amadeus-it-group/microfrontends';
 import type {
   RESIZE_MESSAGE_TYPE,
@@ -12,7 +12,7 @@ import type {
  * This message contain the height of the content of an iframe and is sent to the parent of the iframe, so the parent can adjust the height of the iframe.
  * This will avoid a scroll bar on the iframe. If there will be a scroll bar that will be only on the parent
  */
-export interface ResizeV1_0 extends Message {
+export interface ResizeV1_0 extends VersionedMessage {
   /** The type of a resize message */
   type: typeof RESIZE_MESSAGE_TYPE;
   /** The version of this message */

--- a/packages/@ama-mfe/messages/src/messages/theme/theme.versions.ts
+++ b/packages/@ama-mfe/messages/src/messages/theme/theme.versions.ts
@@ -1,5 +1,5 @@
 import type {
-  Message,
+  VersionedMessage,
 } from '@amadeus-it-group/microfrontends';
 import type {
   THEME_MESSAGE_TYPE,
@@ -10,7 +10,7 @@ import type {
  * Theme message object sent via communication protocol.
  * It contains the theme name and the theme deffinition
  */
-export interface ThemeV1_0 extends Message, ThemeStructure {
+export interface ThemeV1_0 extends VersionedMessage, ThemeStructure {
   /** The type of a theme message */
   type: typeof THEME_MESSAGE_TYPE;
   /** The version of this message */

--- a/packages/@ama-mfe/ng-utils/package.json
+++ b/packages/@ama-mfe/ng-utils/package.json
@@ -6,8 +6,8 @@
   },
   "peerDependencies": {
     "@ama-mfe/messages": "workspace:^",
-    "@amadeus-it-group/microfrontends": "0.0.5",
-    "@amadeus-it-group/microfrontends-angular": "0.0.5",
+    "@amadeus-it-group/microfrontends": "0.0.7",
+    "@amadeus-it-group/microfrontends-angular": "0.0.7",
     "@angular-devkit/core": "~19.2.0",
     "@angular-devkit/schematics": "~19.2.0",
     "@angular/common": "^19.0.0",
@@ -19,8 +19,8 @@
     "rxjs": "^7.8.1"
   },
   "dependencies": {
-    "@amadeus-it-group/microfrontends": "0.0.5",
-    "@amadeus-it-group/microfrontends-angular": "0.0.5",
+    "@amadeus-it-group/microfrontends": "0.0.7",
+    "@amadeus-it-group/microfrontends-angular": "0.0.7",
     "@o3r/logger": "workspace:^",
     "tslib": "^2.6.2"
   },

--- a/packages/@ama-mfe/ng-utils/src/connect/connect.providers.ts
+++ b/packages/@ama-mfe/ng-utils/src/connect/connect.providers.ts
@@ -25,7 +25,11 @@ import {
  */
 export function provideConnection(connectionConfig: ConnectionConfig) {
   persistHostInfo();
-  const config: MessagePeerConfig = { id: connectionConfig.id, knownMessages: [...KNOWN_MESSAGES, ...(connectionConfig.knownMessages || [])] };
+  const config: MessagePeerConfig = {
+    id: connectionConfig.id,
+    messageCheckStrategy: 'version',
+    knownMessages: [...KNOWN_MESSAGES, ...(connectionConfig.knownMessages || [])]
+  };
   return makeEnvironmentProviders([
     {
       provide: MESSAGE_PEER_CONFIG, useValue: config

--- a/packages/@ama-mfe/ng-utils/src/managers/consumer.manager.service.ts
+++ b/packages/@ama-mfe/ng-utils/src/managers/consumer.manager.service.ts
@@ -1,6 +1,6 @@
 import {
-  Message,
   RoutedMessage,
+  VersionedMessage,
 } from '@amadeus-it-group/microfrontends';
 import {
   MessagePeerService,
@@ -61,7 +61,7 @@ export class ConsumerManagerService {
    * Consume a received message
    * @param message the received message body
    */
-  private async consumeMessage(message: RoutedMessage<Message>) {
+  private async consumeMessage(message: RoutedMessage<VersionedMessage>) {
     if (isErrorMessage(message.payload)) {
       const isHandled = await this.producerManagerService.dispatchError(message.payload);
       if (!isHandled) {
@@ -78,7 +78,7 @@ export class ConsumerManagerService {
    * Handle error messages of internal communication protocol messages
    * @param message message to consume
    */
-  private async consumeAdditionalMessage(message: RoutedMessage<Message>) {
+  private async consumeAdditionalMessage(message: RoutedMessage<VersionedMessage>) {
     if (!message.payload) {
       this.logger.warn('Cannot consume a messages with undefined payload.');
       return;

--- a/packages/@ama-mfe/ng-utils/src/managers/interfaces.ts
+++ b/packages/@ama-mfe/ng-utils/src/managers/interfaces.ts
@@ -1,6 +1,6 @@
 import type {
-  Message,
   RoutedMessage,
+  VersionedMessage,
 } from '@amadeus-it-group/microfrontends';
 import type {
   ErrorContent,
@@ -10,18 +10,18 @@ import type {
  * Use the message payload to execute an action based on message type
  * @param message message to consume
  */
-export type MessageCallback<T extends Message> = (message: RoutedMessage<T>) => void | Promise<void>;
+export type MessageCallback<T extends VersionedMessage> = (message: RoutedMessage<T>) => void | Promise<void>;
 
 /**
  * Description of the accepted messages versions and their callbacks for a given message type
  */
-export interface MessageVersions<T extends Message> {
+export interface MessageVersions<T extends VersionedMessage> {
   /** The message callback coresponding to the version */
   [version: string]: MessageCallback<T>;
 }
 
 /** Description for the base message consumer */
-export interface BasicMessageConsumer<T extends Message = Message> {
+export interface BasicMessageConsumer<T extends VersionedMessage = VersionedMessage> {
   /** Contains the message type */
   type: T['type'];
   /** A map of messages versions and their callbacks */
@@ -29,7 +29,7 @@ export interface BasicMessageConsumer<T extends Message = Message> {
 }
 
 /** The consumer of a given message type */
-export interface MessageConsumer<T extends Message> extends BasicMessageConsumer {
+export interface MessageConsumer<T extends VersionedMessage> extends BasicMessageConsumer {
 
   /** The message type which will be handled */
   type: T['type'];
@@ -50,7 +50,7 @@ export interface MessageConsumer<T extends Message> extends BasicMessageConsumer
 /**
  * Definition of a message producer and which types of messages are produced
  */
-export interface MessageProducer<T extends Message = Message> {
+export interface MessageProducer<T extends VersionedMessage = VersionedMessage> {
   /** The types of the produced message */
   types: T['type'] | T['type'][];
 

--- a/packages/@ama-mfe/ng-utils/src/managers/producer.manager.service.spec.ts
+++ b/packages/@ama-mfe/ng-utils/src/managers/producer.manager.service.spec.ts
@@ -1,7 +1,4 @@
 import {
-  Message,
-} from '@amadeus-it-group/microfrontends';
-import {
   TestBed,
 } from '@angular/core/testing';
 import type {
@@ -54,7 +51,7 @@ describe('ProducerManagerService', () => {
   it('should dispatch error messages', async () => {
     const producer: MessageProducer = { types: ['test'], handleError: jest.fn().mockResolvedValue(true) };
     service.register(producer);
-    const message: ErrorContent<Message> = { source: { type: 'test', version: '1.0' }, reason: 'unknown_type' };
+    const message: ErrorContent = { source: { type: 'test', version: '1.0' }, reason: 'unknown_type' };
     const result = await service.dispatchError(message);
     expect(result).toBe(true);
     expect(producer.handleError).toHaveBeenCalledWith(message);
@@ -65,7 +62,7 @@ describe('ProducerManagerService', () => {
     const producer2: MessageProducer = { types: ['test', 'test2'], handleError: jest.fn().mockResolvedValue(true) };
     service.register(producer);
     service.register(producer2);
-    const message: ErrorContent<Message> = { source: { type: 'test', version: '1.0' }, reason: 'unknown_type' };
+    const message: ErrorContent = { source: { type: 'test', version: '1.0' }, reason: 'unknown_type' };
     const result = await service.dispatchError(message);
     expect(result).toBe(true);
     expect(producer.handleError).toHaveBeenCalledWith(message);
@@ -73,7 +70,7 @@ describe('ProducerManagerService', () => {
   });
 
   it('should return false if no producers handle the error message', async () => {
-    const message: ErrorContent<Message> = { source: { type: 'test', version: '1.0' }, reason: 'unknown_type' };
+    const message: ErrorContent = { source: { type: 'test', version: '1.0' }, reason: 'unknown_type' };
     const result = await service.dispatchError(message);
     expect(result).toBe(false);
   });

--- a/packages/@ama-mfe/ng-utils/src/managers/producer.manager.service.ts
+++ b/packages/@ama-mfe/ng-utils/src/managers/producer.manager.service.ts
@@ -1,5 +1,5 @@
 import type {
-  Message,
+  VersionedMessage,
 } from '@amadeus-it-group/microfrontends';
 import {
   Injectable,
@@ -44,7 +44,7 @@ export class ProducerManagerService {
    * @param message - The error message to handle.
    * @returns - A promise that resolves to true if the error was handled by at least one handler, false otherwise.
    */
-  public async dispatchError<T extends Message = Message>(message: ErrorContent<T>) {
+  public async dispatchError<T extends VersionedMessage = VersionedMessage>(message: ErrorContent<T>) {
     const handlers = this.producers
       .filter(({ types }) => (Array.isArray(types) ? types : [types]).includes(message.source.type));
 

--- a/packages/@ama-mfe/ng-utils/src/messages/error.sender.spec.ts
+++ b/packages/@ama-mfe/ng-utils/src/messages/error.sender.spec.ts
@@ -1,6 +1,6 @@
 import type {
-  MessagePeerType,
-} from '@amadeus-it-group/microfrontends';
+  MessagePeerServiceType,
+} from '@amadeus-it-group/microfrontends-angular';
 import type {
   ErrorContent,
 } from './error/index';
@@ -13,7 +13,7 @@ describe('sendError', () => {
   it('should send an error message with the correct content', () => {
     const mockPeer = {
       send: jest.fn()
-    } as unknown as MessagePeerType<any>;
+    } as unknown as MessagePeerServiceType<any>;
     const content: ErrorContent = {
       reason: 'unknown_type',
       source: { type: 'my_type', version: '1' }

--- a/packages/@ama-mfe/ng-utils/src/messages/error.sender.ts
+++ b/packages/@ama-mfe/ng-utils/src/messages/error.sender.ts
@@ -1,7 +1,9 @@
 import type {
-  Message,
-  MessagePeerType,
+  VersionedMessage,
 } from '@amadeus-it-group/microfrontends';
+import type {
+  MessagePeerServiceType,
+} from '@amadeus-it-group/microfrontends-angular';
 import type {
   ERROR_MESSAGE_TYPE,
   ErrorContent,
@@ -13,7 +15,7 @@ import type {
  * @param peer The endpoint sending the message
  * @param content the content of the error message to be sent
  */
-export const sendError = (peer: Pick<MessagePeerType<any>, 'send'>, content: ErrorContent) => {
+export const sendError = (peer: MessagePeerServiceType<any>, content: ErrorContent) => {
   return peer.send({
     type: 'error',
     version: '1.0',
@@ -26,4 +28,4 @@ export const sendError = (peer: Pick<MessagePeerType<any>, 'send'>, content: Err
  * @param message the message to be checked
  */
 // eslint-disable-next-line @stylistic/max-len -- constant definition
-export const isErrorMessage = (message: any): message is Message & { type: typeof ERROR_MESSAGE_TYPE } & ErrorContent => (message && typeof message === 'object' && message.type === 'error' && !!message.reason);
+export const isErrorMessage = (message: any): message is VersionedMessage & { type: typeof ERROR_MESSAGE_TYPE } & ErrorContent => (message && typeof message === 'object' && message.type === 'error' && !!message.reason);

--- a/packages/@ama-mfe/ng-utils/src/messages/error/base.ts
+++ b/packages/@ama-mfe/ng-utils/src/messages/error/base.ts
@@ -1,5 +1,5 @@
 import type {
-  Message,
+  VersionedMessage,
 } from '@amadeus-it-group/microfrontends';
 
 /** the error message type */
@@ -14,7 +14,7 @@ export type ErrorReason = 'unknown_type' | 'version_mismatch' | 'internal_error'
  * The content of an error message.
  * @template S - The type of the source message.
  */
-export interface ErrorContent<S extends Message = Message> {
+export interface ErrorContent<S extends VersionedMessage = VersionedMessage> {
   /** The reason for the error */
   reason: ErrorReason;
   /** The source message that caused the error */

--- a/packages/@ama-mfe/ng-utils/src/messages/error/error.versions.ts
+++ b/packages/@ama-mfe/ng-utils/src/messages/error/error.versions.ts
@@ -1,12 +1,12 @@
 import type {
-  Message,
+  VersionedMessage,
 } from '@amadeus-it-group/microfrontends';
 import type {
   ErrorContent,
 } from './base';
 
 /** An error message with the version 1.0 */
-export interface ErrorMessageV1_0<S extends Message = Message> extends Message, ErrorContent<S> {
+export interface ErrorMessageV1_0<S extends VersionedMessage = VersionedMessage> extends VersionedMessage, ErrorContent<S> {
   /** @inheritdoc */
   type: 'error';
   /** @inheritdoc */

--- a/yarn.lock
+++ b/yarn.lock
@@ -276,7 +276,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@ama-mfe/messages@workspace:packages/@ama-mfe/messages"
   dependencies:
-    "@amadeus-it-group/microfrontends": "npm:0.0.5"
+    "@amadeus-it-group/microfrontends": "npm:0.0.7"
     "@compodoc/compodoc": "npm:^1.1.19"
     "@eslint-community/eslint-plugin-eslint-comments": "npm:^4.4.0"
     "@nx/eslint-plugin": "npm:~20.7.0"
@@ -319,7 +319,7 @@ __metadata:
     typescript: "npm:~5.8.2"
     typescript-eslint: "npm:~8.29.0"
   peerDependencies:
-    "@amadeus-it-group/microfrontends": 0.0.5
+    "@amadeus-it-group/microfrontends": 0.0.7
   peerDependenciesMeta:
     "@amadeus-it-group/microfrontends":
       optional: true
@@ -331,8 +331,8 @@ __metadata:
   resolution: "@ama-mfe/ng-utils@workspace:packages/@ama-mfe/ng-utils"
   dependencies:
     "@ama-mfe/messages": "workspace:^"
-    "@amadeus-it-group/microfrontends": "npm:0.0.5"
-    "@amadeus-it-group/microfrontends-angular": "npm:0.0.5"
+    "@amadeus-it-group/microfrontends": "npm:0.0.7"
+    "@amadeus-it-group/microfrontends-angular": "npm:0.0.7"
     "@angular-devkit/architect": "npm:~0.1902.0"
     "@angular-devkit/build-angular": "npm:~19.2.0"
     "@angular-devkit/core": "npm:~19.2.0"
@@ -382,8 +382,8 @@ __metadata:
     zone.js: "npm:~0.15.0"
   peerDependencies:
     "@ama-mfe/messages": "workspace:^"
-    "@amadeus-it-group/microfrontends": 0.0.5
-    "@amadeus-it-group/microfrontends-angular": 0.0.5
+    "@amadeus-it-group/microfrontends": 0.0.7
+    "@amadeus-it-group/microfrontends-angular": 0.0.7
     "@angular-devkit/core": ~19.2.0
     "@angular-devkit/schematics": ~19.2.0
     "@angular/common": ^19.0.0
@@ -1154,23 +1154,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@amadeus-it-group/microfrontends-angular@npm:0.0.5":
-  version: 0.0.5
-  resolution: "@amadeus-it-group/microfrontends-angular@npm:0.0.5"
+"@amadeus-it-group/microfrontends-angular@npm:0.0.7":
+  version: 0.0.7
+  resolution: "@amadeus-it-group/microfrontends-angular@npm:0.0.7"
   dependencies:
     tslib: "npm:^2.3.0"
   peerDependencies:
-    "@amadeus-it-group/microfrontends": 0.0.5
+    "@amadeus-it-group/microfrontends": 0.0.7
     "@angular/core": ^19.0.0
     rxjs: ^7.8.0
-  checksum: 10/99aa0fd580195589f18df613cb1d535843eb1634ed60be5801856d4d735a13109bef03ca8ce627fc0ed448635f30d168d044c60e656aa5f9bfaab88b4ce107ad
+  checksum: 10/411aa041dbe836f17c86634910d627bb74f4804cc245661a4bf82fb318d38ec1b822a27642cb23018ccf4c526cc0b26d931c5028efcf76ec4e1ee56574199dca
   languageName: node
   linkType: hard
 
-"@amadeus-it-group/microfrontends@npm:0.0.5":
-  version: 0.0.5
-  resolution: "@amadeus-it-group/microfrontends@npm:0.0.5"
-  checksum: 10/6ab66fef578eb472ae06b66ed50fe9d43c64948313306e42c2d784c49fa4c6cf81ce8b0b92043f2ad4c5dbdab986c9f32202aaf75aefdb5d313b4a207d5d8938
+"@amadeus-it-group/microfrontends@npm:0.0.7":
+  version: 0.0.7
+  resolution: "@amadeus-it-group/microfrontends@npm:0.0.7"
+  checksum: 10/222d61c15c5e8b135985a4dd432d2effc09ad1ff2c3b6d2d55d3da99c1029f450e5719339c53d58597fe7a80ac35e515b70434c87b424b35f8cc5cbb476b5f9c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- bump `@amadeus-it-group/microfrontends` to `0.0.7`
- use `VersionedMessage` instead of `Message` as `version` field became optional in `Message`
- use `messageCheckStrategy: 'version'` as message `type` and `version` checks became opt-in.