### PR TITLE
fix: add variables to temporarily deactivate nx cache

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -13,6 +13,11 @@ on:
         default: false
         required: false
         description: Skip the nx cache
+      skipNxRemoteCache:
+        type: boolean
+        default: false
+        required: false
+        description: Skip the nx remote cache
     secrets:
       NX_CLOUD_ACCESS_TOKEN:
         required: false
@@ -25,6 +30,7 @@ env:
   NX_PARALLEL: ${{ vars.NX_PARALLEL }}
   NX_TASK_TARGET_CONFIGURATION: ci
   NX_SKIP_NX_CACHE: ${{ inputs.skipNxCache }}
+  NX_SKIP_REMOTE_CACHE: ${{inputs.skipNxRemoteCache}}
   YARN_ENABLE_HARDENED_MODE: 0
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,6 +8,11 @@ on:
         default: false
         required: false
         description: Skip the nx cache
+      skipNxRemoteCache:
+        type: boolean
+        default: false
+        required: false
+        description: Skip the nx remote cache
     secrets:
       NX_CLOUD_ACCESS_TOKEN:
         required: false
@@ -17,6 +22,7 @@ env:
   NX_PARALLEL: ${{ vars.NX_PARALLEL }}
   NX_TASK_TARGET_CONFIGURATION: ci
   NX_SKIP_NX_CACHE: ${{ inputs.skipNxCache }}
+  NX_SKIP_REMOTE_CACHE: ${{inputs.skipNxRemoteCache}}
   YARN_ENABLE_HARDENED_MODE: 0
   E2E_REPORT: e2e-report
 

--- a/.github/workflows/it-tests.yml
+++ b/.github/workflows/it-tests.yml
@@ -8,6 +8,11 @@ on:
         default: false
         required: false
         description: Skip the nx cache
+      skipNxRemoteCache:
+        type: boolean
+        default: false
+        required: false
+        description: Skip the nx remote cache
       ref:
         type: string
         default: ''
@@ -24,6 +29,7 @@ env:
   NX_PARALLEL: ${{ vars.NX_PARALLEL }}
   NX_TASK_TARGET_CONFIGURATION: ci
   NX_SKIP_NX_CACHE: ${{ inputs.skipNxCache }}
+  NX_SKIP_REMOTE_CACHE: ${{inputs.skipNxRemoteCache}}
   YARN_ENABLE_HARDENED_MODE: 0
 
 permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [yarn_lock_check]
     env:
-      NX_SKIP_NX_CACHE: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') }}
+      NX_SKIP_NX_CACHE: ${{ vars.NX_SKIP_NX_CACHE == 'true' ||  github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') }}
+      NX_SKIP_REMOTE_CACHE: ${{ vars.NX_SKIP_REMOTE_CACHE }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./tools/github-actions/setup
@@ -93,7 +94,8 @@ jobs:
     needs: [yarn_lock_check]
     with:
       affected: ${{ github.event_name == 'pull_request' }}
-      skipNxCache: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') }}
+      skipNxCache: ${{ vars.NX_SKIP_NX_CACHE == 'true' || github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') }}
+      skipNxRemoteCache: ${{ vars.NX_SKIP_REMOTE_CACHE == 'true'  }}
 
   it-tests:
     uses: ./.github/workflows/it-tests.yml
@@ -102,7 +104,8 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     needs: [yarn_lock_check, build]
     with:
-      skipNxCache: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') }}
+      skipNxCache: ${{ vars.NX_SKIP_NX_CACHE == 'true'   || github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') }}
+      skipNxRemoteCache: ${{ vars.NX_SKIP_REMOTE_CACHE == 'true'  }}
 
   e2e-tests:
     permissions:
@@ -114,7 +117,8 @@ jobs:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     needs: [yarn_lock_check, build]
     with:
-      skipNxCache: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') }}
+      skipNxCache: ${{ vars.NX_SKIP_NX_CACHE == 'true' || github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') }}
+      skipNxRemoteCache: ${{ vars.NX_SKIP_REMOTE_CACHE == 'true'}}
 
   publish-packages:
     uses: ./.github/workflows/publish.yml
@@ -129,7 +133,8 @@ jobs:
       version: ${{ needs.version.outputs.nextVersionTag }}
       prerelease: ${{ needs.version.outputs.isPreRelease == 'true' }}
       isPullRequest: false
-      skipNxCache: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') }}
+      skipNxCache: ${{ vars.NX_SKIP_NX_CACHE == 'true' || github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') }}
+      skipNxRemoteCache: ${{ vars.NX_SKIP_REMOTE_CACHE == 'true' }}
 
   documentation-main:
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,11 @@ on:
         default: false
         required: false
         description: Skip the nx cache
+      skipNxRemoteCache:
+        type: boolean
+        default: false
+        required: false
+        description: Skip the nx remote cache
       gitRef:
         type: string
         default: ''
@@ -49,6 +54,7 @@ on:
 env:
   NX_SKIP_NX_CACHE: ${{ inputs.skipNxCache }}
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+  NX_SKIP_REMOTE_CACHE: ${{ inputs.skipNxRemoteCache }}
 
 permissions:
   contents: read


### PR DESCRIPTION
For some reason, NX target a corrupted cache on some PRs which become impossible to merge

Allow a temporary deactivation to avoid stuck PRs

## Proposed change

Cherry-pick https://github.com/AmadeusITGroup/otter/pull/3423/files

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
