### PR TITLE
fix: align tsconfig moduleResolution to bundler

### DIFF
--- a/apps/chrome-devtools/tsconfig.build.components.json
+++ b/apps/chrome-devtools/tsconfig.build.components.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.build",
   "compilerOptions": {
     "composite": false,
-    "moduleResolution": "bundler"
   },
   "include": [
     "src/**/*.ts"

--- a/apps/chrome-devtools/tsconfig.build.devtools.json
+++ b/apps/chrome-devtools/tsconfig.build.devtools.json
@@ -2,8 +2,7 @@
   "extends": "./tsconfig.build",
   "compilerOptions": {
     "tsBuildInfoFile": "build/devtools.tsbuildinfo",
-    "composite": false,
-    "moduleResolution": "bundler"
+    "composite": false
   },
   "include": [
     "src/**/*.ts"

--- a/apps/chrome-devtools/tsconfig.build.json
+++ b/apps/chrome-devtools/tsconfig.build.json
@@ -10,7 +10,6 @@
     ],
     "outDir": "dist/",
     "module": "es2022",
-    "moduleResolution": "bundler",
     "incremental": true,
     "composite": true,
     "tsBuildInfoFile": "build/.tsbuildinfo"

--- a/apps/chrome-devtools/tsconfig.extension.json
+++ b/apps/chrome-devtools/tsconfig.extension.json
@@ -8,7 +8,6 @@
     "outDir": "dist",
     "rootDir": "./src",
     "module": "ES2020",
-    "moduleResolution": "Node",
     "tsBuildInfoFile": "build/extension.tsbuildinfo",
     "composite": true
   },

--- a/apps/github-cascading-app/tsconfig.build.json
+++ b/apps/github-cascading-app/tsconfig.build.json
@@ -8,6 +8,7 @@
     "composite": true,
     "incremental": true,
     "module": "commonjs",
