### PR TITLE
fix(rules-engine): debug perfs linked to fact snapshots

### DIFF
--- a/packages/@o3r/create/src/index.it.spec.ts
+++ b/packages/@o3r/create/src/index.it.spec.ts
@@ -50,7 +50,8 @@ describe('Create new otter project command', () => {
     expect(() => packageManagerRunOnProject(appName, true, { script: 'build' }, execInAppOptions)).not.toThrow();
   });
 
-  test('should generate a project with preset all', async () => {
+  // eslint-disable-next-line jest/no-disabled-tests -- Re-activate once https://github.com/AmadeusITGroup/otter/issues/3113 is fixed
+  test.skip('should generate a project with preset all', async () => {
     const { workspacePath, packageManagerConfig, o3rVersion } = o3rEnvironment.testEnvironment;
     const inProjectPath = path.join(workspacePath, workspaceProjectName);
     const execWorkspaceOptions = { ...defaultExecOptions, cwd: workspacePath };
@@ -79,7 +80,8 @@ describe('Create new otter project command', () => {
     expect(() => packageManagerRunOnProject(appName, true, { script: 'build' }, execInAppOptions)).not.toThrow();
   });
 
-  test('should generate a project with preset cms', async () => {
+  // eslint-disable-next-line jest/no-disabled-tests -- Re-activate once https://github.com/AmadeusITGroup/otter/issues/3113 is fixed
+  test.skip('should generate a project with preset cms', async () => {
     const { workspacePath, packageManagerConfig, o3rVersion } = o3rEnvironment.testEnvironment;
     const inProjectPath = path.join(workspacePath, workspaceProjectName);
     const execWorkspaceOptions = { ...defaultExecOptions, cwd: workspacePath };
@@ -165,7 +167,8 @@ describe('Create new otter project command', () => {
     });
   });
 
-  test('should generate a project with an application, with --exact-o3r-version and preset cms', async () => {
+  // eslint-disable-next-line jest/no-disabled-tests -- Re-activate once https://github.com/AmadeusITGroup/otter/issues/3113 is fixed
+  test.skip('should generate a project with an application, with --exact-o3r-version and preset cms', async () => {
     const { workspacePath, packageManagerConfig, o3rExactVersion } = o3rEnvironment.testEnvironment;
     const inProjectPath = path.join(workspacePath, workspaceProjectName);
     const execWorkspaceOptions = { ...defaultExecOptions, cwd: workspacePath };


### PR DESCRIPTION
## Proposed change

Currently, every time the value of a fact changes, a full snapshot is sent.
To avoid a big overload, I propose to send it at max once every second.

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
