### PR TITLE
fix(eslint): wrong stylistic/operator-linebreak override

### DIFF
--- a/packages/@o3r/eslint-config/src/rules/typescript/stylistic.cjs
+++ b/packages/@o3r/eslint-config/src/rules/typescript/stylistic.cjs
@@ -61,7 +61,7 @@ const config = [
         'error',
         'before',
         {
-          overrides: { '=': 'none' }
+          overrides: { '=': 'ignore' }
         }
       ],
       '@stylistic/quotes': [


### PR DESCRIPTION
## Proposed change

https://eslint.style/rules/operator-linebreak#overrides

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
