### PR TITLE
fix: remove workflow permission restriction to have  write permission for id-token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,9 +55,6 @@ env:
   NX_SKIP_NX_CACHE: ${{ inputs.skipNxCache }}
   NX_SKIP_REMOTE_CACHE: ${{ inputs.skipNxRemoteCache }}
 
-permissions:
-  contents: read
-
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
