### PR TITLE
fix(#3387): do not override some files if jest.config.ut.js is not present at the root

### DIFF
--- a/packages/@o3r/testing/schematics/ng-add/index.ts
+++ b/packages/@o3r/testing/schematics/ng-add/index.ts
@@ -57,7 +57,6 @@ const devDependenciesToInstall = [
   'pixelmatch',
   'pngjs',
   '@angular-devkit/build-angular',
-  '@angular/animations',
   '@angular/core',
   '@angular/common'
 ];

--- a/packages/@o3r/workspace/schematics/index.it.spec.ts
+++ b/packages/@o3r/workspace/schematics/index.it.spec.ts
@@ -39,6 +39,7 @@ describe('new otter workspace', () => {
 
     expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
     expect(() => packageManagerRunOnProject('@my-sdk/sdk', isInWorkspace, { script: 'build' }, execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject('@my-sdk/sdk', isInWorkspace, { script: 'test' }, execAppOptions)).not.toThrow();
   });
 
   test('should add sdk to an existing workspace with local spec', async () => {


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->


<!-- * :bug: Fix #issue -->
* :bug: Fix resolves #3387
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
