### PR TITLE
test(testing): fix o3r-testing unit tests

### DIFF
--- a/packages/@o3r/testing/schematics/playwright/sanity/index.spec.ts
+++ b/packages/@o3r/testing/schematics/playwright/sanity/index.spec.ts
@@ -46,7 +46,7 @@ describe('Playwright Sanity', () => {
     });
 
     it('should have the default template', () => {
-      expect(tree.readContent('/e2e-playwright/sanity/test-playwright-sanity.e2e.ts')).toContain('test.describe.serial');
+      expect(tree.readContent('/e2e-playwright/sanity/test-playwright-sanity.e2e.ts')).toContain('test.describe');
       expect(tree.readContent('/e2e-playwright/sanity/test-playwright-sanity.e2e.ts')).toContain('test(');
     });
   });


### PR DESCRIPTION
## Proposed change

Unit tests broken by https://github.com/AmadeusITGroup/otter/pull/3127
The PR passed due to an issue with `.nxignore` containing the template files

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
