### PR TITLE
Fix @o3r/configuration update schematics

### DIFF
--- a/packages/@o3r/configuration/package.json
+++ b/packages/@o3r/configuration/package.json
@@ -147,5 +147,8 @@
     "node": "^20.11.1 || >=22.0.0"
   },
   "builders": "./builders.json",
-  "schematics": "./collection.json"
+  "schematics": "./collection.json",
+  "ng-update": {
+    "migrations": "./migration.json"
+  }
 }


### PR DESCRIPTION
## Proposed change

Currently running ng update @o3r/configuration results in
`Package does not provide migrations.`

This is because the reference to "./migration.json" is missing in the package.json of this package.

Once it's added the ng update schematics are running properly.

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