+    "moduleResolution": "node10",
     "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo"
   },
   "include": [

--- a/apps/palette-generator/tsconfig.build.json
+++ b/apps/palette-generator/tsconfig.build.json
@@ -5,6 +5,7 @@
     "declaration": true,
     "composite": true,
     "module": "commonjs",
+    "moduleResolution": "node10",
     "outDir": "./dist",
     "importHelpers": false,
     "tsBuildInfoFile": "build/.tsbuildinfo"

--- a/apps/showcase/tsconfig.app.json
+++ b/apps/showcase/tsconfig.app.json
@@ -21,7 +21,6 @@
     "downlevelIteration": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "importHelpers": true,
     "target": "ES2022",

--- a/apps/vscode-extension/tsconfig.build.json
+++ b/apps/vscode-extension/tsconfig.build.json
@@ -5,6 +5,7 @@
     "incremental": true,
     "declaration": true,
     "module": "commonjs",
+    "moduleResolution": "node10",
     "outDir": "./dist",
     "importHelpers": false,
     "tsBuildInfoFile": "build/.tsbuildinfo"

--- a/packages/@ama-mfe/ng-utils/tsconfig.build.json
+++ b/packages/@ama-mfe/ng-utils/tsconfig.build.json
@@ -2,8 +2,7 @@
   "extends": "../../../tsconfig.build",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "src",
-    "moduleResolution": "bundler"
+    "rootDir": "src"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/@ama-mfe/ng-utils/tsconfig.builders.json
+++ b/packages/@ama-mfe/ng-utils/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@ama-sdk/client-angular/tsconfig.builders.json
+++ b/packages/@ama-sdk/client-angular/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@ama-sdk/client-beacon/tsconfig.builders.json
+++ b/packages/@ama-sdk/client-beacon/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@ama-sdk/client-fetch/tsconfig.builders.json
+++ b/packages/@ama-sdk/client-fetch/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@ama-sdk/core/tsconfig.builders.json
+++ b/packages/@ama-sdk/core/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@ama-sdk/create/tsconfig.build.json
+++ b/packages/@ama-sdk/create/tsconfig.build.json
@@ -7,6 +7,7 @@
     "sourceMap": false,
     "declarationMap": false,
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "outDir": "./dist",
     "rootDir": "src",
     "tsBuildInfoFile": "build/.tsbuildinfo"

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/tsconfig.build.json
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "types": [],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noImplicitAny": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/tsconfig.doc.json
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/templates/base/tsconfig.doc.json
@@ -2,7 +2,9 @@
   "extends": "./tsconfig.build",
   "compilerOptions": {
     "rootDir": ".",
-    "baseUrl": "."
+    "baseUrl": ".",
+    "module": "commonjs",
+    "moduleResolution": "node10"
   },
   "exclude": [
     "**/*.fixture.ts",

--- a/packages/@ama-sdk/schematics/tsconfig.builders.json
+++ b/packages/@ama-sdk/schematics/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@ama-sdk/schematics/tsconfig.cli.json
+++ b/packages/@ama-sdk/schematics/tsconfig.cli.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.cli"
   },

--- a/packages/@ama-sdk/swagger-builder/tsconfig.build.json
+++ b/packages/@ama-sdk/swagger-builder/tsconfig.build.json
@@ -4,6 +4,7 @@
     "types": ["node"],
     "lib": ["ES2022"],
     "module": "commonjs",
+    "moduleResolution": "node10",
     "outDir": "./dist",
     "noEmitHelpers": false,
     "importHelpers": false,

--- a/packages/@ama-styling/style-dictionary/tsconfig.builders.json
+++ b/packages/@ama-styling/style-dictionary/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "skipLibCheck": true, // because of @angular-devkit-schematics
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"

--- a/packages/@ama-styling/stylelint-plugin/tsconfig.builders.json
+++ b/packages/@ama-styling/stylelint-plugin/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@ama-terasu/cli/tsconfig.build.json
+++ b/packages/@ama-terasu/cli/tsconfig.build.json
@@ -4,6 +4,7 @@
     "types": ["node"],
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "composite": true,
     "incremental": true,
     "tsBuildInfoFile": "build/.tsbuildinfo",

--- a/packages/@ama-terasu/core/tsconfig.build.json
+++ b/packages/@ama-terasu/core/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "types": ["node"],
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "outDir": "./dist",
     "composite": true,
     "incremental": true,

--- a/packages/@ama-terasu/schematics/tsconfig.build.json
+++ b/packages/@ama-terasu/schematics/tsconfig.build.json
@@ -4,6 +4,7 @@
     "types": ["node"],
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "importHelpers": false,
     "composite": true,
     "incremental": true,

--- a/packages/@o3r-training/showcase-sdk/tsconfig.build.json
+++ b/packages/@o3r-training/showcase-sdk/tsconfig.build.json
@@ -4,7 +4,6 @@
     "src/**/*.ts"
   ],
   "compilerOptions": {
-    "moduleResolution": "bundler",
     "noImplicitAny": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/packages/@o3r-training/training-sdk/tsconfig.build.json
+++ b/packages/@o3r-training/training-sdk/tsconfig.build.json
@@ -4,7 +4,6 @@
     "src/**/*.ts"
   ],
   "compilerOptions": {
-    "moduleResolution": "bundler",
     "noImplicitAny": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/packages/@o3r-training/training-tools/tsconfig.build.json
+++ b/packages/@o3r-training/training-tools/tsconfig.build.json
@@ -6,6 +6,7 @@
     "composite": true,
     "rootDir": ".",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "tsBuildInfoFile": "./build/tsconfig.tsbuildinfo",
     "outDir": "./dist",
     "skipLibCheck": true /* because of @webcontainer/api 1.4.0 */

--- a/packages/@o3r-training/training-tools/tsconfig.builders.json
+++ b/packages/@o3r-training/training-tools/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r-training/training-tools/tsconfig.cli.json
+++ b/packages/@o3r-training/training-tools/tsconfig.cli.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.cli",
     "skipLibCheck": true /* because of @webcontainer/api 1.4.0 */

--- a/packages/@o3r/amaterasu/amaterasu-api-spec/tsconfig.build.json
+++ b/packages/@o3r/amaterasu/amaterasu-api-spec/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "types": ["node"],
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "outDir": "./dist",
     "composite": true,
     "incremental": true,

--- a/packages/@o3r/amaterasu/amaterasu-dodo/tsconfig.build.json
+++ b/packages/@o3r/amaterasu/amaterasu-dodo/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "types": ["node"],
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "outDir": "./dist",
     "composite": true,
     "incremental": true,

--- a/packages/@o3r/amaterasu/amaterasu-otter/tsconfig.build.json
+++ b/packages/@o3r/amaterasu/amaterasu-otter/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "types": ["node"],
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "outDir": "./dist",
     "composite": true,
     "incremental": true,

--- a/packages/@o3r/amaterasu/amaterasu-sdk/tsconfig.build.json
+++ b/packages/@o3r/amaterasu/amaterasu-sdk/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "types": ["node"],
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "outDir": "./dist",
     "composite": true,
     "incremental": true,

--- a/packages/@o3r/analytics/tsconfig.build.json
+++ b/packages/@o3r/analytics/tsconfig.build.json
@@ -7,8 +7,7 @@
     ],
     "skipLibCheck": true, // Due to Jasmine / Jest fixture compilation conflicting on types
     "outDir": "./dist",
