### PR TITLE
fix: use passed ruleset map to determine available rulesets

### DIFF
--- a/packages/@o3r/rules-engine/src/components/rules-engine/shared/ruleset-history.helper.ts
+++ b/packages/@o3r/rules-engine/src/components/rules-engine/shared/ruleset-history.helper.ts
@@ -32,7 +32,7 @@ export const getStatus = (rulesetExecution: RulesetExecutionErrorEvent | Ruleset
  * @param rulesetMap
  */
 export const rulesetReportToHistory = (events: DebugEvent[], rulesetMap: Record<string, Ruleset>): RulesetExecutionDebug[] => {
-  const availableRulesets = (events.filter((e) => e.type === 'AvailableRulesets').reverse()[0])?.availableRulesets || [];
+  const availableRulesets = Object.values(rulesetMap);
   const lastActiveRulesets = (events.filter((e) => e.type === 'ActiveRulesets').reverse()[0])?.rulesets || [];
 
   return availableRulesets


### PR DESCRIPTION
## Proposed change

When the threshold for events is exceeded the entry `AvailableRulesets` is removed. Instead, using the `rulesetMap` as a source for available rulesets, is a more reliable data provider.

### Before
<img width="1025" height="404" alt="Screenshot 2025-11-11 at 13 09 03" src="https://github.com/user-attachments/assets/634b3a02-25f0-4b20-9384-21a5368fceaa" />

### After
<img width="1025" height="404" alt="Screenshot 2025-11-11 at 11 45 54" src="https://github.com/user-attachments/assets/a06d9de2-c7ce-4c0d-9f2e-73512cdf4ad8" />

### Analysis
Looking at the data flow there should be no difference whether to use `rulesetMap` or `AvailableRulesets`.
<img width="1092" height="1007" alt="Screenshot 2025-11-11 at 13 52 17" src="https://github.com/user-attachments/assets/e2d0ab77-4ae7-4e1e-9c62-c97d0fef1962" />


<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

<!-- * :bug: Fix #issue -->
* :bug: Fix resolves #3707
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
