### PR TITLE
fix: export C11nDirective in C11nModule to avoid breaking change (#3162)

### DIFF
--- a/packages/@o3r/components/src/tools/component-replacement/c11n.module.ts
+++ b/packages/@o3r/components/src/tools/component-replacement/c11n.module.ts
@@ -35,7 +35,8 @@ export function createC11nService(config: { registerCompFunc: () => Map<string, 
  * @deprecated Will be removed in v14.
  */
 @NgModule({
-  imports: [C11nDirective]
+  imports: [C11nDirective],
+  exports: [C11nDirective]
 })
 export class C11nModule {
   /**


### PR DESCRIPTION
## Proposed change

In #3000, the `C11nDirective` has been removed from the exports of the `C11nModule` which is a breaking change. A fix has been delivered for the same issue for the `DynamicContentModule` here : #3065 . Doing the same in this PR for the `C11nModule`.

## Related issues

Issue #3162
PR #3000


:bug: Fix resolves #3162
