### PR TITLE
fix: o3r schematics is not compatible with version required

### DIFF
--- a/packages/@o3r/create/src/index.ts
+++ b/packages/@o3r/create/src/index.ts
@@ -201,7 +201,7 @@ const prepareWorkspace = (relativeDirectory = '.', projectPackageManager = 'npm'
   );
   packageJson.devDependencies ||= {};
   mandatoryDependencies.forEach((dep) => {
-    packageJson.devDependencies![dep] = dependencies?.[dep] || devDependencies?.[dep] || 'latest';
+    packageJson.devDependencies![dep] = (dependencies?.[dep] || devDependencies?.[dep] || 'latest').replace(/^\^/, '~');
   });
   if (exactO3rVersion) {
     const o3rPackages = ['@o3r/core', '@o3r/schematics', '@o3r/workspace'];


### PR DESCRIPTION
## Proposed change

o3r create install carret versions of dependencies instead of tilde
This causes incompatibilities later in the flow

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
