### PR TITLE
ci: skip nx remote cache based on pull request label

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
     needs: [yarn_lock_check]
     env:
       NX_SKIP_NX_CACHE: ${{ vars.NX_SKIP_NX_CACHE == 'true' || github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') && !endsWith(github.ref, '-next') }}
-      NX_SKIP_REMOTE_CACHE: ${{ vars.NX_SKIP_REMOTE_CACHE }}
+      NX_SKIP_REMOTE_CACHE: ${{ vars.NX_SKIP_REMOTE_CACHE || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'skipRemoteCache')) }}
       NODE_COMPILE_CACHE: ~/.cache/node-compilation
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -110,7 +110,7 @@ jobs:
     with:
       affected: ${{ github.event_name == 'pull_request' }}
       skipNxCache: ${{ vars.NX_SKIP_NX_CACHE == 'true' || github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') && !endsWith(github.ref, '-next') }}
-      skipNxRemoteCache: ${{ vars.NX_SKIP_REMOTE_CACHE == 'true'  }}
+      skipNxRemoteCache: ${{ vars.NX_SKIP_REMOTE_CACHE == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'skipRemoteCache')) }}
 
   it-tests:
     uses: ./.github/workflows/it-tests.yml
@@ -118,8 +118,8 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     needs: [yarn_lock_check, build]
     with:
-      skipNxCache: ${{ vars.NX_SKIP_NX_CACHE == 'true'   || github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') && !endsWith(github.ref, '-next') }}
-      skipNxRemoteCache: ${{ vars.NX_SKIP_REMOTE_CACHE == 'true'  }}
+      skipNxCache: ${{ vars.NX_SKIP_NX_CACHE == 'true' || github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') && !endsWith(github.ref, '-next') }}
+      skipNxRemoteCache: ${{ vars.NX_SKIP_REMOTE_CACHE == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'skipRemoteCache')) }}
 
   e2e-tests:
     permissions:
@@ -130,7 +130,7 @@ jobs:
     needs: [yarn_lock_check, build]
     with:
       skipNxCache: ${{ vars.NX_SKIP_NX_CACHE == 'true' || github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release') && !endsWith(github.ref, '-next') }}
-      skipNxRemoteCache: ${{ vars.NX_SKIP_REMOTE_CACHE == 'true'}}
+      skipNxRemoteCache: ${{ vars.NX_SKIP_REMOTE_CACHE == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'skipRemoteCache')) }}
 
   publish-packages:
     uses: ./.github/workflows/publish.yml
@@ -166,4 +166,4 @@ jobs:
       version: ${{ needs.version.outputs.nextVersionTag }}
       shouldDeploy: false
       skipNxCache: ${{ vars.NX_SKIP_NX_CACHE == 'true' }}
-      skipNxRemoteCache: ${{ vars.NX_SKIP_REMOTE_CACHE == 'true' }}
+      skipNxRemoteCache: ${{ vars.NX_SKIP_REMOTE_CACHE == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'skipRemoteCache')) }}


### PR DESCRIPTION
## Proposed change

Instead of disabling the remote cache for all runs, we want to disable it for a specific pull request

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