-    "rootDir": "src",
-    "moduleResolution": "bundler"
+    "rootDir": "src"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/@o3r/analytics/tsconfig.builders.json
+++ b/packages/@o3r/analytics/tsconfig.builders.json
@@ -7,6 +7,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r/analytics/tsconfig.plugins.json
+++ b/packages/@o3r/analytics/tsconfig.plugins.json
@@ -6,6 +6,7 @@
     "incremental": true,
     "composite": true,
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "outDir": "./dist/plugins",
     "rootDir": "plugins",
     "tsBuildInfoFile": "build/plugins/.tsbuildinfo"

--- a/packages/@o3r/apis-manager/tsconfig.build.json
+++ b/packages/@o3r/apis-manager/tsconfig.build.json
@@ -2,8 +2,7 @@
   "extends": "../../../tsconfig.build",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "src",
-    "moduleResolution": "bundler"
+    "rootDir": "src"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/@o3r/apis-manager/tsconfig.builders.json
+++ b/packages/@o3r/apis-manager/tsconfig.builders.json
@@ -5,6 +5,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "types": ["node"],
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"

--- a/packages/@o3r/application/tsconfig.build.json
+++ b/packages/@o3r/application/tsconfig.build.json
@@ -2,8 +2,7 @@
   "extends": "../../../tsconfig.build",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "src",
-    "moduleResolution": "bundler"
+    "rootDir": "src"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/@o3r/application/tsconfig.builders.json
+++ b/packages/@o3r/application/tsconfig.builders.json
@@ -5,6 +5,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "types": ["node"],
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"

--- a/packages/@o3r/artifactory-tools/tsconfig.builders.json
+++ b/packages/@o3r/artifactory-tools/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r/azure-tools/tsconfig.build.json
+++ b/packages/@o3r/azure-tools/tsconfig.build.json
@@ -7,7 +7,7 @@
     "incremental": true,
     "composite": true,
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
     "outDir": "./dist",
     "rootDir": ".",
     "tsBuildInfoFile": "./build/.tsbuildinfo"

