### PR TITLE
fix: com protocol resize triggered when a significant height change

### DIFF
--- a/packages/@ama-mfe/ng-utils/src/resize/resize.producer.service.ts
+++ b/packages/@ama-mfe/ng-utils/src/resize/resize.producer.service.ts
@@ -71,7 +71,7 @@ export class ResizeService implements MessageProducer<ResizeMessage> {
    */
   public startResizeObserver() {
     this.resizeObserver = new ResizeObserver(() => {
-      if (document.body.scrollHeight !== this.actualHeight) {
+      if (!this.actualHeight || Math.abs(document.body.scrollHeight - this.actualHeight) > DELTA_RESIZE) {
         this.actualHeight = document.body.scrollHeight;
         const messageV10 = {
           type: 'resize',


### PR DESCRIPTION
## Proposed change

Send a resize message only when the change of the height is significant (bigger than DELTA_RESIZE)

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
