### PR TITLE
feat(mcp): find repositories using otter

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -9,17 +9,6 @@
       "command": "npx",
       "args": ["@angular/cli", "mcp"]
     },
-    "o3r-docs": {
-      "type": "stdio",
-      "command": "npx",
-      "args": [
-        "-y",
-        "@buger/docs-mcp",
-        "--gitUrl", "https://github.com/AmadeusITGroup/otter",
-        "--toolName", "search_otter_docs",
-        "--toolDescription", "Search in Otter documentation using the probe search engine."
-      ]
-    },
     "o3r": {
       "type": "stdio",
       "command": "npx",
@@ -30,6 +19,13 @@
       "args": [
         "node",
         "./tools/@o3r/mcp/dist/cli/index.js"
+      ]
+    },
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@playwright/mcp"
       ]
     }
   }

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -22,6 +22,14 @@
     "configuration": {
       "title": "Otter",
       "properties": {
+        "otter.mcp.githubOrg": {
+          "type": "string",
+          "description": "GitHub organization to use when looking for information with MCP server"
+        },
+        "otter.mcp.cacheFolderPath": {
+          "type": "string",
+          "description": "Path of the cache folder for the MCP server"
+        },
         "otter.design.filesPatterns": {
           "type": "array",
           "default": [
@@ -77,6 +85,10 @@
           {
             "name": "list-tools",
             "description": "Get the list of tools available for the chat participant"
+          },
+          {
+            "name": "list-repos-using-o3r",
+            "description": "Get the list of repositories in the configured GitHub organization that are using Otter dependencies"
           }
         ]
       }

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -1,15 +1,13 @@
 import {
-  chat,
   commands,
   EventEmitter,
   ExtensionContext,
   languages,
   lm,
-  Uri,
   window,
 } from 'vscode';
 import {
-  chatParticipantHandler,
+  initializeChatParticipant,
 } from './chat';
 import {
   extractAllToVariable,
@@ -72,15 +70,14 @@ import {
  */
 export function activate(context: ExtensionContext) {
   const channel = window.createOutputChannel('Otter');
-  const o3rChatParticipant = chat.createChatParticipant('o3r-chat-participant', chatParticipantHandler(context, channel));
-  o3rChatParticipant.iconPath = Uri.joinPath(context.extensionUri, 'assets', 'logo-128x128.png');
+  const o3rChatParticipant = initializeChatParticipant(context, channel);
   const designTokenProviders = designTokenCompletionItemAndHoverProviders();
   // eslint-disable-next-line unicorn/prefer-event-target -- using EventEmitter from vscode
   const didChangeEmitter = new EventEmitter<void>();
 
   context.subscriptions.push(
     o3rChatParticipant,
-    lm.registerMcpServerDefinitionProvider('o3rMCPServerProvider', mcpConfig(didChangeEmitter)),
+    lm.registerMcpServerDefinitionProvider('o3rMCPServerProvider', mcpConfig(didChangeEmitter, channel)),
     languages.registerCompletionItemProvider(['javascript', 'typescript'], configurationCompletionItemProvider({ channel }), configurationCompletionTriggerChar),
     languages.registerCompletionItemProvider(['scss'], stylingCompletionItemProvider(), stylingCompletionTriggerChar),
     languages.registerCompletionItemProvider(['scss', 'css'], designTokenProviders),

--- a/apps/vscode-extension/src/mcp/index.ts
+++ b/apps/vscode-extension/src/mcp/index.ts
@@ -1,31 +1,60 @@
 import {
+  authentication,
   type EventEmitter,
+  lm,
+  McpServerDefinition,
   McpStdioServerDefinition,
+  type OutputChannel,
+  window,
+  workspace,
 } from 'vscode';
 
-export const mcpConfig = (didChangeEmitter: EventEmitter<void>) => ({
-  onDidChangeMcpServerDefinitions: didChangeEmitter.event,
-  provideMcpServerDefinitions: () => [
-    new McpStdioServerDefinition(
-      'o3r',
-      'npx',
-      ['-y', '-p', '@o3r/mcp', 'o3r-mcp-start']
-    ),
-    new McpStdioServerDefinition(
-      'angular',
-      'npx',
-      ['@angular/cli', 'mcp']
-    ),
-    new McpStdioServerDefinition(
-      'o3r-docs',
-      'npx',
-      [
-        '-y',
-        '@buger/docs-mcp',
-        '--gitUrl', 'https://github.com/AmadeusITGroup/otter',
-        '--toolName', 'search_otter_docs',
-        '--toolDescription', 'Search in Otter documentation using the probe search engine.'
-      ]
-    )
-  ]
-});
+const isO3rMcpServer = (server: McpServerDefinition): server is McpStdioServerDefinition => server.label === 'o3r';
+
+export const mcpConfig = (didChangeEmitter: EventEmitter<void>, channel: OutputChannel): Parameters<typeof lm.registerMcpServerDefinitionProvider>[1] => {
+  const mcpConfiguration = workspace.getConfiguration('otter.mcp');
+  return ({
+    onDidChangeMcpServerDefinitions: didChangeEmitter.event,
+    resolveMcpServerDefinition: async (server) => {
+      if (isO3rMcpServer(server)) {
+        const session = await authentication.getSession(
+          'github',
+          ['repo', 'read:user'],
+          { createIfNone: true }
+        );
+        let githubOrg = mcpConfiguration.get<string>('githubOrg');
+        if (!githubOrg) {
+          githubOrg = await window.showInputBox({
+            prompt: 'Please enter the GitHub organization to use for Otter MCP'
+          });
+          mcpConfiguration.update('githubOrg', githubOrg);
+        }
+        channel.appendLine(`Hello ${session?.account.label}, using the organization ${githubOrg}`);
+
+        server.env.O3R_MCP_GITHUB_TOKEN = session.accessToken || null;
+        server.env.O3R_MCP_GITHUB_ORG = githubOrg || null;
+      }
+      return server;
+    },
+    provideMcpServerDefinitions: () => [
+      new McpStdioServerDefinition(
+        'o3r',
+        'npx',
+        ['-y', '-p', '@o3r/mcp', 'o3r-mcp-start'],
+        {
+          O3R_MCP_CACHE_PATH: mcpConfiguration.get<string>('cacheFolderPath') || null
+        }
+      ),
+      new McpStdioServerDefinition(
+        'angular',
+        'npx',
+        ['@angular/cli', 'mcp']
+      ),
+      new McpStdioServerDefinition(
+        'playwright',
+        'npx',
+        ['-y', '@playwright/mcp']
+      )
+    ]
+  });
+};

--- a/packages/@o3r/core/schematics/ng-add/index.ts
+++ b/packages/@o3r/core/schematics/ng-add/index.ts
@@ -115,13 +115,6 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
               command: 'npx',
               args: ['@angular/cli', 'mcp']
             },
-            'o3r-docs': {
-              type: 'stdio',
-              command: 'npx',
-              args: [
-                '-y', '@buger/docs-mcp', '--gitUrl', 'https://github.com/AmadeusITGroup/otter'
-              ]
-            },
             o3r: {
               type: 'stdio',
               command: 'npx',

--- a/tools/@o3r/mcp/eslint.local.config.mjs
+++ b/tools/@o3r/mcp/eslint.local.config.mjs
@@ -20,7 +20,8 @@ export default [
         projectService: true
       },
       globals: {
-        ...globals.node
+        ...globals.node,
+        NodeJS: true
       }
     }
   },

--- a/tools/@o3r/mcp/jest.config.js
+++ b/tools/@o3r/mcp/jest.config.js
@@ -1,0 +1,9 @@
+const { getJestProjectConfig } = require('@o3r/test-helpers');
+
+/** @type {import('ts-jest/dist/types').JestConfigWithTsJest} */
+module.exports = {
+  ...getJestProjectConfig(),
+  projects: [
+    '<rootDir>/testing/jest.config.ut.js'
+  ]
+};

--- a/tools/@o3r/mcp/package.json
+++ b/tools/@o3r/mcp/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "~1.19.0",
+    "@octokit/rest": "^22.0.0",
     "tslib": "^2.6.2",
     "zod": "~3.25.76"
   },

--- a/tools/@o3r/mcp/project.json
+++ b/tools/@o3r/mcp/project.json
@@ -16,6 +16,7 @@
       },
       "dependsOn": ["prepare", "^build"]
     },
+    "test": {},
     "lint": {},
     "prepare-publish": {},
     "publish": {}

--- a/tools/@o3r/mcp/src/cli/index.ts
+++ b/tools/@o3r/mcp/src/cli/index.ts
@@ -5,13 +5,15 @@ import {
 import {
   createMcpServer,
 } from '../mcp-server';
+import {
+  logger,
+} from '../utils/logger';
 
 async function startMcpServer() {
   const server = await createMcpServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  // Logging as error as recommended by modelcontextprotocol.io (https://modelcontextprotocol.io/quickstart/server#quick-examples-2)
-  console.error('Server connected...');
+  logger.info('Server connected...');
 }
 
 void startMcpServer();

--- a/tools/@o3r/mcp/src/index.spec.ts
+++ b/tools/@o3r/mcp/src/index.spec.ts
@@ -1,0 +1,231 @@
+const paginate = jest.fn();
+const listForOrg = jest.fn();
+const getBranch = jest.fn();
+const getTree = jest.fn();
+const getContent = jest.fn();
+const readFile = jest.fn();
+const writeFile = jest.fn();
+
+jest.mock('@octokit/rest', () => {
+  return {
+    Octokit: jest.fn().mockImplementation(() => ({
+      paginate,
+      repos: {
+        listForOrg,
+        getBranch,
+        getContent
+      },
+      git: {
+        getTree
+      }
+    }))
+  };
+});
+jest.mock('node:fs/promises', () => {
+  const originalFs = jest.requireActual('node:fs/promises');
+  return {
+    ...originalFs,
+    readFile,
+    writeFile
+  };
+});
+
+/* eslint-disable import/first -- important to be after the mock */
+import {
+  tmpdir,
+} from 'node:os';
+import {
+  join,
+} from 'node:path';
+import {
+  Client,
+} from '@modelcontextprotocol/sdk/client';
+import {
+  InMemoryTransport,
+} from '@modelcontextprotocol/sdk/inMemory.js';
+import {
+  createMcpServer,
+} from './mcp-server';
+
+const setupClientAndServer = async () => {
+  readFile.mockImplementation((path) => {
+    if (path.toString().endsWith(join('package.json'))) {
+      return Promise.resolve(JSON.stringify({ name: '@o3r/mcp', version: '1.0.0' }));
+    }
+    if (path.toString().endsWith(join('create', 'output.md'))) {
+      return Promise.resolve('This tool helps you create a monorepo <repositoryName> with an application <applicationName>.');
+    }
+    if (path.toString().endsWith('repos-using-otter.json')) {
+      return Promise.resolve(JSON.stringify({ 'testOrg/repoCached': true }));
+    }
+    return Promise.resolve('File content');
+  });
+  const mcpServer = await createMcpServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({
+    name: 'test-client',
+    version: '1.0.0'
+  });
+  await Promise.all([
+    client.connect(clientTransport),
+    mcpServer.server.connect(serverTransport)
+  ]);
+  return { mcpServer, client };
+};
+
+describe('MCP server', () => {
+  beforeEach(() => {
+    process.env.O3R_MCP_GITHUB_TOKEN = 'fake-token';
+    process.env.O3R_MCP_GITHUB_ORG = 'testOrg';
+    process.env.O3R_MCP_USE_CACHED_REPOS = 'false';
+  });
+
+  it('should have 3 tools', async () => {
+    const { client } = await setupClientAndServer();
+    const { tools } = await client.listTools();
+    expect(tools).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'get_best_practices' }),
+      expect.objectContaining({ name: 'create_monorepo_with_app' }),
+      expect.objectContaining({ name: 'get_repositories_using_otter' })
+    ]));
+  });
+
+  it('should get best practices', async () => {
+    const { client } = await setupClientAndServer();
+    readFile.mockResolvedValueOnce('## Best Practices\n\nSome best practices content.');
+    readFile.mockResolvedValueOnce('Developer guide content.');
+    const response = await client.callTool({ name: 'get_best_practices' });
+    expect(response.content).toEqual([{
+      type: 'text',
+      text: 'Developer guide content.\n\n## Best Practices\n\nSome best practices content.'
+    }]);
+  });
+
+  it('should create a monorepo with app', async () => {
+    const { client } = await setupClientAndServer();
+    const response = await client.callTool({
+      name: 'create_monorepo_with_app',
+      arguments: {
+        repositoryName: 'my-repo',
+        applicationName: 'my-app'
+      }
+    });
+    expect(response.content).toEqual([{
+      type: 'text',
+      text: 'This tool helps you create a monorepo my-repo with an application my-app.'
+    }]);
+  });
+
+  describe('should find repositories using Otter dependencies', () => {
+    beforeEach(() => {
+      paginate.mockImplementation(() => {
+        return [
+          { name: 'repo1', full_name: 'testOrg/repo1', default_branch: 'main' },
+          { name: 'repo2', full_name: 'testOrg/repo2', default_branch: 'main' }
+        ];
+      });
+      getBranch.mockImplementation(({ repo }) => {
+        if (repo === 'repo1') {
+          return Promise.resolve({
+            data: {
+              commit: { sha: 'sha-repo1' }
+            }
+          });
+        } else if (repo === 'repo2') {
+          return Promise.resolve({
+            data: {
+              commit: { sha: 'sha-repo2' }
+            }
+          });
+        }
+        return Promise.reject(new Error('Repository not found'));
+      });
+      getTree.mockImplementation(({ repo }) => {
+        if (repo === 'repo1') {
+          return Promise.resolve({
+            data: {
+              tree: [
+                { type: 'blob', path: 'package.json' },
+                { type: 'blob', path: 'src/index.ts' },
+                { type: 'blob', path: 'libs/@scope/name/package.json' }
+              ]
+            }
+          });
+        } else if (repo === 'repo2') {
+          return Promise.resolve({
+            data: {
+              tree: [
+                { type: 'blob', path: 'src/index.ts' },
+                { type: 'blob', path: 'README.md' }
+              ]
+            }
+          });
+        }
+        return Promise.reject(new Error('Tree not found'));
+      });
+      getContent.mockImplementation(({ repo, path }) => {
+        if (repo === 'repo1' && path === 'package.json') {
+          return Promise.resolve({
+            data: {
+              type: 'file',
+              content: Buffer.from(JSON.stringify({
+                dependencies: {
+                  '@o3r/some-package': '^1.0.0'
+                }
+              })).toString('base64')
+            }
+          });
+        } else if (repo === 'repo1' && path === 'libs/@scope/name/package.json') {
+          return Promise.resolve({
+            data: {
+              type: 'file',
+              content: Buffer.from(JSON.stringify({
+                dependencies: {
+                  'some-other-package': '^1.0.0'
+                }
+              })).toString('base64')
+            }
+          });
+        }
+        return Promise.reject(new Error('Content not found'));
+      });
+    });
+
+    it('without cache', async () => {
+      const { client } = await setupClientAndServer();
+      const response = await client.callTool({ name: 'get_repositories_using_otter' });
+      expect(response.content).toEqual([{
+        type: 'text',
+        text: 'The following repositories in the organization testOrg use Otter dependencies:\n- testOrg/repo1'
+      }]);
+    });
+
+    it('with cache', async () => {
+      delete process.env.O3R_MCP_USE_CACHED_REPOS;
+      process.env.O3R_MCP_CACHE_PATH = tmpdir();
+      const { client } = await setupClientAndServer();
+      const response = await client.callTool({ name: 'get_repositories_using_otter' });
+      expect(writeFile).toHaveBeenCalled();
+      expect(writeFile).toHaveBeenCalledWith(
+        expect.stringMatching(/repos-using-otter\.json$/),
+        JSON.stringify({
+          'testOrg/repo1': true,
+          'testOrg/repo2': false,
+          'testOrg/repoCached': true
+        })
+      );
+      expect(response.content).toEqual([{
+        type: 'text',
+        text: 'The following repositories in the organization testOrg use Otter dependencies:\n- testOrg/repo1\n- testOrg/repoCached'
+      }]);
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.O3R_MCP_GITHUB_TOKEN;
+    delete process.env.O3R_MCP_GITHUB_ORG;
+    delete process.env.O3R_MCP_USE_CACHED_REPOS;
+    delete process.env.O3R_MCP_CACHE_PATH;
+    jest.clearAllMocks();
+  });
+});

