### PR TITLE
feat: migrate to signal-based viewChild and viewChildren

### DIFF
--- a/apps/showcase/src/app/component-replacement/component-replacement.spec.ts
+++ b/apps/showcase/src/app/component-replacement/component-replacement.spec.ts
@@ -9,6 +9,9 @@ import {
   RouterModule,
 } from '@angular/router';
 import {
+  NgbScrollSpyService,
+} from '@ng-bootstrap/ng-bootstrap';
+import {
   provideMarkdown,
 } from 'ngx-markdown';
 import {
@@ -21,15 +24,23 @@ import {
 describe('ComponentReplacement', () => {
   let component: ComponentReplacement;
   let fixture: ComponentFixture<ComponentReplacement>;
+  let mockScrollSpyService: Partial<NgbScrollSpyService>;
 
   beforeEach(async () => {
+    mockScrollSpyService = {
+      start: jest.fn(),
+      stop: jest.fn()
+    };
     await TestBed.configureTestingModule({
       imports: [
         ComponentReplacement,
         RouterModule.forRoot([]),
         AsyncPipe
       ],
-      providers: [provideMarkdown()]
+      providers: [
+        { provide: NgbScrollSpyService, useValue: mockScrollSpyService },
+        provideMarkdown()
+      ]
     }).overrideComponent(ComponentReplacement, {
       remove: { imports: [ComponentReplacementPres] }
     }).compileComponents();

--- a/apps/showcase/src/app/component-replacement/component-replacement.ts
+++ b/apps/showcase/src/app/component-replacement/component-replacement.ts
@@ -6,8 +6,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   inject,
-  QueryList,
-  ViewChildren,
+  viewChildren,
   ViewEncapsulation,
 } from '@angular/core';
 import {
@@ -50,13 +49,11 @@ import {
 })
 export class ComponentReplacement implements AfterViewInit {
   private readonly inPageNavPresService = inject(InPageNavPresService);
-
-  @ViewChildren(InPageNavLinkDirective)
-  private readonly inPageNavLinkDirectives!: QueryList<InPageNavLink>;
+  private readonly inPageNavLinkDirectives = viewChildren<InPageNavLink>(InPageNavLinkDirective);
 
   public links$ = this.inPageNavPresService.links$;
 
   public ngAfterViewInit() {
-    this.inPageNavPresService.initialize(this.inPageNavLinkDirectives);
+    this.inPageNavPresService.initialize(this.inPageNavLinkDirectives());
   }
 }

--- a/apps/showcase/src/app/configuration/configuration.spec.ts
+++ b/apps/showcase/src/app/configuration/configuration.spec.ts
@@ -9,6 +9,9 @@ import {
   RouterModule,
 } from '@angular/router';
 import {
+  NgbScrollSpyService,
+} from '@ng-bootstrap/ng-bootstrap';
+import {
   StoreModule,
 } from '@ngrx/store';
 import {
@@ -29,8 +32,13 @@ let componentFixture: ConfigurationFixtureComponent;
 describe('Configuration', () => {
   let component: Configuration;
   let fixture: ComponentFixture<Configuration>;
+  let mockScrollSpyService: Partial<NgbScrollSpyService>;
 
   beforeEach(() => {
+    mockScrollSpyService = {
+      start: jest.fn(),
+      stop: jest.fn()
+    };
     TestBed.configureTestingModule({
       imports: [
         Configuration,
@@ -38,7 +46,10 @@ describe('Configuration', () => {
         RouterModule.forRoot([]),
         AsyncPipe
       ],
-      providers: [provideMarkdown()]
+      providers: [
+        { provide: NgbScrollSpyService, useValue: mockScrollSpyService },
+        provideMarkdown()
+      ]
     });
     fixture = TestBed.createComponent(Configuration);
     component = fixture.componentInstance;

--- a/apps/showcase/src/app/configuration/configuration.ts
+++ b/apps/showcase/src/app/configuration/configuration.ts
@@ -8,9 +8,8 @@ import {
   computed,
   inject,
   input,
-  QueryList,
   signal,
-  ViewChildren,
+  viewChildren,
   ViewEncapsulation,
 } from '@angular/core';
 import {
@@ -72,9 +71,7 @@ const CONFIG_OVERRIDE = {
 })
 export class Configuration implements DynamicConfigurableWithSignal<ConfigurationConfig>, AfterViewInit {
   private readonly inPageNavPresService = inject(InPageNavPresService);
-
-  @ViewChildren(InPageNavLinkDirective)
-  private readonly inPageNavLinkDirectives!: QueryList<InPageNavLink>;
+  private readonly inPageNavLinkDirectives = viewChildren<InPageNavLink>(InPageNavLinkDirective);
 
   public links$ = this.inPageNavPresService.links$;
 
@@ -100,7 +97,7 @@ export class Configuration implements DynamicConfigurableWithSignal<Configuratio
   });
 
   public ngAfterViewInit() {
-    this.inPageNavPresService.initialize(this.inPageNavLinkDirectives);
+    this.inPageNavPresService.initialize(this.inPageNavLinkDirectives());
   }
 
   public toggleConfig() {

--- a/apps/showcase/src/app/design-token/design-token.spec.ts
+++ b/apps/showcase/src/app/design-token/design-token.spec.ts
@@ -6,6 +6,9 @@ import {
   RouterModule,
 } from '@angular/router';
 import {
+  NgbScrollSpyService,
+} from '@ng-bootstrap/ng-bootstrap';
+import {
   provideMarkdown,
 } from 'ngx-markdown';
 import {
@@ -15,14 +18,22 @@ import {
 describe('DesignToken', () => {
   let component: DesignToken;
   let fixture: ComponentFixture<DesignToken>;
+  let mockScrollSpyService: Partial<NgbScrollSpyService>;
 
   beforeEach(async () => {
+    mockScrollSpyService = {
+      start: jest.fn(),
+      stop: jest.fn()
+    };
     await TestBed.configureTestingModule({
       imports: [
         DesignToken,
         RouterModule.forRoot([])
       ],
-      providers: [provideMarkdown()]
+      providers: [
+        { provide: NgbScrollSpyService, useValue: mockScrollSpyService },
+        provideMarkdown()
+      ]
     })
       .compileComponents();
 

--- a/apps/showcase/src/app/design-token/design-token.ts
+++ b/apps/showcase/src/app/design-token/design-token.ts
@@ -6,8 +6,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   inject,
-  QueryList,
-  ViewChildren,
+  viewChildren,
   ViewEncapsulation,
 } from '@angular/core';
 import {
@@ -44,13 +43,11 @@ import {
 })
 export class DesignToken implements AfterViewInit {
   private readonly inPageNavPresService = inject(InPageNavPresService);
-
-  @ViewChildren(InPageNavLinkDirective)
-  private readonly inPageNavLinkDirectives!: QueryList<InPageNavLink>;
+  private readonly inPageNavLinkDirectives = viewChildren<InPageNavLink>(InPageNavLinkDirective);
 
   public links$ = this.inPageNavPresService.links$;
 
   public ngAfterViewInit() {
-    this.inPageNavPresService.initialize(this.inPageNavLinkDirectives);
+    this.inPageNavPresService.initialize(this.inPageNavLinkDirectives());
   }
 }

--- a/apps/showcase/src/app/dynamic-content/dynamic-content.spec.ts
+++ b/apps/showcase/src/app/dynamic-content/dynamic-content.spec.ts
@@ -9,6 +9,9 @@ import {
   RouterModule,
 } from '@angular/router';
 import {
+  NgbScrollSpyService,
+} from '@ng-bootstrap/ng-bootstrap';
+import {
   provideDynamicContent,
 } from '@o3r/dynamic-content';
 import {
@@ -29,8 +32,13 @@ let componentFixture: DynamicContentFixtureComponent;
 describe('DynamicContent', () => {
   let component: DynamicContent;
   let fixture: ComponentFixture<DynamicContent>;
+  let mockScrollSpyService: Partial<NgbScrollSpyService>;
 
   beforeEach(() => {
+    mockScrollSpyService = {
+      start: jest.fn(),
+      stop: jest.fn()
+    };
     TestBed.configureTestingModule({
       imports: [
         DynamicContent,
@@ -38,6 +46,7 @@ describe('DynamicContent', () => {
         AsyncPipe
       ],
       providers: [
+        { provide: NgbScrollSpyService, useValue: mockScrollSpyService },
         provideMarkdown(),
         provideDynamicContent()
       ]

--- a/apps/showcase/src/app/dynamic-content/dynamic-content.ts
+++ b/apps/showcase/src/app/dynamic-content/dynamic-content.ts
@@ -6,8 +6,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   inject,
-  QueryList,
-  ViewChildren,
+  viewChildren,
   ViewEncapsulation,
 } from '@angular/core';
 import {
@@ -46,9 +45,7 @@ import {
 })
 export class DynamicContent implements AfterViewInit {
   private readonly inPageNavPresService = inject(InPageNavPresService);
-
-  @ViewChildren(InPageNavLinkDirective)
-  private readonly inPageNavLinkDirectives!: QueryList<InPageNavLink>;
+  private readonly inPageNavLinkDirectives = viewChildren<InPageNavLink>(InPageNavLinkDirective);
 
   public links$ = this.inPageNavPresService.links$;
 
@@ -59,7 +56,7 @@ export class DynamicContent implements AfterViewInit {
 </body>`;
 
   public ngAfterViewInit() {
-    this.inPageNavPresService.initialize(this.inPageNavLinkDirectives);
+    this.inPageNavPresService.initialize(this.inPageNavLinkDirectives());
   }
 
   public setLocalStorage() {

--- a/apps/showcase/src/app/forms/forms.spec.ts
+++ b/apps/showcase/src/app/forms/forms.spec.ts
@@ -6,6 +6,9 @@ import {
   RouterModule,
 } from '@angular/router';
 import {
+  NgbScrollSpyService,
+} from '@ng-bootstrap/ng-bootstrap';
+import {
   mockTranslationModules,
 } from '@o3r/testing/localization';
 import {
@@ -18,11 +21,19 @@ import {
 describe('Forms', () => {
   let component: Forms;
   let fixture: ComponentFixture<Forms>;
+  let mockScrollSpyService: Partial<NgbScrollSpyService>;
 
   beforeEach(async () => {
+    mockScrollSpyService = {
+      start: jest.fn(),
+      stop: jest.fn()
+    };
     await TestBed.configureTestingModule({
       imports: [RouterModule.forRoot([]), Forms, ...mockTranslationModules()],
-      providers: [provideMarkdown()]
+      providers: [
+        { provide: NgbScrollSpyService, useValue: mockScrollSpyService },
+        provideMarkdown()
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(Forms);

--- a/apps/showcase/src/app/forms/forms.ts
+++ b/apps/showcase/src/app/forms/forms.ts
@@ -6,8 +6,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   inject,
-  QueryList,
-  ViewChildren,
+  viewChildren,
   ViewEncapsulation,
 } from '@angular/core';
 import {
@@ -43,14 +42,12 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class Forms implements AfterViewInit {
-  @ViewChildren(InPageNavLinkDirective)
-  private readonly inPageNavLinkDirectives!: QueryList<InPageNavLink>;
-
+  private readonly inPageNavLinkDirectives = viewChildren<InPageNavLink>(InPageNavLinkDirective);
   private readonly inPageNavPresService = inject(InPageNavPresService);
 
   public links$ = this.inPageNavPresService.links$;
 
   public ngAfterViewInit() {
-    this.inPageNavPresService.initialize(this.inPageNavLinkDirectives);
+    this.inPageNavPresService.initialize(this.inPageNavLinkDirectives());
   }
 }

--- a/apps/showcase/src/app/localization/localization.spec.ts
+++ b/apps/showcase/src/app/localization/localization.spec.ts
@@ -12,6 +12,9 @@ import {
   RouterModule,
 } from '@angular/router';
 import {
+  NgbScrollSpyService,
+} from '@ng-bootstrap/ng-bootstrap';
+import {
   TranslateCompiler,
   TranslateFakeCompiler,
 } from '@ngx-translate/core';
@@ -39,8 +42,13 @@ const mockTranslationsCompilerProvider: Provider = {
 describe('Localization', () => {
   let component: Localization;
   let fixture: ComponentFixture<Localization>;
+  let mockScrollSpyService: Partial<NgbScrollSpyService>;
 
   beforeEach(async () => {
+    mockScrollSpyService = {
+      start: jest.fn(),
+      stop: jest.fn()
+    };
     TestBed.configureTestingModule({
       imports: [
         RouterModule.forRoot([]),
@@ -48,7 +56,10 @@ describe('Localization', () => {
         ...mockTranslationModules(localizationConfiguration, mockTranslations, mockTranslationsCompilerProvider),
         AsyncPipe
       ],
-      providers: [provideMarkdown()]
+      providers: [
+        { provide: NgbScrollSpyService, useValue: mockScrollSpyService },
+        provideMarkdown()
+      ]
     });
     fixture = TestBed.createComponent(Localization);
     component = fixture.componentInstance;

--- a/apps/showcase/src/app/localization/localization.ts
+++ b/apps/showcase/src/app/localization/localization.ts
@@ -6,8 +6,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   inject,
-  QueryList,
-  ViewChildren,
+  viewChildren,
   ViewEncapsulation,
 } from '@angular/core';
 import {
@@ -44,13 +43,11 @@ import {
 })
 export class Localization implements AfterViewInit {
   private readonly inPageNavPresService = inject(InPageNavPresService);
-
-  @ViewChildren(InPageNavLinkDirective)
-  private readonly inPageNavLinkDirectives!: QueryList<InPageNavLink>;
+  private readonly inPageNavLinkDirectives = viewChildren<InPageNavLink>(InPageNavLinkDirective);
 
   public links$ = this.inPageNavPresService.links$;
 
   public ngAfterViewInit() {
-    this.inPageNavPresService.initialize(this.inPageNavLinkDirectives);
+    this.inPageNavPresService.initialize(this.inPageNavLinkDirectives());
   }
 }

--- a/apps/showcase/src/app/placeholder/placeholder.spec.ts
+++ b/apps/showcase/src/app/placeholder/placeholder.spec.ts
@@ -3,6 +3,9 @@ import {
   TestBed,
 } from '@angular/core/testing';
 import {
+  NgbScrollSpyService,
+} from '@ng-bootstrap/ng-bootstrap';
+import {
   EffectsModule,
 } from '@ngrx/effects';
 import {
@@ -21,8 +24,13 @@ import {
 describe('Placeholder', () => {
   let component: Placeholder;
   let fixture: ComponentFixture<Placeholder>;
+  let mockScrollSpyService: Partial<NgbScrollSpyService>;
 
   beforeEach(async () => {
+    mockScrollSpyService = {
+      start: jest.fn(),
+      stop: jest.fn()
+    };
     await TestBed.configureTestingModule({
       imports: [
         Placeholder,
@@ -31,6 +39,7 @@ describe('Placeholder', () => {
         RulesEngineRunnerModule.forRoot()
       ],
       providers: [
+        { provide: NgbScrollSpyService, useValue: mockScrollSpyService },
         provideDynamicContent()
       ]
     }).compileComponents();

--- a/apps/showcase/src/app/placeholder/placeholder.ts
+++ b/apps/showcase/src/app/placeholder/placeholder.ts
@@ -6,8 +6,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   inject,
-  type QueryList,
-  ViewChildren,
+  viewChildren,
   ViewEncapsulation,
 } from '@angular/core';
 import {
@@ -71,9 +70,7 @@ export class Placeholder implements AfterViewInit {
   private readonly inPageNavPresService = inject(InPageNavPresService);
   private readonly dynamicContentService = inject(DynamicContentService);
   private readonly store = inject(Store<RulesetsStore>);
-
-  @ViewChildren(InPageNavLinkDirective)
-  private readonly inPageNavLinkDirectives!: QueryList<InPageNavLink>;
+  private readonly inPageNavLinkDirectives = viewChildren<InPageNavLink>(InPageNavLinkDirective);
 
   public links$ = this.inPageNavPresService.links$;
 
@@ -99,6 +96,6 @@ export class Placeholder implements AfterViewInit {
   }
 
   public ngAfterViewInit() {
-    this.inPageNavPresService.initialize(this.inPageNavLinkDirectives);
+    this.inPageNavPresService.initialize(this.inPageNavLinkDirectives());
   }
 }

--- a/apps/showcase/src/app/rules-engine/rules-engine.spec.ts
+++ b/apps/showcase/src/app/rules-engine/rules-engine.spec.ts
@@ -12,6 +12,9 @@ import {
   RouterModule,
 } from '@angular/router';
 import {
+  NgbScrollSpyService,
+} from '@ng-bootstrap/ng-bootstrap';
+import {
   EffectsModule,
 } from '@ngrx/effects';
 import {
@@ -49,8 +52,13 @@ const mockTranslationsCompilerProvider: Provider = {
 describe('RulesEngine', () => {
   let component: RulesEngine;
   let fixture: ComponentFixture<RulesEngine>;
+  let mockScrollSpyService: Partial<NgbScrollSpyService>;
 
   beforeEach(async () => {
+    mockScrollSpyService = {
+      start: jest.fn(),
+      stop: jest.fn()
+    };
     TestBed.configureTestingModule({
       imports: [
         RulesEngine,
@@ -61,7 +69,10 @@ describe('RulesEngine', () => {
         ...mockTranslationModules(localizationConfiguration, mockTranslations, mockTranslationsCompilerProvider),
         AsyncPipe
       ],
-      providers: [provideMarkdown()]
+      providers: [
+        { provide: NgbScrollSpyService, useValue: mockScrollSpyService },
+        provideMarkdown()
+      ]
     });
     global.fetch = jest.fn(() =>
       Promise.resolve({

--- a/apps/showcase/src/app/rules-engine/rules-engine.ts
+++ b/apps/showcase/src/app/rules-engine/rules-engine.ts
@@ -6,8 +6,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   inject,
-  QueryList,
-  ViewChildren,
+  viewChildren,
   ViewEncapsulation,
 } from '@angular/core';
 import {
@@ -115,14 +114,12 @@ export class RulesEngine implements AfterViewInit {
   private readonly inPageNavPresService = inject(InPageNavPresService);
   private readonly dynamicContentService = inject(DynamicContentService);
   private readonly rulesEngineService = inject(RulesEngineRunnerService);
+  private readonly inPageNavLinkDirectives = viewChildren<InPageNavLink>(InPageNavLinkDirective);
 
   public newYorkAvailableRule = '';
   public helloNewYorkRule = '';
   public summerOtterRule = '';
   public lateOtterRule = '';
-
-  @ViewChildren(InPageNavLinkDirective)
-  private readonly inPageNavLinkDirectives!: QueryList<InPageNavLink>;
 
   public links$ = this.inPageNavPresService.links$;
 
@@ -176,7 +173,7 @@ export class RulesEngine implements AfterViewInit {
   }
 
   public ngAfterViewInit() {
-    this.inPageNavPresService.initialize(this.inPageNavLinkDirectives);
+    this.inPageNavPresService.initialize(this.inPageNavLinkDirectives());
   }
 
   public activateRuleTab(tab: string) {

--- a/apps/showcase/src/app/sdk-intro/sdk-intro.spec.ts
+++ b/apps/showcase/src/app/sdk-intro/sdk-intro.spec.ts
@@ -3,16 +3,27 @@ import {
   TestBed,
 } from '@angular/core/testing';
 import {
+  NgbScrollSpyService,
+} from '@ng-bootstrap/ng-bootstrap';
+import {
   SdkIntro,
 } from './sdk-intro';
 
 describe('Sdk', () => {
   let component: SdkIntro;
   let fixture: ComponentFixture<SdkIntro>;
+  let mockScrollSpyService: Partial<NgbScrollSpyService>;
 
   beforeEach(() => {
+    mockScrollSpyService = {
+      start: jest.fn(),
+      stop: jest.fn()
+    };
     TestBed.configureTestingModule({
-      imports: [SdkIntro]
+      imports: [SdkIntro],
+      providers: [
+        { provide: NgbScrollSpyService, useValue: mockScrollSpyService }
+      ]
     });
     fixture = TestBed.createComponent(SdkIntro);
     component = fixture.componentInstance;

--- a/apps/showcase/src/app/sdk-intro/sdk-intro.ts
+++ b/apps/showcase/src/app/sdk-intro/sdk-intro.ts
@@ -6,8 +6,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   inject,
-  QueryList,
-  ViewChildren,
+  viewChildren,
   ViewEncapsulation,
 } from '@angular/core';
 import {
@@ -34,13 +33,11 @@ import {
 })
 export class SdkIntro implements AfterViewInit {
   private readonly inPageNavPresService = inject(InPageNavPresService);
-
-  @ViewChildren(InPageNavLinkDirective)
-  private readonly inPageNavLinkDirectives!: QueryList<InPageNavLink>;
+  private readonly inPageNavLinkDirectives = viewChildren<InPageNavLink>(InPageNavLinkDirective);
 
   public links$ = this.inPageNavPresService.links$;
 
   public ngAfterViewInit() {
-    this.inPageNavPresService.initialize(this.inPageNavLinkDirectives);
+    this.inPageNavPresService.initialize(this.inPageNavLinkDirectives());
   }
 }

--- a/apps/showcase/src/app/sdk/sdk.spec.ts
+++ b/apps/showcase/src/app/sdk/sdk.spec.ts
@@ -9,6 +9,9 @@ import {
   RouterModule,
 } from '@angular/router';
 import {
+  NgbScrollSpyService,
+} from '@ng-bootstrap/ng-bootstrap';
+import {
   PetApi,
 } from '@o3r-training/showcase-sdk';
 import {
@@ -25,10 +28,16 @@ import '@angular/localize/init';
 describe('Sdk', () => {
   let component: Sdk;
   let fixture: ComponentFixture<Sdk>;
+  let mockScrollSpyService: Partial<NgbScrollSpyService>;
   const petApiFixture = new PetApiFixture();
   petApiFixture.findPetsByStatus = petApiFixture.findPetsByStatus.mockResolvedValue([]);
 
   beforeEach(() => {
+    mockScrollSpyService = {
+      start: jest.fn(),
+      stop: jest.fn()
+    };
+
     TestBed.configureTestingModule({
       imports: [
         Sdk,
@@ -37,6 +46,7 @@ describe('Sdk', () => {
       ],
       providers: [
         { provide: PetApi, useValue: petApiFixture },
+        { provide: NgbScrollSpyService, useValue: mockScrollSpyService },
         provideMarkdown()
       ]
     });

--- a/apps/showcase/src/app/sdk/sdk.ts
+++ b/apps/showcase/src/app/sdk/sdk.ts
@@ -6,8 +6,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   inject,
-  QueryList,
-  ViewChildren,
+  viewChildren,
   ViewEncapsulation,
 } from '@angular/core';
 import {
@@ -44,13 +43,11 @@ import {
 })
 export class Sdk implements AfterViewInit {
   private readonly inPageNavPresService = inject(InPageNavPresService);
-
-  @ViewChildren(InPageNavLinkDirective)
-  private readonly inPageNavLinkDirectives!: QueryList<InPageNavLink>;
+  private readonly inPageNavLinkDirectives = viewChildren<InPageNavLink>(InPageNavLinkDirective);
 
   public links$ = this.inPageNavPresService.links$;
 
   public ngAfterViewInit() {
-    this.inPageNavPresService.initialize(this.inPageNavLinkDirectives);
+    this.inPageNavPresService.initialize(this.inPageNavLinkDirectives());
   }
 }

--- a/apps/showcase/src/components/training/code-editor-control/code-editor-control.ts
+++ b/apps/showcase/src/components/training/code-editor-control/code-editor-control.ts
@@ -7,7 +7,7 @@ import {
   inject,
   Input,
   OnDestroy,
-  ViewChild,
+  viewChild,
   ViewEncapsulation,
 } from '@angular/core';
 import {
@@ -56,8 +56,7 @@ export class CodeEditorControl implements OnDestroy, AfterViewInit {
   /**
    * Reference to the iframe used to display the content of the application served in the web container
    */
-  @ViewChild('iframe')
-  public iframeEl!: ElementRef<HTMLIFrameElement>;
+  public iframeEl = viewChild.required<ElementRef<HTMLIFrameElement>>('iframe');
 
   /**
    * Manage the web-container commands and outputs.
@@ -103,7 +102,7 @@ export class CodeEditorControl implements OnDestroy, AfterViewInit {
    * @inheritDoc
    */
   public ngAfterViewInit() {
-    this.webContainerService.runner.registerIframe(this.iframeEl.nativeElement);
+    this.webContainerService.runner.registerIframe(this.iframeEl().nativeElement);
   }
 
   /**

--- a/apps/showcase/src/components/training/code-editor-terminal/code-editor-terminal.ts
+++ b/apps/showcase/src/components/training/code-editor-terminal/code-editor-terminal.ts
@@ -8,7 +8,7 @@ import {
   EventEmitter,
   inject,
   Output,
-  ViewChild,
+  viewChild,
 } from '@angular/core';
 import {
   FitAddon,
@@ -36,8 +36,7 @@ export class CodeEditorTerminal implements AfterViewChecked, AfterViewInit {
   /**
    * HTML reference to the terminal container in the CodeEditorTerminal component
    */
-  @ViewChild('terminal')
-  public terminalEl!: ElementRef<HTMLDivElement>;
+  public terminalEl = viewChild.required<ElementRef<HTMLDivElement>>('terminal');
 
   /**
    * Inform the parent that the terminal of the component has been created and is ready to use as input/output
@@ -74,7 +73,7 @@ export class CodeEditorTerminal implements AfterViewChecked, AfterViewInit {
    * Create terminal instance and share the information with the component parent
    */
   private initTerminal() {
-    this.terminal.open(this.terminalEl.nativeElement);
+    this.terminal.open(this.terminalEl().nativeElement);
     this.terminalUpdated.emit(this.terminal);
   }
 

--- a/apps/showcase/src/components/utilities/in-page-nav/in-page-nav-pres-service.ts
+++ b/apps/showcase/src/components/utilities/in-page-nav/in-page-nav-pres-service.ts
@@ -1,14 +1,10 @@
 import {
   Injectable,
-  QueryList,
 } from '@angular/core';
 import {
+  BehaviorSubject,
   delay,
-  map,
   shareReplay,
-  startWith,
-  Subject,
-  switchMap,
 } from 'rxjs';
 import {
   InPageNavLink,
@@ -18,14 +14,10 @@ import {
   providedIn: 'root'
 })
 export class InPageNavPresService {
-  private readonly linksSubject = new Subject<QueryList<InPageNavLink>>();
+  private readonly linksSubject = new BehaviorSubject<readonly InPageNavLink[]>([]);
 
   /** Observable of links */
   public links$ = this.linksSubject.pipe(
-    switchMap((inPageNavLinkDirectives) => inPageNavLinkDirectives.changes.pipe(
-      startWith([]),
-      map(() => inPageNavLinkDirectives.toArray())
-    )),
     delay(0), // Delay needed else ExpressionChangedAfterItHasBeenCheckedError throws
     shareReplay(1)
   );
@@ -34,7 +26,7 @@ export class InPageNavPresService {
    * Initialize the navigation links list
    * @param inPageNavLinkDirectives
    */
-  public initialize(inPageNavLinkDirectives: QueryList<InPageNavLink>) {
+  public initialize(inPageNavLinkDirectives: readonly InPageNavLink[]) {
     this.linksSubject.next(inPageNavLinkDirectives);
   }
 }

--- a/apps/showcase/src/components/utilities/in-page-nav/in-page-nav-pres.ts
+++ b/apps/showcase/src/components/utilities/in-page-nav/in-page-nav-pres.ts
@@ -73,7 +73,7 @@ export class InPageNavPres implements OnChanges, OnDestroy {
 
   /** List of links */
   @Input()
-  public links: InPageNavLink[] = [];
+  public links: readonly InPageNavLink[] = [];
 
   private readonly scrollSpyService = inject(NgbScrollSpyService);
 


### PR DESCRIPTION
## Proposed change

Migration to signal-based `viewChild` and `viewChildren`

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

<!-- *- No issue associated -* -->

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
* :rocket: Feature #3609
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
