### PR TITLE
feat(renovate): update presets to handle the weird versioning of angular-devkit/architect

### DIFF
--- a/tools/renovate/base.json
+++ b/tools/renovate/base.json
@@ -15,6 +15,8 @@
     "github>AmadeusITGroup/otter//tools/renovate/group/typescript",
     "github>AmadeusITGroup/otter//tools/renovate/managers/github-node-version.json5"
   ],
+  "separateMajorMinor": true,
+  "separateMinorPatch": true,
   "hostRules": [
     {
       "timeout": 240000

--- a/tools/renovate/branching-strategy/release-branches.json
+++ b/tools/renovate/branching-strategy/release-branches.json
@@ -4,12 +4,6 @@
   "packageRules": [
     {
       "matchPackageNames": [
-        "*"
-      ],
-      "rangeStrategy": "replace"
-    },
-    {
-      "matchPackageNames": [
         "typescript"
       ],
       "rangeStrategy": "in-range-only"

--- a/tools/renovate/group/angular.json
+++ b/tools/renovate/group/angular.json
@@ -17,6 +17,10 @@
       ],
       "groupName": "Angular dependencies",
       "groupSlug": "angular-dependencies"
+    },
+    {
+      "matchPackageNames": ["@angular-devkit/architect"],
+      "versioning": "regex:^[~^]?0\\.(?<major>\\d{2})(?<minor>\\d{2})\\.(?<patch>\\d+)$"
     }
   ]
 }


### PR DESCRIPTION
## Proposed change

Update renovate presets to support the versioning of `@angular-devkit/architect` which doesn't follow the versioning of other angular packages
Assumption is `0.XXYY.ZZ` where `XX` is the major, `YY` is the minor and `ZZ` is the patch
Example:
Angular 21 -> `0.2100.0`
Angular 20.3 -> `0.2003.0`

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
