### PR TITLE
chore: reduce the coverage threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,19 +7,19 @@ coverage:
     patch:
       default:
         target: auto
-        threshold: 5%
+        threshold: 0.3%
         informational: true
 
     default_rules:
       flag_coverage_not_uploaded_behavior: exclude
       target: auto
-      threshold: 5%
+      threshold: 0.3%
       informational: true
 
     project:
       default:
         target: auto
-        threshold: 5%
+        threshold: 0.3%
         base: auto
         if_ci_failed: error
         informational: true


### PR DESCRIPTION
## Proposed change

As the status reported by codeCov has been fixed, we can now set the correct amount of threshold we want.
The threshold is the percentage of the whole code coverage we accept to lose on a single PR
I propose 0.3% based on the worse PR we got (The creation of the MCP packages)

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

- threshold definition: https://docs.codecov.com/docs/commit-status#threshold
- CodeCov report: https://app.codecov.io/gh/AmadeusITGroup/otter

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
