### PR TITLE
feat: support a computed id for the memorize route in com protocol

### DIFF
--- a/packages/@ama-mfe/ng-utils/src/navigation/route-memorize/route-memorize.directive.spec.ts
+++ b/packages/@ama-mfe/ng-utils/src/navigation/route-memorize/route-memorize.directive.spec.ts
@@ -85,15 +85,21 @@ describe('RouteMemorizeDirective', () => {
   });
 
   it('should not memorize route if memorizeRoute is true but the id (from memorizeRouteId input) provided does not match the channelId from requestedUrl', () => {
-    parentComponentInstance.memorizeRouteId = 'testChannelIdNotMatch';
+    parentComponentInstance.memorizeRouteId = 'notMatchTestChannelId';
     parentComponentFixture.detectChanges();
     expect(routeMemorizeService.memorizeRoute).not.toHaveBeenCalled();
   });
 
   it('should not memorize route if memorizeRoute is true but the id (from connect input) provided does not match the channelId from requestedUrl', () => {
-    parentComponentInstance.connect = 'testChannelIdNotMatch';
+    parentComponentInstance.connect = 'notMatchTestChannelId';
     parentComponentFixture.detectChanges();
     expect(routeMemorizeService.memorizeRoute).not.toHaveBeenCalled();
+  });
+
+  it('should memorize route if memorizeRoute is true and the id (from memorizeRouteId input) starts with channelId from requestedUrl', () => {
+    parentComponentInstance.memorizeRouteId = 'testChannelIdPlusBasePath';
+    parentComponentFixture.detectChanges();
+    expect(routeMemorizeService.memorizeRoute).toHaveBeenCalledWith('testChannelIdPlusBasePath', 'testUrl', 0);
   });
 
   it('should call memorize route when passing the memorizeRouteId which matches the channelId from requestedUrl', () => {

--- a/packages/@ama-mfe/ng-utils/src/navigation/route-memorize/route-memorize.directive.ts
+++ b/packages/@ama-mfe/ng-utils/src/navigation/route-memorize/route-memorize.directive.ts
@@ -68,7 +68,7 @@ export class RouteMemorizeDirective {
       }
       const requested = requestedUrlSignal();
       const id = this.memorizeRouteId() || this.connect();
-      if (requested && id && requested.channelId === id) {
+      if (requested && id && requested.channelId && id.startsWith(requested.channelId)) {
         memory.memorizeRoute(id, requested.url, untracked(this.maxAge));
       }
     });


### PR DESCRIPTION
## Proposed change

This is just a proposal to have a computed id for the route to memorize (the moduleId + routeId)
<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