--- a/packages/@o3r/azure-tools/tsconfig.builders.json
+++ b/packages/@o3r/azure-tools/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r/components/builders/component-extractor/index.ts
+++ b/packages/@o3r/components/builders/component-extractor/index.ts
@@ -5,8 +5,8 @@ import {
   createBuilder,
 } from '@angular-devkit/architect';
 import type {
-  LoggerApi,
-} from '@angular-devkit/core/src/logger';
+  logging,
+} from '@angular-devkit/core';
 import {
   CmsMetadataData,
   createBuilderWithMetricsIfInstalled,
@@ -48,7 +48,7 @@ const STEP_NUMBER = 5;
  * @param logger
  * @param strictMode
  */
-function checkUniquenessLibraryAndName(configurations: ComponentConfigOutput[], logger: LoggerApi, strictMode = false) {
+function checkUniquenessLibraryAndName(configurations: ComponentConfigOutput[], logger: logging.LoggerApi, strictMode = false) {
   const setOfLibraryAndName: Set<string> = new Set();
   let errors = '';
   configurations.forEach((configuration) => {

--- a/packages/@o3r/components/tsconfig.build.json
+++ b/packages/@o3r/components/tsconfig.build.json
@@ -2,8 +2,7 @@
   "extends": "../../../tsconfig.build",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "src",
-    "moduleResolution": "bundler"
+    "rootDir": "src"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/@o3r/components/tsconfig.builders.json
+++ b/packages/@o3r/components/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders",
     "esModuleInterop": true,

--- a/packages/@o3r/configuration/tsconfig.build.json
+++ b/packages/@o3r/configuration/tsconfig.build.json
@@ -7,8 +7,7 @@
     ],
     "skipLibCheck": true, // Due to Jasmine / Jest fixture compilation conflicting on types
     "outDir": "./dist",
-    "rootDir": "src",
-    "moduleResolution": "bundler"
+    "rootDir": "src"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/@o3r/configuration/tsconfig.builders.json
+++ b/packages/@o3r/configuration/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r/core/tsconfig.build.json
+++ b/packages/@o3r/core/tsconfig.build.json
@@ -2,8 +2,7 @@
   "extends": "../../../tsconfig.build",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "src",
-    "moduleResolution": "bundler"
+    "rootDir": "src"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/@o3r/core/tsconfig.builders.json
+++ b/packages/@o3r/core/tsconfig.builders.json
@@ -5,6 +5,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r/create/tsconfig.build.json
+++ b/packages/@o3r/create/tsconfig.build.json
@@ -7,6 +7,7 @@
     "sourceMap": false,
     "declarationMap": false,
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "outDir": "./dist",
     "rootDir": "src",
     "tsBuildInfoFile": "build/.tsbuildinfo"

--- a/packages/@o3r/design/tsconfig.build.json
+++ b/packages/@o3r/design/tsconfig.build.json
@@ -5,6 +5,7 @@
     "incremental": true,
     "composite": true,
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "outDir": "./dist",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo"

--- a/packages/@o3r/design/tsconfig.builders.json
+++ b/packages/@o3r/design/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r/dynamic-content/tsconfig.build.json
+++ b/packages/@o3r/dynamic-content/tsconfig.build.json
@@ -7,8 +7,7 @@
     ],
     "skipLibCheck": true, // Due to Jasmine / Jest fixture compilation conflicting on types
     "outDir": "./dist",
-    "rootDir": "src",
-    "moduleResolution": "bundler"
+    "rootDir": "src"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/@o3r/dynamic-content/tsconfig.builders.json
+++ b/packages/@o3r/dynamic-content/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r/eslint-config-otter/tsconfig.builders.json
+++ b/packages/@o3r/eslint-config-otter/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r/eslint-config/tsconfig.build.json
+++ b/packages/@o3r/eslint-config/tsconfig.build.json
@@ -4,6 +4,7 @@
     "incremental": true,
     "composite": true,
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/packages/@o3r/eslint-config/tsconfig.builders.json
+++ b/packages/@o3r/eslint-config/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r/eslint-plugin/tsconfig.build.json
+++ b/packages/@o3r/eslint-plugin/tsconfig.build.json
@@ -10,7 +10,8 @@
     "types": ["node"],
     "baseUrl": ".",
     "outDir": "dist",
-    "module": "CommonJS"
+    "module": "CommonJS",
+    "moduleResolution": "node10"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/@o3r/eslint-plugin/tsconfig.builders.json
+++ b/packages/@o3r/eslint-plugin/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r/extractors/schematics/cms-adapter/templates/tsconfig.cms.json.template
+++ b/packages/@o3r/extractors/schematics/cms-adapter/templates/tsconfig.cms.json.template
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "target": "es5",
     "module": "es2020",
-    "moduleResolution": "node",
     "experimentalDecorators": true,
     "lib": [
       "dom",

--- a/packages/@o3r/extractors/tsconfig.build.json
+++ b/packages/@o3r/extractors/tsconfig.build.json
@@ -5,6 +5,7 @@
     "incremental": true,
     "composite": true,
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "outDir": "./dist",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo"

--- a/packages/@o3r/extractors/tsconfig.builders.json
+++ b/packages/@o3r/extractors/tsconfig.builders.json
@@ -5,6 +5,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "skipLibCheck": true, // because of @gerrit0/mini-shiki from typedoc
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"

--- a/packages/@o3r/forms/tsconfig.build.json
+++ b/packages/@o3r/forms/tsconfig.build.json
@@ -2,8 +2,7 @@
   "extends": "../../../tsconfig.build",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "src",
-    "moduleResolution": "bundler"
+    "rootDir": "src"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/@o3r/forms/tsconfig.builders.json
+++ b/packages/@o3r/forms/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r/localization/builders/localization/index.ts
+++ b/packages/@o3r/localization/builders/localization/index.ts
@@ -7,8 +7,8 @@ import {
   Target,
 } from '@angular-devkit/architect';
 import {
-  LogEntry,
-} from '@angular-devkit/core/src/logger';
+  logging,
+} from '@angular-devkit/core';
 import {
   createBuilderWithMetricsIfInstalled,
 } from '@o3r/extractors';
@@ -299,7 +299,7 @@ function startMetadataGenerator(localizationExtractorTarget: Target, context: Bu
       logger.pipe(),
       from(extractorBuild.then((build) => build.result))
     ).pipe(
-      filter((entry) => !(entry as LogEntry).message || /Localization metadata bundle extracted/.test((entry as LogEntry).message))
+      filter((entry) => !(entry as logging.LogEntry).message || /Localization metadata bundle extracted/.test((entry as logging.LogEntry).message))
     )
   );
 }

--- a/packages/@o3r/localization/tsconfig.build.json
+++ b/packages/@o3r/localization/tsconfig.build.json
@@ -2,8 +2,7 @@
   "extends": "../../../tsconfig.build",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "src",
-    "moduleResolution": "bundler"
+    "rootDir": "src"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/@o3r/localization/tsconfig.builders.json
+++ b/packages/@o3r/localization/tsconfig.builders.json
@@ -5,6 +5,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "types": ["node"],
     "skipLibCheck": true, // because of @gerrit0/mini-shiki from typedoc

--- a/packages/@o3r/logger/tsconfig.build.json
+++ b/packages/@o3r/logger/tsconfig.build.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "src",
-    "target": "ES2020",
-    "moduleResolution": "bundler"
+    "target": "ES2020"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/@o3r/logger/tsconfig.builders.json
+++ b/packages/@o3r/logger/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r/mobile/tsconfig.build.json
+++ b/packages/@o3r/mobile/tsconfig.build.json
@@ -2,8 +2,7 @@
   "extends": "../../../tsconfig.build",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "src",
-    "moduleResolution": "bundler"
+    "rootDir": "src"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/@o3r/mobile/tsconfig.builders.json
+++ b/packages/@o3r/mobile/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r/mobile/tsconfig.pcloudy.json
+++ b/packages/@o3r/mobile/tsconfig.pcloudy.json
@@ -7,7 +7,7 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
     "noEmitHelpers": true,
     "noUnusedLocals": true,
     "outDir": "./dist/pcloudy",

--- a/packages/@o3r/new-version/tsconfig.build.json
+++ b/packages/@o3r/new-version/tsconfig.build.json
@@ -7,7 +7,7 @@
     "incremental": true,
     "composite": true,
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
     "outDir": "./dist",
     "rootDir": ".",
     "tsBuildInfoFile": "./build/.tsbuildinfo"

--- a/packages/@o3r/new-version/tsconfig.builders.json
+++ b/packages/@o3r/new-version/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r/pipeline/tsconfig.build.json
+++ b/packages/@o3r/pipeline/tsconfig.build.json
@@ -4,6 +4,7 @@
     "incremental": true,
     "composite": true,
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "outDir": "./dist",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo"

--- a/packages/@o3r/pipeline/tsconfig.builders.json
+++ b/packages/@o3r/pipeline/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r/routing/tsconfig.build.json
+++ b/packages/@o3r/routing/tsconfig.build.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "skipLibCheck": true, // Due to Jasmine / Jest fixture compilation conflicting on types
     "outDir": "./dist",
-    "rootDir": "src",
-    "moduleResolution": "bundler"
+    "rootDir": "src"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/@o3r/routing/tsconfig.builders.json
+++ b/packages/@o3r/routing/tsconfig.builders.json
@@ -7,6 +7,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r/rules-engine/builders/rules-engine-extractor/helpers/rules-engine.extractor.ts
+++ b/packages/@o3r/rules-engine/builders/rules-engine-extractor/helpers/rules-engine.extractor.ts
@@ -3,11 +3,9 @@ import {
 } from 'node:fs';
 import * as path from 'node:path';
 import {
+  logging,
   strings,
 } from '@angular-devkit/core';
-import type {
-  LoggerApi,
-} from '@angular-devkit/core/src/logger';
 import {
   ConfigDocParser,
 } from '@o3r/extractors';
@@ -60,7 +58,7 @@ export class RulesEngineExtractor {
   /** Instance of the comment parser */
   private readonly commentParser = new ConfigDocParser();
 
-  constructor(tsconfigPath: string, private readonly basePath: string, private readonly logger: LoggerApi) {
+  constructor(tsconfigPath: string, private readonly basePath: string, private readonly logger: logging.LoggerApi) {
     const { config } = ts.readConfigFile(tsconfigPath, (p) => ts.sys.readFile(p));
     this.tsconfig = config;
   }

--- a/packages/@o3r/rules-engine/tsconfig.build.json
+++ b/packages/@o3r/rules-engine/tsconfig.build.json
@@ -7,8 +7,7 @@
     ],
     "skipLibCheck": true, // Due to Jasmine / Jest fixture compilation conflicting on types
     "outDir": "./dist",
-    "rootDir": "src",
-    "moduleResolution": "bundler"
+    "rootDir": "src"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/@o3r/rules-engine/tsconfig.builders.json
+++ b/packages/@o3r/rules-engine/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders",
     "esModuleInterop": true,

--- a/packages/@o3r/schematics/src/rule-factories/check-packages-peers/index.ts
+++ b/packages/@o3r/schematics/src/rule-factories/check-packages-peers/index.ts
@@ -2,9 +2,9 @@ import {
   readFileSync,
 } from 'node:fs';
 import * as path from 'node:path';
-import type {
-  LoggerApi,
-} from '@angular-devkit/core/src/logger';
+import {
+  logging,
+} from '@angular-devkit/core';
 import type {
   SchematicContext,
   Tree,
@@ -80,7 +80,7 @@ function getPackagesToInstallOrUpdate(packageName: string) {
  * @param logger
  * @param angularJsonString
  */
-function checkPackagesToInstallOrUpdate(packageName: string, logger: LoggerApi, angularJsonString?: string | null) {
+function checkPackagesToInstallOrUpdate(packageName: string, logger: logging.LoggerApi, angularJsonString?: string | null) {
   const packageManager = getPackageManager({ workspaceConfig: angularJsonString });
   const { packagesToInstall, packagesWrongVersion } = getPackagesToInstallOrUpdate(packageName);
 

--- a/packages/@o3r/schematics/src/utility/migration/migration.ts
+++ b/packages/@o3r/schematics/src/utility/migration/migration.ts
@@ -1,6 +1,6 @@
 import type {
-  LoggerApi,
-} from '@angular-devkit/core/src/logger';
+  logging,
+} from '@angular-devkit/core';
 import {
   chain,
   type Rule,
@@ -34,7 +34,7 @@ export interface MigrationRulesMap {
  */
 interface MigrationRuleRunnerOptions {
   /** Logger */
-  logger?: LoggerApi;
+  logger?: logging.LoggerApi;
 }
 
 /**

--- a/packages/@o3r/schematics/tsconfig.build.json
+++ b/packages/@o3r/schematics/tsconfig.build.json
@@ -5,6 +5,7 @@
     "incremental": true,
     "composite": true,
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "outDir": "./dist",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo"

--- a/packages/@o3r/schematics/tsconfig.builders.json
+++ b/packages/@o3r/schematics/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r/schematics/tsconfig.cli.json
+++ b/packages/@o3r/schematics/tsconfig.cli.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.cli"
   },

--- a/packages/@o3r/store-sync/tsconfig.build.json
+++ b/packages/@o3r/store-sync/tsconfig.build.json
@@ -4,8 +4,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "outDir": "./dist",
-    "rootDir": "src",
-    "moduleResolution": "bundler"
+    "rootDir": "src"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/@o3r/store-sync/tsconfig.builders.json
+++ b/packages/@o3r/store-sync/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r/style-dictionary/tsconfig.builders.json
+++ b/packages/@o3r/style-dictionary/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "skipLibCheck": true, // because of @angular-devkit-schematics
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"

--- a/packages/@o3r/stylelint-plugin/tsconfig.builders.json
+++ b/packages/@o3r/stylelint-plugin/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r/styling/tsconfig.build.json
+++ b/packages/@o3r/styling/tsconfig.build.json
@@ -2,8 +2,7 @@
   "extends": "../../../tsconfig.build",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": ".",
-    "moduleResolution": "bundler"
+    "rootDir": "."
   },
   "include": [
     "src/**/*.ts"

--- a/packages/@o3r/styling/tsconfig.builders.json
+++ b/packages/@o3r/styling/tsconfig.builders.json
@@ -5,6 +5,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "skipLibCheck": true, // because of @gerrit0/mini-shiki from typedoc
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"

--- a/packages/@o3r/telemetry/tsconfig.build.json
+++ b/packages/@o3r/telemetry/tsconfig.build.json
@@ -6,6 +6,7 @@
     "incremental": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo",
     "esModuleInterop": true

--- a/packages/@o3r/telemetry/tsconfig.builders.json
+++ b/packages/@o3r/telemetry/tsconfig.builders.json
@@ -5,6 +5,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "types": ["node"],
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"

--- a/packages/@o3r/test-helpers/tsconfig.build.json
+++ b/packages/@o3r/test-helpers/tsconfig.build.json
@@ -7,6 +7,7 @@
     "outDir": "./dist",
     "rootDir": "src",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "tsBuildInfoFile": "build/.tsbuildinfo",
     "skipLibCheck": true // due to ts-jest which contains non-exposed "babel__core" reference
   },

--- a/packages/@o3r/test-helpers/tsconfig.spec.json
+++ b/packages/@o3r/test-helpers/tsconfig.spec.json
@@ -4,7 +4,8 @@
     "allowSyntheticDefaultImports": true,
     "incremental": true,
     "outDir": "../../dist/out-tsc",
-    "module": "commonjs"
+    "module": "commonjs",
+    "moduleResolution": "node10"
   },
   "include": [
     "src/**/*.test.ts",

--- a/packages/@o3r/testing/tsconfig.build.json
+++ b/packages/@o3r/testing/tsconfig.build.json
@@ -11,6 +11,7 @@
     "rootDir": "./src",
     "inlineSources": true,
     "target": "ES5",
+    "moduleResolution": "node10",
     "module": "CommonJS",
   },
   "include": [

--- a/packages/@o3r/testing/tsconfig.builders.json
+++ b/packages/@o3r/testing/tsconfig.builders.json
@@ -5,6 +5,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r/testing/tsconfig.schematics.json
+++ b/packages/@o3r/testing/tsconfig.schematics.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.schematics"
   },

--- a/packages/@o3r/third-party/tsconfig.build.json
+++ b/packages/@o3r/third-party/tsconfig.build.json
@@ -5,8 +5,7 @@
     "types": [
       "node"
     ],
-    "rootDir": "src",
-    "moduleResolution": "bundler"
+    "rootDir": "src"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/@o3r/third-party/tsconfig.builders.json
+++ b/packages/@o3r/third-party/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/packages/@o3r/workspace/tsconfig.build.json
+++ b/packages/@o3r/workspace/tsconfig.build.json
@@ -4,6 +4,7 @@
     "incremental": true,
     "composite": true,
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "outDir": "./dist",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo"

--- a/packages/@o3r/workspace/tsconfig.builders.json
+++ b/packages/@o3r/workspace/tsconfig.builders.json
@@ -6,6 +6,7 @@
     "composite": true,
     "outDir": "./dist",
     "module": "CommonJS",
+    "moduleResolution": "node10",
     "rootDir": ".",
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },

--- a/tools/github-actions/audit/tsconfig.build.json
+++ b/tools/github-actions/audit/tsconfig.build.json
@@ -4,6 +4,7 @@
     "types": ["node"],
     "target": "ES2022",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "moduleResolution": "node10",
     "outDir": "./tmp",                        /* Redirect output structure to the directory. */
     "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     "strict": true,                           /* Enable all strict type-checking options. */

--- a/tools/github-actions/get-npm-tag/tsconfig.json
+++ b/tools/github-actions/get-npm-tag/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "target": "ES2022",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "moduleResolution": "node10",
     "outDir": "./tmp",                        /* Redirect output structure to the directory. */
     "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     "strict": true,                           /* Enable all strict type-checking options. */

--- a/tools/github-actions/new-version/tsconfig.json
+++ b/tools/github-actions/new-version/tsconfig.json
@@ -4,6 +4,7 @@
     "types": ["node"],
     "target": "ES2022",
     "module": "commonjs",
+    "moduleResolution": "node10",
     "outDir": "./tmp",
     "rootDir": "./src",
     "strict": true,

--- a/tools/github-actions/release/tsconfig.build.json
+++ b/tools/github-actions/release/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "types": ["node"],
     "module": "commonjs",
+    "moduleResolution": "node10",
     "outDir": "./tmp",
     "incremental": true,
     "composite": true

--- a/tools/github-actions/yarn-errors-reporter/tsconfig.build.json
+++ b/tools/github-actions/yarn-errors-reporter/tsconfig.build.json
@@ -4,6 +4,7 @@
     "types": ["node"],
     "target": "ES2022",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "moduleResolution": "node10",
     "outDir": "./tmp",                        /* Redirect output structure to the directory. */
     "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     "strict": true,                           /* Enable all strict type-checking options. */

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,7 +21,7 @@
       "ES2022"
     ],
     "module": "ES2022",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noEmitHelpers": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
## Proposed change

Only use other moduleResolution if module is node or commonjs:
<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

<!-- * :bug: Fix #issue -->
* :bug: Fix resolves #3340 
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
