### PR TITLE
cherry-pick: ama-mfe resize based on getClientBoundRect

### DIFF
--- a/packages/@ama-mfe/ng-utils/src/resize/resize.producer.service.spec.ts
+++ b/packages/@ama-mfe/ng-utils/src/resize/resize.producer.service.spec.ts
@@ -18,7 +18,6 @@ import {
   ErrorContent,
 } from '../messages/index';
 import {
-  DELTA_RESIZE,
   ResizeService,
 } from './resize.producer.service';
 
@@ -61,6 +60,10 @@ describe('ResizeService', () => {
     injector = TestBed.inject(Injector);
   });
 
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('should register itself when instantiated', () => {
     expect(producerManagerService.register).toHaveBeenCalledWith(resizeService);
   });
@@ -70,40 +73,40 @@ describe('ResizeService', () => {
     runInInjectionContext(injector, () => {
       resizeService.startResizeObserver();
 
-      Object.defineProperty(document.body, 'scrollHeight', { value: 1000, configurable: true });
+      jest.spyOn(document.body, 'getBoundingClientRect').mockReturnValue({ height: 1000 } as DOMRect);
 
       // simulate observer change as there is no api for ResizeObserver in jest
       // eslint-disable-next-line @typescript-eslint/dot-notation, dot-notation -- access a private property for test
       const resizeObserverInstance = (resizeService as any)['resizeObserver'];
-      resizeObserverInstance.observerCallback();
-      expect(messageService.send).toHaveBeenCalledWith({ height: 1000 + DELTA_RESIZE, type: 'resize', version: '1.0' });
 
-      Object.defineProperty(document.body, 'scrollHeight', { value: 1200, configurable: true });
       resizeObserverInstance.observerCallback();
-      expect(messageService.send).toHaveBeenCalledWith({ height: 1200 + DELTA_RESIZE, type: 'resize', version: '1.0' });
+      expect(messageService.send).toHaveBeenCalledWith({ height: 1000, type: 'resize', version: '1.0' });
+
+      jest.spyOn(document.body, 'getBoundingClientRect').mockReturnValue({ height: 1200 } as DOMRect);
+
+      resizeObserverInstance.observerCallback();
+      expect(messageService.send).toHaveBeenCalledWith({ height: 1200, type: 'resize', version: '1.0' });
     });
   });
 
-  it('should not send resize message when body height changes with less then DELTA_RESIZE', () => {
+  it('should not send resize message when body height does not change', () => {
     global.ResizeObserver = MockedResizeObserver;
     runInInjectionContext(injector, () => {
       resizeService.startResizeObserver();
 
-      Object.defineProperty(document.body, 'scrollHeight', { value: 1000, configurable: true });
+      jest.spyOn(document.body, 'getBoundingClientRect').mockReturnValue({ height: 101 } as DOMRect);
 
       // simulate observer change as there is no api for ResizeObserver in jest
       // eslint-disable-next-line @typescript-eslint/dot-notation, dot-notation -- access a private property for test
       const resizeObserverInstance = (resizeService as any)['resizeObserver'];
       resizeObserverInstance.observerCallback();
-      expect(messageService.send).toHaveBeenCalledWith({ height: 1000 + DELTA_RESIZE, type: 'resize', version: '1.0' });
-      jest.clearAllMocks();
-      Object.defineProperty(document.body, 'scrollHeight', { value: 1001.6, configurable: true });
-      Object.defineProperty(document.body, 'scrollHeight', { value: 1000.3, configurable: true });
+      jest.spyOn(document.body, 'getBoundingClientRect').mockReturnValue({ height: 101 } as DOMRect);
       resizeObserverInstance.observerCallback();
-      expect(messageService.send).not.toHaveBeenCalled();
-      Object.defineProperty(document.body, 'scrollHeight', { value: 1008.2, configurable: true });
+      expect(messageService.send).toHaveBeenCalledTimes(1);
+      expect(messageService.send).toHaveBeenCalledWith({ height: 101, type: 'resize', version: '1.0' });
+      jest.spyOn(document.body, 'getBoundingClientRect').mockReturnValue({ height: 1008.2 } as DOMRect);
       resizeObserverInstance.observerCallback();
-      expect(messageService.send).toHaveBeenCalledWith({ height: 1008.2 + DELTA_RESIZE, type: 'resize', version: '1.0' });
+      expect(messageService.send).toHaveBeenCalledWith({ height: 1008.2, type: 'resize', version: '1.0' });
     });
   });
 

--- a/packages/@ama-mfe/ng-utils/src/resize/resize.producer.service.ts
+++ b/packages/@ama-mfe/ng-utils/src/resize/resize.producer.service.ts
@@ -22,14 +22,6 @@ import {
 } from '../messages/index';
 
 /**
- * `scrollHeight` is a rounded number (cf https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight)
- *
- * So we have to add a delta to ensure no scrollbar will appear on the host,
- * in case the `scrollHeight` is rounded down
- */
-export const DELTA_RESIZE = 1;
-
-/**
  * This service observe changes in the document's body height.
  * When the height changes, it sends a resize message with the new height, to the connected peers
  */
@@ -64,12 +56,13 @@ export class ResizeService implements MessageProducer<ResizeMessage> {
    */
   public startResizeObserver() {
     this.resizeObserver = new ResizeObserver(() => {
-      if (!this.actualHeight || Math.abs(document.body.scrollHeight - this.actualHeight) > DELTA_RESIZE) {
-        this.actualHeight = document.body.scrollHeight;
+      const newHeight = document.body.getBoundingClientRect().height;
+      if (!this.actualHeight || newHeight !== this.actualHeight) {
+        this.actualHeight = newHeight;
         const messageV10 = {
           type: 'resize',
           version: '1.0',
-          height: document.body.scrollHeight + DELTA_RESIZE
+          height: this.actualHeight
         } satisfies ResizeV1_0;
         // TODO: sendBest() is not implemented -- https://github.com/AmadeusITGroup/microfrontends/issues/11
         this.messageService.send(messageV10);


### PR DESCRIPTION
## Proposed change
Cherry-picked from 
https://github.com/AmadeusITGroup/otter/pull/3248
<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
