### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/analytics/TRACK_EVENTS.md
+++ b/docs/analytics/TRACK_EVENTS.md
@@ -155,7 +155,7 @@ For the time being we will consider only the implementation of __data ready__
 As the browser can't understand when a route event happens in an SPA, the NavigationTimingAPI can't be directly used apart from the first page load at most.
 Subsequent routing changes won't profit of the API connection timings.
 
-In regard of the __server fetches__ (filter out from the resource timing API), the [PerformanceMetricPlugin](https://github.com/AmadeusITGroup/otter/blob/main/packages/@ama-sdk/core/src/plugins/perf-metric/perf-metric.fetch.ts)
+In regard of the __server fetches__ (filter out from the resource timing API), the [PerformanceMetricPlugin](https://github.com/AmadeusITGroup/otter/blob/main/packages/@ama-sdk/client-fetch/src/plugins/perf-metric/perf-metric.fetch.ts)
 has been put in place to get the metrics associated to server calls.
 Check [ServerCallMetric](https://github.com/AmadeusITGroup/otter/blob/main/packages/@o3r/analytics/src/contracts/events-contracts.ts)
 model to see which information is saved for each call.

--- a/packages/@ama-sdk/client-fetch/src/plugins/abort/readme.md
+++ b/packages/@ama-sdk/client-fetch/src/plugins/abort/readme.md
@@ -52,7 +52,7 @@ const client = new ApiFetchClient(
 ```
 
 > [!WARN]
-> We recommend to use the [Timeout plugin](https://github.com/AmadeusITGroup/otter/tree/main/packages/%40ama-sdk/core/src/plugins/timeout) to implement more easily and properly a request timeout.
+> We recommend to use the [Timeout plugin](https://github.com/AmadeusITGroup/otter/tree/main/packages/%40ama-sdk/client-fetch/src/plugins/timeout) to implement more easily and properly a request timeout.
 
 ### Type of plugins
 


### PR DESCRIPTION
## Proposed change

See run [output](https://github.com/AmadeusITGroup/otter/actions/runs/17367799571/job/49297768570)
https://styledictionary.com/ was only temporary not accessible

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

<!-- * :bug: Fix #issue -->
* :bug: Fix resolves #3471
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