--- a/tools/@o3r/mcp/src/mcp-server.ts
+++ b/tools/@o3r/mcp/src/mcp-server.ts
@@ -16,6 +16,9 @@ import {
 import {
   registerCreateMonorepoWithAppTool,
 } from './tools/create-monorepo-with-app';
+import {
+  registerGetRepositoriesUsingOtterTool,
+} from './tools/find-repositories-using-otter';
 
 /**
  * Create an MCP server instance.
@@ -35,6 +38,6 @@ export async function createMcpServer(): Promise<McpServer> {
   await registerBestPracticesResources(server, resourcesPath);
   await registerBestPracticesTool(server, resourcesPath);
   await registerCreateMonorepoWithAppTool(server, resourcesPath);
-
+  registerGetRepositoriesUsingOtterTool(server);
   return server;
 }

--- a/tools/@o3r/mcp/src/tools/find-repositories-using-otter.ts
+++ b/tools/@o3r/mcp/src/tools/find-repositories-using-otter.ts
@@ -1,0 +1,188 @@
+import {
+  existsSync,
+} from 'node:fs';
+import {
+  mkdir,
+  readFile,
+  writeFile,
+} from 'node:fs/promises';
+import {
+  resolve,
+} from 'node:path';
+import type {
+  McpServer,
+} from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  Octokit,
+} from '@octokit/rest';
+import {
+  logger,
+} from '../utils/logger';
+
+async function listOrgRepos(octokit: Octokit) {
+  const repos = (await octokit.paginate(octokit.repos.listForOrg, {
+    org: process.env.O3R_MCP_GITHUB_ORG as string,
+    per_page: 100,
+    type: 'all',
+    sort: 'updated' // Prioritize recently updated repositories
+  })).filter((repo) => !repo.archived && !repo.fork);
+  logger.info(`Found ${repos.length} repositories in the organization ${process.env.O3R_MCP_GITHUB_ORG}`);
+  return repos;
+}
+
+type Repository = Awaited<ReturnType<typeof listOrgRepos>>[number];
+
+function findPackageJsonFiles(octokit: Octokit) {
+  return async (repository: Repository) => {
+    const owner = process.env.O3R_MCP_GITHUB_ORG as string;
+    const repo = repository.name;
+    const { data: { commit: { sha } } } = await octokit.repos.getBranch({
+      owner,
+      repo,
+      branch: repository.default_branch || 'main'
+    });
+    const { data: { tree } } = await octokit.git.getTree({
+      owner,
+      repo,
+      tree_sha: sha
+    });
+    return tree.filter((t) => t.type === 'blob' && t.path.endsWith('package.json'));
+  };
+}
+
+const O3R_SCOPE_REGEX = /^@(o3r|ama-styling|ama-mfe|ama-sdk)\//gm;
+
+function dependsOnOtter(octokit: Octokit) {
+  return async (repository: Repository, packageJsonPath: string) => {
+    const owner = process.env.O3R_MCP_GITHUB_ORG as string;
+    const repo = repository.name;
+    const { data } = await octokit.repos.getContent({
+      owner,
+      repo,
+      path: packageJsonPath
+    });
+    if (Array.isArray(data) || data.type !== 'file') {
+      throw new Error('Unexpected content response structure');
+    }
+    const content = Buffer.from(data.content, 'base64').toString('utf8');
+    const packageJson = JSON.parse(content) as { dependencies?: Record<string, string>; devDependencies?: Record<string, string> };
+    return [
+      ...Object.keys(packageJson.devDependencies || {}),
+      ...Object.keys(packageJson.dependencies || {})
+    ].some((dep) => O3R_SCOPE_REGEX.test(dep));
+  };
+}
+
+async function findRepositoriesUsingOtter(octokit: Octokit, reposUsingOtter: string[]) {
+  const cacheFolderPath = process.env.O3R_MCP_CACHE_PATH || '.cache/o3r/mcp';
+  const cachePath = resolve(cacheFolderPath, 'repos-using-otter.json');
+  let cachedRepos: Record<string, boolean> = {};
+  if (process.env.O3R_MCP_USE_CACHED_REPOS === 'false') {
+    logger.info('Ignoring cached repositories as O3R_MCP_USE_CACHED_REPOS is set to false');
+  } else {
+    try {
+      cachedRepos = JSON.parse(await readFile(cachePath, { encoding: 'utf8' })) as Record<string, boolean>;
+      reposUsingOtter.push(...Object.entries(cachedRepos).filter(([, usesOtter]) => usesOtter).map(([repo]) => repo));
+      logger.info(`Loaded ${Object.keys(cachedRepos).length} cached repositories, ${reposUsingOtter.length} of them using Otter dependencies.`);
+    } catch (e) {
+      logger.info('No cache file found, starting fresh search for repositories using Otter dependencies.', e);
+    }
+  }
+  const repositories = (await listOrgRepos(octokit)).filter((r) => !cachedRepos[r.full_name]);
+  const findPackageJsonFilesInRepo = findPackageJsonFiles(octokit);
+  const dependsOnOtterInRepo = dependsOnOtter(octokit);
+
+  await Promise.allSettled(repositories.map(async (repository) => {
+    logger.debug(`Checking repository ${repository.full_name}...`);
+    const packageJsonFiles: Awaited<ReturnType<typeof findPackageJsonFilesInRepo>> = [];
+    try {
+      packageJsonFiles.push(...await findPackageJsonFilesInRepo(repository));
+    } catch (e) {
+      logger.warn(`Failed to list package.json files in repository ${repository.full_name}`, e);
+    }
+    if (packageJsonFiles.length === 0) {
+      logger.info(`No package.json files found in repository ${repository.full_name}`);
+      cachedRepos[repository.full_name] = false;
+      return;
+    }
+    try {
+      await Promise.any(packageJsonFiles.map(async (packageJsonFile) => {
+        let depFound = false;
+        try {
+          depFound = await dependsOnOtterInRepo(repository, packageJsonFile.path);
+        } catch (e) {
+          logger.error(`Failed to check package.json file at ${packageJsonFile.path} in repository ${repository.full_name}`, e);
+        }
+        if (depFound) {
+          reposUsingOtter.push(repository.full_name);
+          logger.info(`Repository ${repository.full_name} uses Otter dependencies`);
+          cachedRepos[repository.full_name] = true;
+        } else {
+          throw new Error('No Otter dependencies found in this package.json');
+        }
+      }));
+    } catch {}
+    cachedRepos[repository.full_name] ||= false;
+  }));
+  logger.info(`Found ${reposUsingOtter.length} repositories using Otter dependencies in the organization ${process.env.O3R_MCP_GITHUB_ORG}`);
+  if (process.env.O3R_MCP_USE_CACHED_REPOS === 'false') {
+    logger.info('Not updating cache as O3R_MCP_USE_CACHED_REPOS is set to false');
+  } else {
+    if (!existsSync(cacheFolderPath)) {
+      await mkdir(cacheFolderPath, { recursive: true });
+    }
+    try {
+      await writeFile(cachePath, JSON.stringify(cachedRepos, Object.keys(cachedRepos).sort()));
+    } catch (e) {
+      logger.error('Failed to update cache', e);
+    }
+  }
+}
+
+/**
+ * Register the get repositories using otter tool.
+ * @param server
+ */
+export function registerGetRepositoriesUsingOtterTool(server: McpServer) {
+  if (!process.env.O3R_MCP_GITHUB_TOKEN) {
+    logger.error('Missing O3R_MCP_GITHUB_TOKEN environment variable for search_code_example tool');
+    return;
+  }
+  if (!process.env.O3R_MCP_GITHUB_ORG) {
+    logger.error('Missing O3R_MCP_GITHUB_ORG environment variable');
+    return;
+  }
+
+  const octokit = new Octokit({ auth: process.env.O3R_MCP_GITHUB_TOKEN });
+
+  let isLookingForRepos = true;
+  const reposUsingOtter: string[] = [];
+  findRepositoriesUsingOtter(octokit, reposUsingOtter).catch((e) => {
+    logger.error('Error finding repositories using Otter:', e);
+  });
+  isLookingForRepos = false;
+
+  server.registerTool(
+    'get_repositories_using_otter',
+    {
+      title: 'Get repositories using Otter dependencies',
+      description: 'List all repositories in the specified GitHub organization that use Otter dependencies (@o3r/* or @ama-*/*) in their package.json files.',
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false
+      }
+    },
+    () => ({
+      content: [
+        {
+          type: 'text',
+          text: (isLookingForRepos ? 'I did not finish to look for repositories. For the moment:\n' : '')
+            + reposUsingOtter.length
+            ? `The following repositories in the organization ${process.env.O3R_MCP_GITHUB_ORG} use Otter dependencies:\n`
+            + reposUsingOtter.sort().map((repo) => `- ${repo}`).join('\n')
+            : `No repositories in the organization ${process.env.O3R_MCP_GITHUB_ORG} were found to use Otter dependencies.`
+        }
+      ]
+    })
+  );
+}

