### PR TITLE
fix: logger.error should get the error as first argument

### DIFF
--- a/packages/@o3r/rules-engine/src/engine/ruleset-executor.ts
+++ b/packages/@o3r/rules-engine/src/engine/ruleset-executor.ts
@@ -300,7 +300,8 @@ export class RulesetExecutor {
               if (this.rulesEngine.debugMode) {
                 output.evaluation = handleRuleEvaluationDebug(rule, this.ruleset.name, output.actions, output.error, runtimeFactValues, factValues, oldFactValues, inputFacts);
               } else if (output.error) {
-                this.rulesEngine.logger?.error(`Error while evaluating rule ID: ${rule.id}`, output.error);
+                const errorToLog = output.error instanceof Error || typeof output.error === 'string' ? output.error.toString() : JSON.stringify(output.error);
+                this.rulesEngine.logger?.error(`Error while evaluating rule ID: ${rule.id}; message: ${errorToLog}`);
                 this.rulesEngine.logger?.warn(`Skipping rule ${rule.name}, and the associated ruleset`);
               }
               return output;


### PR DESCRIPTION
## Proposed change
This is a merge of the custom message with the error message to be sent to the logger.
it is a follow up of https://github.com/AmadeusITGroup/otter/commit/e8cb1d66aa181ef3ebdb53c888dc0ae236623ba8


<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
