### PR TITLE
fix: revive dictionaries deep

### DIFF
--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/java/com/amadeus/codegen/ts/AbstractTypeScriptClientCodegen.java
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/java/com/amadeus/codegen/ts/AbstractTypeScriptClientCodegen.java
@@ -491,10 +491,28 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
 
     // Check that we have vendor extensions for dictionary
     if (property.vendorExtensions.containsKey("x-dictionary-name")) {
+      String name = (String) property.vendorExtensions.get("x-field-name");
+      String type = (String) property.vendorExtensions.get("x-field-type");
+      boolean propertyNameExists = false;
+      // Check if a property with the same name and type already exists
+      for (CodegenProperty prop : model.vars) {
+        if (type.equals(prop.baseType) && name.equals(prop.baseName)) {
+          String textToAdd = "Property is backed up as a dictionary extraction";
+          // Check if the text hasn't already been added
+          if (prop.description == null || !prop.description.contains(textToAdd)) {
+              prop.description = (prop.description != null && !prop.description.isEmpty())
+                  ? prop.description + " " + textToAdd
+                  : textToAdd;
+          }
+          propertyNameExists = true;
+          break;
+        }
+      }
+      property.vendorExtensions.put("x-field-exists", propertyNameExists);
+
       boolean isPrimitive = false;
       boolean isRevived = false;
 
-      String type = (String) property.vendorExtensions.get("x-field-type");
       if (typeMapping.containsKey(type) || languageSpecificPrimitives.contains(type)) {
         if (typeMapping.containsKey(type)) {
           property.vendorExtensions.put("x-field-type", (String) typeMapping.get(type));

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/model/model.mustache
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/model/model.mustache
@@ -54,8 +54,10 @@ export interface {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
       {{#vars}}
         {{#vendorExtensions}}
           {{#x-field-name}}
+            {{^x-field-exists}}
   /** Dictionary extraction for {{baseName}} */
   {{#readOnly}}readonly {{/readOnly}}{{x-field-name}}{{^required}}?{{/required}}: {{x-field-type}};
+            {{/x-field-exists}}
           {{/x-field-name}}
         {{/vendorExtensions}}
       {{/vars}}

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/model/reviver.mustache
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/model/reviver.mustache
@@ -72,7 +72,7 @@ export function revive{{classname}}<T extends {{classname}} = {{classname}}>(dat
     if (data{{#propertyAccess}}{{baseName}}{{/propertyAccess}} && !data.{{x-field-name}}) {
       if (dictionaries.{{x-dictionary-name}} && typeof dictionaries.{{x-dictionary-name}}[data{{#propertyAccess}}{{baseName}}{{/propertyAccess}}] !== 'undefined') {
                       {{^x-field-is-primitive}}
-        data.{{x-field-name}} = revive{{x-field-type}}(dictionaries.{{x-dictionary-name}}[data{{#propertyAccess}}{{baseName}}{{/propertyAccess}}], undefined, options);
+        data.{{x-field-name}} = revive{{x-field-type}}(dictionaries.{{x-dictionary-name}}[data{{#propertyAccess}}{{baseName}}{{/propertyAccess}}], dictionaries, options);
                       {{/x-field-is-primitive}}
                       {{#x-field-is-primitive}}
         data.{{x-field-name}} = dictionaries.{{x-dictionary-name}}[data{{#propertyAccess}}{{baseName}}{{/propertyAccess}}];
@@ -90,7 +90,7 @@ export function revive{{classname}}<T extends {{classname}} = {{classname}}>(dat
                     {{#x-map-name}}
                       {{#x-field-is-revived}}
     if (data.{{x-map-name}}) {
-      data.{{x-map-name}} = options?.clearDictionaryFields ? undefined : reviveMap<{{x-field-type}}>(data.{{x-map-name}}, null, revive{{x-field-type}}, options);
+      data.{{x-map-name}} = options?.clearDictionaryFields ? undefined : reviveMap<{{x-field-type}}>(data.{{x-map-name}}, dictionaries, revive{{x-field-type}}, options);
     }
                       {{/x-field-is-revived}}
                     {{/x-map-name}}
@@ -101,7 +101,7 @@ export function revive{{classname}}<T extends {{classname}} = {{classname}}>(dat
                     {{#x-field-name}}
                       {{#x-field-is-revived}}
     if (data.{{x-field-name}}) {
-      data.{{x-field-name}} = options?.clearDictionaryFields ? undefined : revive{{x-field-type}}(data.{{x-field-name}}, undefined, options);
+      data.{{x-field-name}} = options?.clearDictionaryFields ? undefined : revive{{x-field-type}}(data.{{x-field-name}}, dictionaries, options);
     }
                       {{/x-field-is-revived}}
                     {{/x-field-name}}


### PR DESCRIPTION
## Proposed change

Possibility to revive fields from a dictionary which has a field to be revived.

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