--- a/tools/@o3r/mcp/src/utils/logger.ts
+++ b/tools/@o3r/mcp/src/utils/logger.ts
@@ -1,0 +1,25 @@
+type Level = 'error' | 'warn' | 'info' | 'debug';
+
+/**
+ * Logging as error as recommended by modelcontextprotocol.io (https://modelcontextprotocol.io/quickstart/server#quick-examples-2)
+ * @param level
+ * @param message
+ * @param meta Should be stringifyable
+ */
+const log = (level: Level, message: string, meta: any) => process.stderr.write(
+  JSON.stringify({
+    level,
+    message,
+    meta
+  }) + '\n'
+);
+
+/**
+ * Logger for MCP server
+ */
+export const logger = {
+  error: (m: string, meta?: any) => log('error', m, meta),
+  warn: (m: string, meta?: any) => log('warn', m, meta),
+  info: (m: string, meta?: any) => log('info', m, meta),
+  debug: (m: string, meta?: any) => log('debug', m, meta)
+};

--- a/tools/@o3r/mcp/testing/jest.config.ut.js
+++ b/tools/@o3r/mcp/testing/jest.config.ut.js
@@ -1,0 +1,17 @@
+const path = require('node:path');
+const { getTsJestBaseConfig, getOtterJestBaseConfig, getJestUnitTestConfig } = require('@o3r/test-helpers');
+const { createDefaultPreset } = require('ts-jest');
+
+const rootDir = path.join(__dirname, '..');
+
+/** @type {import('ts-jest/dist/types').JestConfigWithTsJest} */
+module.exports = {
+  ...createDefaultPreset(getTsJestBaseConfig()),
+  ...getOtterJestBaseConfig(rootDir),
+  ...getJestUnitTestConfig({
+    testPathIgnorePatterns: [
+      '<rootDir>/builders/.*',
+      '<rootDir>/schematics/.*'
+    ]
+  })
+};

