### PR TITLE
fix: adjust path replacement script to work with node 20.19.0

### DIFF
--- a/.github/workflows/it-tests.yml
+++ b/.github/workflows/it-tests.yml
@@ -23,7 +23,7 @@ on:
 env:
   NX_PARALLEL: ${{ vars.NX_PARALLEL }}
   NX_TASK_TARGET_CONFIGURATION: ci
-  NX_SKIP_NX_CACHE: ${{ inputs.skipNxCache }}
+  NX_SKIP_NX_CACHE: true
   YARN_ENABLE_HARDENED_MODE: 0
 
 permissions:


### PR DESCRIPTION
## Proposed change

Follow-up PR after it-tests breaking due to pnp infinite loop and maximum call stack exceeded

## Related issues

Fixes 🐛  #3047 

