### PR TITLE
fix: add variables to temporarily deactivate nx cache

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -13,6 +13,11 @@ on:
         default: false
         required: false
         description: Skip the nx cache
+      skipNxRemoteCache:
+        type: boolean
+        default: false
+        required: false
+        description: Skip the nx remote cache
     secrets:
       CODECOV_TOKEN:
         required: false
@@ -22,6 +27,7 @@ env:
   NX_PARALLEL: ${{ vars.NX_PARALLEL }}
   NX_TASK_TARGET_CONFIGURATION: ci
   NX_SKIP_NX_CACHE: ${{ inputs.skipNxCache }}
+  NX_SKIP_REMOTE_CACHE: ${{inputs.skipNxRemoteCache}}
   YARN_ENABLE_HARDENED_MODE: 0
 
 permissions:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,11 +8,17 @@ on:
         default: false
         required: false
         description: Skip the nx cache
+      skipNxRemoteCache:
+        type: boolean
+        default: false
+        required: false
+        description: Skip the nx remote cache
 
 env:
   NX_PARALLEL: ${{ vars.NX_PARALLEL }}
   NX_TASK_TARGET_CONFIGURATION: ci
   NX_SKIP_NX_CACHE: ${{ inputs.skipNxCache }}
+  NX_SKIP_REMOTE_CACHE: ${{inputs.skipNxRemoteCache}}
   YARN_ENABLE_HARDENED_MODE: 0
   E2E_REPORT: e2e-report
 

--- a/.github/workflows/it-tests.yml
+++ b/.github/workflows/it-tests.yml
@@ -8,6 +8,11 @@ on:
         default: false
         required: false
         description: Skip the nx cache
+      skipNxRemoteCache:
+        type: boolean
+        default: false
+        required: false
+        description: Skip the nx remote cache
       ref:
         type: string
         default: ''
@@ -21,6 +26,7 @@ env:
   NX_PARALLEL: ${{ vars.NX_PARALLEL }}
   NX_TASK_TARGET_CONFIGURATION: ci
   NX_SKIP_NX_CACHE: ${{ inputs.skipNxCache }}
+  NX_SKIP_REMOTE_CACHE: ${{inputs.skipNxRemoteCache}}
   YARN_ENABLE_HARDENED_MODE: 0
 
 permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [yarn_lock_check]
     env:
-      NX_SKIP_NX_CACHE: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') }}
+      NX_SKIP_NX_CACHE: ${{ vars.NX_SKIP_NX_CACHE == 'true' ||  github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') }}
+      NX_SKIP_REMOTE_CACHE: ${{ vars.NX_SKIP_REMOTE_CACHE }}
       NODE_COMPILE_CACHE: ~/.cache/node-compilation
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -107,7 +108,8 @@ jobs:
     needs: [yarn_lock_check]
     with:
       affected: ${{ github.event_name == 'pull_request' }}
-      skipNxCache: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') }}
+      skipNxCache: ${{ vars.NX_SKIP_NX_CACHE == 'true' || github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') }}
+      skipNxRemoteCache: ${{ vars.NX_SKIP_REMOTE_CACHE == 'true'  }}
 
   it-tests:
     uses: ./.github/workflows/it-tests.yml
@@ -115,7 +117,8 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     needs: [yarn_lock_check, build]
     with:
-      skipNxCache: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') }}
+      skipNxCache: ${{ vars.NX_SKIP_NX_CACHE == 'true'   || github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') }}
+      skipNxRemoteCache: ${{ vars.NX_SKIP_REMOTE_CACHE == 'true'  }}
 
   e2e-tests:
     permissions:
@@ -125,7 +128,8 @@ jobs:
     uses: ./.github/workflows/e2e-tests.yml
     needs: [yarn_lock_check, build]
     with:
-      skipNxCache: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') }}
+      skipNxCache: ${{ vars.NX_SKIP_NX_CACHE == 'true' || github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') }}
+      skipNxRemoteCache: ${{ vars.NX_SKIP_REMOTE_CACHE == 'true'}}
 
   publish-packages:
     uses: ./.github/workflows/publish.yml
@@ -140,7 +144,8 @@ jobs:
       version: ${{ needs.version.outputs.nextVersionTag }}
       prerelease: ${{ needs.version.outputs.isPreRelease == 'true' }}
       isPullRequest: false
-      skipNxCache: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') }}
+      skipNxCache: ${{ vars.NX_SKIP_NX_CACHE == 'true' || github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') }}
+      skipNxRemoteCache: ${{ vars.NX_SKIP_REMOTE_CACHE == 'true' }}
 
   documentation-main:
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,11 @@ on:
         default: false
         required: false
         description: Skip the nx cache
+      skipNxRemoteCache:
+        type: boolean
+        default: false
+        required: false
+        description: Skip the nx remote cache
       gitRef:
         type: string
         default: ''
@@ -48,6 +53,7 @@ on:
 
 env:
   NX_SKIP_NX_CACHE: ${{ inputs.skipNxCache }}
+  NX_SKIP_REMOTE_CACHE: ${{ inputs.skipNxRemoteCache }}
 
 permissions:
   contents: read


### PR DESCRIPTION

## Proposed change
For some reason, NX target a corrupted cache on some PRs which become impossible to merge

Allow a temporary deactivation to avoid stucked PRs


## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