--- a/tools/@o3r/workspace-helpers/scripts/create-monorepo-scope.mjs
+++ b/tools/@o3r/workspace-helpers/scripts/create-monorepo-scope.mjs
@@ -87,6 +87,13 @@ const updatePackageJson = async (scopeName) => {
   await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
 };
 
+const updateMcp = async (scopeName) => {
+  const path = resolve(root, 'tools/@o3r/mcp/src/tools/find-repositories-using-otter.ts');
+  const content = await readFile(path, { encoding: 'utf8' });
+  const newContent = content.replace(/(const O3R_SCOPE_REGEX = \/[^)]*)(\))(.*\/;)$/gm, `$1|${scopeName})$3`);
+  await writeFile(path, newContent);
+};
+
 (() => {
   if (!scopeName) {
     throw new Error('No scope name provided');
@@ -97,6 +104,7 @@ const updatePackageJson = async (scopeName) => {
     updateItTestWorkflow(scopeName),
     updateNpmrcPr(scopeName),
     updateRenovateGroup(scopeName),
-    updatePackageJson(scopeName)
+    updatePackageJson(scopeName),
+    updateMcp(scopeName)
   ]);
 })();

--- a/yarn.lock
+++ b/yarn.lock
@@ -10814,6 +10814,7 @@ __metadata:
     "@o3r/eslint-config": "workspace:^"
     "@o3r/eslint-plugin": "workspace:^"
     "@o3r/test-helpers": "workspace:^"
