### PR TITLE
fix: do not start server for pw in int tests

### DIFF
--- a/packages/@o3r/testing/schematics/ng-add/playwright/templates/e2e-playwright/playwright-config.ts.template
+++ b/packages/@o3r/testing/schematics/ng-add/playwright/templates/e2e-playwright/playwright-config.ts.template
@@ -35,7 +35,7 @@ const config = defineConfig({
       command: '<%= startCommand %>',
       cwd: path.join(__dirname, '..'),
       port: <%= serverPort %>,
-      timeout: 10 * 1000,
+      timeout: 120 * 1000,
       reuseExistingServer: !process.env.CI
     }] : []
   ]


### PR DESCRIPTION
## Proposed change

The Playwright server is already started via the config (https://github.com/AmadeusITGroup/otter/pull/3157) 
No need to start another server in the integration test.