### PR TITLE
fix: verdaccio increase timeout

### DIFF
--- a/packages/@o3r/test-helpers/src/utilities/verdaccio.ts
+++ b/packages/@o3r/test-helpers/src/utilities/verdaccio.ts
@@ -22,7 +22,7 @@ export function isVerdaccioInUse(): boolean {
   try {
     // eslint-disable-next-line no-console -- need to inform user about the check
     console.log(`Checking for Verdaccio registry at ${verdaccioAddress}...`);
-    execFileSync('npm', ['ping', `--registry=${verdaccioAddress}`], { stdio: 'pipe', shell: true, timeout: 5000 });
+    execFileSync('npm', ['ping', `--registry=${verdaccioAddress}`], { stdio: 'pipe', shell: true, timeout: 60_000 });
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Proposed change

Increase the timeout in verdaccio to avoid the following error in the IT tests:
```
Error: Verdaccio is not running.
      Please set it up with the following commands:
       - verdaccio:start or verdaccio:start-local
       - verdaccio:publish
```

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
