### PR TITLE
feat(ama-openapi): add custom decorator for ref redirection

### DIFF
--- a/docs/redocly/DECORATORS.md
+++ b/docs/redocly/DECORATORS.md
@@ -1,0 +1,136 @@
+# Custom Decorators
+
+The plugin offers additional Redocly decorators that you can pick and choose in the Redocly configuration
+
+## Decorator `redirect-refs`
+
+This custom decorator helps redirect the references to any specified URL after the bundling process.
+
+**Available for the formats :**
+
+`oas3`, `oas2`, `async3` and `async2`
+
+**Example of usage :**
+
+```yaml
+# Redirect the references to a model in `my-models/` to `https://my-spec.website.com/` URL
+
+plugins:
+  - '@ama-openapi/redocly-plugin'
+
+apis:
+  mySpec:
+    root: apis/mySpec.json
+    decorators:
+      ama-openapi/redirect-ref:
+        rules:
+          - redirectUrl: "https://my-spec.website.com/"
+            includeRefPatterns: "my-models/.*"
+```
+
+will turn the spec :
+
+```yaml
+
+paths:
+  '/example-url':
+    get:
+      responses:
+        "200":
+          $ref: "#/components/schemas/model1"
+components:
+  schema:
+    model1:
+      $ref: my-models/somewhere
+
+```
+
+to:
+
+```yaml
+
+paths:
+  '/example-url':
+    get:
+      responses:
+        "200":
+          $ref: "#/components/schemas/model1"
+components:
+  schema:
+    model1:
+      $ref: https://my-spec.website.com/
+
+```
+
+**Options available :**
+
+| Options | Type | Description |
+| --- | --- | --- |
+| `rules` | `array` | List of rules to be apply to the specification references |
+| `rules.includeRefPatterns` *(optional)* | `string` or `string[]` | Pattern the `$ref` url should match to apply the redirection if specified.<br /> In case a list is provided, at least one from the list should match to apply the redirection. |
+| `rules.excludeRefPatterns`*(optional)*  | `string` or `string[]` | Pattern the `$ref` url should match to apply the redirection if specified.<br /> In case a list is provided, at least one from the list should match to apply the redirection. |
+| `rules.hasTag` *(optional)* | `string` | Not only the model should have the reference, but a specific `x-vendor` tag must be present, if specified, in order to apply the transformation. |
+| `rules.redirectUrl` | `string` | Redirect the reference to a define URL |
+| `rules.keepFinalInnerPath` *(optional)* | `boolean` | Determine the final inner path should be kept. The final inner path is ignored otherwise. |
+
+## Decorator `remove-unused-components`
+
+This decorator removes the components with no reference from the bundled specification.
+
+**Available for the formats :**
+
+`oas3`
+
+**Example of usage :**
+
+```yaml
+plugins:
+  - '@ama-openapi/redocly-plugin'
+
+apis:
+  mySpec:
+    root: apis/mySpec.json
+    decorators:
+      ama-openapi/remove-unused-component: on
+```
+
+will turn the spec :
+
+```yaml
+paths:
+  '/example-url':
+    get:
+      responses:
+        "200":
+          $ref: "#/components/schemas/model3"
+components:
+  schema:
+    model1:
+      type: object
+    model2:
+      type: object
+      properties:
+        ref:
+          $ref: "#/components/schemas/model1"
+    model3:
+      type: object
+```
+
+To:
+
+```yaml
+paths:
+  '/example-url':
+    get:
+      responses:
+        "200":
+          $ref: "#/components/schemas/model3"
+components:
+  schema:
+    model3:
+      type: object
+```
+
+> [!NOTE]
+> The purpose of this plugin is to support inter-dependencies which is currently missing in the Redocly built-in [remove-unused-components](https://redocly.com/docs/cli/decorators/remove-unused-components).
+> This plugin will be deprecated in favor to the built-in plugin when  [the Redocly issue](https://github.com/Redocly/redocly-cli/issues/1783) is fixed

--- a/packages/@ama-openapi/core/src/logger.mts
+++ b/packages/@ama-openapi/core/src/logger.mts
@@ -28,7 +28,7 @@ export interface Logger {
    * @param message Message to log
    * @param optionalParams Optional parameters to log
    */
-  log(message?: any, ...optionalParams: any[]): void;
+  log?(message?: any, ...optionalParams: any[]): void;
 
   /**
    * Log a debug message.

--- a/packages/@ama-openapi/redocly-plugin/README.md
+++ b/packages/@ama-openapi/redocly-plugin/README.md
@@ -103,6 +103,12 @@ The following environment variables are supported:
 | `AMA_OPENAPI_REDOCLY_VERBOSE` | Display debug level logs | `false` |
 | `AMA_OPENAPI_REDOCLY_QUIET` | Suppress all output| `false` |
 
+## Additional custom decorators
+
+The plugin offer additional [Redocly decorator](https://redocly.com/docs/cli/decorators) which can be selected and configured in [Redocly configuration](https://redocly.com/docs/cli/rules/configure-rules).
+
+The full list of available decorators, along with their options, is provided in the [dedicated documentation](https://github.com/AmadeusITGroup/otter/blob/main/docs/redocly/DECORATORS.md).
+
 ## Integration
 
 This Redocly Plugin is designed to work with the following tools:

--- a/packages/@ama-openapi/redocly-plugin/src/plugin.mts
+++ b/packages/@ama-openapi/redocly-plugin/src/plugin.mts
@@ -11,6 +11,14 @@ import {
   ENVIRONMENT_VARIABLE_PREFIX,
 } from './constants.mjs';
 import {
+  DECORATOR_ID_REDIRECT_REF,
+  redirectRefsDecorator,
+} from './plugins/decorators/common/replace-refs/replace-refs.decorator.mjs';
+import {
+  DECORATOR_ID_REMOVE_UNUSED_COMPONENT,
+  removeUnusedComponentsDecorator,
+} from './plugins/decorators/oas3/remove-unused-components/remove-unused-components.decorator.mjs';
+import {
   retrieveDependency,
   type RetrieveDependencyOptions,
 } from './plugins/meta/retrieve-dependency.meta.mjs';
@@ -41,6 +49,21 @@ export const amaOpenapiPlugin = async (options?: AmaOpenapiPluginOptions): Promi
   });
 
   return {
-    id: 'ama-openapi'
+    id: 'ama-openapi',
+    decorators: {
+      oas2: {
+        [DECORATOR_ID_REDIRECT_REF]: redirectRefsDecorator
+      },
+      oas3: {
+        [DECORATOR_ID_REDIRECT_REF]: redirectRefsDecorator,
+        [DECORATOR_ID_REMOVE_UNUSED_COMPONENT]: removeUnusedComponentsDecorator
+      },
+      async2: {
+        [DECORATOR_ID_REDIRECT_REF]: redirectRefsDecorator
+      },
+      async3: {
+        [DECORATOR_ID_REDIRECT_REF]: redirectRefsDecorator
+      }
+    }
   };
 };

--- a/packages/@ama-openapi/redocly-plugin/src/plugins/decorators/common/replace-refs/replace-refs.decorator.mts
+++ b/packages/@ama-openapi/redocly-plugin/src/plugins/decorators/common/replace-refs/replace-refs.decorator.mts
@@ -1,0 +1,92 @@
+import type {
+  Async2Preprocessor,
+  Async3Preprocessor,
+  Oas2Preprocessor,
+  Oas3Preprocessor,
+} from '@redocly/openapi-core';
+
+type Preprocessor = Oas2Preprocessor & Oas3Preprocessor & Async2Preprocessor & Async3Preprocessor;
+
+interface RedirectCriteria {
+  /** Pattern, or one of the listed patterns, the $ref url should match to apply the redirection */
+  includeRefPatterns?: string | string[];
+  /** Pattern, or one of the listed patterns, the $ref url should not match to apply the redirection */
+  excludeRefPatterns?: string | string[];
+  /** Detect if a specific `x-vendor` tag is present beside of the reference */
+  hasTag?: string;
+}
+
+/** Rule to redirect the reference matching the criteria in the final specification */
+export interface RedirectRule extends RedirectCriteria {
+  /** Redirect the reference to a define URL */
+  redirectUrl: string;
+  /** Determine the final inner path should be kept */
+  keepFinalInnerPath?: boolean;
+}
+
+/** Options for the RedirectRefs custom decorator */
+export interface RedirectRefDecoratorOptions {
+  /** Rules to be apply to the specification references */
+  rules?: RedirectRule[];
+}
+
+/** Name of the redirectRef custom decorator */
+export const DECORATOR_ID_REDIRECT_REF = 'redirect-ref';
+
+const regExpify = (patterns: string | string[] | undefined) =>
+  patterns
+    ? (Array.isArray(patterns) ? patterns : [patterns])
+      .map((pattern) => new RegExp(pattern))
+    : undefined;
+
+/**
+ * Custom decorator to redirect the references in the final specification
+ * @example Redirect specific model to external URL
+ * ```yaml
+ * plugins:
+ *   - '@ama-openapi/redocly-plugin'
+ *
+ * apis:
+ *   mySpec:
+ *     root: apis/mySpec.json
+ *     decorators:
+ *       ama-openapi/redirect-ref:
+ *         rules:
+ *          - redirectUrl: "https://my-spec.website.com/"
+ *            keepFinalInnerPath: true
+ *            matchingRefPattern: "my-models/.*"
+ * ```
+ * @param options
+ */
+export const redirectRefsDecorator: Preprocessor = (options: RedirectRefDecoratorOptions) => {
+  const rules = options.rules?.map((rule) => {
+    return {
+      ...rule,
+      include: regExpify(rule.includeRefPatterns),
+      exclude: regExpify(rule.excludeRefPatterns)
+    };
+  }) ?? [];
+  const toRedirectMap = new Map<string, RedirectRule>();
+  return {
+    ref: {
+      enter: (node, { parent, location }) => {
+        const matchingRule = rules.find(({ include, exclude, hasTag }) =>
+          ([include, exclude, hasTag].some((item) => !!item))
+          && (!include || include.some((regExp) => node.$ref.match(regExp)))
+          && (!exclude || !exclude.some((regExp) => node.$ref.match(regExp)))
+          && (!hasTag || Object.values(parent).some((obj: any) => obj && typeof obj === 'object' && typeof obj[hasTag] !== 'undefined' && !!obj[hasTag]))
+        );
+        if (matchingRule) {
+          toRedirectMap.set(location.absolutePointer, matchingRule);
+        }
+      },
+      leave: (node, { location }) => {
+        const toRedirect = toRedirectMap.get(location.absolutePointer);
+
+        if (toRedirect) {
+          node.$ref = toRedirect.redirectUrl + (toRedirect.keepFinalInnerPath ? node.$ref : '');
+        }
+      }
+    }
+  };
+};

--- a/packages/@ama-openapi/redocly-plugin/src/plugins/decorators/common/replace-refs/replace-refs.decorator.spec.ts
+++ b/packages/@ama-openapi/redocly-plugin/src/plugins/decorators/common/replace-refs/replace-refs.decorator.spec.ts
@@ -1,0 +1,310 @@
+import {
+  DECORATOR_ID_REDIRECT_REF,
+  redirectRefsDecorator,
+} from './replace-refs.decorator.mjs';
+import type {
+  RedirectRefDecoratorOptions,
+} from './replace-refs.decorator.mjs';
+
+describe('redirectRefsDecorator', () => {
+  describe('DECORATOR_ID_REDIRECT_REF', () => {
+    it('should have the correct decorator ID', () => {
+      expect(DECORATOR_ID_REDIRECT_REF).toBe('redirect-ref');
+    });
+  });
+
+  describe('decorator initialization', () => {
+    it('should create a decorator with ref visitor methods', () => {
+      const decorator = redirectRefsDecorator({});
+      expect(decorator).toBeDefined();
+      expect(decorator.ref).toBeDefined();
+      expect(decorator.ref.enter).toBeDefined();
+      expect(decorator.ref.leave).toBeDefined();
+    });
+
+    it('should handle empty options', () => {
+      const decorator = redirectRefsDecorator({});
+      expect(decorator).toBeDefined();
+    });
+
+    it('should handle undefined rules', () => {
+      const decorator = redirectRefsDecorator({ rules: undefined });
+      expect(decorator).toBeDefined();
+    });
+
+    it('should handle empty rules array', () => {
+      const decorator = redirectRefsDecorator({ rules: [] });
+      expect(decorator).toBeDefined();
+    });
+  });
+
+  describe('ref.leave', () => {
+    it('should redirect ref when rule is matched', () => {
+      const options: RedirectRefDecoratorOptions = {
+        rules: [{
+          includeRefPatterns: 'my-models/.*',
+          redirectUrl: 'https://example.com/'
+        }]
+      };
+      const decorator = redirectRefsDecorator(options);
+      const node = { $ref: 'my-models/User' };
+      const parent = { node };
+
+      decorator.ref.enter(node, { parent, location: { absolutePointer: '#/test' } } as any);
+      decorator.ref.leave(node, { location: { absolutePointer: '#/test' } } as any);
+
+      expect(node.$ref).toBe('https://example.com/');
+    });
+
+    it('should keep final inner path when keepFinalInnerPath is true', () => {
+      const options: RedirectRefDecoratorOptions = {
+        rules: [{
+          includeRefPatterns: 'my-models/.*',
+          redirectUrl: 'https://example.com/my-models/',
+          keepFinalInnerPath: true
+        }]
+      };
+      const decorator = redirectRefsDecorator(options);
+      const nodeEnter = { $ref: 'my-models/User' };
+      const node = { $ref: '#/User' };
+      const parent = { node };
+
+      decorator.ref.enter(nodeEnter, { parent, location: { absolutePointer: '#/test' } } as any);
+      decorator.ref.leave(node, { location: { absolutePointer: '#/test' } } as any);
+
+      expect(node.$ref).toBe('https://example.com/my-models/#/User');
+    });
+
+    it('should not redirect ref when no rule is matched', () => {
+      const options: RedirectRefDecoratorOptions = {
+        rules: [{
+          includeRefPatterns: 'my-models/.*',
+          redirectUrl: 'https://example.com/'
+        }]
+      };
+      const decorator = redirectRefsDecorator(options);
+      const node = { $ref: 'other-models/User' };
+      const parent = { node };
+
+      decorator.ref.enter(node, { parent, location: { absolutePointer: '#/test' } } as any);
+      decorator.ref.leave(node, { location: { absolutePointer: '#/test' } } as any);
+
+      expect(node.$ref).toBe('other-models/User');
+    });
+
+    it('should handle multiple nodes in parent with same ref', () => {
+      const options: RedirectRefDecoratorOptions = {
+        rules: [{
+          includeRefPatterns: 'my-models/.*',
+          redirectUrl: 'https://example.com/my-models/',
+          keepFinalInnerPath: true
+        }]
+      };
+      const decorator = redirectRefsDecorator(options);
+      const enterNode = { $ref: 'my-models/user' };
+      const node = { $ref: '#/User' };
+      const parent = {
+        ...enterNode,
+        anotherNode: { $ref: 'Product' },
+        'x-custom': 'value'
+      };
+
+      decorator.ref.enter(enterNode, { parent, location: { absolutePointer: '#/test' } } as any);
+      decorator.ref.leave(node, { location: { absolutePointer: '#/test' } } as any);
+
+      expect(node.$ref).toBe('https://example.com/my-models/#/User');
+    });
+
+    it('should use the first rule when multiple rules match different nodes', () => {
+      const options: RedirectRefDecoratorOptions = {
+        rules: [
+          {
+            includeRefPatterns: 'models-v2/.*',
+            redirectUrl: 'https://example.com/models-v1/'
+          },
+          {
+            includeRefPatterns: 'models-v2/.*',
+            redirectUrl: 'https://example2.com/models-v2/',
+            keepFinalInnerPath: true
+          }
+        ]
+      };
+      const decorator = redirectRefsDecorator(options);
+      const node = { $ref: '#/models-v2/User' };
+      const parent = {
+        node
+      };
+
+      decorator.ref.enter(node, { parent, location: { absolutePointer: '#/test' } } as any);
+      decorator.ref.leave(node, { location: { absolutePointer: '#/test' } } as any);
+
+      expect(node.$ref).toBe('https://example.com/models-v1/');
+    });
+
+    it('should handle undefined redirect index gracefully', () => {
+      const options: RedirectRefDecoratorOptions = {
+        rules: [{
+          includeRefPatterns: 'my-models/.*',
+          redirectUrl: 'https://example.com/'
+        }]
+      };
+      const decorator = redirectRefsDecorator(options);
+      const node = { $ref: 'other-models/User' };
+      const parent = {
+        node
+      };
+
+      decorator.ref.enter(node, { parent, location: { absolutePointer: '#/test' } } as any);
+      decorator.ref.leave(node, { location: { absolutePointer: '#/test' } } as any);
+
+      expect(node.$ref).toBe('other-models/User');
+    });
+
+    it('should handle -1 redirect index gracefully', () => {
+      const options: RedirectRefDecoratorOptions = {
+        rules: [{
+          includeRefPatterns: 'my-models/.*',
+          redirectUrl: 'https://example.com/'
+        }]
+      };
+      const decorator = redirectRefsDecorator(options);
+      const node = { $ref: 'other-models/User' };
+      const parent = {
+        node
+      };
+
+      decorator.ref.enter(node, { parent, location: { absolutePointer: '#/test' } } as any);
+      decorator.ref.leave(node, { location: { absolutePointer: '#/test' } } as any);
+
+      expect(node.$ref).toBe('other-models/User');
+    });
+  });
+
+  describe('complex scenarios', () => {
+    it('should handle refs with hash fragments', () => {
+      const options: RedirectRefDecoratorOptions = {
+        rules: [{
+          includeRefPatterns: 'my-models/.*',
+          redirectUrl: 'https://example.com/my-models/',
+          keepFinalInnerPath: true
+        }]
+      };
+      const decorator = redirectRefsDecorator(options);
+      const node = { $ref: 'schema.json#/definitions/User' };
+      const parent = { node };
+
+      decorator.ref.enter(node, { parent, location: { absolutePointer: '#/test' } } as any);
+      decorator.ref.leave(node, { location: { absolutePointer: '#/test' } } as any);
+
+      expect(node.$ref).toBe('schema.json#/definitions/User');
+    });
+
+    it('should handle refs with special characters', () => {
+      const options: RedirectRefDecoratorOptions = {
+        rules: [{
+          includeRefPatterns: 'my-models/.*',
+          redirectUrl: 'https://example.com/my-models/',
+          keepFinalInnerPath: true
+        }]
+      };
+      const decorator = redirectRefsDecorator(options);
+      const enterNode = { $ref: 'my-models/User-Model_v2' };
+      const node = { $ref: 'User-Model_v2.json' };
+      const parent = { node };
+
+      decorator.ref.enter(enterNode, { parent, location: { absolutePointer: '#/test' } } as any);
+      decorator.ref.leave(node, { location: { absolutePointer: '#/test' } } as any);
+
+      expect(node.$ref).toBe('https://example.com/my-models/User-Model_v2.json');
+    });
+
+    it('should work with tag-based rules', () => {
+      const options: RedirectRefDecoratorOptions = {
+        rules: [{
+          hasTag: 'x-external-api',
+          redirectUrl: 'https://external-api.com/',
+          keepFinalInnerPath: true
+        }]
+      };
+      const decorator = redirectRefsDecorator(options);
+      const node = { $ref: '#/User' };
+      const parent = {
+        ex: {
+          ...node,
+          'x-external-api': true
+        }
+      };
+
+      decorator.ref.enter(node, { parent, location: { absolutePointer: '#/test' } } as any);
+      decorator.ref.leave(node, { location: { absolutePointer: '#/test' } } as any);
+
+      expect(node.$ref).toBe('https://external-api.com/#/User');
+    });
+
+    it('should handle complex parent objects with nested structures', () => {
+      const options: RedirectRefDecoratorOptions = {
+        rules: [{
+          hasTag: 'x-redirect',
+          redirectUrl: 'https://example.com/',
+          keepFinalInnerPath: true
+        }]
+      };
+      const decorator = redirectRefsDecorator(options);
+      const node = { $ref: 'User' };
+      const parent = {
+        node: {
+          ...node,
+          nested: {
+            deep: {
+              'x-redirect': true
+            }
+          },
+          'x-redirect': 'to be considered'
+        }
+      };
+
+      decorator.ref.enter(node, { parent, location: { absolutePointer: '#/test' } } as any);
+      decorator.ref.leave(node, { location: { absolutePointer: '#/test' } } as any);
+
+      expect(node.$ref).toBe('https://example.com/User');
+    });
+
+    it('should handle multiple sequential ref operations', () => {
+      const options: RedirectRefDecoratorOptions = {
+        rules: [{
+          includeRefPatterns: 'models/.*',
+          redirectUrl: 'https://api.example.com/v1/',
+          keepFinalInnerPath: true
+        }]
+      };
+      const decorator = redirectRefsDecorator(options);
+
+      const node1 = { $ref: 'models/User' };
+      const parent1 = { node: node1 };
+      decorator.ref.enter(node1, { parent: parent1, location: { absolutePointer: '#/paths/~1users/get/responses/200' } } as any);
+      decorator.ref.leave(node1, { location: { absolutePointer: '#/paths/~1users/get/responses/200' } } as any);
+
+      const node2 = { $ref: 'models/Product' };
+      const parent2 = { node: node2 };
+      decorator.ref.enter(node2, { parent: parent2, location: { absolutePointer: '#/paths/~1products/get/responses/200' } } as any);
+      decorator.ref.leave(node2, { location: { absolutePointer: '#/paths/~1products/get/responses/200' } } as any);
+
+      expect(node1.$ref).toBe('https://api.example.com/v1/models/User');
+      expect(node2.$ref).toBe('https://api.example.com/v1/models/Product');
+    });
+
+    it('should handle refs without redirection when rules array is empty', () => {
+      const options: RedirectRefDecoratorOptions = {
+        rules: []
+      };
+      const decorator = redirectRefsDecorator(options);
+      const node = { $ref: 'models/User' };
+      const parent = { node };
+
+      decorator.ref.enter(node, { parent, location: { absolutePointer: '#/test' } } as any);
+      decorator.ref.leave(node, { location: { absolutePointer: '#/test' } } as any);
+
+      expect(node.$ref).toBe('models/User');
+    });
+  });
+});

--- a/packages/@ama-openapi/redocly-plugin/src/plugins/decorators/oas3/remove-unused-components/remove-unused-components.decorator.mts
+++ b/packages/@ama-openapi/redocly-plugin/src/plugins/decorators/oas3/remove-unused-components/remove-unused-components.decorator.mts
@@ -1,0 +1,112 @@
+import {
+  logger,
+  type Oas3Preprocessor,
+  type UserContext,
+} from '@redocly/openapi-core';
+
+/** Name of the removeUnusedComponents custom decorator */
+export const DECORATOR_ID_REMOVE_UNUSED_COMPONENT = 'remove-unused-component';
+
+/**
+ * This decorator remove the components not referred in the bundled specification
+ *
+ * Note:
+ * The purpose of this plugin is to support inter dependencies not supported currently by the Redocly built-in `remove-unused-components`.
+ * This plugin will be deprecated in favor to the built-in plugin when issue https://github.com/Redocly/redocly-cli/issues/1783 is fixed
+ */
+export const removeUnusedComponentsDecorator: Oas3Preprocessor = () => {
+  const refMaps = new Map<string, string[]>();
+
+  const registerComponent = (node: any, ctx: UserContext) => {
+    const rec = (obj: any) => {
+      if (obj && typeof obj === 'object' && obj.$ref && !ctx.location.absolutePointer.endsWith(obj.$ref)) {
+        if (refMaps.has(obj.$ref)) {
+          const refs = refMaps.get(obj.$ref)!;
+          if (!refs.includes(ctx.location.absolutePointer)) {
+            return refMaps.set(obj.$ref, [...refs, ctx.location.absolutePointer]);
+          }
+        } else {
+          return refMaps.set(obj.$ref, [ctx.location.absolutePointer]);
+        }
+      }
+      if (typeof obj === 'object') {
+        if (Array.isArray(obj)) {
+          obj.forEach((item) => rec(item));
+        } else if (obj) {
+          Object.values(obj).forEach((value) => rec(value));
+        }
+      }
+    };
+    rec(node);
+  };
+
+  return {
+    Paths: {
+      leave: registerComponent
+    },
+    NamedSchemas: {
+      Schema: registerComponent
+    },
+    NamedParameters: {
+      Parameter: registerComponent
+    },
+    NamedResponses: {
+      Response: registerComponent
+    },
+    NamedExamples: {
+      Example: registerComponent
+    },
+    NamedRequestBodies: {
+      RequestBody: registerComponent
+    },
+    NamedHeaders: {
+      Header: registerComponent
+    },
+    Components: {
+      leave: (node, ctx) => {
+        const removeUnusedSchemas = (): number => {
+          if (!node.schemas) {
+            return 0;
+          }
+
+          const toRemoveSchemaNames = Object.keys(node.schemas)
+            .filter((name) => !refMaps.has(`#/components/schemas/${name}`));
+
+          toRemoveSchemaNames
+            .forEach((name) => {
+              delete node.schemas![name];
+              const elementRef = `${ctx.location.absolutePointer}/schemas/${name}`;
+              refMaps.forEach((locations, ref) => {
+                if (locations.includes(elementRef)) {
+                  locations = locations.filter((location) => location !== elementRef);
+                  if (locations.length === 0) {
+                    refMaps.delete(ref);
+                  } else {
+                    refMaps.set(ref, locations);
+                  }
+                }
+              });
+            });
+          return toRemoveSchemaNames.length > 0 ? toRemoveSchemaNames.length + removeUnusedSchemas() : 0;
+        };
+
+        const removedCount = removeUnusedSchemas();
+
+        if (node.schemas && Object.keys(node.schemas).length === 0) {
+          delete node.schemas;
+        }
+
+        if (removedCount > 0) {
+          logger.info(`Removed ${removedCount} unused components`);
+        }
+      }
+    },
+    Root: {
+      leave: (root) => {
+        if (root.components && Object.keys(root.components).length === 0) {
+          delete root.components;
+        }
+      }
+    }
+  };
+};

