### PR TITLE
fix(style-dictionary): remove sizeRem transform

### DIFF
--- a/packages/@o3r/style-dictionary/src/transform-groups/css-recommended.transform-group.mts
+++ b/packages/@o3r/style-dictionary/src/transform-groups/css-recommended.transform-group.mts
@@ -16,7 +16,8 @@ export const cssRecommendedTransformGroup: TransformGroup = {
     transforms.nameKebab,
     transforms.timeSeconds,
     transforms.htmlIcon,
-    transforms.sizeRem,
+    // The following transform is commented because it is part of default CSS transform but conflict on the way Figma manage font weights:
+    // transforms.sizeRem,
     transforms.colorCss,
     transforms.assetUrl,
     transforms.fontFamilyCss,


### PR DESCRIPTION
## Proposed change

fix(style-dictionary): remove sizeRem from recommended transforms

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
