### PR TITLE
fix(vscode-ext): do not re-run publish dependencies before publishing extension

### DIFF
--- a/apps/vscode-extension/project.json
+++ b/apps/vscode-extension/project.json
@@ -40,8 +40,7 @@
       "options": {
         "command": "npm install && npx @vscode/vsce publish",
         "cwd": "apps/vscode-extension/dist"
-      },
-      "dependsOn": ["prepare-publish"]
+      }
     }
   },
   "tags": []

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:lint": "yarn nx run-many --target=build --projects=eslint-plugin",
     "build:swagger-gen": "yarn nx run-many --target=build-swagger",
     "publish": "yarn nx run-many --target=prepare-publish --exclude-task-dependencies && yarn nx run-many --target=publish --exclude=tag:private",
-    "publish:extensions": "yarn nx run-many --target=publish-extension",
+    "publish:extensions": "yarn nx run-many --target=prepare-publish --exclude-task-dependencies && yarn nx run-many --target=publish-extension",
     "publish:extensions:affected": "yarn nx affected --target=publish-extension",
     "package-github-actions:affected": "yarn nx affected --target=package-github-action",
     "lint": "yarn nx run-many --target=lint",


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
