### PR TITLE
fix: add check for navigation entry if load event was fired prematurely

### DIFF
--- a/packages/@o3r/analytics/src/services/event-track/event-track.helpers.spec.ts
+++ b/packages/@o3r/analytics/src/services/event-track/event-track.helpers.spec.ts
@@ -1,0 +1,29 @@
+import {
+  isPerformanceNavigationEntry,
+} from './event-track.helpers';
+
+describe('isPerformanceNavigationEntry', () => {
+  test('should return true if entry is navigation', () => {
+    const performanceEntry: PerformanceEntry = {
+      duration: 0,
+      name: '',
+      startTime: 0,
+      entryType: 'navigation',
+      toJSON: () => ({})
+    };
+
+    expect(isPerformanceNavigationEntry(performanceEntry)).toEqual(true);
+  });
+
+  test('should return false if entry is anything else', () => {
+    const performanceEntry: PerformanceEntry = {
+      duration: 0,
+      name: '',
+      startTime: 0,
+      entryType: 'resource',
+      toJSON: () => ({})
+    };
+
+    expect(isPerformanceNavigationEntry(performanceEntry)).toEqual(false);
+  });
+});

--- a/packages/@o3r/analytics/src/services/event-track/event-track.helpers.ts
+++ b/packages/@o3r/analytics/src/services/event-track/event-track.helpers.ts
@@ -1,0 +1,8 @@
+/**
+ * Check if input is of type {@link PerformanceNavigationTiming}
+ * @param entry PerformanceEntry
+ * @returns type indicator if {@link entry} meets the condition of {@link PerformanceNavigationTiming}
+ */
+export function isPerformanceNavigationEntry(entry: PerformanceEntry | undefined): entry is PerformanceNavigationTiming {
+  return entry?.entryType === 'navigation';
+}

--- a/packages/@o3r/analytics/src/services/event-track/event-track.service.ts
+++ b/packages/@o3r/analytics/src/services/event-track/event-track.service.ts
@@ -17,7 +17,9 @@ import {
   combineLatest,
   fromEvent,
   Observable,
+  of,
   ReplaySubject,
+  switchMap,
 } from 'rxjs';
 import {
   delay,
@@ -42,6 +44,9 @@ import {
   EVENT_TRACK_SERVICE_CONFIGURATION,
   EventTrackConfiguration,
 } from './event-track.configuration';
+import {
+  isPerformanceNavigationEntry,
+} from './event-track.helpers';
 
 /** The initial value of the performance measurements */
 export const performanceMarksInitialState: Readonly<PerfEventPayload> = {
@@ -133,7 +138,17 @@ export class EventTrackService {
         filter(() => typeof window.performance.timing !== 'undefined'),
         takeWhile(([_event, active]) => active)
       ),
-      fromEvent(window, 'load').pipe(delay(0))
+      of(window.performance).pipe(
+        switchMap((windowPerformance) => {
+          const latestPerformanceEntry = windowPerformance.getEntriesByType?.('navigation').at(-1);
+          const wasLoadEventTriggered = isPerformanceNavigationEntry(latestPerformanceEntry) && latestPerformanceEntry.duration > 0;
+          if (wasLoadEventTriggered) {
+            return of(true);
+          }
+
+          return fromEvent(window, 'load').pipe(delay(0));
+        })
+      )
     ).subscribe(async () => {
       if (eventConfiguration.useBrowserApiForFirstFP) {
         const browserEntries = window.performance.getEntriesByType && window.performance.getEntriesByType('paint');

--- a/packages/@o3r/analytics/src/services/event-track/index.ts
+++ b/packages/@o3r/analytics/src/services/event-track/index.ts
@@ -1,2 +1,3 @@
 export * from './event-track.configuration';
+export * from './event-track.helpers';
 export * from './event-track.service';


### PR DESCRIPTION
## Proposed change
When a page is loaded without having Angular initialized, the load event is missed by the `EventTrackService`. To fix the case of missed `load` event the navigation entry from the `performance` API is used.

`loadEventStart` and `loadEventEnd` are the most reliable markers that indicate that the load is completed, when their value is not 0. The alias for these attributes is `duration`:
<img width="240" height="346" alt="Screenshot 2025-08-25 at 15 21 15" src="https://github.com/user-attachments/assets/88d4a6ec-127e-4785-bca8-e56d8dff7647" />

For further reference check out
[Processing Model of Navigation Timing](https://w3c.github.io/navigation-timing/#processing-model)

## Test Results
### Case: Angular Initialized Instantly (listening for load)
<img width="354" height="359" alt="Screenshot 2025-08-26 at 13 30 02" src="https://github.com/user-attachments/assets/59f35c90-77b2-4543-8111-6a40cbfe4ee8" />

### Case: Angular Initialization Postponed (check for existing load)
<img width="354" height="359" alt="Screenshot 2025-08-26 at 13 26 09" src="https://github.com/user-attachments/assets/ec9b4404-ffb4-4185-8232-b77ab9c704f3" />



## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

<!-- * :bug: Fix #issue -->
* :bug: Fix resolves #3444
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
