### PR TITLE
chore: bump `@amadeus-it-group/microfrontends` to 0.0.9

### DIFF
--- a/packages/@ama-mfe/messages/package.json
+++ b/packages/@ama-mfe/messages/package.json
@@ -32,7 +32,7 @@
     "tslib": "^2.6.2"
   },
   "peerDependencies": {
-    "@amadeus-it-group/microfrontends": "0.0.7"
+    "@amadeus-it-group/microfrontends": "0.0.9"
   },
   "peerDependenciesMeta": {
     "@amadeus-it-group/microfrontends": {
@@ -40,7 +40,7 @@
     }
   },
   "devDependencies": {
-    "@amadeus-it-group/microfrontends": "0.0.7",
+    "@amadeus-it-group/microfrontends": "0.0.9",
     "@compodoc/compodoc": "^1.1.19",
     "@eslint-community/eslint-plugin-eslint-comments": "^4.4.0",
     "@nx/eslint-plugin": "~20.8.0",

--- a/packages/@ama-mfe/ng-utils/package.json
+++ b/packages/@ama-mfe/ng-utils/package.json
@@ -6,8 +6,8 @@
   },
   "peerDependencies": {
     "@ama-mfe/messages": "workspace:^",
-    "@amadeus-it-group/microfrontends": "0.0.7",
-    "@amadeus-it-group/microfrontends-angular": "0.0.7",
+    "@amadeus-it-group/microfrontends": "0.0.9",
+    "@amadeus-it-group/microfrontends-angular": "0.0.9",
     "@angular-devkit/core": "~19.2.0",
     "@angular-devkit/schematics": "~19.2.0",
     "@angular/common": "^19.0.0",
@@ -20,8 +20,8 @@
     "type-fest": "^4.30.1"
   },
   "dependencies": {
-    "@amadeus-it-group/microfrontends": "0.0.7",
-    "@amadeus-it-group/microfrontends-angular": "0.0.7",
+    "@amadeus-it-group/microfrontends": "0.0.9",
+    "@amadeus-it-group/microfrontends-angular": "0.0.9",
     "@o3r/logger": "workspace:^",
     "@o3r/schematics": "workspace:^",
     "tslib": "^2.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -279,7 +279,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@ama-mfe/messages@workspace:packages/@ama-mfe/messages"
   dependencies:
-    "@amadeus-it-group/microfrontends": "npm:0.0.7"
+    "@amadeus-it-group/microfrontends": "npm:0.0.9"
     "@compodoc/compodoc": "npm:^1.1.19"
     "@eslint-community/eslint-plugin-eslint-comments": "npm:^4.4.0"
     "@nx/eslint-plugin": "npm:~20.8.0"
@@ -322,7 +322,7 @@ __metadata:
     typescript: "npm:~5.8.2"
     typescript-eslint: "npm:~8.34.0"
   peerDependencies:
-    "@amadeus-it-group/microfrontends": 0.0.7
+    "@amadeus-it-group/microfrontends": 0.0.9
   peerDependenciesMeta:
     "@amadeus-it-group/microfrontends":
       optional: true
@@ -334,8 +334,8 @@ __metadata:
   resolution: "@ama-mfe/ng-utils@workspace:packages/@ama-mfe/ng-utils"
   dependencies:
     "@ama-mfe/messages": "workspace:^"
-    "@amadeus-it-group/microfrontends": "npm:0.0.7"
-    "@amadeus-it-group/microfrontends-angular": "npm:0.0.7"
+    "@amadeus-it-group/microfrontends": "npm:0.0.9"
+    "@amadeus-it-group/microfrontends-angular": "npm:0.0.9"
     "@angular-devkit/architect": "npm:~0.1902.0"
     "@angular-devkit/build-angular": "npm:~19.2.0"
     "@angular-devkit/core": "npm:~19.2.0"
@@ -388,8 +388,8 @@ __metadata:
     zone.js: "npm:~0.15.0"
   peerDependencies:
     "@ama-mfe/messages": "workspace:^"
-    "@amadeus-it-group/microfrontends": 0.0.7
-    "@amadeus-it-group/microfrontends-angular": 0.0.7
+    "@amadeus-it-group/microfrontends": 0.0.9
+    "@amadeus-it-group/microfrontends-angular": 0.0.9
     "@angular-devkit/core": ~19.2.0
     "@angular-devkit/schematics": ~19.2.0
     "@angular/common": ^19.0.0
@@ -1243,23 +1243,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@amadeus-it-group/microfrontends-angular@npm:0.0.7":
-  version: 0.0.7
-  resolution: "@amadeus-it-group/microfrontends-angular@npm:0.0.7"
+"@amadeus-it-group/microfrontends-angular@npm:0.0.9":
+  version: 0.0.9
+  resolution: "@amadeus-it-group/microfrontends-angular@npm:0.0.9"
   dependencies:
     tslib: "npm:^2.3.0"
   peerDependencies:
-    "@amadeus-it-group/microfrontends": 0.0.7
-    "@angular/core": ^19.0.0
+    "@amadeus-it-group/microfrontends": 0.0.9
+    "@angular/core": ^19.0.0 || ^20.0.0
     rxjs: ^7.8.0
-  checksum: 10/411aa041dbe836f17c86634910d627bb74f4804cc245661a4bf82fb318d38ec1b822a27642cb23018ccf4c526cc0b26d931c5028efcf76ec4e1ee56574199dca
+  checksum: 10/68a0b5cd6f8a6052180e8150251c05bb862e676d543b7329b46954c6f367cc52ac73bdd336c05d6cfb0f4b53b93aa0375aaf94bc57d1473d20196c7d96aa53c0
   languageName: node
   linkType: hard
 
-"@amadeus-it-group/microfrontends@npm:0.0.7":
-  version: 0.0.7
-  resolution: "@amadeus-it-group/microfrontends@npm:0.0.7"
-  checksum: 10/222d61c15c5e8b135985a4dd432d2effc09ad1ff2c3b6d2d55d3da99c1029f450e5719339c53d58597fe7a80ac35e515b70434c87b424b35f8cc5cbb476b5f9c
+"@amadeus-it-group/microfrontends@npm:0.0.9":
+  version: 0.0.9
+  resolution: "@amadeus-it-group/microfrontends@npm:0.0.9"
+  checksum: 10/d36c1b72978f797e01fb4113eea8ddaa43da24a7d7e74553fa09990e259a2a8ba0f847a9b26f0953e4d4f61d6b4fc8e014d30cbc7691e1f98a3d7298a5b69620
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`.listen()` API changed allowing for:
 - synchronous API with listening happening in the background
 - better control for when to start and stop listening
 - better reconnection handling

---

not sure about the value of having the `try / catch` block at all now