### PR TITLE
fix(openapi): the name of the decorator remove-unused-components

### DIFF
--- a/docs/openapi/DECORATORS.md
+++ b/docs/openapi/DECORATORS.md
@@ -91,7 +91,7 @@ apis:
   mySpec:
     root: apis/mySpec.json
     decorators:
-      ama-openapi/remove-unused-component: on
+      ama-openapi/remove-unused-components: on
 ```
 
 will turn the spec :

--- a/packages/@ama-openapi/redocly-plugin/README.md
+++ b/packages/@ama-openapi/redocly-plugin/README.md
@@ -110,7 +110,7 @@ The following environment variables are supported:
 
 The plugin offer additional [Redocly decorator](https://redocly.com/docs/cli/decorators) which can be selected and configured in [Redocly configuration](https://redocly.com/docs/cli/rules/configure-rules).
 
-The full list of available decorators, along with their options, is provided in the [dedicated documentation](https://github.com/AmadeusITGroup/otter/blob/main/docs/redocly/DECORATORS.md).
+The full list of available decorators, along with their options, is provided in the [dedicated documentation](https://github.com/AmadeusITGroup/otter/blob/main/docs/openapi/DECORATORS.md).
 
 ## Integration
 

--- a/packages/@ama-openapi/redocly-plugin/src/plugin.mts
+++ b/packages/@ama-openapi/redocly-plugin/src/plugin.mts
@@ -15,7 +15,7 @@ import {
   redirectRefsDecorator,
 } from './plugins/decorators/common/replace-refs/replace-refs.decorator.mjs';
 import {
-  DECORATOR_ID_REMOVE_UNUSED_COMPONENT,
+  DECORATOR_ID_REMOVE_UNUSED_COMPONENTS,
   removeUnusedComponentsDecorator,
 } from './plugins/decorators/oas3/remove-unused-components/remove-unused-components.decorator.mjs';
 import {
@@ -56,7 +56,7 @@ export const amaOpenapiPlugin = async (options?: AmaOpenapiPluginOptions): Promi
       },
       oas3: {
         [DECORATOR_ID_REDIRECT_REF]: redirectRefsDecorator,
-        [DECORATOR_ID_REMOVE_UNUSED_COMPONENT]: removeUnusedComponentsDecorator
+        [DECORATOR_ID_REMOVE_UNUSED_COMPONENTS]: removeUnusedComponentsDecorator
       },
       async2: {
         [DECORATOR_ID_REDIRECT_REF]: redirectRefsDecorator

--- a/packages/@ama-openapi/redocly-plugin/src/plugins/decorators/oas3/remove-unused-components/remove-unused-components.decorator.mts
+++ b/packages/@ama-openapi/redocly-plugin/src/plugins/decorators/oas3/remove-unused-components/remove-unused-components.decorator.mts
@@ -5,7 +5,7 @@ import {
 } from '@redocly/openapi-core';
 
 /** Name of the removeUnusedComponents custom decorator */
-export const DECORATOR_ID_REMOVE_UNUSED_COMPONENT = 'remove-unused-component';
+export const DECORATOR_ID_REMOVE_UNUSED_COMPONENTS = 'remove-unused-components';
 
 /**
  * This decorator remove the components not referred in the bundled specification

--- a/packages/@ama-openapi/redocly-plugin/src/plugins/decorators/oas3/remove-unused-components/remove-unused-components.decorator.spec.ts
+++ b/packages/@ama-openapi/redocly-plugin/src/plugins/decorators/oas3/remove-unused-components/remove-unused-components.decorator.spec.ts
@@ -2,7 +2,7 @@ import type {
   UserContext,
 } from '@redocly/openapi-core';
 import {
-  DECORATOR_ID_REMOVE_UNUSED_COMPONENT,
+  DECORATOR_ID_REMOVE_UNUSED_COMPONENTS,
   removeUnusedComponentsDecorator,
 } from './remove-unused-components.decorator.mjs';
 
@@ -15,9 +15,9 @@ jest.mock('@redocly/openapi-core', () => {
 });
 
 describe('removeUnusedComponentsDecorator', () => {
-  describe('DECORATOR_ID_REMOVE_UNUSED_COMPONENT', () => {
+  describe('DECORATOR_ID_REMOVE_UNUSED_COMPONENTS', () => {
     it('should have the correct decorator ID', () => {
-      expect(DECORATOR_ID_REMOVE_UNUSED_COMPONENT).toBe('remove-unused-component');
+      expect(DECORATOR_ID_REMOVE_UNUSED_COMPONENTS).toBe('remove-unused-components');
     });
   });
 


### PR DESCRIPTION
fix(openapi): the name of the decorator `remove-unused-components` to align on Redocly default on

## Proposed change

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
