### PR TITLE
fix: broken links in forms documentation

### DIFF
--- a/docs/forms/FORM_STRUCTURE.md
+++ b/docs/forms/FORM_STRUCTURE.md
@@ -95,7 +95,7 @@ __Parent component class:__
 * Create a form control to set the binding and the default data.
 * This form control will be passed as an input to the input component class through the HTML template.
 
-You can find the implementation of a parent component class in the [showcase application](https://github.com/AmadeusITGroup/otter/tree/main/apps/showcase/src/components/showcase/forms/forms-pres.component.ts).
+You can find the implementation of a parent component class in the [showcase application](https://github.com/AmadeusITGroup/otter/tree/main/apps/showcase/src/components/showcase/forms-parent/forms-parent.component.ts).
 
 __Input component class:__
    * Here we have to create the `formGroup`/`formArray`/`formControl` object.

--- a/docs/forms/FORM_VALIDATION.md
+++ b/docs/forms/FORM_VALIDATION.md
@@ -89,7 +89,7 @@ The validation function can be defined anywhere, but it has to be added to the v
 The object returned by the custom validator will be of type `ErrorMessageObject` compatible with the form error store. (See [Form Errors](./FORM_ERRORS.md)).
 The key `customErrors` of this object is used to identify the custom errors in the errors returned by a form control.
 
-You can find an [example](https://github.com/AmadeusITGroup/otter/tree/main/apps/showcase/src/components/showcase/forms/forms-pres.validators.ts) of two custom validators in the forms example of the showcase application.
+You can find an [example](https://github.com/AmadeusITGroup/otter/tree/main/apps/showcase/src/components/showcase/forms-parent/forms-parent.validators.ts) of two custom validators in the forms example of the showcase application.
 
 * __Parent component__: 
 
@@ -97,7 +97,7 @@ The validators object in the parent component is of type [__CustomFormValidation
 This interface contains two entries: one for global (root) form validation and one for the other fields.
 The `fields` entry is receiving the form contract as generic type.
 
-The implementation of the two custom validators in the validators object of the parent component can be found in the [forms component of the showcase application](https://github.com/AmadeusITGroup/otter/tree/main/apps/showcase/src/components/showcase/forms/forms-pres.component.ts).
+The implementation of the two custom validators in the validators object of the parent component can be found in the [forms component of the showcase application](https://github.com/AmadeusITGroup/otter/tree/main/apps/showcase/src/components/showcase/forms-parent/forms-parent.component.ts).
 
 #### Apply custom validators
 

--- a/docs/forms/README.md
+++ b/docs/forms/README.md
@@ -60,6 +60,6 @@ See [Form Submit and Intercommunication](./FORM_SUBMIT_AND_INTERCOMMUNICATION.md
 > The first subcomponent has a form for the user to fill out their personal information and the second subcomponent has a form for the user to fill out
 > information about their emergency contact. In this example, the two subcomponents correspond to input components.
 >
-> You can find the implementation of this forms example [in the source code of the showcase application](https://github.com/AmadeusITGroup/otter/tree/main/apps/showcase/src/components/showcase/forms).
+> You can find the implementation of this forms example [in the source code of the showcase application](https://github.com/AmadeusITGroup/otter/tree/main/apps/showcase/src/components/showcase/forms-parent).
 >
 > This example will be referenced throughout this documentation.


### PR DESCRIPTION
## Proposed change

Fix the broken links in the forms documentation.
 * :bug: Fix resolves #3168

