### PR TITLE
feat(ama-mfe): handle `NavigationMessage` consumption by `RoutingService`

### DIFF
--- a/packages/@ama-mfe/ng-utils/README.md
+++ b/packages/@ama-mfe/ng-utils/README.md
@@ -7,8 +7,7 @@ interaction between host and embedded applications.
 
 Key features include:
 - [Connect](https://github.com/AmadeusITGroup/otter/blob/main/packages/%40ama-mfe/ng-utils/src/connect/): Connect to the communication protocol and send messages to registered applications.
-- [Navigation](https://github.com/AmadeusITGroup/otter/blob/main/packages/%40ama-mfe/ng-utils/src/navigation/): Ensures the host application can update its navigation to reflect the embedded application's URL,
-maintaining consistency even after a page refresh.
+- [Navigation](https://github.com/AmadeusITGroup/otter/blob/main/packages/%40ama-mfe/ng-utils/src/navigation/): Handles navigation messages between the host and embedded applications. Embedded applications can use `RoutingService` to sync their internal routing with the host application. The host application can use `NavigationConsumerService` to get notifications about navigation events in the embedded applications.
 - [Theme](https://github.com/AmadeusITGroup/otter/blob/main/packages/%40ama-mfe/ng-utils/src/theme/): Allows the application of unified CSS variables and styles across embedded modules, ensuring a cohesive
 look and feel.
 - [Resize](https://github.com/AmadeusITGroup/otter/blob/main/packages/%40ama-mfe/ng-utils/src/resize/): Dynamically adjusts the iframe dimensions to fit the content of the embedded application, enhancing the

--- a/packages/@ama-mfe/ng-utils/eslint.local.config.mjs
+++ b/packages/@ama-mfe/ng-utils/eslint.local.config.mjs
@@ -32,7 +32,7 @@ export default [
   },
   {
     name: '@ama-mfe/ng-utils/messages-definition',
-    files: ['**/*.versions.ts', '**/*.consumer.service.ts'],
+    files: ['**/*.versions.ts', '**/*.consumer.service.ts', '**/routing.service.ts'],
     rules: {
       '@typescript-eslint/naming-convention': [
         'error',

--- a/packages/@ama-mfe/ng-utils/src/managers/interfaces.ts
+++ b/packages/@ama-mfe/ng-utils/src/managers/interfaces.ts
@@ -29,7 +29,7 @@ export interface BasicMessageConsumer<T extends VersionedMessage = VersionedMess
 }
 
 /** The consumer of a given message type */
-export interface MessageConsumer<T extends VersionedMessage> extends BasicMessageConsumer {
+export interface MessageConsumer<T extends VersionedMessage = VersionedMessage> extends BasicMessageConsumer {
 
   /** The message type which will be handled */
   type: T['type'];

--- a/packages/@ama-mfe/ng-utils/src/managers/utils.ts
+++ b/packages/@ama-mfe/ng-utils/src/managers/utils.ts
@@ -2,7 +2,11 @@ import {
   DestroyRef,
   inject,
 } from '@angular/core';
+import {
+  ConsumerManagerService,
+} from './consumer.manager.service';
 import type {
+  MessageConsumer,
   MessageProducer,
 } from './interfaces';
 import {
@@ -20,5 +24,19 @@ export const registerProducer = (producer: MessageProducer) => {
 
   inject(DestroyRef).onDestroy(() => {
     producerManagerService.unregister(producer);
+  });
+};
+
+/**
+ * Method to call in the constructor of a consumer
+ * @note should be used in injection context
+ * @param consumer
+ */
+export const registerConsumer = (consumer: MessageConsumer) => {
+  const consumerManagerService = inject(ConsumerManagerService);
+  consumerManagerService.register(consumer);
+
+  inject(DestroyRef).onDestroy(() => {
+    consumerManagerService.unregister(consumer);
   });
 };

--- a/packages/@ama-mfe/ng-utils/src/navigation/index.ts
+++ b/packages/@ama-mfe/ng-utils/src/navigation/index.ts
@@ -1,4 +1,4 @@
 export * from './navigation.consumer.service';
 export * from './route-memorize/index';
-export * from './navigation.producer.service';
+export * from './routing.service';
 export * from './restore-route.pipe';

--- a/packages/@ama-mfe/ng-utils/src/navigation/routing.service.spec.ts
+++ b/packages/@ama-mfe/ng-utils/src/navigation/routing.service.spec.ts
@@ -24,6 +24,7 @@ import {
   Subject,
 } from 'rxjs';
 import {
+  ConsumerManagerService,
   ProducerManagerService,
 } from '../managers/index';
 import type {
@@ -31,19 +32,30 @@ import type {
 } from '../messages/error';
 import {
   RoutingService,
-} from './navigation.producer.service';
+} from './routing.service';
 
 describe('Navigation Producer Service', () => {
-  let navProducerService: RoutingService;
+  let routingService: RoutingService;
   let producerManagerService: ProducerManagerService;
   let messageService: MessagePeerService<NavigationMessage>;
   let loggerServiceMock: jest.Mocked<LoggerService>;
 
   let routerEventsSubject: Subject<any>;
+  let mockRouter: Partial<Router>;
   let router: Router;
 
   beforeEach(() => {
     routerEventsSubject = new Subject<any>();
+    mockRouter = {
+      events: routerEventsSubject.asObservable(),
+      navigateByUrl: jest.fn(),
+      getCurrentNavigation: jest.fn()
+    };
+
+    const consumerManagerServiceMock: Partial<ConsumerManagerService> = {
+      register: jest.fn(),
+      unregister: jest.fn()
+    };
     const producerManagerServiceMock = {
       register: jest.fn(),
       unregister: jest.fn()
@@ -61,14 +73,15 @@ describe('Navigation Producer Service', () => {
       providers: [
         RoutingService,
         { provide: LoggerService, useValue: loggerServiceMock },
-        { provide: Router, useValue: { events: routerEventsSubject.asObservable(), getCurrentNavigation: jest.fn(() => {}) } },
-        { provide: ProducerManagerService, useValue: producerManagerServiceMock },
+        { provide: Router, useValue: mockRouter },
+        { provide: ProducerManagerService, useValue: consumerManagerServiceMock },
+        { provide: ConsumerManagerService, useValue: producerManagerServiceMock },
         { provide: MessagePeerService, useValue: messageServiceMock },
         { provide: ActivatedRoute, useValue: { routeConfig: { path: 'test-path' } } }
       ]
     });
 
-    navProducerService = TestBed.inject(RoutingService);
+    routingService = TestBed.inject(RoutingService);
     messageService = TestBed.inject(MessagePeerService<NavigationMessage>);
     producerManagerService = TestBed.inject(ProducerManagerService);
     router = TestBed.inject(Router);
@@ -76,7 +89,7 @@ describe('Navigation Producer Service', () => {
 
   it('should register itself when instantiated', () => {
     jest.spyOn(producerManagerService, 'register');
-    expect(producerManagerService.register).toHaveBeenCalledWith(navProducerService);
+    expect(producerManagerService.register).toHaveBeenCalledWith(routingService);
   });
 
   it('should send navigation message via messageService if embedded', () => {
@@ -85,7 +98,7 @@ describe('Navigation Producer Service', () => {
     Object.defineProperty(mockedWindow, 'self', { value: mockedWindow });
     const windowSpy = jest.spyOn(globalThis, 'window', 'get').mockReturnValue(mockedWindow);
     runInInjectionContext(TestBed.inject(Injector), () => {
-      navProducerService.handleEmbeddedRouting();
+      routingService.handleEmbeddedRouting();
     });
 
     routerEventsSubject.next(new NavigationEnd(1, 'start-url', 'end-url'));
@@ -98,11 +111,29 @@ describe('Navigation Producer Service', () => {
     windowSpy.mockRestore();
   });
 
+  it('should forward received Navigation message to the router', () => {
+    TestBed.runInInjectionContext(() => {
+      expect(Object.keys(routingService.supportedVersions)).toEqual(['1.0']);
+
+      routingService.supportedVersions['1.0']({
+        from: 'sender',
+        to: ['receiver'],
+        payload: {
+          type: 'navigation',
+          version: '1.0',
+          url: '/test'
+        }
+      });
+
+      expect(mockRouter.navigateByUrl).toHaveBeenCalledWith('/test');
+    });
+  });
+
   it('should send navigation message via endpointManagerService if channelId is present and not embedded', () => {
     jest.spyOn(router, 'getCurrentNavigation').mockReturnValue({ extras: { state: { channelId: 'test-channel-id' } } } as any);
 
     runInInjectionContext(TestBed.inject(Injector), () => {
-      navProducerService.handleEmbeddedRouting();
+      routingService.handleEmbeddedRouting();
     });
 
     routerEventsSubject.next(new NavigationEnd(1, 'start-url', 'end-url'));
@@ -121,7 +152,7 @@ describe('Navigation Producer Service', () => {
     });
 
     runInInjectionContext(TestBed.inject(Injector), () => {
-      navProducerService.handleEmbeddedRouting();
+      routingService.handleEmbeddedRouting();
     });
 
     routerEventsSubject.next(new NavigationEnd(1, 'start-url', 'end-url'));
@@ -131,7 +162,7 @@ describe('Navigation Producer Service', () => {
 
   it('should warn if no channelId is provided and not embedded', () => {
     runInInjectionContext(TestBed.inject(Injector), () => {
-      navProducerService.handleEmbeddedRouting();
+      routingService.handleEmbeddedRouting();
     });
 
     routerEventsSubject.next(new NavigationEnd(1, 'start-url', 'end-url'));
@@ -142,7 +173,7 @@ describe('Navigation Producer Service', () => {
   it('should handle errors', () => {
     const errorMessage: ErrorContent<NavigationV1_0> = { reason: 'unknown_type', source: { type: 'navigation', version: '1.0', url: '' } };
 
-    navProducerService.handleError(errorMessage);
+    routingService.handleError(errorMessage);
 
     expect(loggerServiceMock.error).toHaveBeenCalledWith('Error in navigation service message', errorMessage);
   });

--- a/packages/@ama-mfe/ng-utils/src/navigation/routing.service.ts
+++ b/packages/@ama-mfe/ng-utils/src/navigation/routing.service.ts
@@ -5,6 +5,9 @@ import type {
 import {
   NAVIGATION_MESSAGE_TYPE,
 } from '@ama-mfe/messages';
+import type {
+  RoutedMessage,
+} from '@amadeus-it-group/microfrontends';
 import {
   MessagePeerService,
 } from '@amadeus-it-group/microfrontends-angular';
@@ -28,7 +31,9 @@ import {
   map,
 } from 'rxjs';
 import {
+  type MessageConsumer,
   type MessageProducer,
+  registerConsumer,
   registerProducer,
 } from '../managers/index';
 import {
@@ -49,15 +54,15 @@ export interface RoutingServiceOptions {
 }
 
 /**
- * A service that handles routing and message production for navigation events.
+ * A service that keeps in sync Router navigation and navigation messages.
  *
- * This service listens to Angular router events and sends navigation messages
- * to a message peer service. It also handles errors related to navigation messages.
+ * - listens to Router events and sends navigation messages
+ * - handles incoming navigation messages and triggers Router navigation
  */
 @Injectable({
   providedIn: 'root'
 })
-export class RoutingService implements MessageProducer<NavigationMessage> {
+export class RoutingService implements MessageProducer<NavigationMessage>, MessageConsumer<NavigationMessage> {
   private readonly router = inject(Router);
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly messageService = inject(MessagePeerService<NavigationMessage>);
@@ -68,9 +73,35 @@ export class RoutingService implements MessageProducer<NavigationMessage> {
    */
   public readonly types = NAVIGATION_MESSAGE_TYPE;
 
+  /**
+   * @inheritdoc
+   */
+  public readonly type = 'navigation';
+
+  /**
+   * Use the message payload to navigate to the specified URL.
+   * @param message message to consume
+   */
+  public readonly supportedVersions = {
+    '1.0': (message: RoutedMessage<any>) => {
+      void this.router.navigateByUrl(message.payload.url);
+    }
+  };
+
   constructor() {
     registerProducer(this);
+    registerConsumer(this);
   }
+
+  /**
+   * @inheritdoc
+   */
+  public start(): void {}
+
+  /**
+   * @inheritdoc
+   */
+  public stop(): void {}
 
   /**
    * @inheritdoc


### PR DESCRIPTION
`RoutingService` used by embedded modules now both produces and consumes Navigation messages:

- when a module receives a message - it triggers internal Routing navigation
- when internal Routing navigation is finished - it sends a message to notify others