### PR TITLE
chore: remove swagger builder lib to inherit the global one

### DIFF
--- a/packages/@ama-sdk/swagger-builder/tsconfig.build.json
+++ b/packages/@ama-sdk/swagger-builder/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "../../../tsconfig.build",
   "compilerOptions": {
     "types": ["node"],
-    "lib": ["es2019"],
     "module": "commonjs",
     "outDir": "./dist",
     "noEmitHelpers": false,


### PR DESCRIPTION
## Proposed change

Fix the build of lock file maintenance pull request

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
