### PR TITLE
fix(sdk gen): the default should be last in list of exports in packaage.json

### DIFF
--- a/packages/@ama-sdk/schematics/cli/files-pack.cts
+++ b/packages/@ama-sdk/schematics/cli/files-pack.cts
@@ -64,6 +64,13 @@ const updateExports = async () => {
       packageJson.exports[folder].import = packageJson.exports[folder].module || packageJson.exports[folder].esm2020 || packageJson.exports[folder].esm2015 || packageJson.exports[folder].node;
       packageJson.exports[folder].require = packageJson.exports[folder].node;
       packageJson.exports[folder].main = packageJson.exports[folder].import || packageJson.exports[folder].require;
+
+      // put default field at the end of the map
+      if (packageJson.exports[folder].default) {
+        const defaultField = packageJson.exports[folder].default;
+        delete packageJson.exports[folder].default;
+        packageJson.exports[folder].default = defaultField;
+      }
     } catch (e) {
       if (watch) {
         logger.warn(`Exception in ${packageJsonFile}`, e);


### PR DESCRIPTION
For bundlers, the 'default' keyword should be the last one in the list of 'exports' in package.json file.
Update the script used for the sdks :)

## Proposed change

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
