### PR TITLE
feat: moved schematics helpers to dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+!.vscode/mcp.json
 *.code-workspace
 
 # Local History for Visual Studio Code

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,8 @@
+{
+  "servers": {
+    "nx-mcp": {
+      "type": "sse",
+      "url": "http://localhost:9569/sse"
+    }
+  }
+}

--- a/apps/chrome-devtools/tsconfig.json
+++ b/apps/chrome-devtools/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../tsconfig.base",
   "references": [
@@ -10,6 +10,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/apps/github-cascading-app/tsconfig.json
+++ b/apps/github-cascading-app/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../tsconfig.base",
   "references": [
@@ -7,6 +7,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/apps/showcase/tsconfig.json
+++ b/apps/showcase/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../tsconfig.base",
   "references": [
@@ -10,6 +10,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/apps/vscode-extension/tsconfig.json
+++ b/apps/vscode-extension/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../tsconfig.base",
   "references": [
@@ -7,6 +7,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/eslint.local.config.mjs
+++ b/eslint.local.config.mjs
@@ -10,7 +10,10 @@ export default defineConfig([
     languageOptions: {
       sourceType: 'module',
       parserOptions: {
-        projectService: true
+        projectService: [
+          './**/tsconfig.json',
+          './**/tsconfig.eslint.json'
+        ]
       }
     }
   },

--- a/packages/@ama-mfe/ng-utils/package.json
+++ b/packages/@ama-mfe/ng-utils/package.json
@@ -22,6 +22,7 @@
     "@amadeus-it-group/microfrontends": "0.0.7",
     "@amadeus-it-group/microfrontends-angular": "0.0.7",
     "@o3r/logger": "workspace:^",
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "sideEffects": false,
@@ -52,7 +53,6 @@
     "@o3r/build-helpers": "workspace:^",
     "@o3r/eslint-config": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",
     "@types/jest": "~29.5.2",

--- a/packages/@ama-mfe/ng-utils/schematics/ng-add/index.ts
+++ b/packages/@ama-mfe/ng-utils/schematics/ng-add/index.ts
@@ -5,6 +5,14 @@ import {
   noop,
   Rule,
 } from '@angular-devkit/schematics';
+import {
+  applyEsLintFix,
+  createOtterSchematic,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  setupDependencies,
+} from '@o3r/schematics';
 import type {
   NgAddSchematicsSchema,
 } from './schema';
@@ -29,9 +37,7 @@ const dependenciesToNgAdd: string[] = [
  * @param options
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
-  return async (tree) => {
-    // use dynamic import to properly raise an exception if it is not an Otter project.
-    const { getProjectNewDependenciesTypes, getPackageInstallConfig, applyEsLintFix, getWorkspaceConfig, setupDependencies } = await import('@o3r/schematics');
+  return (tree) => {
     // current package version
     const version = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' })).version;
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
@@ -62,7 +68,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add module to an Angular Project
  * @param options ng add options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async () => {
-  const { createOtterSchematic } = await import('@o3r/schematics').catch(() => ({ createOtterSchematic: (ngAddCallback: (options: NgAddSchematicsSchema) => Rule) => ngAddCallback }));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@ama-mfe/ng-utils/src/ng-package.json
+++ b/packages/@ama-mfe/ng-utils/src/ng-package.json
@@ -6,5 +6,10 @@
   "lib": {
     "entryFile": "public_api.ts"
   },
-  "allowedNonPeerDependencies": ["@amadeus-it-group/microfrontends", "@amadeus-it-group/microfrontends-angular", "@o3r/logger"]
+  "allowedNonPeerDependencies": [
+    "@amadeus-it-group/microfrontends",
+    "@amadeus-it-group/microfrontends-angular",
+    "@o3r/logger",
+    "@o3r/schematics"
+  ]
 }

--- a/packages/@ama-mfe/ng-utils/tsconfig.json
+++ b/packages/@ama-mfe/ng-utils/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -10,6 +10,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@ama-sdk/client-angular/package.json
+++ b/packages/@ama-sdk/client-angular/package.json
@@ -38,6 +38,7 @@
     "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest"
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "@swc/helpers": "~0.5.0",
     "tslib": "^2.6.2",
     "uuid": "^11.0.5"
@@ -83,7 +84,6 @@
     "@nx/jest": "~20.7.0",
     "@o3r/build-helpers": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",
     "@stylistic/eslint-plugin": "~3.1.0",

--- a/packages/@ama-sdk/client-angular/schematics/ng-add/index.ts
+++ b/packages/@ama-sdk/client-angular/schematics/ng-add/index.ts
@@ -5,6 +5,17 @@ import {
   Rule,
 } from '@angular-devkit/schematics';
 import {
+  applyEsLintFix,
+  createOtterSchematic,
+  getExternalDependenciesVersionRange,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  setupDependencies,
+  updateImports,
+} from '@o3r/schematics';
+import {
   NodeDependencyType,
 } from '@schematics/angular/utility/dependencies';
 import {
@@ -18,31 +29,12 @@ const devDependenciesToInstall: string[] = [
 
 ];
 
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @ama-sdk/client-angular has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/schematics' as devDependency to be able to use this schematics. Please run 'ng add @o3r/schematics'.
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
-
 /**
  * Add SDk Angular Client to an Otter Project
  * @param options
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
-  return async (tree, context) => {
-    // use dynamic import to properly raise an exception if it is not an Otter project.
-    const {
-      getPackageInstallConfig,
-      applyEsLintFix,
-      setupDependencies,
-      getO3rPeerDeps,
-      getProjectNewDependenciesTypes,
-      getWorkspaceConfig,
-      getExternalDependenciesVersionRange,
-      updateImports
-    } = await import('@o3r/schematics');
-
+  return (tree, context) => {
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
     const depsInfo = getO3rPeerDeps(packageJsonPath);
@@ -86,9 +78,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add SDk Angular Client to an Otter Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@ama-sdk/client-angular/tsconfig.json
+++ b/packages/@ama-sdk/client-angular/tsconfig.json
@@ -7,6 +7,9 @@
     },
     {
       "path": "./tsconfig.build.json"
+    },
+    {
+      "path": "./tsconfig.builders.json"
     }
   ]
 }

--- a/packages/@ama-sdk/client-beacon/package.json
+++ b/packages/@ama-sdk/client-beacon/package.json
@@ -38,6 +38,7 @@
     "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest"
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "@swc/helpers": "~0.5.0",
     "tslib": "^2.6.2",
     "uuid": "^11.0.5"
@@ -82,7 +83,6 @@
     "@nx/jest": "~20.7.0",
     "@o3r/build-helpers": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",
     "@stylistic/eslint-plugin": "~3.1.0",

--- a/packages/@ama-sdk/client-beacon/schematics/ng-add/index.ts
+++ b/packages/@ama-sdk/client-beacon/schematics/ng-add/index.ts
@@ -5,6 +5,17 @@ import {
   Rule,
 } from '@angular-devkit/schematics';
 import {
+  applyEsLintFix,
+  createOtterSchematic,
+  getExternalDependenciesVersionRange,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  setupDependencies,
+  updateImports,
+} from '@o3r/schematics';
+import {
   NodeDependencyType,
 } from '@schematics/angular/utility/dependencies';
 import {
@@ -18,31 +29,12 @@ const devDependenciesToInstall: string[] = [
 
 ];
 
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @ama-sdk/client-beacon has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/schematics' as devDependency to be able to use this schematics. Please run 'ng add @o3r/schematics'.
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
-
 /**
  * Add SDk Beacon Client to an Otter Project
  * @param options
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
-  return async (tree, context) => {
-    // use dynamic import to properly raise an exception if it is not an Otter project.
-    const {
-      getPackageInstallConfig,
-      applyEsLintFix,
-      setupDependencies,
-      getO3rPeerDeps,
-      getProjectNewDependenciesTypes,
-      getWorkspaceConfig,
-      getExternalDependenciesVersionRange,
-      updateImports
-    } = await import('@o3r/schematics');
-
+  return (tree, context) => {
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
     const depsInfo = getO3rPeerDeps(packageJsonPath);
@@ -86,9 +78,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add SDk Beacon Client to an Otter Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@ama-sdk/client-beacon/tsconfig.json
+++ b/packages/@ama-sdk/client-beacon/tsconfig.json
@@ -7,6 +7,9 @@
     },
     {
       "path": "./tsconfig.build.json"
+    },
+    {
+      "path": "./tsconfig.builders.json"
     }
   ]
 }

--- a/packages/@ama-sdk/client-fetch/package.json
+++ b/packages/@ama-sdk/client-fetch/package.json
@@ -38,6 +38,7 @@
     "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest"
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "@swc/helpers": "~0.5.0",
     "ts-node": "~10.9.2",
     "tslib": "^2.6.2",
@@ -87,7 +88,6 @@
     "@nx/jest": "~20.7.0",
     "@o3r/build-helpers": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",
     "@stylistic/eslint-plugin": "~3.1.0",

--- a/packages/@ama-sdk/client-fetch/schematics/ng-add/index.ts
+++ b/packages/@ama-sdk/client-fetch/schematics/ng-add/index.ts
@@ -5,6 +5,17 @@ import {
   Rule,
 } from '@angular-devkit/schematics';
 import {
+  applyEsLintFix,
+  createOtterSchematic,
+  getExternalDependenciesVersionRange,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  setupDependencies,
+  updateImports,
+} from '@o3r/schematics';
+import {
   NodeDependencyType,
 } from '@schematics/angular/utility/dependencies';
 import {
@@ -18,31 +29,12 @@ const devDependenciesToInstall: string[] = [
 
 ];
 
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @ama-sdk/client-fetch has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/schematics' as devDependency to be able to use this schematics. Please run 'ng add @o3r/schematics'.
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
-
 /**
  * Add SDk Fetch Client to an Otter Project
  * @param options
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
-  return async (tree, context) => {
-    // use dynamic import to properly raise an exception if it is not an Otter project.
-    const {
-      getPackageInstallConfig,
-      applyEsLintFix,
-      setupDependencies,
-      getO3rPeerDeps,
-      getProjectNewDependenciesTypes,
-      getWorkspaceConfig,
-      getExternalDependenciesVersionRange,
-      updateImports
-    } = await import('@o3r/schematics');
-
+  return (tree, context) => {
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
     const depsInfo = getO3rPeerDeps(packageJsonPath);
@@ -86,9 +78,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add SDk Fetch Client to an Otter Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@ama-sdk/client-fetch/tsconfig.json
+++ b/packages/@ama-sdk/client-fetch/tsconfig.json
@@ -6,6 +6,9 @@
       "path": "./tsconfig.spec.json"
     },
     {
+      "path": "./tsconfig.builders.json"
+    },
+    {
       "path": "./tsconfig.build.json"
     }
   ]

--- a/packages/@ama-sdk/core/package.json
+++ b/packages/@ama-sdk/core/package.json
@@ -81,6 +81,7 @@
     "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest"
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "@swc/helpers": "~0.5.0",
     "ts-node": "~10.9.2",
     "tslib": "^2.6.2",
@@ -132,7 +133,6 @@
     "@nx/jest": "~20.7.0",
     "@o3r/build-helpers": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",
     "@stylistic/eslint-plugin": "~3.1.0",

--- a/packages/@ama-sdk/core/tsconfig.json
+++ b/packages/@ama-sdk/core/tsconfig.json
@@ -6,6 +6,9 @@
       "path": "./tsconfig.spec.json"
     },
     {
+      "path": "./tsconfig.builders.json"
+    },
+    {
       "path": "./tsconfig.build.json"
     }
   ]

--- a/packages/@ama-sdk/create/tsconfig.json
+++ b/packages/@ama-sdk/create/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -7,6 +7,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@ama-sdk/schematics/package.json
+++ b/packages/@ama-sdk/schematics/package.json
@@ -76,6 +76,7 @@
   "dependencies": {
     "@angular-devkit/core": "~19.2.0",
     "@angular-devkit/schematics": "~19.2.0",
+    "@o3r/schematics": "workspace:^",
     "chokidar": "^4.0.3",
     "globby": "^11.1.0",
     "js-yaml": "^4.1.0",
@@ -94,7 +95,6 @@
     "@nx/jest": "~20.7.0",
     "@o3r/build-helpers": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/telemetry": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@openapitools/openapi-generator-cli": "~2.18.0",

--- a/packages/@ama-sdk/schematics/schematics/api-extension/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/api-extension/index.ts
@@ -10,6 +10,9 @@ import {
   url,
 } from '@angular-devkit/schematics';
 import {
+  createOtterSchematic,
+} from '@o3r/schematics';
+import {
   NgGenerateApiExtensionSchematicsSchema,
 } from './schema';
 
@@ -32,9 +35,4 @@ function ngGenerateApiExtensionFn(options: NgGenerateApiExtensionSchematicsSchem
  * Generate a Extension of a API core definition
  * @param options
  */
-export const ngGenerateApiExtension = (options: NgGenerateApiExtensionSchematicsSchema) => async () => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics');
-  return createOtterSchematic(ngGenerateApiExtensionFn)(options);
-};
+export const ngGenerateApiExtension = (options: NgGenerateApiExtensionSchematicsSchema) => createOtterSchematic(ngGenerateApiExtensionFn)(options);

--- a/packages/@ama-sdk/schematics/schematics/migrate/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/migrate/index.ts
@@ -13,6 +13,9 @@ import {
   type MigrationRulesMap,
 } from '@o3r/schematics';
 import {
+  createOtterSchematic,
+} from '@o3r/schematics';
+import {
   gt,
   minVersion,
 } from 'semver';
@@ -66,9 +69,4 @@ function migrateFn(options: MigrateSchematicsSchemaOptions): Rule {
  * Facilitate the migration of a version to another by the run of migration rules
  * @param options
  */
-export const migrate = (options: MigrateSchematicsSchemaOptions) => async () => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics');
-  return createOtterSchematic(migrateFn)(options);
-};
+export const migrate = (options: MigrateSchematicsSchemaOptions) => createOtterSchematic(migrateFn)(options);

--- a/packages/@ama-sdk/schematics/schematics/ng-add/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/ng-add/index.ts
@@ -13,6 +13,10 @@ import {
   Tree,
 } from '@angular-devkit/schematics';
 import {
+  createOtterSchematic,
+  registerPackageCollectionSchematics,
+} from '@o3r/schematics';
+import {
   lastValueFrom,
 } from 'rxjs';
 import type {
@@ -160,10 +164,7 @@ const registerPackageSchematics = async (tree: Tree, context: SchematicContext) 
   }
   return () => chain([
     ...schematicsDependencies.map((dep) => externalSchematic(dep, 'ng-add', {})),
-    async (t, c) => {
-      const { registerPackageCollectionSchematics } = await import('@o3r/schematics');
-      return () => registerPackageCollectionSchematics(amaSdkSchematicsPackageJsonContent)(t, c);
-    }
+    registerPackageCollectionSchematics(amaSdkSchematicsPackageJsonContent)
   ]);
 };
 
@@ -186,9 +187,4 @@ function ngAddFn(): Rule {
  * Add Otter ama-sdk-schematics to a Project
  * @param opts
  */
-export const ngAdd = (opts: NgAddSchematicsSchema): Rule => async () => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics');
-  return createOtterSchematic(ngAddFn)(opts);
-};
+export const ngAdd = (opts: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(opts);

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/index.ts
@@ -22,6 +22,9 @@ import {
   Tree,
   url,
 } from '@angular-devkit/schematics';
+import {
+  createOtterSchematic,
+} from '@o3r/schematics';
 import * as semver from 'semver';
 import type {
   JsonObject,
@@ -317,9 +320,4 @@ function ngGenerateTypescriptSDKFn(options: NgGenerateTypescriptSDKCoreSchematic
  * Generate a typescript SDK source code base on swagger specification
  * @param options
  */
-export const ngGenerateTypescriptSDK = (options: NgGenerateTypescriptSDKCoreSchematicsSchema) => async () => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics');
-  return createOtterSchematic(ngGenerateTypescriptSDKFn)(options);
-};
+export const ngGenerateTypescriptSDK = (options: NgGenerateTypescriptSDKCoreSchematicsSchema) => createOtterSchematic(ngGenerateTypescriptSDKFn)(options);

--- a/packages/@ama-sdk/schematics/schematics/typescript/mock/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/mock/index.ts
@@ -16,6 +16,9 @@ import {
   url,
 } from '@angular-devkit/schematics';
 import {
+  createOtterSchematic,
+} from '@o3r/schematics';
+import {
   NgGenerateMockSchematicsSchema,
 } from './schema';
 
@@ -97,9 +100,4 @@ function ngGenerateMockFn(options: NgGenerateMockSchematicsSchema): Rule {
  * Add mock
  * @param options
  */
-export const ngGenerateMock = (options: NgGenerateMockSchematicsSchema) => async () => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics');
-  return createOtterSchematic(ngGenerateMockFn)(options);
-};
+export const ngGenerateMock = (options: NgGenerateMockSchematicsSchema) => createOtterSchematic(ngGenerateMockFn)(options);

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/index.ts
@@ -17,6 +17,10 @@ import {
   url,
 } from '@angular-devkit/schematics';
 import {
+  createOtterSchematic,
+  enforceTildeRange,
+} from '@o3r/schematics';
+import {
   dump,
   load,
 } from 'js-yaml';
@@ -44,8 +48,6 @@ function ngGenerateTypescriptSDKFn(options: NgGenerateTypescriptSDKShellSchemati
 
   const setupRule = async (tree: Tree, context: SchematicContext) => {
     const amaSdkSchematicsPackageJson = await readPackageJson();
-
-    const { enforceTildeRange } = await import('@o3r/schematics');
 
     const versions = Object.fromEntries(Object.entries({
       tslib: amaSdkSchematicsPackageJson.dependencies!.tslib,
@@ -181,9 +183,4 @@ function ngGenerateTypescriptSDKFn(options: NgGenerateTypescriptSDKShellSchemati
  * Generate Typescript SDK shell
  * @param options
  */
-export const ngGenerateTypescriptSDK = (options: NgGenerateTypescriptSDKShellSchematicsSchema) => async () => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics');
-  return createOtterSchematic(ngGenerateTypescriptSDKFn)(options);
-};
+export const ngGenerateTypescriptSDK = (options: NgGenerateTypescriptSDKShellSchematicsSchema) => createOtterSchematic(ngGenerateTypescriptSDKFn)(options);

--- a/packages/@ama-sdk/schematics/tsconfig.json
+++ b/packages/@ama-sdk/schematics/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -10,6 +10,9 @@
     },
     {
       "path": "./tsconfig.cli.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@ama-sdk/swagger-builder/tsconfig.json
+++ b/packages/@ama-sdk/swagger-builder/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -7,6 +7,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@ama-terasu/cli/tsconfig.json
+++ b/packages/@ama-terasu/cli/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -7,6 +7,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@ama-terasu/core/tsconfig.json
+++ b/packages/@ama-terasu/core/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -7,6 +7,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@ama-terasu/schematics/tsconfig.json
+++ b/packages/@ama-terasu/schematics/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -7,6 +7,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r-training/training-tools/package.json
+++ b/packages/@o3r-training/training-tools/package.json
@@ -59,6 +59,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "commander": "^13.0.0",
     "tslib": "^2.6.2"
   },
@@ -84,7 +85,6 @@
     "@o3r/build-helpers": "workspace:^",
     "@o3r/eslint-config": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",
     "@stylistic/eslint-plugin": "~3.1.0",

--- a/packages/@o3r-training/training-tools/schematics/ng-add/index.ts
+++ b/packages/@o3r-training/training-tools/schematics/ng-add/index.ts
@@ -2,6 +2,11 @@ import * as path from 'node:path';
 import type {
   Rule,
 } from '@angular-devkit/schematics';
+import {
+  createOtterSchematic,
+  getPackageInstallConfig,
+  setupDependencies,
+} from '@o3r/schematics';
 import type {
   NgAddSchematicsSchema,
 } from './schema';
@@ -11,9 +16,8 @@ import type {
  * @param options
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
-  return async (tree) => {
+  return (tree) => {
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
-    const { getPackageInstallConfig, setupDependencies } = await import('@o3r/schematics');
     return setupDependencies({
       projectName: options.projectName,
       dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, false)
@@ -25,9 +29,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter training tools to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async () => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics');
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r-training/training-tools/tsconfig.json
+++ b/packages/@o3r-training/training-tools/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base.json",
   "references": [
@@ -13,6 +13,9 @@
     },
     {
       "path": "./tsconfig.cli.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/amaterasu/amaterasu-api-spec/tsconfig.json
+++ b/packages/@o3r/amaterasu/amaterasu-api-spec/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../../tsconfig.base",
   "references": [
@@ -7,6 +7,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/amaterasu/amaterasu-dodo/tsconfig.json
+++ b/packages/@o3r/amaterasu/amaterasu-dodo/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../../tsconfig.base",
   "references": [
@@ -7,6 +7,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/amaterasu/amaterasu-otter/tsconfig.json
+++ b/packages/@o3r/amaterasu/amaterasu-otter/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../../tsconfig.base",
   "references": [
@@ -7,6 +7,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/amaterasu/amaterasu-sdk/tsconfig.json
+++ b/packages/@o3r/amaterasu/amaterasu-sdk/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../../tsconfig.base",
   "references": [
@@ -7,6 +7,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/analytics/package.json
+++ b/packages/@o3r/analytics/package.json
@@ -61,6 +61,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -88,7 +89,6 @@
     "@o3r/build-helpers": "workspace:^",
     "@o3r/core": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",
     "@stylistic/eslint-plugin": "~3.1.0",

--- a/packages/@o3r/analytics/schematics/ng-add/index.ts
+++ b/packages/@o3r/analytics/schematics/ng-add/index.ts
@@ -2,18 +2,16 @@ import * as path from 'node:path';
 import type {
   Rule,
 } from '@angular-devkit/schematics';
+import {
+  createOtterSchematic,
+  getPackageInstallConfig,
+  setupDependencies,
+} from '@o3r/schematics';
 import type {
   NgAddSchematicsSchema,
 } from './schema';
 
 const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
-
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/analytics has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/core'. Please run 'ng add @o3r/core'.
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
 
 /**
  * Add Otter analytics to an Angular Project
@@ -21,8 +19,7 @@ Otherwise, use the error message as guidance.`);
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
-  return async (tree) => {
-    const { getPackageInstallConfig, setupDependencies } = await import('@o3r/schematics');
+  return (tree) => {
     return setupDependencies({
       projectName: options.projectName,
       dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion)
@@ -30,9 +27,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
   };
 }
 
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/analytics/src/ng-package.json
+++ b/packages/@o3r/analytics/src/ng-package.json
@@ -2,7 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",
   "deleteDestPath": false,
-
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/packages/@o3r/analytics/tsconfig.json
+++ b/packages/@o3r/analytics/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -19,6 +19,9 @@
     },
     {
       "path": "./tsconfig.fixture.jest.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/apis-manager/ng-package.json
+++ b/packages/@o3r/apis-manager/ng-package.json
@@ -2,7 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "./dist",
   "deleteDestPath": false,
-
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
   "lib": {
     "entryFile": "src/public_api.ts"
   }

--- a/packages/@o3r/apis-manager/package.json
+++ b/packages/@o3r/apis-manager/package.json
@@ -44,6 +44,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -69,7 +70,6 @@
     "@nx/js": "~20.7.0",
     "@o3r/build-helpers": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",
     "@stylistic/eslint-plugin": "~3.1.0",

--- a/packages/@o3r/apis-manager/schematics/ng-add/index.ts
+++ b/packages/@o3r/apis-manager/schematics/ng-add/index.ts
@@ -4,15 +4,18 @@ import {
   noop,
   type Rule,
 } from '@angular-devkit/schematics';
+import {
+  applyEsLintFix,
+  createOtterSchematic,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  setupDependencies,
+} from '@o3r/schematics';
 import type {
   NgAddSchematicsSchema,
 } from './schema';
-
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/apis-manager has failed.
-You need to install '@o3r/schematics' to be able to use the o3r apis-manager package. Please run 'ng add @o3r/schematics'.`);
-  throw reason;
-};
 
 /**
  * Add Otter apis manager to an Angular Project
@@ -20,8 +23,6 @@ You need to install '@o3r/schematics' to be able to use the o3r apis-manager pac
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   return async (tree) => {
-    const { getPackageInstallConfig } = await import('@o3r/schematics');
-    const { setupDependencies, getO3rPeerDeps, applyEsLintFix, getWorkspaceConfig, getProjectNewDependenciesTypes } = await import('@o3r/schematics');
     const { updateApiDependencies } = await import('../helpers/update-api-deps');
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
     const depsInfo = getO3rPeerDeps(packageJsonPath);
@@ -63,9 +64,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter apis manager to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/apis-manager/tsconfig.json
+++ b/packages/@o3r/apis-manager/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -6,7 +6,13 @@
       "path": "./tsconfig.build.composite.json"
     },
     {
+      "path": "./tsconfig.builders.json"
+    },
+    {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/application/ng-package.json
+++ b/packages/@o3r/application/ng-package.json
@@ -2,7 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "./dist",
   "deleteDestPath": false,
-
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
   "lib": {
     "entryFile": "src/public_api.ts"
   },

--- a/packages/@o3r/application/package.json
+++ b/packages/@o3r/application/package.json
@@ -48,6 +48,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -74,7 +75,6 @@
     "@o3r/eslint-plugin": "workspace:^",
     "@o3r/logger": "workspace:^",
     "@o3r/routing": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@o3r/testing": "workspace:^",
     "@schematics/angular": "~19.2.0",

--- a/packages/@o3r/application/schematics/ng-add/helpers/devtools-registration.ts
+++ b/packages/@o3r/application/schematics/ng-add/helpers/devtools-registration.ts
@@ -4,8 +4,10 @@ import {
 import * as path from 'node:path';
 import {
   chain,
-  Rule,
 } from '@angular-devkit/schematics';
+import {
+  registerDevtoolsToApplication,
+} from '@o3r/schematics';
 import type {
   NgAddSchematicsSchema,
 } from '../schema';
@@ -19,8 +21,7 @@ const PACKAGE_NAME: string = JSON.parse(readFileSync(path.resolve(__dirname, '..
  * Register Devtools to the application
  * @param options
  */
-export const registerDevtools = async (options: NgAddSchematicsSchema): Promise<Rule> => {
-  const { registerDevtoolsToApplication } = await import('@o3r/schematics');
+export const registerDevtools = (options: NgAddSchematicsSchema) => {
   return chain([
     registerDevtoolsToApplication({
       moduleName: DEVTOOL_MODULE_NAME,

--- a/packages/@o3r/application/schematics/ng-add/index.ts
+++ b/packages/@o3r/application/schematics/ng-add/index.ts
@@ -8,6 +8,16 @@ import {
   chain,
 } from '@angular-devkit/schematics';
 import {
+  createOtterSchematic,
+  getAppModuleFilePath,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  insertImportToModuleFile,
+  setupDependencies,
+} from '@o3r/schematics';
+import {
   addRootImport,
 } from '@schematics/angular/utility';
 import {
@@ -17,13 +27,6 @@ import type {
   NgAddSchematicsSchema,
 } from './schema';
 
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/application has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/core' to be able to use the o3r application package. Please run 'ng add @o3r/core' .
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
-
 /**
  * Add Otter application to an Angular Project
  * @param options The options to pass to ng-add execution
@@ -31,15 +34,6 @@ Otherwise, use the error message as guidance.`);
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
   return async (tree: Tree, context: SchematicContext) => {
-    const {
-      getAppModuleFilePath,
-      getWorkspaceConfig,
-      insertImportToModuleFile,
-      setupDependencies,
-      getO3rPeerDeps,
-      getProjectNewDependenciesTypes,
-      getPackageInstallConfig
-    } = await import('@o3r/schematics');
     const { isImported } = await import('@schematics/angular/utility/ast-utils').catch(() => ({ isImported: undefined }));
     const ts = await import('typescript').catch(() => undefined);
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
@@ -111,7 +105,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       return acc;
     }, getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion));
 
-    const registerDevtoolRule = await registerDevtools(options);
+    const registerDevtoolRule = registerDevtools(options);
     return () => chain([
       setupDependencies({
         projectName: options.projectName,
@@ -128,9 +122,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter application to an Angular Project
  * @param options The options to pass to ng-add execution
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/application/tsconfig.json
+++ b/packages/@o3r/application/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -6,7 +6,13 @@
       "path": "./tsconfig.build.composite.json"
     },
     {
+      "path": "./tsconfig.builders.json"
+    },
+    {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/artifactory-tools/tsconfig.json
+++ b/packages/@o3r/artifactory-tools/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -7,6 +7,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/azure-tools/tsconfig.json
+++ b/packages/@o3r/azure-tools/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -7,6 +7,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/components/package.json
+++ b/packages/@o3r/components/package.json
@@ -136,6 +136,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -170,7 +171,6 @@
     "@o3r/localization": "workspace:^",
     "@o3r/logger": "workspace:^",
     "@o3r/rules-engine": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@o3r/testing": "workspace:^",
     "@schematics/angular": "~19.2.0",

--- a/packages/@o3r/components/schematics/ng-add/helpers/devtools-registration.ts
+++ b/packages/@o3r/components/schematics/ng-add/helpers/devtools-registration.ts
@@ -3,8 +3,8 @@ import {
 } from 'node:fs';
 import * as path from 'node:path';
 import {
-  Rule,
-} from '@angular-devkit/schematics';
+  registerDevtoolsToApplication,
+} from '@o3r/schematics';
 import type {
   NgAddSchematicsSchema,
 } from '../schema';
@@ -17,8 +17,7 @@ const PACKAGE_NAME: string = JSON.parse(readFileSync(path.resolve(__dirname, '..
  * Register Devtools to the application
  * @param options
  */
-export const registerDevtools = async (options: NgAddSchematicsSchema): Promise<Rule> => {
-  const { registerDevtoolsToApplication } = await import('@o3r/schematics');
+export const registerDevtools = (options: NgAddSchematicsSchema) => {
   return registerDevtoolsToApplication({
     moduleName: DEVTOOL_MODULE_NAME,
     packageName: PACKAGE_NAME,

--- a/packages/@o3r/components/schematics/ng-add/index.ts
+++ b/packages/@o3r/components/schematics/ng-add/index.ts
@@ -9,6 +9,17 @@ import {
 import type {
   DependencyToAdd,
 } from '@o3r/schematics';
+import {
+  createOtterSchematic,
+  getDefaultOptionsForSchematic,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  registerPackageCollectionSchematics,
+  removePackages,
+  setupDependencies,
+} from '@o3r/schematics';
 import type {
   NodeDependencyType as NodeDependencyTypeEnum,
 } from '@schematics/angular/utility/dependencies';
@@ -22,13 +33,6 @@ import type {
   NgAddSchematicsSchema,
 } from './schema';
 
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/components has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/core' to be able to use the components package. Please run 'ng add @o3r/core' .
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
-
 /**
  * Add Otter components to an Angular Project
  * @param options
@@ -36,16 +40,6 @@ Otherwise, use the error message as guidance.`);
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
   return async (tree: Tree, context: SchematicContext) => {
-    const {
-      getDefaultOptionsForSchematic,
-      getO3rPeerDeps,
-      getProjectNewDependenciesTypes,
-      getWorkspaceConfig,
-      setupDependencies,
-      removePackages,
-      registerPackageCollectionSchematics,
-      getPackageInstallConfig
-    } = await import('@o3r/schematics');
     const { NodeDependencyType } = await import('@schematics/angular/utility/dependencies').catch(() => ({ NodeDependencyType: { Dev: 'devDependencies' as NodeDependencyTypeEnum.Dev } }));
     options = { ...getDefaultOptionsForSchematic(getWorkspaceConfig(tree), '@o3r/components', 'ng-add', options), ...options };
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
@@ -86,7 +80,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       }),
       registerPackageCollectionSchematics(packageJson),
       ...(options.enableMetadataExtract ? [updateCmsAdapter(options)] : []),
-      await registerDevtools(options)
+      registerDevtools(options)
     ]);
 
     context.logger.info(`The package ${depsInfo.packageName!} comes with a debug mechanism`);
@@ -100,9 +94,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter components to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/components/src/ng-package.json
+++ b/packages/@o3r/components/src/ng-package.json
@@ -2,7 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",
   "deleteDestPath": false,
-
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/packages/@o3r/components/tsconfig.json
+++ b/packages/@o3r/components/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -10,6 +10,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/configuration/package.json
+++ b/packages/@o3r/configuration/package.json
@@ -76,6 +76,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -103,7 +104,6 @@
     "@o3r/core": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
     "@o3r/logger": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@o3r/testing": "workspace:^",
     "@schematics/angular": "~19.2.0",

--- a/packages/@o3r/configuration/schematics/ng-add/helpers/devtools-registration.ts
+++ b/packages/@o3r/configuration/schematics/ng-add/helpers/devtools-registration.ts
@@ -4,8 +4,10 @@ import {
 import * as path from 'node:path';
 import {
   chain,
-  Rule,
 } from '@angular-devkit/schematics';
+import {
+  registerDevtoolsToApplication,
+} from '@o3r/schematics';
 import type {
   NgAddSchematicsSchema,
 } from '../schema';
@@ -19,8 +21,7 @@ const PACKAGE_NAME: string = JSON.parse(readFileSync(path.resolve(__dirname, '..
  * Register Devtools to the application
  * @param options
  */
-export const registerDevtools = async (options: NgAddSchematicsSchema): Promise<Rule> => {
-  const { registerDevtoolsToApplication } = await import('@o3r/schematics');
+export const registerDevtools = (options: NgAddSchematicsSchema) => {
   return chain([
     registerDevtoolsToApplication({
       moduleName: DEVTOOL_MODULE_NAME,

--- a/packages/@o3r/configuration/schematics/ng-add/index.ts
+++ b/packages/@o3r/configuration/schematics/ng-add/index.ts
@@ -7,18 +7,21 @@ import {
   Tree,
 } from '@angular-devkit/schematics';
 import {
+  createOtterSchematic,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  registerPackageCollectionSchematics,
+  setupDependencies,
+  setupSchematicsParamsForProject,
+} from '@o3r/schematics';
+import {
   registerDevtools,
 } from './helpers/devtools-registration';
 import type {
   NgAddSchematicsSchema,
 } from './schema';
-
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/configuration has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/core' to be able to use the configuration package. Please run 'ng add @o3r/core' .
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
 
 /**
  * Add Otter configuration to an Angular Project
@@ -26,16 +29,7 @@ Otherwise, use the error message as guidance.`);
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
-  return async (tree: Tree, context: SchematicContext) => {
-    const {
-      setupDependencies,
-      getProjectNewDependenciesTypes,
-      getWorkspaceConfig,
-      getO3rPeerDeps,
-      registerPackageCollectionSchematics,
-      setupSchematicsParamsForProject,
-      getPackageInstallConfig
-    } = await import('@o3r/schematics');
+  return (tree: Tree, context: SchematicContext) => {
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
     const depsInfo = getO3rPeerDeps(packageJsonPath);
@@ -74,9 +68,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter configuration to an Angular Project
  * @param options The options to pass to ng-add execution
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/configuration/src/ng-package.json
+++ b/packages/@o3r/configuration/src/ng-package.json
@@ -2,7 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",
   "deleteDestPath": false,
-
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/packages/@o3r/configuration/tsconfig.json
+++ b/packages/@o3r/configuration/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -16,6 +16,9 @@
     },
     {
       "path": "./tsconfig.fixture.jest.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/core/schematics/ng-add-create/index.ts
+++ b/packages/@o3r/core/schematics/ng-add-create/index.ts
@@ -61,8 +61,9 @@ function updateTemplatesFn(options: NgGenerateUpdateSchematicsSchema): Rule {
       packageJson.peerDependenciesMeta['@o3r/schematics'] = { optional: true };
       packageJson.devDependencies['@angular-devkit/schematics'] = angularVersion;
       packageJson.devDependencies['@angular-devkit/core'] = angularVersion;
-      packageJson.devDependencies['@o3r/schematics'] = otterVersion;
       packageJson.devDependencies['cpy-cli'] = o3rCorePackageJson.generatorDependencies!['cpy-cli'];
+      packageJson.dependencies ||= {};
+      packageJson.dependencies['@o3r/schematics'] = otterVersion;
 
       tree.overwrite(packageJsonPath, JSON.stringify(packageJson, null, 2));
     }

--- a/packages/@o3r/core/schematics/ng-add-create/templates/schematics/ng-add/index.ts.template
+++ b/packages/@o3r/core/schematics/ng-add-create/templates/schematics/ng-add/index.ts.template
@@ -2,6 +2,14 @@ import { chain, noop, Rule } from '@angular-devkit/schematics';
 import type { NgAddSchematicsSchema } from './schema';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import {
+  createOtterSchematic,
+  getProjectNewDependenciesTypes,
+  getPackageInstallConfig,
+  applyEsLintFix,
+  getWorkspaceConfig,
+  setupDependencies,
+} from '@o3r/schematics';
 
 const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
 
@@ -32,8 +40,6 @@ Otherwise, use the error message as guidance.`);
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   return async (tree) => {
-    // use dynamic import to properly raise an exception if it is not an Otter project.
-    const { getProjectNewDependenciesTypes, getPackageInstallConfig, applyEsLintFix, getWorkspaceConfig, setupDependencies } = await import('@o3r/schematics');
     // current package version
     const version = JSON.parse(fs.readFileSync(packageJsonPath, {encoding: 'utf8'})).version;
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
@@ -64,9 +70,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add module to an Angular Project
  * @param options ng add options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/core/schematics/ng-add/component-decorator/index.ts
+++ b/packages/@o3r/core/schematics/ng-add/component-decorator/index.ts
@@ -1,7 +1,9 @@
 import {
   Rule,
-  Tree,
 } from '@angular-devkit/schematics';
+import {
+  getFilesInFolderFromWorkspaceProjectsInTree,
+} from '@o3r/schematics';
 import {
   insertImport,
 } from '@schematics/angular/utility/ast-utils';
@@ -34,8 +36,7 @@ const removeImport = (source: ts.SourceFile, symbolName: string, fileName: strin
  * Update component file with new decorators for otter devtools
  * @param tree Tree
  */
-export const updateComponentDecorators: Rule = async (tree: Tree) => {
-  const { getFilesInFolderFromWorkspaceProjectsInTree } = await import('@o3r/schematics');
+export const updateComponentDecorators: Rule = (tree) => {
   const componentFiles = new Set<string>(getFilesInFolderFromWorkspaceProjectsInTree(tree, '', 'component.ts'));
   componentFiles.forEach((filePath) => {
     const source = ts.createSourceFile(filePath, tree.readText(filePath), ts.ScriptTarget.ES2015, true);

--- a/packages/@o3r/core/tsconfig.json
+++ b/packages/@o3r/core/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -10,6 +10,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/create/tsconfig.json
+++ b/packages/@o3r/create/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -7,6 +7,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/design/package.json
+++ b/packages/@o3r/design/package.json
@@ -49,6 +49,7 @@
     "o3r-css-from-design-token": "./dist/cli/generate-css-from-design-token.cli.cjs"
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "jsonschema": "~1.5.0",
     "minimatch": "~10.0.0",
     "minimist": "^1.2.6",
@@ -119,7 +120,6 @@
     "@o3r/build-helpers": "workspace:^",
     "@o3r/core": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/styling": "workspace:^",
     "@o3r/telemetry": "workspace:^",
     "@o3r/test-helpers": "workspace:^",

--- a/packages/@o3r/design/schematics/design-token-to-component/index.ts
+++ b/packages/@o3r/design/schematics/design-token-to-component/index.ts
@@ -13,7 +13,7 @@ import {
   template,
   url,
 } from '@angular-devkit/schematics';
-import type {
+import {
   createOtterSchematic,
 } from '@o3r/schematics';
 import type {
@@ -45,15 +45,4 @@ export function ngAddDesignTokenFn(options: NgAddDesignTokenSchematicsSchema): R
  * Add Design Token to an existing component
  * @param options
  */
-export const ngAddDesignToken = (options: NgAddDesignTokenSchematicsSchema) => async () => {
-  let createOtterSchematicWrapper: typeof createOtterSchematic = (fn) => fn;
-  try {
-    const {
-      createOtterSchematic: wrapper
-    } = await import('@o3r/schematics');
-    createOtterSchematicWrapper = wrapper;
-  } catch {
-    // No @o3r/schematics detected
-  }
-  return createOtterSchematicWrapper(ngAddDesignTokenFn)(options);
-};
+export const ngAddDesignToken = (options: NgAddDesignTokenSchematicsSchema) => createOtterSchematic(ngAddDesignTokenFn)(options);

--- a/packages/@o3r/design/schematics/extract-token/index.ts
+++ b/packages/@o3r/design/schematics/extract-token/index.ts
@@ -5,7 +5,7 @@ import {
 import type {
   Rule,
 } from '@angular-devkit/schematics';
-import type {
+import {
   createOtterSchematic,
 } from '@o3r/schematics';
 import {
@@ -123,15 +123,4 @@ function extractTokenFn(options: ExtractTokenSchematicsSchema): Rule {
  * Extract the token from o3r mixin sass file
  * @param options
  */
-export const extractToken = (options: ExtractTokenSchematicsSchema) => async () => {
-  let createOtterSchematicWrapper: typeof createOtterSchematic = (fn) => fn;
-  try {
-    const {
-      createOtterSchematic: wrapper
-    } = await import('@o3r/schematics');
-    createOtterSchematicWrapper = wrapper;
-  } catch {
-    // No @o3r/schematics detected
-  }
-  return createOtterSchematicWrapper(extractTokenFn)(options);
-};
+export const extractToken = (options: ExtractTokenSchematicsSchema) => createOtterSchematic(extractTokenFn)(options);

--- a/packages/@o3r/design/schematics/generate-css/index.ts
+++ b/packages/@o3r/design/schematics/generate-css/index.ts
@@ -1,8 +1,9 @@
 import type {
   Rule,
 } from '@angular-devkit/schematics';
-import type {
+import {
   createOtterSchematic,
+  globInTree,
 } from '@o3r/schematics';
 import type {
   GenerateCssSchematicsSchema,
@@ -43,8 +44,6 @@ function generateCssFn(options: GenerateCssSchematicsSchema): Rule {
       logger: context.logger
     } as const satisfies DesignTokenRendererOptions;
 
-    const { globInTree } = await import('@o3r/schematics');
-
     const files = globInTree(tree, Array.isArray(options.designTokenFilePatterns) ? options.designTokenFilePatterns : [options.designTokenFilePatterns]);
 
     const duplicatedToken: DesignTokenVariableStructure[] = [];
@@ -69,15 +68,4 @@ function generateCssFn(options: GenerateCssSchematicsSchema): Rule {
  * Generate CSS from Design Token files
  * @param options
  */
-export const generateCss = (options: GenerateCssSchematicsSchema) => async () => {
-  let createOtterSchematicWrapper: typeof createOtterSchematic = (fn) => fn;
-  try {
-    const {
-      createOtterSchematic: wrapper
-    } = await import('@o3r/schematics');
-    createOtterSchematicWrapper = wrapper;
-  } catch {
-    // No @o3r/schematics detected
-  }
-  return createOtterSchematicWrapper(generateCssFn)(options);
-};
+export const generateCss = (options: GenerateCssSchematicsSchema) => createOtterSchematic(generateCssFn)(options);

--- a/packages/@o3r/design/schematics/ng-add/index.ts
+++ b/packages/@o3r/design/schematics/ng-add/index.ts
@@ -6,6 +6,10 @@ import {
 } from '@angular-devkit/schematics';
 import {
   applyEditorConfig,
+  createOtterSchematic,
+  getPackageInstallConfig,
+  setupDependencies,
+  setupSchematicsParamsForProject,
 } from '@o3r/schematics';
 import {
   extractToken,
@@ -25,8 +29,7 @@ const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
  */
 export function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
-  return async (tree) => {
-    const { getPackageInstallConfig, setupDependencies, setupSchematicsParamsForProject } = await import('@o3r/schematics');
+  return (tree) => {
     const schematicsDefaultOptions = {
       useOtterDesignToken: true
     };
@@ -51,22 +54,4 @@ export function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter design to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const missingSchematicDependencyMessage = 'Missing @o3r/schematics';
-  try {
-    const {
-      createOtterSchematic
-    } = await import('@o3r/schematics').catch(() => {
-      throw new Error(missingSchematicDependencyMessage);
-    });
-    return createOtterSchematic(ngAddFn)(options);
-  } catch (err) {
-    if (err instanceof Error && err.message === missingSchematicDependencyMessage) {
-      logger.warn(`[WARNING]: The run of the ng-add schematics of @o3r/design has failed, the setup of default features will not be done.
-The failure is due to miss of the package '@o3r/schematics'.
-To get benefit of the setup scripts, please run 'ng add @o3r/schematics' before.`);
-    } else {
-      throw err;
-    }
-  }
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/design/schematics/ng-add/register-generate-css/register-task.ts
+++ b/packages/@o3r/design/schematics/ng-add/register-generate-css/register-task.ts
@@ -12,6 +12,10 @@ import {
   template,
   url,
 } from '@angular-devkit/schematics';
+import {
+  getWorkspaceConfig,
+  registerBuilder,
+} from '@o3r/schematics';
 import type {
   GenerateStyleSchematicsSchema,
 } from '../../../builders/generate-style/schema';
@@ -22,8 +26,7 @@ import type {
  * @param taskName name of the task to generate
  */
 export const registerGenerateCssBuilder = (projectName?: string, taskName = 'generate-css'): Rule => {
-  const registerBuilderRule: Rule = async (tree, { logger }) => {
-    const { getWorkspaceConfig, registerBuilder } = await import('@o3r/schematics');
+  const registerBuilderRule: Rule = (tree, { logger }) => {
     const workspace = getWorkspaceConfig(tree);
     const workspaceProject = projectName ? workspace?.projects[projectName] : undefined;
     const workspaceRootPath = workspaceProject?.root || '.';
@@ -53,8 +56,7 @@ export const registerGenerateCssBuilder = (projectName?: string, taskName = 'gen
     tree.overwrite('/angular.json', JSON.stringify(workspace, null, 2));
   };
 
-  const generateDesignTokenFilesRule: Rule = async (tree) => {
-    const { getWorkspaceConfig } = await import('@o3r/schematics');
+  const generateDesignTokenFilesRule: Rule = (tree) => {
     const workspaceProject = projectName ? getWorkspaceConfig(tree)?.projects[projectName] : undefined;
     const srcBasePath = workspaceProject?.sourceRoot || (workspaceProject?.root ? posix.join(workspaceProject.root, 'src') : './src');
     const themeFolder = posix.join(srcBasePath, 'style');
@@ -65,8 +67,7 @@ export const registerGenerateCssBuilder = (projectName?: string, taskName = 'gen
     ]), MergeStrategy.Overwrite);
   };
 
-  const generateTemplateFilesRule: Rule = async (tree) => {
-    const { getWorkspaceConfig } = await import('@o3r/schematics');
+  const generateTemplateFilesRule: Rule = (tree) => {
     const workspaceProject = projectName ? getWorkspaceConfig(tree)?.projects[projectName] : undefined;
     const workspaceRootPath = workspaceProject?.root || '.';
     return mergeWith(apply(url('./register-generate-css/templates-workspace'), [
@@ -76,8 +77,7 @@ export const registerGenerateCssBuilder = (projectName?: string, taskName = 'gen
     ]), MergeStrategy.Overwrite);
   };
 
-  const importTheme: Rule = async (tree, context) => {
-    const { getWorkspaceConfig } = await import('@o3r/schematics');
+  const importTheme: Rule = (tree, context) => {
     const workspaceProject = projectName ? getWorkspaceConfig(tree)?.projects[projectName] : undefined;
     const srcBasePath = workspaceProject?.sourceRoot || (workspaceProject?.root ? posix.join(workspaceProject.root, 'src') : './src');
     const styleFile = posix.join(srcBasePath, 'styles.scss');

--- a/packages/@o3r/design/tsconfig.json
+++ b/packages/@o3r/design/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -10,6 +10,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/dynamic-content/package.json
+++ b/packages/@o3r/dynamic-content/package.json
@@ -64,6 +64,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -91,7 +92,6 @@
     "@o3r/core": "workspace:^",
     "@o3r/eslint-config": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",
     "@stylistic/eslint-plugin": "~3.1.0",

--- a/packages/@o3r/dynamic-content/schematics/ng-add/index.ts
+++ b/packages/@o3r/dynamic-content/schematics/ng-add/index.ts
@@ -2,17 +2,16 @@ import * as path from 'node:path';
 import type {
   Rule,
 } from '@angular-devkit/schematics';
+import {
+  createOtterSchematic,
+  getPackageInstallConfig,
+  setupDependencies,
+} from '@o3r/schematics';
 import type {
   NgAddSchematicsSchema,
 } from './schema';
 
 const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
-
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/apis-manager has failed.
-You need to install '@o3r/schematics' to be able to use the o3r apis-manager package. Please run 'ng add @o3r/schematics' .`);
-  throw reason;
-};
 
 /**
  * Add Otter dynamic-content to an Angular Project
@@ -20,8 +19,7 @@ You need to install '@o3r/schematics' to be able to use the o3r apis-manager pac
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
-  return async (tree) => {
-    const { getPackageInstallConfig, setupDependencies } = await import('@o3r/schematics');
+  return (tree) => {
     return setupDependencies({
       projectName: options.projectName,
       dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion)
@@ -33,9 +31,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter dynamic-content to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/dynamic-content/src/ng-package.json
+++ b/packages/@o3r/dynamic-content/src/ng-package.json
@@ -2,7 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",
   "deleteDestPath": false,
-
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/packages/@o3r/dynamic-content/tsconfig.json
+++ b/packages/@o3r/dynamic-content/tsconfig.json
@@ -1,9 +1,12 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
     {
       "path": "./tsconfig.build.composite.json"
+    },
+    {
+      "path": "./tsconfig.builders.json"
     },
     {
       "path": "./tsconfig.spec.json"
@@ -13,6 +16,9 @@
     },
     {
       "path": "./tsconfig.fixture.jest.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/eslint-config-otter/package.json
+++ b/packages/@o3r/eslint-config-otter/package.json
@@ -36,6 +36,9 @@
     "prepare:build:builders": "yarn cpy 'schematics/**/*.json' 'schematics/**/templates/**' dist/schematics && yarn cpy '{collection,migration}.json' dist",
     "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest"
   },
+  "dependencies": {
+    "@o3r/schematics": "workspace:^"
+  },
   "peerDependencies": {
     "@angular-devkit/schematics": "^19.0.0",
     "@angular-eslint/builder": "^19.0.0",
@@ -76,7 +79,6 @@
     "@o3r/build-helpers": "workspace:^",
     "@o3r/eslint-config": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",
     "@stylistic/eslint-plugin": "~3.1.0",

--- a/packages/@o3r/eslint-config-otter/schematics/ng-add/index.ts
+++ b/packages/@o3r/eslint-config-otter/schematics/ng-add/index.ts
@@ -6,17 +6,22 @@ import {
   Tree,
 } from '@angular-devkit/schematics';
 import {
+  addVsCodeRecommendations,
+  createOtterSchematic,
+  getExternalDependenciesVersionRange,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  removePackages,
+  setupDependencies,
+} from '@o3r/schematics';
+import {
   updateLinterConfigs,
 } from './linter';
 import type {
   NgAddSchematicsSchema,
 } from './schema';
-
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/eslint-config-otter has failed.
-You need to install '@o3r/schematics' package to be able to use the eslint-config-otter package. Please run 'ng add @o3r/schematics' .`);
-  throw reason;
-};
 
 /**
  * Add Otter eslint-config to an Angular Project
@@ -42,16 +47,6 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       'yaml-eslint-parser'
     ];
 
-    const {
-      getExternalDependenciesVersionRange,
-      addVsCodeRecommendations,
-      setupDependencies,
-      getWorkspaceConfig,
-      getO3rPeerDeps,
-      getProjectNewDependenciesTypes,
-      removePackages,
-      getPackageInstallConfig
-    } = await import('@o3r/schematics');
     const depsInfo = getO3rPeerDeps(path.resolve(__dirname, '..', '..', 'package.json'), true, /^@(?:o3r|ama-sdk|eslint-)/);
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
     const linterSchematicsFolder = __dirname;
@@ -94,9 +89,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter eslint-config to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/eslint-config-otter/schematics/ng-add/linter/index.ts
+++ b/packages/@o3r/eslint-config-otter/schematics/ng-add/linter/index.ts
@@ -9,13 +9,14 @@ import {
   move,
   renameTemplateFiles,
   Rule,
-  SchematicContext,
   template,
-  Tree,
   url,
 } from '@angular-devkit/schematics';
 import {
   applyEditorConfig,
+  getAllFilesInTree,
+  getTemplateFolder,
+  getWorkspaceConfig,
 } from '@o3r/schematics';
 
 /**
@@ -30,7 +31,7 @@ export function updateLinterConfigs(options: { projectName?: string | null | und
    * @param tree
    * @param context
    */
-  const updateTslintExtend: Rule = async (tree: Tree, context: SchematicContext) => {
+  const updateTslintExtend: Rule = (tree, context) => {
     const eslintFilePath = '/.eslintrc.json';
 
     if (tree.exists(eslintFilePath)) {
@@ -44,7 +45,6 @@ export function updateLinterConfigs(options: { projectName?: string | null | und
 
       tree.overwrite(eslintFilePath, JSON.stringify(eslintFile, null, 2));
     } else {
-      const { getAllFilesInTree, getTemplateFolder } = await import('@o3r/schematics');
       const eslintConfigFiles = getAllFilesInTree(tree, '/', ['**/.eslintrc.js'], false).filter((file) => /\.eslintrc/i.test(file));
       if (eslintConfigFiles.length === 0) {
         return mergeWith(apply(url(getTemplateFolder(rootPath, __dirname, 'templates/workspace')), [
@@ -66,11 +66,10 @@ export function updateLinterConfigs(options: { projectName?: string | null | und
    * @param tree
    * @param context
    */
-  const createProjectFiles: Rule = async (tree: Tree, context: SchematicContext) => {
+  const createProjectFiles: Rule = (tree, context) => {
     if (!options.projectName) {
       return;
     }
-    const { getWorkspaceConfig } = await import('@o3r/schematics');
     const workspace = getWorkspaceConfig(tree);
     if (!workspace) {
       return;
@@ -89,7 +88,6 @@ export function updateLinterConfigs(options: { projectName?: string | null | und
       context.logger.info(`${eslintFilePath} already exists.`);
       return;
     } else {
-      const { getTemplateFolder } = await import('@o3r/schematics');
       const rootRelativePath = posix.relative(projectRoot, tree.root.path.replace(/^\//, './'));
       return mergeWith(apply(url(getTemplateFolder(rootPath, __dirname, 'templates/project')), [
         template({
@@ -107,8 +105,7 @@ export function updateLinterConfigs(options: { projectName?: string | null | und
    * @param tree
    * @param context
    */
-  const editAngularJson: Rule = async (tree: Tree, context: SchematicContext) => {
-    const { getWorkspaceConfig } = await import('@o3r/schematics');
+  const editAngularJson: Rule = (tree, context) => {
     const workspace = getWorkspaceConfig(tree);
     if (!workspace) {
       return;
@@ -140,11 +137,10 @@ export function updateLinterConfigs(options: { projectName?: string | null | und
    * @param tree
    * @param context
    */
-  const handleOtterEslintErrors: Rule = async (tree: Tree, context: SchematicContext) => {
+  const handleOtterEslintErrors: Rule = (tree, context) => {
     if (!options.projectName) {
       return;
     }
-    const { getWorkspaceConfig } = await import('@o3r/schematics');
     const workspace = getWorkspaceConfig(tree);
     if (!workspace) {
       return;

--- a/packages/@o3r/eslint-config-otter/schematics/ng-update/v11.6/update-configs/update-configs.ts
+++ b/packages/@o3r/eslint-config-otter/schematics/ng-update/v11.6/update-configs/update-configs.ts
@@ -5,7 +5,9 @@ import type {
   FileEntry,
   Rule,
 } from '@angular-devkit/schematics';
-
+import {
+  findFilesInTree,
+} from '@o3r/schematics';
 /**
  * Update Eslint files to new recommended names
  */
@@ -20,10 +22,9 @@ export function updateEslintRecommended(): Rule {
 
   const isFileToParse = (path: string) => configFilePattern.test(basename(path));
 
-  return async (tree) => {
+  return (tree) => {
     let files: FileEntry[];
     try {
-      const { findFilesInTree } = await import('@o3r/schematics');
       files = findFilesInTree(tree.getDir('/'), isFileToParse);
     } catch {
       files = [];

--- a/packages/@o3r/eslint-config-otter/tsconfig.json
+++ b/packages/@o3r/eslint-config-otter/tsconfig.json
@@ -1,9 +1,12 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
     {
       "path": "./tsconfig.builders.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/eslint-config/package.json
+++ b/packages/@o3r/eslint-config/package.json
@@ -36,6 +36,9 @@
     "prepare:build:builders": "yarn cpy 'schematics/**/*.json' 'schematics/**/templates/**' dist/schematics && yarn cpy 'collection.json' dist",
     "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest"
   },
+  "dependencies": {
+    "@o3r/schematics": "workspace:^"
+  },
   "peerDependencies": {
     "@angular-devkit/core": "^19.0.0",
     "@angular-devkit/schematics": "^19.0.0",
@@ -78,7 +81,6 @@
     "@nx/eslint-plugin": "~20.7.0",
     "@o3r/build-helpers": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",
     "@stylistic/eslint-plugin": "~3.1.0",

--- a/packages/@o3r/eslint-config/schematics/ng-add/eslint/index.ts
+++ b/packages/@o3r/eslint-config/schematics/ng-add/eslint/index.ts
@@ -15,6 +15,11 @@ import {
   template,
   url,
 } from '@angular-devkit/schematics';
+import {
+  findFilesInTree,
+  getTemplateFolder,
+  getWorkspaceConfig,
+} from '@o3r/schematics';
 import type {
   WorkspaceSchema,
 } from '@o3r/schematics';
@@ -22,10 +27,9 @@ import {
   updateOrAddTsconfigEslint,
 } from '../tsconfig/index';
 
-const editAngularJson = (projectName: string, extension: string): Rule => async (tree, context) => {
+const editAngularJson = (projectName: string, extension: string): Rule => (tree, context) => {
   let workspace: WorkspaceSchema | null = null;
   try {
-    const { getWorkspaceConfig } = await import('@o3r/schematics');
     workspace = getWorkspaceConfig(tree);
   } catch {
     context.logger.warn(`No @o3r/schematics installed, we could not detect the workspace. The linter task for ${projectName} can not be added.`);
@@ -56,8 +60,7 @@ const editAngularJson = (projectName: string, extension: string): Rule => async 
  * @param rootPath
  * @param projectName
  */
-export const updateEslintConfig = (rootPath: string, projectName?: string): Rule => async (tree, context) => {
-  const { findFilesInTree, getTemplateFolder, getWorkspaceConfig } = await import('@o3r/schematics');
+export const updateEslintConfig = (rootPath: string, projectName?: string): Rule => (tree, context) => {
   const workspace = getWorkspaceConfig(tree);
   const workspaceProject = workspace?.projects[projectName || ''];
   const projectRootPath = workspaceProject?.root || '.';

--- a/packages/@o3r/eslint-config/schematics/ng-add/index.ts
+++ b/packages/@o3r/eslint-config/schematics/ng-add/index.ts
@@ -8,6 +8,13 @@ import {
 } from '@angular-devkit/schematics';
 import {
   applyEditorConfig,
+  createOtterSchematic,
+  getExternalDependenciesVersionRange,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  setupDependencies,
 } from '@o3r/schematics';
 import {
   updateEslintConfig,
@@ -19,17 +26,10 @@ import {
   updateVscode,
 } from './vscode/index';
 
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/eslint-config has failed.
-You need to install '@o3r/schematics' package to be able to use the eslint-config package. Please run 'ng add @o3r/schematics' .`);
-  throw reason;
-};
-
-const handleOtterEslintErrors = (projectName: string): Rule => async (tree: Tree, context: SchematicContext) => {
+const handleOtterEslintErrors = (projectName: string): Rule => (tree, context) => {
   if (!projectName) {
     return;
   }
-  const { getWorkspaceConfig } = await import('@o3r/schematics');
   const workspace = getWorkspaceConfig(tree);
   if (!workspace) {
     return;
@@ -92,14 +92,6 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
       ...(options.projectName ? ['@angular-eslint/builder'] : [])
     ];
 
-    const {
-      getExternalDependenciesVersionRange,
-      setupDependencies,
-      getWorkspaceConfig,
-      getO3rPeerDeps,
-      getProjectNewDependenciesTypes,
-      getPackageInstallConfig
-    } = await import('@o3r/schematics');
     const depsInfo = getO3rPeerDeps(path.resolve(__dirname, '..', '..', 'package.json'), true, /^@(?:o3r|ama-sdk)/);
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
     const { NodeDependencyType } = await import('@schematics/angular/utility/dependencies');
@@ -147,9 +139,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter eslint-config to an Angular Project
  * @param options Options for the schematic
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/eslint-config/schematics/ng-add/tsconfig/index.ts
+++ b/packages/@o3r/eslint-config/schematics/ng-add/tsconfig/index.ts
@@ -11,13 +11,15 @@ import {
   template,
   url,
 } from '@angular-devkit/schematics';
-
+import {
+  getTemplateFolder,
+} from '@o3r/schematics';
 /**
  * Update or add tsconfig.eslint.json file
  * @param rootPath
  * @param projectTsConfig
  */
-export const updateOrAddTsconfigEslint = (rootPath: string, projectTsConfig = 'tsconfig'): Rule => async (tree) => {
+export const updateOrAddTsconfigEslint = (rootPath: string, projectTsConfig = 'tsconfig'): Rule => (tree) => {
   const tsconfigPath = 'tsconfig.eslint.json';
   if (tree.exists(tsconfigPath)) {
     const tsconfig = tree.readJson(tsconfigPath) as JsonObject;
@@ -25,7 +27,7 @@ export const updateOrAddTsconfigEslint = (rootPath: string, projectTsConfig = 't
     tree.overwrite(tsconfigPath, JSON.stringify(tsconfig, null, 2));
     return () => tree;
   }
-  const { getTemplateFolder } = await import('@o3r/schematics');
+
   return () => mergeWith(apply(url(getTemplateFolder(rootPath, __dirname)), [
     template({ projectTsConfig }),
     renameTemplateFiles()

--- a/packages/@o3r/eslint-config/schematics/ng-add/vscode/index.ts
+++ b/packages/@o3r/eslint-config/schematics/ng-add/vscode/index.ts
@@ -5,6 +5,9 @@ import {
   chain,
   type Rule,
 } from '@angular-devkit/schematics';
+import {
+  addVsCodeRecommendations,
+} from '@o3r/schematics';
 
 type ESLintRulesCustomization = {
   rule: string;
@@ -43,8 +46,7 @@ type VScodeSettings = JsonObject & EditorSettings & ESLintSettings;
 /**
  * Update VSCode recommendations and settings
  */
-export const updateVscode: Rule = async () => {
-  const { addVsCodeRecommendations } = await import('@o3r/schematics');
+export const updateVscode: Rule = () => {
   return chain([
     addVsCodeRecommendations(['dbaeumer.vscode-eslint']),
     (tree) => {

--- a/packages/@o3r/eslint-config/tsconfig.build.json
+++ b/packages/@o3r/eslint-config/tsconfig.build.json
@@ -4,6 +4,7 @@
     "incremental": true,
     "composite": true,
     "module": "CommonJS",
+    "allowJs": true,
     "esModuleInterop": true
   },
   "include": [

--- a/packages/@o3r/eslint-config/tsconfig.json
+++ b/packages/@o3r/eslint-config/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -10,6 +10,9 @@
     },
     {
       "path": "./tsconfig.builders.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/eslint-plugin/tsconfig.json
+++ b/packages/@o3r/eslint-plugin/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -10,6 +10,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/extractors/schematics/ng-add/index.ts
+++ b/packages/@o3r/extractors/schematics/ng-add/index.ts
@@ -5,6 +5,15 @@ import {
 import type {
   Rule,
 } from '@angular-devkit/schematics';
+import {
+  createOtterSchematic,
+  getExternalDependenciesVersionRange,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  setupDependencies,
+} from '@o3r/schematics';
 import type {
   NodeDependencyType as NodeDependencyTypeEnum,
 } from '@schematics/angular/utility/dependencies';
@@ -19,27 +28,12 @@ const dependenciesToInstall = [
   'semver'
 ];
 
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/extractors has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/core' to be able to use the localization package. Please run 'ng add @o3r/core' .
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
-
 /**
  * Add Otter extractors to an Angular Project
  * @param options
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   return async (tree, context) => {
-    const {
-      getExternalDependenciesVersionRange,
-      getPackageInstallConfig,
-      getProjectNewDependenciesTypes,
-      setupDependencies,
-      getO3rPeerDeps,
-      getWorkspaceConfig
-    } = await import('@o3r/schematics');
     const { NodeDependencyType } = await import('@schematics/angular/utility/dependencies').catch(() => ({ NodeDependencyType: { Dev: 'devDependencies' as NodeDependencyTypeEnum.Dev } }));
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
     const depsInfo = getO3rPeerDeps(packageJsonPath);
@@ -77,9 +71,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter extractors to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/extractors/tsconfig.json
+++ b/packages/@o3r/extractors/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -7,6 +7,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/forms/ng-package.json
+++ b/packages/@o3r/forms/ng-package.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "./dist",
   "deleteDestPath": false,
+  "allowedNonPeerDependencies": ["@o3r/schematics"],
 
   "lib": {
     "entryFile": "src/public_api.ts"

--- a/packages/@o3r/forms/package.json
+++ b/packages/@o3r/forms/package.json
@@ -43,6 +43,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -72,7 +73,6 @@
     "@o3r/core": "workspace:^",
     "@o3r/eslint-config": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",
     "@stylistic/eslint-plugin": "~3.1.0",

--- a/packages/@o3r/forms/schematics/ng-add/index.ts
+++ b/packages/@o3r/forms/schematics/ng-add/index.ts
@@ -2,17 +2,16 @@ import * as path from 'node:path';
 import type {
   Rule,
 } from '@angular-devkit/schematics';
+import {
+  createOtterSchematic,
+  getPackageInstallConfig,
+  setupDependencies,
+} from '@o3r/schematics';
 import type {
   NgAddSchematicsSchema,
 } from './schema';
 
 const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
-
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/form has failed.
-You need to install '@o3r/core' package to be able to use the form package. Please run 'ng add @o3r/core'.`);
-  throw reason;
-};
 
 /**
  * Add Otter forms to an Angular Project
@@ -20,8 +19,7 @@ You need to install '@o3r/core' package to be able to use the form package. Plea
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
-  return async (tree) => {
-    const { getPackageInstallConfig, setupDependencies } = await import('@o3r/schematics');
+  return (tree) => {
     return setupDependencies({
       projectName: options.projectName,
       dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion)
@@ -33,9 +31,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter forms to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/forms/tsconfig.json
+++ b/packages/@o3r/forms/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -10,6 +10,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/localization/package.json
+++ b/packages/@o3r/localization/package.json
@@ -116,6 +116,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -149,7 +150,6 @@
     "@o3r/eslint-plugin": "workspace:^",
     "@o3r/extractors": "workspace:^",
     "@o3r/logger": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",
     "@stylistic/eslint-plugin": "~3.1.0",

--- a/packages/@o3r/localization/schematics/ng-add/helpers/devtools-registration.ts
+++ b/packages/@o3r/localization/schematics/ng-add/helpers/devtools-registration.ts
@@ -6,6 +6,9 @@ import {
   chain,
   Rule,
 } from '@angular-devkit/schematics';
+import {
+  registerDevtoolsToApplication,
+} from '@o3r/schematics';
 import type {
   NgAddSchematicsSchema,
 } from '../schema';
@@ -19,8 +22,7 @@ const PACKAGE_NAME: string = JSON.parse(readFileSync(path.resolve(__dirname, '..
  * Register Devtools to the application
  * @param options
  */
-export const registerDevtools = async (options: NgAddSchematicsSchema): Promise<Rule> => {
-  const { registerDevtoolsToApplication } = await import('@o3r/schematics');
+export const registerDevtools = (options: NgAddSchematicsSchema): Rule => {
   return chain([
     registerDevtoolsToApplication({
       moduleName: DEVTOOL_MODULE_NAME,

--- a/packages/@o3r/localization/schematics/ng-add/index.ts
+++ b/packages/@o3r/localization/schematics/ng-add/index.ts
@@ -6,6 +6,18 @@ import {
   Rule,
 } from '@angular-devkit/schematics';
 import {
+  applyEsLintFix,
+  createOtterSchematic,
+  getExternalDependenciesVersionRange,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  registerPackageCollectionSchematics,
+  setupDependencies,
+  setupSchematicsParamsForProject,
+} from '@o3r/schematics';
+import {
   updateCmsAdapter,
 } from '../cms-adapter';
 import {
@@ -20,30 +32,12 @@ const dependenciesToInstall = [
   'globby'
 ];
 
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/localization has failed.
-      If the error is related to missing @o3r dependencies you need to install '@o3r/core' to be able to use the localization package. Please run 'ng add @o3r/core' .
-      Otherwise, use the error message as guidance.`);
-  throw reason;
-};
-
 /**
  * Add Otter localization to an Angular Project
  * @param options for the dependencies installations
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   return async (tree, context) => {
-    const {
-      applyEsLintFix,
-      getPackageInstallConfig,
-      getProjectNewDependenciesTypes,
-      getWorkspaceConfig,
-      setupDependencies,
-      getO3rPeerDeps,
-      getExternalDependenciesVersionRange,
-      registerPackageCollectionSchematics,
-      setupSchematicsParamsForProject
-    } = await import('@o3r/schematics');
     const { updateI18n, updateLocalization } = await import('../localization-base');
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
@@ -71,7 +65,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
         }]
       };
     });
-    const registerDevtoolRule = await registerDevtools(options);
+    const registerDevtoolRule = registerDevtools(options);
     return chain([
       updateLocalization(options, __dirname),
       updateI18n(options),
@@ -93,9 +87,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter localization to an Angular Project
  * @param options for the dependencies installations
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/localization/src/ng-package.json
+++ b/packages/@o3r/localization/src/ng-package.json
@@ -2,6 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",
   "deleteDestPath": false,
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/packages/@o3r/localization/tsconfig.json
+++ b/packages/@o3r/localization/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -10,6 +10,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/logger/package.json
+++ b/packages/@o3r/logger/package.json
@@ -60,6 +60,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -88,7 +89,6 @@
     "@o3r/core": "workspace:^",
     "@o3r/eslint-config": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",
     "@stylistic/eslint-plugin": "~3.1.0",

--- a/packages/@o3r/logger/schematics/ng-add/index.ts
+++ b/packages/@o3r/logger/schematics/ng-add/index.ts
@@ -2,18 +2,16 @@ import * as path from 'node:path';
 import type {
   Rule,
 } from '@angular-devkit/schematics';
+import {
+  createOtterSchematic,
+  getPackageInstallConfig,
+  setupDependencies,
+} from '@o3r/schematics';
 import type {
   NgAddSchematicsSchema,
 } from './schema';
 
 const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
-
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/logger has failed.
-      If the error is related to missing @o3r dependencies you need to install '@o3r/core' to be able to use the logger package. Please run 'ng add @o3r/core' .
-      Otherwise, use the error message as guidance.`);
-  throw reason;
-};
 
 /**
  * Add Otter logger to an Angular Project
@@ -21,8 +19,7 @@ const reportMissingSchematicsDep = (logger: { error: (message: string) => any })
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
-  return async (tree) => {
-    const { getPackageInstallConfig, setupDependencies } = await import('@o3r/schematics');
+  return (tree) => {
     return setupDependencies({
       projectName: options.projectName,
       dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion)
@@ -34,9 +31,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter logger to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/logger/src/ng-package.json
+++ b/packages/@o3r/logger/src/ng-package.json
@@ -2,7 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",
   "deleteDestPath": false,
-
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/packages/@o3r/logger/tsconfig.json
+++ b/packages/@o3r/logger/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -10,6 +10,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/mobile/ng-package.json
+++ b/packages/@o3r/mobile/ng-package.json
@@ -2,10 +2,11 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "./dist",
   "deleteDestPath": false,
+
   "lib": {
     "entryFile": "src/public_api.ts"
   },
   "allowedNonPeerDependencies": [
-    "commander", "winston", "form-data", "node-fetch"
+    "commander", "winston", "form-data", "node-fetch", "@o3r/schematics"
   ]
 }

--- a/packages/@o3r/mobile/package.json
+++ b/packages/@o3r/mobile/package.json
@@ -26,6 +26,7 @@
     "prepare:build:builders": "yarn cpy 'schematics/**/*.json' dist/schematics && yarn cpy 'collection.json' dist"
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "commander": "^13.0.0",
     "form-data": "^4.0.0",
     "node-fetch": "^3.0.0",
@@ -90,7 +91,6 @@
     "@o3r/core": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
     "@o3r/logger": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/store-sync": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",

--- a/packages/@o3r/mobile/schematics/ng-add/index.ts
+++ b/packages/@o3r/mobile/schematics/ng-add/index.ts
@@ -3,18 +3,20 @@ import {
   chain,
   Rule,
 } from '@angular-devkit/schematics';
+import {
+  createOtterSchematic,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  removePackages,
+  setupDependencies,
+} from '@o3r/schematics';
 import type {
   NgAddSchematicsSchema,
 } from './schema';
 
 const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
-
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/mobile has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/core' to be able to use the mobile package. Please run 'ng add @o3r/core' .
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
 
 /**
  * Add Otter mobile to an Angular Project
@@ -22,8 +24,7 @@ Otherwise, use the error message as guidance.`);
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
-  return async (tree) => {
-    const { getPackageInstallConfig, getProjectNewDependenciesTypes, setupDependencies, getO3rPeerDeps, getWorkspaceConfig, removePackages } = await import('@o3r/schematics');
+  return (tree) => {
     const depsInfo = getO3rPeerDeps(path.resolve(__dirname, '..', '..', 'package.json'));
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
     const dependencies = depsInfo.o3rPeerDeps.reduce((acc, dep) => {
@@ -51,9 +52,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter mobile to an Angular Project
  * @param options ng add options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/mobile/tsconfig.json
+++ b/packages/@o3r/mobile/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -10,6 +10,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/new-version/package.json
+++ b/packages/@o3r/new-version/package.json
@@ -19,6 +19,7 @@
     "prepare:build:builders": "yarn cpy 'schematics/**/*.json' dist/schematics && yarn cpy 'collection.json' dist"
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "semver": "^7.5.2",
     "ts-node": "~10.9.2",
     "tslib": "^2.6.2"
@@ -46,7 +47,6 @@
     "@nx/jest": "~20.7.0",
     "@o3r/build-helpers": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",
     "@stylistic/eslint-plugin": "~3.1.0",

--- a/packages/@o3r/new-version/schematics/ng-add/index.ts
+++ b/packages/@o3r/new-version/schematics/ng-add/index.ts
@@ -2,6 +2,11 @@ import * as path from 'node:path';
 import type {
   Rule,
 } from '@angular-devkit/schematics';
+import {
+  createOtterSchematic,
+  getPackageInstallConfig,
+  setupDependencies,
+} from '@o3r/schematics';
 import type {
   NgAddSchematicsSchema,
 } from './schema';
@@ -14,9 +19,7 @@ const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
-  return async (tree) => {
-    const { getPackageInstallConfig, setupDependencies } = await import('@o3r/schematics');
-
+  return (tree) => {
     return setupDependencies({
       projectName: options.projectName,
       dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, true, !!options.exactO3rVersion)
@@ -24,9 +27,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
   };
 }
 
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async () => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics');
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/new-version/tsconfig.json
+++ b/packages/@o3r/new-version/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -6,7 +6,13 @@
       "path": "./tsconfig.build.json"
     },
     {
+      "path": "./tsconfig.builders.json"
+    },
+    {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/pipeline/package.json
+++ b/packages/@o3r/pipeline/package.json
@@ -33,6 +33,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "js-yaml": "^4.1.0",
     "tslib": "^2.6.2"
   },
@@ -67,7 +68,6 @@
     "@nx/js": "~20.7.0",
     "@o3r/build-helpers": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/telemetry": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",

--- a/packages/@o3r/pipeline/tsconfig.json
+++ b/packages/@o3r/pipeline/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -10,6 +10,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/routing/package.json
+++ b/packages/@o3r/routing/package.json
@@ -54,6 +54,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -86,7 +87,6 @@
     "@o3r/eslint-config": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
     "@o3r/routing": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",
     "@stylistic/eslint-plugin": "~3.1.0",

--- a/packages/@o3r/routing/schematics/ng-add/index.ts
+++ b/packages/@o3r/routing/schematics/ng-add/index.ts
@@ -2,25 +2,23 @@ import * as path from 'node:path';
 import type {
   Rule,
 } from '@angular-devkit/schematics';
+import {
+  createOtterSchematic,
+  getPackageInstallConfig,
+  setupDependencies,
+} from '@o3r/schematics';
 import type {
   NgAddSchematicsSchema,
 } from './schema';
 
 const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
 
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/routing has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/core' to be able to use the mobile package. Please run 'ng add @o3r/core' .
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
 /**
  * Add Otter routing to an Angular Project
  * @param options
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
-  return async (tree) => {
-    const { getPackageInstallConfig, setupDependencies } = await import('@o3r/schematics');
+  return (tree) => {
     return setupDependencies({
       projectName: options.projectName,
       dependencies: getPackageInstallConfig(packageJsonPath, tree, options.projectName, false, !!options.exactO3rVersion)
@@ -32,9 +30,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter routing to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/routing/src/ng-package.json
+++ b/packages/@o3r/routing/src/ng-package.json
@@ -2,7 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",
   "deleteDestPath": false,
-
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/packages/@o3r/routing/tsconfig.json
+++ b/packages/@o3r/routing/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -10,6 +10,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/rules-engine/package.json
+++ b/packages/@o3r/rules-engine/package.json
@@ -90,6 +90,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -124,7 +125,6 @@
     "@o3r/eslint-plugin": "workspace:^",
     "@o3r/extractors": "workspace:^",
     "@o3r/logger": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@o3r/testing": "workspace:^",
     "@schematics/angular": "~19.2.0",

--- a/packages/@o3r/rules-engine/schematics/ng-add/helpers/devtools-registration.ts
+++ b/packages/@o3r/rules-engine/schematics/ng-add/helpers/devtools-registration.ts
@@ -4,8 +4,10 @@ import {
 import * as path from 'node:path';
 import {
   chain,
-  Rule,
 } from '@angular-devkit/schematics';
+import {
+  registerDevtoolsToApplication,
+} from '@o3r/schematics';
 import type {
   NgAddSchematicsSchema,
 } from '../schema';
@@ -20,8 +22,7 @@ const PACKAGE_NAME: string = JSON.parse(readFileSync(path.resolve(__dirname, '..
  * @param options
  * @param options.projectName
  */
-export const registerDevtools = async (options: NgAddSchematicsSchema): Promise<Rule> => {
-  const { registerDevtoolsToApplication } = await import('@o3r/schematics');
+export const registerDevtools = (options: NgAddSchematicsSchema) => {
   return chain([
     registerDevtoolsToApplication({
       moduleName: DEVTOOL_MODULE_NAME,

--- a/packages/@o3r/rules-engine/schematics/ng-add/index.ts
+++ b/packages/@o3r/rules-engine/schematics/ng-add/index.ts
@@ -5,6 +5,20 @@ import {
   type Rule,
 } from '@angular-devkit/schematics';
 import {
+  createOtterSchematic,
+  getAppModuleFilePath,
+  getDefaultOptionsForSchematic,
+  getExternalDependenciesVersionRange,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  registerPackageCollectionSchematics,
+  removePackages,
+  setupDependencies,
+  setupSchematicsParamsForProject,
+} from '@o3r/schematics';
+import {
   addRootImport,
 } from '@schematics/angular/utility';
 import {
@@ -25,17 +39,7 @@ const devDependenciesToInstall = [
   'jsonpath-plus'
 ];
 
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/rules-engine has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/core' to be able to use the rules-engine package. Please run 'ng add @o3r/core' .
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
-
-const updateAppModuleOrAppConfig = (projectName: string | undefined): Rule => async (tree, context) => {
-  const {
-    getAppModuleFilePath
-  } = await import('@o3r/schematics');
+const updateAppModuleOrAppConfig = (projectName: string | undefined): Rule => (tree, context) => {
   const moduleFilePath = getAppModuleFilePath(tree, context, projectName);
   if (!moduleFilePath) {
     return () => tree;
@@ -65,19 +69,7 @@ const updateAppModuleOrAppConfig = (projectName: string | undefined): Rule => as
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
-  return async (tree, context) => {
-    const {
-      setupDependencies,
-      getPackageInstallConfig,
-      getDefaultOptionsForSchematic,
-      getO3rPeerDeps,
-      getProjectNewDependenciesTypes,
-      getWorkspaceConfig,
-      getExternalDependenciesVersionRange,
-      removePackages,
-      setupSchematicsParamsForProject,
-      registerPackageCollectionSchematics
-    } = await import('@o3r/schematics');
+  return (tree, context) => {
     options = { ...getDefaultOptionsForSchematic(getWorkspaceConfig(tree), '@o3r/rules-engine', 'ng-add', options), ...options };
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
@@ -121,7 +113,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
         ngAddToRun: depsInfo.o3rPeerDeps
       }),
       ...(options.enableMetadataExtract ? [updateCmsAdapter(options)] : []),
-      await registerDevtools(options),
+      registerDevtools(options),
       updateAppModuleOrAppConfig(options.projectName)
     ]);
 
@@ -136,9 +128,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter rules-engine to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/rules-engine/src/ng-package.json
+++ b/packages/@o3r/rules-engine/src/ng-package.json
@@ -2,7 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "../dist",
   "deleteDestPath": false,
-
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/packages/@o3r/rules-engine/tsconfig.json
+++ b/packages/@o3r/rules-engine/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -16,6 +16,9 @@
     },
     {
       "path": "./tsconfig.fixture.jest.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/schematics/schematics/ng-add/index.ts
+++ b/packages/@o3r/schematics/schematics/ng-add/index.ts
@@ -53,6 +53,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter schematics to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => () => {
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/schematics/tsconfig.json
+++ b/packages/@o3r/schematics/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -13,6 +13,9 @@
     },
     {
       "path": "./tsconfig.cli.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/store-sync/ng-package.json
+++ b/packages/@o3r/store-sync/ng-package.json
@@ -2,7 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "./dist",
   "deleteDestPath": false,
-
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
   "lib": {
     "entryFile": "src/public_api.ts"
   }

--- a/packages/@o3r/store-sync/package.json
+++ b/packages/@o3r/store-sync/package.json
@@ -48,6 +48,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -73,7 +74,6 @@
     "@o3r/eslint-config": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
     "@o3r/logger": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",
     "@stylistic/eslint-plugin": "~3.1.0",

--- a/packages/@o3r/store-sync/schematics/ng-add/index.ts
+++ b/packages/@o3r/store-sync/schematics/ng-add/index.ts
@@ -5,6 +5,16 @@ import {
   Rule,
 } from '@angular-devkit/schematics';
 import {
+  applyEsLintFix,
+  createOtterSchematic,
+  getExternalDependenciesVersionRange,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  setupDependencies,
+} from '@o3r/schematics';
+import {
   NodeDependencyType,
 } from '@schematics/angular/utility/dependencies';
 import type {
@@ -15,29 +25,13 @@ const devDependenciesToInstall = [
   'fast-deep-equal'
 ];
 
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding store-sync has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/core' to be able to use the store-sync package. Please run 'ng add @o3r/core' .
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
-
 /**
  * Add Otter store-sync to an Otter Project
  * @param options
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
-  return async (tree, context) => {
+  return (tree, context) => {
     // use dynamic import to properly raise an exception if it is not an Otter project.
-    const {
-      getPackageInstallConfig,
-      applyEsLintFix,
-      setupDependencies,
-      getO3rPeerDeps,
-      getProjectNewDependenciesTypes,
-      getWorkspaceConfig,
-      getExternalDependenciesVersionRange
-    } = await import('@o3r/schematics');
 
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
@@ -80,9 +74,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter store-sync to an Otter Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/store-sync/tsconfig.json
+++ b/packages/@o3r/store-sync/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -10,6 +10,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/style-dictionary/package.json
+++ b/packages/@o3r/style-dictionary/package.json
@@ -47,6 +47,7 @@
   },
   "peerDependencies": {
     "@o3r/core": "workspace:^",
+    "@o3r/schematics": "workspace:^",
     "@o3r/telemetry": "workspace:^",
     "style-dictionary": "^4.3.2",
     "type-fest": "^4.30.1"
@@ -84,7 +85,6 @@
     "@o3r/build-helpers": "workspace:^",
     "@o3r/core": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/telemetry": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",

--- a/packages/@o3r/style-dictionary/tsconfig.json
+++ b/packages/@o3r/style-dictionary/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -10,6 +10,9 @@
     },
     {
       "path": "./tsconfig.builders.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/stylelint-plugin/package.json
+++ b/packages/@o3r/stylelint-plugin/package.json
@@ -23,6 +23,7 @@
     "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest"
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "ts-node": "~10.9.2",
     "tslib": "^2.6.2"
   },
@@ -59,7 +60,6 @@
     "@o3r/build-helpers": "workspace:^",
     "@o3r/eslint-config": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",
     "@stylistic/eslint-plugin": "~3.1.0",

--- a/packages/@o3r/stylelint-plugin/schematics/ng-add/index.ts
+++ b/packages/@o3r/stylelint-plugin/schematics/ng-add/index.ts
@@ -2,6 +2,15 @@ import * as path from 'node:path';
 import type {
   Rule,
 } from '@angular-devkit/schematics';
+import {
+  createOtterSchematic,
+  getExternalDependenciesVersionRange,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  setupDependencies,
+} from '@o3r/schematics';
 import type {
   NgAddSchematicsSchema,
 } from './schema';
@@ -13,13 +22,6 @@ const dependenciesToInstall = [
   'stylelint'
 ];
 
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/stylelint-plugin has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/core' to be able to use the mobile package. Please run 'ng add @o3r/core' .
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
-
 /**
  * Add Otter stylelint-plugin to an Angular Project
  * @param options
@@ -27,15 +29,6 @@ Otherwise, use the error message as guidance.`);
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   /* ng add rules */
   return async (tree, context) => {
-    const {
-      getExternalDependenciesVersionRange,
-      getPackageInstallConfig,
-      getProjectNewDependenciesTypes,
-      getO3rPeerDeps,
-      getWorkspaceConfig,
-      setupDependencies
-    } = await import('@o3r/schematics');
-
     const { NodeDependencyType } = await import('@schematics/angular/utility/dependencies');
     const depsInfo = getO3rPeerDeps(packageJsonPath);
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
@@ -67,9 +60,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter stylelint-plugin to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/stylelint-plugin/tsconfig.json
+++ b/packages/@o3r/stylelint-plugin/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -6,7 +6,13 @@
       "path": "./tsconfig.build.composite.json"
     },
     {
+      "path": "./tsconfig.builders.json"
+    },
+    {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/styling/ng-package.json
+++ b/packages/@o3r/styling/ng-package.json
@@ -2,6 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json",
   "dest": "./dist",
   "deleteDestPath": false,
+  "allowedNonPeerDependencies": [
+    "@o3r/schematics"
+  ],
   "lib": {
     "entryFile": "src/public_api.ts"
   },

--- a/packages/@o3r/styling/package.json
+++ b/packages/@o3r/styling/package.json
@@ -130,6 +130,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -161,7 +162,6 @@
     "@o3r/eslint-config": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
     "@o3r/extractors": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",
     "@stylistic/eslint-plugin": "~3.1.0",

--- a/packages/@o3r/styling/schematics/ng-add/index.ts
+++ b/packages/@o3r/styling/schematics/ng-add/index.ts
@@ -5,6 +5,20 @@ import {
   Rule,
 } from '@angular-devkit/schematics';
 import {
+  createOtterSchematic,
+  getDefaultOptionsForSchematic,
+  getExternalDependenciesVersionRange,
+  getO3rPeerDeps,
+  getPackageInstallConfig,
+  getProjectNewDependenciesTypes,
+  getWorkspaceConfig,
+  registerPackageCollectionSchematics,
+  removePackages,
+  setupDependencies,
+  setupSchematicsParamsForProject,
+  updateSassImports,
+} from '@o3r/schematics';
+import {
   updateCmsAdapter,
 } from '../cms-adapter';
 import type {
@@ -21,13 +35,6 @@ const dependenciesToInstall = [
   '@angular/cdk'
 ];
 
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/styling has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/core' to be able to use the styling package. Please run 'ng add @o3r/core' .
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
-
 /**
  * Add Otter styling to an Angular Project
  * Update the styling if the app/lib used otter v7
@@ -36,19 +43,7 @@ Otherwise, use the error message as guidance.`);
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
   return async (tree, context) => {
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
-    const {
-      getDefaultOptionsForSchematic,
-      getPackageInstallConfig,
-      getO3rPeerDeps,
-      getProjectNewDependenciesTypes,
-      getWorkspaceConfig,
-      setupDependencies,
-      removePackages,
-      registerPackageCollectionSchematics,
-      setupSchematicsParamsForProject,
-      updateSassImports,
-      getExternalDependenciesVersionRange
-    } = await import('@o3r/schematics');
+
     options = { ...getDefaultOptionsForSchematic(getWorkspaceConfig(tree), '@o3r/styling', 'ng-add', options), ...options };
     const { updateThemeFiles, removeV7OtterAssetsInAngularJson } = await import('./theme-files');
     const { NodeDependencyType } = await import('@schematics/angular/utility/dependencies');
@@ -113,9 +108,4 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Update the styling if the app/lib used otter v7
  * @param options for the dependency installations
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
-  return createOtterSchematic(ngAddFn)(options);
-};
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/styling/schematics/ng-add/theme-files/index.ts
+++ b/packages/@o3r/styling/schematics/ng-add/theme-files/index.ts
@@ -14,6 +14,11 @@ import {
   Tree,
   url,
 } from '@angular-devkit/schematics';
+import {
+  getTemplateFolder,
+  getWorkspaceConfig,
+  writeAngularJson,
+} from '@o3r/schematics';
 
 /**
  * Added styling support
@@ -22,8 +27,7 @@ import {
  * @param options.projectName
  */
 export function updateThemeFiles(rootPath: string, options: { projectName?: string | null | undefined }): Rule {
-  return async (tree: Tree, context: SchematicContext) => {
-    const { getTemplateFolder, getWorkspaceConfig } = await import('@o3r/schematics');
+  return (tree: Tree, context: SchematicContext) => {
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
     if (!workspaceProject || workspaceProject.projectType === 'library') {
       return noop;
@@ -79,8 +83,7 @@ type Asset = { glob: string; input: string; output: string };
  * @param options.projectName
  */
 export function removeV7OtterAssetsInAngularJson(options: { projectName?: string | null | undefined }): Rule {
-  return async (tree: Tree, context: SchematicContext) => {
-    const { writeAngularJson, getWorkspaceConfig } = await import('@o3r/schematics');
+  return (tree: Tree, context: SchematicContext) => {
     const workspace = getWorkspaceConfig(tree);
     const projectName = options.projectName;
     const workspaceProject = options.projectName ? workspace?.projects[options.projectName] : undefined;

--- a/packages/@o3r/styling/tsconfig.json
+++ b/packages/@o3r/styling/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -10,6 +10,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/testing/package.json
+++ b/packages/@o3r/testing/package.json
@@ -177,6 +177,7 @@
     }
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "esbuild": "~0.25.1",
     "module-from-string": "^3.2.0",
     "tslib": "^2.6.2"
@@ -207,7 +208,6 @@
     "@o3r/core": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
     "@o3r/localization": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@playwright/test": "~1.51.0",
     "@schematics/angular": "~19.2.0",

--- a/packages/@o3r/testing/schematics/ng-add/fixture/index.ts
+++ b/packages/@o3r/testing/schematics/ng-add/fixture/index.ts
@@ -4,6 +4,10 @@ import {
   SchematicContext,
   Tree,
 } from '@angular-devkit/schematics';
+import {
+  getTestFramework,
+  getWorkspaceConfig,
+} from '@o3r/schematics';
 import type {
   TsConfigJson,
 } from 'type-fest';
@@ -22,8 +26,7 @@ export function updateFixtureConfig(options: { projectName?: string | null | und
    * @param tree
    * @param context
    */
-  const updateTestTsconfig: Rule = async (tree: Tree, context: SchematicContext) => {
-    const { getTestFramework, getWorkspaceConfig } = await import('@o3r/schematics');
+  const updateTestTsconfig: Rule = (tree: Tree, context: SchematicContext) => {
     const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
 
     if (!workspaceProject) {

--- a/packages/@o3r/testing/tsconfig.json
+++ b/packages/@o3r/testing/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -10,6 +10,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/third-party/ng-package.json
+++ b/packages/@o3r/third-party/ng-package.json
@@ -6,6 +6,7 @@
     "entryFile": "src/index.ts"
   },
   "allowedNonPeerDependencies": [
-    "uuid"
+    "uuid",
+    "@o3r/schematics"
   ]
 }

--- a/packages/@o3r/third-party/package.json
+++ b/packages/@o3r/third-party/package.json
@@ -19,6 +19,7 @@
     "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest"
   },
   "dependencies": {
+    "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2",
     "uuid": "^11.0.5"
   },
@@ -69,7 +70,6 @@
     "@o3r/core": "workspace:^",
     "@o3r/eslint-config": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",
     "@stylistic/eslint-plugin": "~3.1.0",

--- a/packages/@o3r/third-party/schematics/ng-add/index.ts
+++ b/packages/@o3r/third-party/schematics/ng-add/index.ts
@@ -4,26 +4,24 @@ import {
   chain,
   type Rule,
 } from '@angular-devkit/schematics';
+import {
+  createOtterSchematic,
+  getPackageInstallConfig,
+  registerPackageCollectionSchematics,
+  setupDependencies,
+} from '@o3r/schematics';
 import type {
   NgAddSchematicsSchema,
 } from './schema';
-
-const reportMissingSchematicsDep = (logger: { error: (message: string) => any }) => (reason: any) => {
-  logger.error(`[ERROR]: Adding @o3r/third-party has failed.
-If the error is related to missing @o3r dependencies you need to install '@o3r/core' to be able to use the configuration package. Please run 'ng add @o3r/core' .
-Otherwise, use the error message as guidance.`);
-  throw reason;
-};
 
 /**
  * Add Otter third-party to an Angular Project
  * @param options
  */
 function ngAddFn(options: NgAddSchematicsSchema): Rule {
-  return async (tree) => {
+  return (tree) => {
     const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
-    const { getPackageInstallConfig, registerPackageCollectionSchematics, setupDependencies } = await import('@o3r/schematics');
     return chain([
       registerPackageCollectionSchematics(packageJson),
       setupDependencies({
@@ -38,9 +36,6 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
  * Add Otter third-party to an Angular Project
  * @param options
  */
-export const ngAdd = (options: NgAddSchematicsSchema): Rule => async (_, { logger }) => {
-  const {
-    createOtterSchematic
-  } = await import('@o3r/schematics').catch(reportMissingSchematicsDep(logger));
+export const ngAdd = (options: NgAddSchematicsSchema): Rule => () => {
   return createOtterSchematic(ngAddFn)(options);
 };

--- a/packages/@o3r/third-party/tsconfig.json
+++ b/packages/@o3r/third-party/tsconfig.json
@@ -1,3 +1,4 @@
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "files": [],
@@ -7,7 +8,13 @@
       "path": "./tsconfig.build.json"
     },
     {
+      "path": "./tsconfig.builders.json"
+    },
+    {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/packages/@o3r/workspace/package.json
+++ b/packages/@o3r/workspace/package.json
@@ -41,6 +41,7 @@
     "@angular/common": "^19.0.0",
     "@angular/compiler-cli": "^19.0.0",
     "@angular/core": "^19.0.0",
+    "@o3r/schematics": "workspace:^",
     "@o3r/telemetry": "workspace:^",
     "@schematics/angular": "^19.0.0",
     "ts-node": "~10.9.2",
@@ -49,6 +50,9 @@
   },
   "peerDependenciesMeta": {
     "@angular/cli": {
+      "optional": true
+    },
+    "@o3r/schematics": {
       "optional": true
     },
     "@o3r/telemetry": {
@@ -95,7 +99,6 @@
     "@o3r/build-helpers": "workspace:^",
     "@o3r/core": "workspace:^",
     "@o3r/eslint-plugin": "workspace:^",
-    "@o3r/schematics": "workspace:^",
     "@o3r/telemetry": "workspace:^",
     "@o3r/test-helpers": "workspace:^",
     "@schematics/angular": "~19.2.0",

--- a/packages/@o3r/workspace/schematics/library/rules/shared.ts
+++ b/packages/@o3r/workspace/schematics/library/rules/shared.ts
@@ -90,6 +90,11 @@ export function updateNgPackagrFactory(targetPath: string): Rule {
     const ngPackagr = tree.readJson(path.posix.join(targetPath, 'ng-package.json')) as any;
     ngPackagr.$schema = 'https://raw.githubusercontent.com/ng-packagr/ng-packagr/master/src/ng-package.schema.json';
     ngPackagr.dest = './dist';
+    ngPackagr.allowedNonPeerDependencies ||= [];
+    const schematicDependency = '@o3r/schematics';
+    if (!ngPackagr.allowedNonPeerDependencies.includes(schematicDependency)) {
+      ngPackagr.allowedNonPeerDependencies.push(schematicDependency);
+    }
     tree.overwrite(path.posix.join(targetPath, 'ng-package.json'), JSON.stringify(ngPackagr, null, 2));
     return tree;
   };

--- a/packages/@o3r/workspace/tsconfig.json
+++ b/packages/@o3r/workspace/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "extends": "../../../tsconfig.base",
   "references": [
@@ -10,6 +10,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/tools/github-actions/audit/tsconfig.json
+++ b/tools/github-actions/audit/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "references": [
     {
@@ -6,6 +6,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/tools/github-actions/new-version/tsconfig.json
+++ b/tools/github-actions/new-version/tsconfig.json
@@ -12,7 +12,7 @@
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/*.spec.ts"],
-  /* For IDE usage only */
+  /* For IDE and EsLint usage */
   "references": [
     {
       "path": "./tsconfig.spec.json"

--- a/tools/github-actions/release/tsconfig.json
+++ b/tools/github-actions/release/tsconfig.json
@@ -1,8 +1,11 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "references": [
     {
       "path": "./tsconfig.build.composite.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/tools/github-actions/yarn-errors-reporter/tsconfig.json
+++ b/tools/github-actions/yarn-errors-reporter/tsconfig.json
@@ -1,4 +1,4 @@
-/* For IDE usage only */
+/* For IDE and EsLint usage */
 {
   "references": [
     {
@@ -6,6 +6,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.eslint.json"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10983,6 +10983,7 @@ __metadata:
     zone.js: "npm:~0.15.0"
   peerDependencies:
     "@o3r/core": "workspace:^"
+    "@o3r/schematics": "workspace:^"
     "@o3r/telemetry": "workspace:^"
     style-dictionary: ^4.3.2
     type-fest: ^4.30.1
@@ -11718,6 +11719,7 @@ __metadata:
     "@angular/common": ^19.0.0
     "@angular/compiler-cli": ^19.0.0
     "@angular/core": ^19.0.0
+    "@o3r/schematics": "workspace:^"
     "@o3r/telemetry": "workspace:^"
     "@schematics/angular": ^19.0.0
     ts-node: ~10.9.2
@@ -11725,6 +11727,8 @@ __metadata:
     typescript: ^5.5.4
   peerDependenciesMeta:
     "@angular/cli":
+      optional: true
+    "@o3r/schematics":
       optional: true
     "@o3r/telemetry":
       optional: true


### PR DESCRIPTION
## Proposed change

- Avoid `ng-add` issue in non-otter project
- Simplified schematics implementation

### Includes

- [x] `@o3r/schematics` moved to prod dependencies
- [x] fix issue regarding global EsLint not applied to builders
- [x] add `tsconfig.eslint.json` into referred TS Config
- [x] add mcp configuration suggested by Nx for VsCode

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

- 🍒  #3144
- 🍒 #3143
- 🍒 #3142 

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