+    "@octokit/rest": "npm:^22.0.0"
     "@stylistic/eslint-plugin": "npm:~5.3.0"
     "@types/jest": "npm:~29.5.2"
     "@types/node": "npm:~22.18.0"
@@ -12624,7 +12625,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/core@npm:^7.0.3":
+"@octokit/core@npm:^7.0.2, @octokit/core@npm:^7.0.3":
   version: 7.0.5
   resolution: "@octokit/core@npm:7.0.5"
   dependencies:
@@ -12745,7 +12746,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/plugin-paginate-rest@npm:^13.1.1":
+"@octokit/plugin-paginate-rest@npm:^13.0.1, @octokit/plugin-paginate-rest@npm:^13.1.1":
   version: 13.2.0
   resolution: "@octokit/plugin-paginate-rest@npm:13.2.0"
   dependencies:
@@ -12764,6 +12765,15 @@ __metadata:
   peerDependencies:
     "@octokit/core": 5
   checksum: 10/9afdd61d24a276ed7c2a8e436f735066d1b71601177deb97afa204a1f224257ca9c02681bc94dcda921d37c288a342124f7dfdd88393817306fe0b1ad1f0690f
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-request-log@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@octokit/plugin-request-log@npm:6.0.0"
+  peerDependencies:
+    "@octokit/core": ">=6"
+  checksum: 10/8a79973b1429bfead9113c4117f418aaef5ff368795daded3415ba14623d97d5fc08d1e822dbd566ecc9f041119e1a48a11853a9c48d9eb1caa62baa79c17f83
   languageName: node
   linkType: hard
 
