### PR TITLE
Fix/no nav message when no browser history update

### DIFF
--- a/packages/@ama-mfe/ng-utils/src/navigation/routing.service.spec.ts
+++ b/packages/@ama-mfe/ng-utils/src/navigation/routing.service.spec.ts
@@ -111,6 +111,23 @@ describe('Navigation Producer Service', () => {
     windowSpy.mockRestore();
   });
 
+  it('should not send navigation message via messageService if embedded, if the skipLocationChange is true', () => {
+    const mockedWindow = { ...globalThis.window };
+    Object.defineProperty(mockedWindow, 'top', { value: globalThis.window.top });
+    Object.defineProperty(mockedWindow, 'self', { value: mockedWindow });
+    const windowSpy = jest.spyOn(globalThis, 'window', 'get').mockReturnValue(mockedWindow);
+    jest.spyOn(router, 'getCurrentNavigation').mockReturnValue({ extras: { skipLocationChange: true } } as any);
+
+    runInInjectionContext(TestBed.inject(Injector), () => {
+      routingService.handleEmbeddedRouting();
+    });
+
+    routerEventsSubject.next(new NavigationEnd(1, 'start-url', 'end-url'));
+
+    expect(messageService.send).not.toHaveBeenCalled();
+    windowSpy.mockRestore();
+  });
+
   it('should forward received Navigation message to the router', () => {
     TestBed.runInInjectionContext(() => {
       expect(Object.keys(routingService.supportedVersions)).toEqual(['1.0']);

--- a/packages/@ama-mfe/ng-utils/src/navigation/routing.service.ts
+++ b/packages/@ama-mfe/ng-utils/src/navigation/routing.service.ts
@@ -121,6 +121,7 @@ export class RoutingService implements MessageProducer<NavigationMessage>, Messa
     this.router.events.pipe(
       takeUntilDestroyed(),
       filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+      filter((_event) => !this.router.getCurrentNavigation()?.extras?.skipLocationChange),
       map(({ urlAfterRedirects }) => {
         const channelId = this.router.getCurrentNavigation()?.extras?.state?.channelId;
         const currentRouteRegExp = subRouteOnly && this.activatedRoute.routeConfig?.path && new RegExp('^' + this.activatedRoute.routeConfig.path.replace(/(?=\W)/g, '\\'), 'i');


### PR DESCRIPTION
When an embedded module does a navigate without updating the browser history, to not send a navigation message to the host app. In this way both history will match.

## Proposed change

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