--- a/packages/@ama-openapi/redocly-plugin/src/plugins/decorators/oas3/remove-unused-components/remove-unused-components.decorator.spec.ts
+++ b/packages/@ama-openapi/redocly-plugin/src/plugins/decorators/oas3/remove-unused-components/remove-unused-components.decorator.spec.ts
@@ -1,0 +1,707 @@
+import type {
+  UserContext,
+} from '@redocly/openapi-core';
+import {
+  DECORATOR_ID_REMOVE_UNUSED_COMPONENT,
+  removeUnusedComponentsDecorator,
+} from './remove-unused-components.decorator.mjs';
+
+jest.mock('@redocly/openapi-core', () => {
+  return {
+    logger: {
+      info: jest.fn()
+    }
+  };
+});
+
+describe('removeUnusedComponentsDecorator', () => {
+  describe('DECORATOR_ID_REMOVE_UNUSED_COMPONENT', () => {
+    it('should have the correct decorator ID', () => {
+      expect(DECORATOR_ID_REMOVE_UNUSED_COMPONENT).toBe('remove-unused-component');
+    });
+  });
+
+  describe('decorator initialization', () => {
+    it('should create a decorator with required visitor methods', () => {
+      const decorator = removeUnusedComponentsDecorator();
+      expect(decorator).toBeDefined();
+      expect(decorator.Paths).toBeDefined();
+      expect(decorator.NamedSchemas).toBeDefined();
+      expect(decorator.NamedParameters).toBeDefined();
+      expect(decorator.NamedResponses).toBeDefined();
+      expect(decorator.NamedExamples).toBeDefined();
+      expect(decorator.NamedRequestBodies).toBeDefined();
+      expect(decorator.NamedHeaders).toBeDefined();
+      expect(decorator.Components).toBeDefined();
+      expect(decorator.Root).toBeDefined();
+    });
+  });
+
+  describe('registerComponent (via Paths.leave)', () => {
+    it('should register refs from paths', () => {
+      const decorator = removeUnusedComponentsDecorator();
+      const node = {
+        '/users': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/User' }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+      const ctx = {
+        location: { absolutePointer: '#/paths' }
+      } as UserContext;
+
+      decorator.Paths.leave!(node, ctx);
+
+      // Now check if the component is considered used
+      const components = {
+        schemas: {
+          User: { type: 'object', properties: { name: { type: 'string' } } },
+          UnusedSchema: { type: 'object' }
+        }
+      };
+      const componentsCtx = {
+        location: { absolutePointer: '#/components' }
+      } as UserContext;
+
+      decorator.Components.leave!(components, componentsCtx);
+
+      expect(components.schemas).toBeDefined();
+      expect(components.schemas.User).toBeDefined();
+      expect(components.schemas.UnusedSchema).toBeUndefined();
+    });
+
+    it('should handle nested refs in arrays', () => {
+      const decorator = removeUnusedComponentsDecorator();
+      const node = {
+        '/users': {
+          get: {
+            parameters: [
+              { $ref: '#/components/parameters/PageParam' },
+              { $ref: '#/components/parameters/LimitParam' }
+            ]
+          }
+        }
+      };
+      const ctx = {
+        location: { absolutePointer: '#/paths' }
+      } as UserContext;
+
+      decorator.Paths.leave!(node, ctx);
+
+      // Component cleanup should not remove referenced parameters
+      const components = {
+        schemas: {
+          UnusedSchema: { type: 'object' }
+        }
+      };
+      const componentsCtx = {
+        location: { absolutePointer: '#/components' }
+      } as UserContext;
+
+      decorator.Components.leave!(components, componentsCtx);
+
+      expect(components.schemas).toBeUndefined();
+    });
+
+    it('should handle deeply nested objects with refs', () => {
+      const decorator = removeUnusedComponentsDecorator({});
+      const node = {
+        '/users': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    allOf: [
+                      { $ref: '#/components/schemas/Base' },
+                      { $ref: '#/components/schemas/Extended' }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+      const ctx = {
+        location: { absolutePointer: '#/paths' }
+      } as UserContext;
+
+      decorator.Paths.leave!(node, ctx);
+
+      const components = {
+        schemas: {
+          Base: { type: 'object' },
+          Extended: { type: 'object' },
+          Unused: { type: 'object' }
+        }
+      };
+      const componentsCtx = {
+        location: { absolutePointer: '#/components' }
+      } as UserContext;
+
+      decorator.Components.leave!(components, componentsCtx);
+
+      expect(components.schemas.Base).toBeDefined();
+      expect(components.schemas.Extended).toBeDefined();
+      expect(components.schemas.Unused).toBeUndefined();
+    });
+
+    it('should not register self-referencing refs', () => {
+      const decorator = removeUnusedComponentsDecorator({});
+      const node = {
+        type: 'object',
+        properties: {
+          self: { $ref: '#/components/schemas/RecursiveSchema' }
+        }
+      };
+      const ctx = {
+        location: { absolutePointer: '#/components/schemas/RecursiveSchema' }
+      } as UserContext;
+
+      // eslint-disable-next-line new-cap -- Part of the Redocly definition
+      decorator.NamedSchemas.Schema(node, ctx);
+
+      // Self-references should not be counted as external usage
+      const components = {
+        schemas: {
+          RecursiveSchema: node
+        }
+      };
+      const componentsCtx = {
+        location: { absolutePointer: '#/components' }
+      } as UserContext;
+
+      decorator.Components.leave!(components, componentsCtx);
+
+      // RecursiveSchema is not referenced from paths, so it should be removed
+      expect(components.schemas).toBeUndefined();
+    });
+
+    it('should not duplicate ref registrations', () => {
+      const decorator = removeUnusedComponentsDecorator({});
+      const node1 = {
+        '/users': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/User' }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+      const node2 = {
+        '/posts': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/User' }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const ctx1 = {
+        location: { absolutePointer: '#/paths/users' }
+      } as UserContext;
+      const ctx2 = {
+        location: { absolutePointer: '#/paths/users' }
+      } as UserContext;
+
+      decorator.Paths.leave!(node1, ctx1);
+      decorator.Paths.leave!(node2, ctx2);
+
+      const components = {
+        schemas: {
+          User: { type: 'object' }
+        }
+      };
+      const componentsCtx = {
+        location: { absolutePointer: '#/components' }
+      } as UserContext;
+
+      decorator.Components.leave!(components, componentsCtx);
+
+      expect(components.schemas.User).toBeDefined();
+    });
+  });
+
+  describe('NamedSchemas.Schema', () => {
+    it('should register refs from schema components', () => {
+      const decorator = removeUnusedComponentsDecorator({});
+
+      // Register schema with ref
+      const schemaNode = {
+        allOf: [{ $ref: '#/components/schemas/BaseModel' }]
+      };
+      const schemaCtx = {
+        location: { absolutePointer: '#/components/schemas/ExtendedModel' }
+      } as UserContext;
+
+      // eslint-disable-next-line new-cap -- Part of the Redocly definition
+      decorator.NamedSchemas.Schema(schemaNode, schemaCtx);
+
+      // Register usage from paths
+      const pathNode = {
+        '/items': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/ExtendedModel' }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+      const pathCtx = {
+        location: { absolutePointer: '#/paths' }
+      } as UserContext;
+
+      decorator.Paths.leave!(pathNode, pathCtx);
+
+      // Test component cleanup
+      const components = {
+        schemas: {
+          BaseModel: { type: 'object' },
+          ExtendedModel: schemaNode,
+          UnusedModel: { type: 'object' }
+        }
+      };
+      const componentsCtx = {
+        location: { absolutePointer: '#/components' }
+      } as UserContext;
+
+      decorator.Components.leave!(components, componentsCtx);
+
+      expect(components.schemas.BaseModel).toBeDefined();
+      expect(components.schemas.ExtendedModel).toBeDefined();
+      expect(components.schemas.UnusedModel).toBeUndefined();
+    });
+  });
+
+  describe('Components.leave', () => {
+    it('should remove unused schemas', () => {
+      const decorator = removeUnusedComponentsDecorator({});
+
+      const pathNode = {
+        '/users': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/User' }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+      const pathCtx = {
+        location: { absolutePointer: '#/paths' }
+      } as UserContext;
+
+      decorator.Paths.leave!(pathNode, pathCtx);
+
+      const components = {
+        schemas: {
+          User: { type: 'object', properties: { name: { type: 'string' } } },
+          Product: { type: 'object', properties: { title: { type: 'string' } } },
+          Category: { type: 'object', properties: { label: { type: 'string' } } }
+        }
+      };
+      const componentsCtx = {
+        location: { absolutePointer: '#/components' }
+      } as UserContext;
+
+      decorator.Components.leave!(components, componentsCtx);
+
+      expect(components.schemas.User).toBeDefined();
+      expect(components.schemas.Product).toBeUndefined();
+      expect(components.schemas.Category).toBeUndefined();
+    });
+
+    it('should handle inter-dependent schemas (cascading removal)', () => {
+      const decorator = removeUnusedComponentsDecorator({});
+
+      // Register schema B that references schema C
+      const schemaB = {
+        type: 'object',
+        properties: {
+          data: { $ref: '#/components/schemas/SchemaC' }
+        }
+      };
+      const schemaBCtx = {
+        location: { absolutePointer: '#/components/schemas/SchemaB' }
+      } as UserContext;
+
+      // eslint-disable-next-line new-cap -- Part of the Redocly definition
+      decorator.NamedSchemas.Schema(schemaB, schemaBCtx);
+
+      // Register path that only uses schema A
+      const pathNode = {
+        '/items': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/SchemaA' }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+      const pathCtx = {
+        location: { absolutePointer: '#/paths' }
+      } as UserContext;
+
+      decorator.Paths.leave!(pathNode, pathCtx);
+
+      const components = {
+        schemas: {
+          SchemaA: { type: 'object' },
+          SchemaB: schemaB,
+          SchemaC: { type: 'object' }
+        }
+      };
+      const componentsCtx = {
+        location: { absolutePointer: '#/components' }
+      } as UserContext;
+
+      decorator.Components.leave!(components, componentsCtx);
+
+      // SchemaA is used from path
+      expect(components.schemas.SchemaA).toBeDefined();
+      // SchemaB is not used, should be removed along with its reference to SchemaC
+      expect(components.schemas.SchemaB).toBeUndefined();
+      expect(components.schemas.SchemaC).toBeUndefined();
+    });
+
+    it('should delete schemas property when all schemas are removed', () => {
+      const decorator = removeUnusedComponentsDecorator({});
+
+      const components = {
+        schemas: {
+          UnusedA: { type: 'object' },
+          UnusedB: { type: 'object' }
+        }
+      };
+      const componentsCtx = {
+        location: { absolutePointer: '#/components' }
+      } as UserContext;
+
+      decorator.Components.leave!(components, componentsCtx);
+
+      expect(components.schemas).toBeUndefined();
+    });
+
+    it('should return early if no schemas exist', () => {
+      const decorator = removeUnusedComponentsDecorator({});
+
+      const components = {
+        parameters: {
+          PageParam: { name: 'page', in: 'query', schema: { type: 'integer' } }
+        }
+      };
+      const componentsCtx = {
+        location: { absolutePointer: '#/components' }
+      } as UserContext;
+
+      expect(() => decorator.Components.leave!(components as any, componentsCtx)).not.toThrow();
+      expect(components.parameters).toBeDefined();
+    });
+
+    it('should handle chain of dependent schemas', () => {
+      const decorator = removeUnusedComponentsDecorator({});
+
+      // Schema chain: SchemaA -> SchemaB -> SchemaC
+      const schemaC = { type: 'object', properties: { value: { type: 'string' } } };
+      const schemaCCtx = {
+        location: { absolutePointer: '#/components/schemas/SchemaC' }
+      } as UserContext;
+      // eslint-disable-next-line new-cap -- Part of the Redocly definition
+      decorator.NamedSchemas.Schema(schemaC, schemaCCtx);
+
+      const schemaB = {
+        type: 'object',
+        properties: {
+          nested: { $ref: '#/components/schemas/SchemaC' }
+        }
+      };
+      const schemaBCtx = {
+        location: { absolutePointer: '#/components/schemas/SchemaB' }
+      } as UserContext;
+      // eslint-disable-next-line new-cap -- Part of the Redocly definition
+      decorator.NamedSchemas.Schema(schemaB, schemaBCtx);
+
+      const schemaA = {
+        type: 'object',
+        properties: {
+          data: { $ref: '#/components/schemas/SchemaB' }
+        }
+      };
+      const schemaACtx = {
+        location: { absolutePointer: '#/components/schemas/SchemaA' }
+      } as UserContext;
+      // eslint-disable-next-line new-cap -- Part of the Redocly definition
+      decorator.NamedSchemas.Schema(schemaA, schemaACtx);
+
+      // Use SchemaA from path
+      const pathNode = {
+        '/items': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/SchemaA' }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+      const pathCtx = {
+        location: { absolutePointer: '#/paths' }
+      } as UserContext;
+      decorator.Paths.leave!(pathNode, pathCtx);
+
+      const components = {
+        schemas: {
+          SchemaA: schemaA,
+          SchemaB: schemaB,
+          SchemaC: schemaC,
+          UnusedSchema: { type: 'object' }
+        }
+      };
+      const componentsCtx = {
+        location: { absolutePointer: '#/components' }
+      } as UserContext;
+
+      decorator.Components.leave!(components, componentsCtx);
+
+      // All schemas in the chain should be kept
+      expect(components.schemas.SchemaA).toBeDefined();
+      expect(components.schemas.SchemaB).toBeDefined();
+      expect(components.schemas.SchemaC).toBeDefined();
+      expect(components.schemas.UnusedSchema).toBeUndefined();
+    });
+  });
+
+  describe('Root.leave', () => {
+    it('should remove empty components object', () => {
+      const decorator = removeUnusedComponentsDecorator({});
+
+      const root = {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+        components: {}
+      };
+
+      decorator.Root.leave!(root as any);
+
+      expect(root.components).toBeUndefined();
+    });
+
+    it('should keep components object if not empty', () => {
+      const decorator = removeUnusedComponentsDecorator({});
+
+      const root = {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+        components: {
+          schemas: {
+            User: { type: 'object' }
+          }
+        }
+      };
+
+      decorator.Root.leave!(root as any);
+
+      expect(root.components).toBeDefined();
+      expect(root.components.schemas).toBeDefined();
+    });
+
+    it('should handle root without components', () => {
+      const decorator = removeUnusedComponentsDecorator({});
+
+      const root = {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {}
+      };
+
+      expect(() => decorator.Root.leave!(root as any)).not.toThrow();
+      expect((root as any).components).toBeUndefined();
+    });
+  });
+
+  describe('other component types', () => {
+    it('should register parameter refs via NamedParameters.Parameter', () => {
+      const decorator = removeUnusedComponentsDecorator({});
+
+      const parameterNode = {
+        name: 'id',
+        in: 'path',
+        required: true,
+        schema: { type: 'string' }
+      };
+      const ctx = {
+        location: { absolutePointer: '#/components/parameters/IdParam' }
+      } as UserContext;
+
+      // eslint-disable-next-line new-cap -- Part of the Redocly definition
+      expect(() => decorator.NamedParameters.Parameter(parameterNode, ctx)).not.toThrow();
+    });
+
+    it('should register response refs via NamedResponses.Response', () => {
+      const decorator = removeUnusedComponentsDecorator({});
+
+      const responseNode = {
+        description: 'Success',
+        content: {
+          'application/json': {
+            schema: { $ref: '#/components/schemas/SuccessResponse' }
+          }
+        }
+      };
+      const ctx = {
+        location: { absolutePointer: '#/components/responses/SuccessResponse' }
+      } as UserContext;
+
+      // eslint-disable-next-line new-cap -- Part of the Redocly definition
+      expect(() => decorator.NamedResponses.Response(responseNode, ctx)).not.toThrow();
+    });
+
+    it('should register example refs via NamedExamples.Example', () => {
+      const decorator = removeUnusedComponentsDecorator({});
+
+      const exampleNode = {
+        value: { name: 'John Doe' }
+      };
+      const ctx = {
+        location: { absolutePointer: '#/components/examples/UserExample' }
+      } as UserContext;
+
+      // eslint-disable-next-line new-cap -- Part of the Redocly definition
+      expect(() => decorator.NamedExamples.Example(exampleNode, ctx)).not.toThrow();
+    });
+
+    it('should register request body refs via NamedRequestBodies.RequestBody', () => {
+      const decorator = removeUnusedComponentsDecorator({});
+
+      const requestBodyNode = {
+        content: {
+          'application/json': {
+            schema: { $ref: '#/components/schemas/CreateUserRequest' }
+          }
+        }
+      };
+      const ctx = {
+        location: { absolutePointer: '#/components/requestBodies/CreateUser' }
+      } as UserContext;
+
+      // eslint-disable-next-line new-cap -- Part of the Redocly definition
+      expect(() => decorator.NamedRequestBodies.RequestBody(requestBodyNode, ctx)).not.toThrow();
+    });
+
+    it('should register header refs via NamedHeaders.Header', () => {
+      const decorator = removeUnusedComponentsDecorator({});
+
+      const headerNode = {
+        description: 'API Key',
+        schema: { type: 'string' }
+      };
+      const ctx = {
+        location: { absolutePointer: '#/components/headers/ApiKey' }
+      } as UserContext;
+
+      // eslint-disable-next-line new-cap -- Part of the Redocly definition
+      expect(() => decorator.NamedHeaders.Header(headerNode, ctx)).not.toThrow();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle null values in objects', () => {
+      const decorator = removeUnusedComponentsDecorator({});
+
+      const node = {
+        '/users': {
+          get: {
+            responses: {
+              200: {
+                content: null as any,
+                description: 'Success'
+              }
+            }
+          }
+        }
+      };
+      const ctx = {
+        location: { absolutePointer: '#/paths' }
+      } as UserContext;
+
+      expect(() => decorator.Paths.leave!(node as any, ctx)).not.toThrow();
+    });
+
+    it('should handle empty objects', () => {
+      const decorator = removeUnusedComponentsDecorator({});
+
+      const node = {};
+      const ctx = {
+        location: { absolutePointer: '#/paths' }
+      } as UserContext;
+
+      expect(() => decorator.Paths.leave!(node, ctx)).not.toThrow();
+    });
+
+    it('should handle primitive values in objects', () => {
+      const decorator = removeUnusedComponentsDecorator({});
+
+      const node = {
+        '/users': {
+          get: {
+            summary: 'Get users',
+            deprecated: false,
+            operationId: 'getUsers'
+          }
+        }
+      };
+      const ctx = {
+        location: { absolutePointer: '#/paths' }
+      } as UserContext;
+
+      expect(() => decorator.Paths.leave!(node, ctx)).not.toThrow();
+    });
+  });
+});

--- a/packages/@ama-openapi/redocly-plugin/src/plugins/meta/retrieve-dependency.meta.mts
+++ b/packages/@ama-openapi/redocly-plugin/src/plugins/meta/retrieve-dependency.meta.mts
@@ -5,6 +5,9 @@ import {
   type LogLevel,
   // eslint-disable-next-line import/no-unresolved -- Cannot resolve mjs file in current setup (see #3738)
 } from '@ama-openapi/core';
+import {
+  logger,
+} from '@redocly/openapi-core';
 
 /**
  * Options to retrieve dependency
@@ -29,13 +32,13 @@ export interface RetrieveDependencyOptions extends InstallDependenciesOptions {
  * @param options
  */
 export const retrieveDependency = async (options: RetrieveDependencyOptions) => {
-  const logger = options.quiet ? undefined : getLogger(options.logLevel);
+  const amaLogger = options.quiet ? undefined : getLogger(options.logLevel, logger);
 
   try {
-    await installDependencies(process.cwd(), { ...options, logger });
+    await installDependencies(process.cwd(), { ...options, logger: amaLogger });
   } catch (e) {
     if (options?.continueOnError) {
-      logger?.error(e);
+      amaLogger?.error(e);
     } else {
       throw e;
     }


### PR DESCRIPTION
## Proposed change

feat(ama-openapi): add custom decorator for ref redirection

The purpose is to offer a way to re-write the references after bundling (based on rule to run before it).
This is going to be used by middlewares to fit the API mapping requirements

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
