### PR TITLE
fix(localization): issue when a translation is confure() call

### DIFF
--- a/docs/localization/LOCALIZATION.md
+++ b/docs/localization/LOCALIZATION.md
@@ -478,7 +478,7 @@ import { LocalizationService } from '@o3r/localization';
 
 // Inject LocalizationService which will take care of configuring TranslateService using LocalizationConfiguration and call configure() method
 constructor() {
-  inject(LocalizationService).configure();
+  void inject(LocalizationService).configure();
 }
 ```
 

--- a/packages/@o3r/localization/src/tools/localization-translate.pipe.spec.ts
+++ b/packages/@o3r/localization/src/tools/localization-translate.pipe.spec.ts
@@ -77,7 +77,7 @@ describe('LocalizationTranslatePipe', () => {
 
       localizationService = TestBed.inject(LocalizationService);
       // initialize TranslateService via configure of LocalizationService
-      localizationService.configure();
+      await localizationService.configure();
       translate = TestBed.inject(TranslateService);
       ref = new FakeChangeDetectorRef();
       pipe = new O3rLocalizationTranslatePipe(localizationService, translate, ref, TestBed.inject(LOCALIZATION_CONFIGURATION_TOKEN));
@@ -106,7 +106,7 @@ describe('LocalizationTranslatePipe', () => {
 
         localizationService = TestBed.inject(LocalizationService);
         // initialize TranslateService via configure of LocalizationService
-        localizationService.configure();
+        await localizationService.configure();
         translate = TestBed.inject(TranslateService);
         ref = new FakeChangeDetectorRef();
         pipe = new O3rLocalizationTranslatePipe(localizationService, translate, ref, TestBed.inject(LOCALIZATION_CONFIGURATION_TOKEN));
@@ -148,7 +148,7 @@ describe('LocalizationTranslatePipe', () => {
         }).compileComponents();
         localizationService = TestBed.inject(LocalizationService);
         // initialize TranslateService via configure of LocalizationService
-        localizationService.configure();
+        await localizationService.configure();
         translate = TestBed.inject(TranslateService);
         ref = new FakeChangeDetectorRef();
         pipe = new O3rLocalizationTranslatePipe(localizationService, translate, ref, TestBed.inject(LOCALIZATION_CONFIGURATION_TOKEN));

--- a/packages/@o3r/localization/src/tools/localization.service.spec.ts
+++ b/packages/@o3r/localization/src/tools/localization.service.spec.ts
@@ -33,7 +33,7 @@ describe('LocalizationService', () => {
       }).compileComponents();
       localizationService = TestBed.inject(LocalizationService);
 
-      localizationService.configure();
+      await localizationService.configure();
     });
 
     it('should be used for translations (en)', () => {
@@ -62,7 +62,7 @@ describe('LocalizationService', () => {
       }).compileComponents();
       localizationService = TestBed.inject(LocalizationService);
 
-      localizationService.configure();
+      await localizationService.configure();
     });
 
     it('should translate to the same language, when supported language provided', () => {
@@ -126,7 +126,7 @@ describe('LocalizationService', () => {
       localizationService = TestBed.inject(LocalizationService);
       const translateService = localizationService.getTranslateService();
       translateServiceSpy = jest.spyOn(translateService, 'setDefaultLang');
-      localizationService.configure();
+      await localizationService.configure();
     });
 
     it('should translate to the language provided in the configuration, when a supported language is provided', () => {
@@ -157,7 +157,7 @@ describe('LocalizationService', () => {
       localizationService = TestBed.inject(LocalizationService);
       const translateService = localizationService.getTranslateService();
       translateServiceSpy = jest.spyOn(translateService, 'setDefaultLang');
-      localizationService.configure();
+      await localizationService.configure();
     });
 
     it('should translate to the fallback language provided in the configuration, when a non supported language is provided', () => {
@@ -194,7 +194,7 @@ describe('LocalizationService', () => {
       }).compileComponents();
       localizationService = TestBed.inject(LocalizationService);
 
-      localizationService.configure();
+      await localizationService.configure();
     });
 
     it('should translate to the same language, when supported language provided', () => {


### PR DESCRIPTION
## Proposed change

fix(localization): issue when a translation is listen before the first bundle download

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