@@ -12856,6 +12866,18 @@ __metadata:
     "@octokit/types": "npm:^13.1.0"
     universal-user-agent: "npm:^6.0.0"
   checksum: 10/2b2c9131cc9b608baeeef8ce2943768cc9db5fbe36a665f734a099bd921561c760e4391fbdf39d5aefb725db26742db1488c65624940ef7cec522e10863caa5e
+  languageName: node
+  linkType: hard
+
+"@octokit/rest@npm:^22.0.0":
+  version: 22.0.0
+  resolution: "@octokit/rest@npm:22.0.0"
+  dependencies:
+    "@octokit/core": "npm:^7.0.2"
+    "@octokit/plugin-paginate-rest": "npm:^13.0.1"
+    "@octokit/plugin-request-log": "npm:^6.0.0"
+    "@octokit/plugin-rest-endpoint-methods": "npm:^16.0.0"
+  checksum: 10/d2b80fefd6aed307cb728980cb1d94cb484d48fabf0055198664287a7fb50544d312b005e4fb8dec2a6e97a153ec0ad7654d62f59898e1077a4cfba64e6d5c3e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed change
New MCP tool to search for repositories using otter to later be able to search inspiration code on repos with the tool `githubRepo`.

Don't hesitate to propose ideas to accelerate the startup process of the tool  `get_repositories_using_otter`.
<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
