### PR TITLE
chore(artifactory-tools): add missing node global types

### DIFF
--- a/packages/@o3r/artifactory-tools/eslint.local.config.mjs
+++ b/packages/@o3r/artifactory-tools/eslint.local.config.mjs
@@ -4,6 +4,7 @@ import {
 import {
   fileURLToPath,
 } from 'node:url';
+import globals from 'globals';
 
 const __filename = fileURLToPath(import.meta.url);
 // __dirname is not defined in ES module scope
@@ -17,6 +18,16 @@ export default [
       parserOptions: {
         tsconfigRootDir: __dirname,
         projectService: true
+      }
+    }
+  },
+  {
+    name: '@o3r/artifactory-tools/globals',
+    languageOptions: {
+      sourceType: 'module',
+      globals: {
+        ...globals.node,
+        NodeJS: true
       }
     }
   }


### PR DESCRIPTION
## Proposed change

chore(artifactory-tools): add missing node global types

mainly required for the usage of `process` global variable

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
