### PR TITLE
fix: supportedType for exploded syntax is too restrictive

### DIFF
--- a/packages/@ama-sdk/core/src/fwk/api.helpers.ts
+++ b/packages/@ama-sdk/core/src/fwk/api.helpers.ts
@@ -3,7 +3,7 @@ import {
 } from '../plugins/core/request-plugin';
 import {
   isDateType,
-  type SupportedParamType,
+  type SupportedParamInterface,
 } from './param-serialization';
 import type {
   ReviverType,
@@ -70,7 +70,7 @@ export function getPropertiesFromData<T, K extends keyof T>(data: T, keys: K[]):
  * Stringifies the values of the query parameters
  * @param queryParams Query parameters of supported parameter types
  */
-export function stringifyQueryParams<T extends { [key: string]: SupportedParamType }>(queryParams: T): { [p in keyof T]: string; } {
+export function stringifyQueryParams<T extends SupportedParamInterface<T>>(queryParams: T): { [p in keyof T]: string; } {
   const names = Object.keys(queryParams) as (keyof T)[];
   return names
     .filter((name) => typeof queryParams[name] !== 'undefined' && queryParams[name] !== null)

--- a/packages/@ama-sdk/core/src/fwk/core/api-client.ts
+++ b/packages/@ama-sdk/core/src/fwk/core/api-client.ts
@@ -13,7 +13,7 @@ import type {
 } from '../api.interface';
 import type {
   ParamSerialization,
-  SupportedParamType,
+  SupportedParamInterface,
 } from '../param-serialization';
 import type {
   ReviverType,
@@ -74,7 +74,7 @@ export interface ApiClient {
    * Returns a map containing the query parameters
    * @param queryParams Query parameters of supported parameter types
    */
-  stringifyQueryParams<T extends { [key: string]: SupportedParamType }>(queryParams: T): { [p in keyof T]: string; };
+  stringifyQueryParams<T extends SupportedParamInterface<T>>(queryParams: T): { [p in keyof T]: string; };
 
   /**
    * Retrieve the option to process the HTTP Call
@@ -102,14 +102,14 @@ export interface ApiClient {
    * @param queryParams
    * @param queryParamSerialization
    */
-  serializeQueryParams<T extends { [key: string]: SupportedParamType }>(queryParams: T, queryParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string };
+  serializeQueryParams<T extends SupportedParamInterface<T>>(queryParams: T, queryParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string };
 
   /**
    * Prepares the path parameters for the URL to be called
    * @param pathParams
    * @param pathParamSerialization key value pair with the parameters. If the value is undefined, the key is dropped
    */
-  serializePathParams<T extends { [key: string]: SupportedParamType }>(pathParams: T, pathParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string };
+  serializePathParams<T extends SupportedParamInterface<T>>(pathParams: T, pathParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string };
 
   /**
    * Returns tokenized request options:

--- a/packages/@ama-sdk/core/src/fwk/core/base-api-constructor.ts
+++ b/packages/@ama-sdk/core/src/fwk/core/base-api-constructor.ts
@@ -5,9 +5,9 @@ import {
 import type {
   Logger,
 } from '../logger';
-import {
+import type {
   ParamSerialization,
-  SupportedParamType,
+  SupportedParamInterface,
 } from '../param-serialization';
 
 /** Interface of the constructor configuration object */
@@ -30,9 +30,9 @@ export interface BaseApiClientOptions {
   /** Enable parameter serialization with exploded syntax */
   enableParameterSerialization?: boolean;
   /** Custom query parameter serialization method */
-  serializeQueryParams?<T extends { [key: string]: SupportedParamType }>(queryParams: T, queryParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string };
+  serializeQueryParams?<T extends SupportedParamInterface<T>>(queryParams: T, queryParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string };
   /** Custom query parameter serialization method */
-  serializePathParams?<T extends { [key: string]: SupportedParamType }>(pathParams: T, pathParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string };
+  serializePathParams?<T extends SupportedParamInterface<T>>(pathParams: T, pathParamSerialization: { [p in keyof T]: ParamSerialization }): { [p in keyof T]: string };
 }
 
 /** Interface of the constructor configuration object */

--- a/packages/@ama-sdk/core/src/fwk/param-deserialization.ts
+++ b/packages/@ama-sdk/core/src/fwk/param-deserialization.ts
@@ -5,6 +5,7 @@ import {
   PIPE_URL_CODE,
   type PrimitiveType,
   SPACE_URL_CODE,
+  type SupportedParamInterface,
   type SupportedParamType,
 } from './param-serialization';
 
@@ -112,7 +113,7 @@ function deserializeObjectQueryParams(serializedParamValue: string, paramSeriali
 export function deserializeQueryParams<T extends { [key: string]: string }>(
   serializedQueryParams: T,
   queryParamSerialization: { [p in keyof T]: ParamSerialization & { paramType: ParamTypeForDeserialization } }
-): { [p in keyof T]: SupportedParamType } {
+): SupportedParamInterface<T> {
   return Object.entries(serializedQueryParams).reduce((acc, [queryParamName, serializedParamValue]) => {
     const paramSerialization = queryParamSerialization[queryParamName];
     let deserializedValue: SupportedParamType;
@@ -130,7 +131,7 @@ export function deserializeQueryParams<T extends { [key: string]: string }>(
       throw new Error(`Unable to deserialize query parameter ${queryParamName} since the combination explode=${paramSerialization.explode} and style='${paramSerialization.style}' is not supported.`);
     }
     return acc;
-  }, {} as Record<string, SupportedParamType>) as { [p in keyof T]: SupportedParamType };
+  }, {} as Record<string, SupportedParamType>) as SupportedParamInterface<T>;
 }
 
 /**
@@ -199,7 +200,7 @@ function deserializeObjectPathParams(serializedParamValue: string, paramSerializ
 export function deserializePathParams<T extends { [key: string]: string }>(
   serializedPathParams: T,
   pathParamSerialization: { [p in keyof T]: ParamSerialization & { paramType: ParamTypeForDeserialization } }
-): { [p in keyof T]: SupportedParamType } {
+): SupportedParamInterface<T> {
   return Object.entries(serializedPathParams).reduce((acc, [pathParamName, serializedParamValue]) => {
     const paramSerialization = pathParamSerialization[pathParamName];
     let deserializedValue: SupportedParamType;
@@ -216,5 +217,5 @@ export function deserializePathParams<T extends { [key: string]: string }>(
       throw new Error(`Unable to deserialize path parameter ${pathParamName} since the combination explode=${paramSerialization.explode} and style='${paramSerialization.style}' is not supported.`);
     }
     return acc;
-  }, {} as Record<string, SupportedParamType>) as { [p in keyof T]: SupportedParamType };
+  }, {} as Record<string, SupportedParamType>) as SupportedParamInterface<T>;
 }


### PR DESCRIPTION
## Proposed change
Interfaces do not match the `[key: string]: any` type if they do not extend it.

Rework the type to allow interface to match the SupportedParamType

## Proposed change

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
