### PR TITLE
feature: data sources for functional contents - schema update

### DIFF
--- a/packages/@o3r/application/schemas/functional-content.metadata.schema.json
+++ b/packages/@o3r/application/schemas/functional-content.metadata.schema.json
@@ -91,6 +91,10 @@
                   "type": "string",
                   "description": "Unique name of the definition in the section (which can be referenced by the rootReference property)"
                 },
+                "title": {
+                  "type": "string",
+                  "description": "Title to display to the CMS user"
+                },
                 "properties": {
                   "type": "array",
                   "description": "Array of properties of this definition",
@@ -152,6 +156,17 @@
           }
         }
       }
+    },
+    "dataSources": {
+      "type": "object",
+      "description": "Map of data sources that can be used to populate the choices of enum/string properties",
+      "additionalProperties": {
+        "type": "array",
+        "description": "Array of object to define the data source items",
+        "items": {
+          "$ref": "#/definitions/choiceItem"
+        }
+      }
     }
   },
   "definitions": {
@@ -169,28 +184,15 @@
       "description": "Array of object to define the choices for a property",
       "minItems": 1,
       "items": {
-        "type": "object",
-        "required": [
-          "key",
-          "title"
-        ],
-        "properties": {
-          "key": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
+        "$ref": "#/definitions/choiceItem"
       }
     },
     "enumProperty": {
       "type": "object",
-      "description": "Type of the property (enum)",
+      "description": "Type of the property (enum). The enum values can be defined in the choices array or can be fetched from a data source specified in the widget parameter 'dataSource'",
       "required": [
         "valueType",
-        "collectionType",
-        "choices"
+        "collectionType"
       ],
       "additionalProperties": false,
       "properties": {
@@ -322,6 +324,24 @@
           }
         }
       }
+    },
+    "choiceItem": {
+      "type": "object",
+      "description": "A choice item",
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "The key of the choice item"
+        },
+        "title": {
+          "type": "string",
+          "description": "The title of the choice item"
+        }
+      },
+      "required": [
+        "key",
+        "title"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Proposed change

Adds data sources to functional contents to share lists of choices between properties: For ENUM or STRING properties that need a list a choices, the choices can be provided either by the "choices" attribute (as it used to be), or by a data source. The data sources are defined at the root of the functional content definition. A property references a data source by providing its name in the widget parameter "dataSource". If both "dataSource" and "choices" are provided by the property, the "choices" have priority.

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
