### PR TITLE
fix: use array.tosorted instead of array.sort

### DIFF
--- a/apps/chrome-devtools/src/app-devtools/theming-panel/theming-panel-pres.ts
+++ b/apps/chrome-devtools/src/app-devtools/theming-panel/theming-panel-pres.ts
@@ -236,7 +236,7 @@ export class ThemingPanelPres {
           isPalette,
           defaultVariable
         }]);
-      }, []).sort((a, b) => {
+      }, []).toSorted((a, b) => {
         // Others should go at the end
         if (a.name === 'others') {
           return 1;

--- a/apps/github-cascading-app/src/cascading/cascading-probot.ts
+++ b/apps/github-cascading-app/src/cascading/cascading-probot.ts
@@ -253,7 +253,7 @@ export class CascadingProbot extends Cascading {
     const { data } = await this.options.octokit.rest.pulls.list(this.options.repo);
     return data
       .filter(({ head, base }) => (!targetBranch || base.ref === targetBranch) && (!baseBranch || head.ref === baseBranch))
-      .sort((prA, prB) => (Date.parse(prA.created_at) - Date.parse(prB.created_at)))
+      .toSorted((prA, prB) => (Date.parse(prA.created_at) - Date.parse(prB.created_at)))
       .map((pr): CascadingPullRequestInfo => ({
         ...pr,
         originBranchName: pr.head.ref,

--- a/apps/github-cascading-app/src/cascading/cascading.ts
+++ b/apps/github-cascading-app/src/cascading/cascading.ts
@@ -197,7 +197,7 @@ export abstract class Cascading {
         }
         return true;
       })
-      .sort((branchObjectA, branchObjectB) => {
+      .toSorted((branchObjectA, branchObjectB) => {
         if (!branchObjectA.semver) {
           return 1;
         } else if (!branchObjectB.semver) {

--- a/apps/showcase/src/components/showcase/sdk/sdk-pres.ts
+++ b/apps/showcase/src/components/showcase/sdk/sdk-pres.ts
@@ -149,7 +149,7 @@ export class SdkPres {
     this.isLoading.set(true);
     this.hasErrors.set(false);
     return this.petStoreApi.findPetsByStatus({ status: 'available' }).then((pets) => {
-      this.pets.set(pets.filter((p) => p.category?.name === 'otter').sort((a, b) => (a.id && b.id && (a.id - b.id)) || 0));
+      this.pets.set(pets.filter((p) => p.category?.name === 'otter').toSorted((a, b) => (a.id && b.id && (a.id - b.id)) || 0));
       this.isLoading.set(false);
     }).catch(() => {
       this.isLoading.set(false);

--- a/apps/showcase/tsconfig.app.json
+++ b/apps/showcase/tsconfig.app.json
@@ -36,7 +36,7 @@
     "jsx": "react",
     "allowSyntheticDefaultImports": true,
     "lib": [
-      "ES2022",
+      "ES2024",
       "es6",
       "dom",
       "dom.iterable"

--- a/apps/vscode-extension/src/commands/helpers.ts
+++ b/apps/vscode-extension/src/commands/helpers.ts
@@ -51,7 +51,7 @@ const getInfoFromWorkspaceJsonUris = async <T>(
   getInfo: (workspaceJsonUri: vscode.Uri) => Promise<T | undefined>
 ) => {
   const workspaceJsonUris = await vscode.workspace.findFiles('{angular,nx}.json');
-  const sortedWorkspaceJsonUris = workspaceJsonUris.sort(sortWorkspaceUris);
+  const sortedWorkspaceJsonUris = workspaceJsonUris.toSorted(sortWorkspaceUris);
   for (const workspaceJsonUri of sortedWorkspaceJsonUris) {
     const infoFromWorkspace = await getInfo(workspaceJsonUri);
     if (infoFromWorkspace) {

--- a/packages/@ama-mcp/github/src/find-repositories-using-library/index.spec.ts
+++ b/packages/@ama-mcp/github/src/find-repositories-using-library/index.spec.ts
@@ -192,8 +192,8 @@ describe('Find repositories using library', () => {
     }]);
     expect(response.structuredContent).toEqual(expect.objectContaining({
       repositories: [
-        'testOrg/repo1',
-        'testOrg/repoCached'
+        'testOrg/repoCached',
+        'testOrg/repo1'
       ]
     }));
   });

--- a/packages/@ama-mcp/github/src/find-repositories-using-library/index.ts
+++ b/packages/@ama-mcp/github/src/find-repositories-using-library/index.ts
@@ -234,7 +234,7 @@ export function registerGetRepositoriesUsingLibraryTool(server: McpServer, optio
             text: (isLookingForRepos ? 'I did not finish to look for repositories. For the moment:\n' : '')
               + reposUsingLibrary.length
               ? `The following repositories use ${libraryName} dependencies:\n`
-              + reposUsingLibrary.sort().map((repo) => `- ${repo}`).join('\n')
+              + reposUsingLibrary.toSorted().map((repo) => `- ${repo}`).join('\n')
               : `No repositories found using ${libraryName} dependencies.`
           }
         ],

--- a/packages/@ama-sdk/schematics/schematics/typescript/mock/index.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/mock/index.ts
@@ -66,7 +66,7 @@ function ngGenerateMockFn(options: NgGenerateMockSchematicsSchema): Rule {
       if (!(new RegExp(`./${dasherizeModelName}/index`).test(currentComponentIndex))) {
         currentComponentIndex = `export * from './${dasherizeModelName}/index';\n` + currentComponentIndex;
       }
-      currentComponentIndex = `${currentComponentIndex.split('\n').filter((e) => !!e).sort().join('\n')}\n`;
+      currentComponentIndex = `${currentComponentIndex.split('\n').filter((e) => !!e).toSorted().join('\n')}\n`;
       tree.overwrite(barrelPath, currentComponentIndex);
     }
     return tree;

--- a/packages/@ama-sdk/schematics/schematics/typescript/shell/index.spec.ts
+++ b/packages/@ama-sdk/schematics/schematics/typescript/shell/index.spec.ts
@@ -109,7 +109,7 @@ describe('Typescript Shell Generator', () => {
   });
 
   it('should generate basic SDK package', () => {
-    expect(yarnTree.files.sort()).toEqual(baseFileList.sort());
+    expect(yarnTree.files.toSorted()).toEqual(baseFileList.toSorted());
   });
 
   it('should generate correct package name', () => {

--- a/packages/@ama-styling/figma-extractor/src/core/requests/get-versions-request.ts
+++ b/packages/@ama-styling/figma-extractor/src/core/requests/get-versions-request.ts
@@ -80,7 +80,7 @@ export const getFileVersions = async (apiClient: ApiClient, options: VersionsOpt
       label: coerce(version.label)!.toString(),
       fileKey: options.fileKey
     }))
-    .sort((a, b) => -compare(a.label, b.label));
+    .toSorted((a, b) => -compare(a.label, b.label));
 };
 
 /**
@@ -121,7 +121,7 @@ export const getAvailableMajorVersions = async (apiClient: ApiClient, options: M
       });
       return acc;
     }, [] as { version: string; range: string; file: (typeof filesResponse.files)[0] }[])
-    .sort((a, b) => -compare(a.version, b.version));
+    .toSorted((a, b) => -compare(a.version, b.version));
 };
 
 /**
@@ -139,5 +139,5 @@ export const getAllVersions = async (apiClient: ApiClient, options: MajorVersion
     }));
   return (await Promise.all(fullVersionsMap))
     .flat()
-    .sort((a, b) => -compare(a.label, b.label));
+    .toSorted((a, b) => -compare(a.label, b.label));
 };

--- a/packages/@ama-styling/style-dictionary/schematics/index.it.spec.ts
+++ b/packages/@ama-styling/style-dictionary/schematics/index.it.spec.ts
@@ -27,15 +27,15 @@ describe('ng add otter style-dictionary hooks', () => {
 
     let diff = getGitDiff(workspacePath);
 
-    expect(diff.modified.sort()).toEqual([
+    expect(diff.modified.toSorted()).toEqual([
       'package.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json',
       path.join(relativeApplicationPath, 'package.json').replace(/[/\\]+/g, '/')
-    ].sort());
-    expect(diff.added.sort()).toEqual([
+    ].toSorted());
+    expect(diff.added.toSorted()).toEqual([
       path.join(relativeApplicationPath, 'token.extensions.json').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, 'config.mjs').replace(/[/\\]+/g, '/')
-    ].sort());
+    ].toSorted());
 
     await fs.writeFile(path.join(applicationPath, 'test.tokens.json'), JSON.stringify({ colors: { primary: { $value: '#000' } } }));
 
@@ -62,15 +62,15 @@ describe('ng add otter style-dictionary hooks', () => {
 
     let diff = getGitDiff(workspacePath);
 
-    expect(diff.modified.sort()).toEqual([
+    expect(diff.modified.toSorted()).toEqual([
       path.join(relativeLibraryPath, 'package.json').replace(/[/\\]+/g, '/'),
       isYarnTest ? 'yarn.lock' : 'package-lock.json',
       'package.json'
-    ].sort());
-    expect(diff.added.sort()).toEqual([
+    ].toSorted());
+    expect(diff.added.toSorted()).toEqual([
       path.join(relativeLibraryPath, 'token.extensions.json').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'config.mjs').replace(/[/\\]+/g, '/')
-    ].sort());
+    ].toSorted());
 
     await fs.writeFile(path.join(libraryPath, 'test.tokens.json'), JSON.stringify({ colors: { primary: { $value: '#000' } } }));
 

--- a/packages/@ama-styling/style-dictionary/src/formats/css-format.mts
+++ b/packages/@ama-styling/style-dictionary/src/formats/css-format.mts
@@ -51,8 +51,8 @@ export const cssFormat: Format = {
       const propertyFormatter = getDefaultCssFormatter(baseFormatterOptions);
 
       return allTokens
-        .sort(sortByPath)
-        .sort(outputReferences ? sortByReference(tokens, { unfilteredTokens, usesDtcg }) : () => 0)
+        .toSorted(sortByPath)
+        .toSorted(outputReferences ? sortByReference(tokens, { unfilteredTokens, usesDtcg }) : () => 0)
         .filter(({ attributes }) => !attributes?.private)
         .map((token) => ({
           token,

--- a/packages/@ama-styling/style-dictionary/src/formats/metadata-format.mts
+++ b/packages/@ama-styling/style-dictionary/src/formats/metadata-format.mts
@@ -53,7 +53,7 @@ export const metadataFormat: Format = {
     let allTokens = dictionary.allTokens;
     const tokens = dictionary.tokens;
     if (outputReferences) {
-      allTokens = [...allTokens].sort(
+      allTokens = [...allTokens].toSorted(
         sortByReference(tokens, { unfilteredTokens: dictionary.unfilteredTokens, usesDtcg })
       );
     }

--- a/packages/@ama-styling/style-dictionary/src/helpers/sort-by-path-sort-helpers.spec.ts
+++ b/packages/@ama-styling/style-dictionary/src/helpers/sort-by-path-sort-helpers.spec.ts
@@ -18,7 +18,7 @@ describe('sortByPath', () => {
       }
     ] as TransformedToken[];
 
-    const res = tokens.sort(sortByPath);
+    const res = tokens.toSorted(sortByPath);
     expect(res.length).toBe(2);
     expect(res[0].name).toBe('my.var.a');
     expect(res[1].name).toBe('my.var.z');
@@ -40,7 +40,7 @@ describe('sortByPath', () => {
       }
     ] as TransformedToken[];
 
-    const res = tokens.sort(sortByPath);
+    const res = tokens.toSorted(sortByPath);
     expect(res.length).toBe(3);
     expect(res[0].name).toBe('my.var');
     expect(res[1].name).toBe('my.var.a');
@@ -67,7 +67,7 @@ describe('sortByPath', () => {
       }
     ] as TransformedToken[];
 
-    const res = tokens.sort(sortByPath);
+    const res = tokens.toSorted(sortByPath);
     expect(res.length).toBe(4);
     expect(res[0].name).toBe('my.var');
     expect(res[1].name).toBe('my.var.00');
@@ -95,7 +95,7 @@ describe('sortByPath', () => {
       }
     ] as TransformedToken[];
 
-    const res = tokens.sort(sortByPath);
+    const res = tokens.toSorted(sortByPath);
     expect(res.length).toBe(4);
     expect(res[0].name).toBe('my.var');
     expect(res[1].name).toBe('my.var.00');

--- a/packages/@ama-styling/stylelint-plugin/schematics/index.it.spec.ts
+++ b/packages/@ama-styling/stylelint-plugin/schematics/index.it.spec.ts
@@ -26,11 +26,11 @@ describe('ng add stylelint-plugin', () => {
     packageManagerExec({ script: 'ng', args: ['add', `@ama-styling/stylelint-plugin@${o3rVersion}`, '--enable-metadata-extract', '--skip-confirmation', '--project-name', appName] }, execAppOptions);
     const diff = getGitDiff(workspacePath);
 
-    expect(diff.modified.sort()).toEqual([
+    expect(diff.modified.toSorted()).toEqual([
       'apps/test-app/package.json',
       'package.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json'
-    ].sort());
+    ].toSorted());
     expect(diff.added.length).toBe(0);
 
     [libraryPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {
@@ -61,11 +61,11 @@ describe('ng add stylelint-plugin', () => {
     packageManagerExec({ script: 'ng', args: ['add', `@ama-styling/stylelint-plugin@${o3rVersion}`, '--enable-metadata-extract', '--skip-confirmation', '--project-name', libName] }, execAppOptions);
     const diff = getGitDiff(workspacePath);
 
-    expect(diff.modified.sort()).toEqual([
+    expect(diff.modified.toSorted()).toEqual([
       'libs/test-lib/package.json',
       'package.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json'
-    ].sort());
+    ].toSorted());
     expect(diff.added.length).toBe(0);
 
     [applicationPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {

--- a/packages/@o3r/analytics/schematics/analytics-to-component/index.ts
+++ b/packages/@o3r/analytics/schematics/analytics-to-component/index.ts
@@ -165,7 +165,7 @@ export function ngAddAnalyticsFn(options: NgAddAnalyticsSchematicsSchema): Rule 
 
                   const newMembers = node.members
                     .concat(propertiesToAdd)
-                    .sort(sortClassElement);
+                    .toSorted(sortClassElement);
 
                   addCommentsOnClassProperties(
                     newMembers,

--- a/packages/@o3r/analytics/schematics/index.it.spec.ts
+++ b/packages/@o3r/analytics/schematics/index.it.spec.ts
@@ -29,7 +29,7 @@ describe('ng add analytics', () => {
 
     const diff = getGitDiff(workspacePath);
 
-    expect(diff.added.sort()).toEqual([
+    expect(diff.added.toSorted()).toEqual([
       path.join(relativeApplicationPath, 'src/components/test/README.md').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, 'src/components/test/index.ts').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, 'src/components/test/test-analytics.ts').replace(/[/\\]+/g, '/'),
@@ -38,14 +38,14 @@ describe('ng add analytics', () => {
       path.join(relativeApplicationPath, 'src/components/test/test.spec.ts').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, 'src/components/test/test.scss').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, 'src/components/test/test.html').replace(/[/\\]+/g, '/')
-    ].sort());
-    expect(diff.modified.sort()).toEqual([
+    ].toSorted());
+    expect(diff.modified.toSorted()).toEqual([
       'angular.json',
       'apps/test-app/package.json',
       'apps/test-app/src/app/app.ts',
       'package.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json'
-    ].sort());
+    ].toSorted());
 
     [libraryPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {
       expect(diff.all.some((file) => file.startsWith(path.relative(workspacePath, untouchedProject).replace(/\\+/g, '/')))).toBe(false);
@@ -67,7 +67,7 @@ describe('ng add analytics', () => {
     const diff = getGitDiff(workspacePath);
 
     expect(diff.added).toContain(path.join(relativeLibraryPath, 'src/components/test/test-analytics.ts').replace(/[/\\]+/g, '/'));
-    expect(diff.added.sort()).toEqual([
+    expect(diff.added.toSorted()).toEqual([
       path.join(relativeLibraryPath, 'src/components/test/README.md').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'src/components/test/index.ts').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'src/components/test/test-analytics.ts').replace(/[/\\]+/g, '/'),
@@ -76,13 +76,13 @@ describe('ng add analytics', () => {
       path.join(relativeLibraryPath, 'src/components/test/test-context.ts').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'src/components/test/test.scss').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'src/components/test/test.html').replace(/[/\\]+/g, '/')
-    ].sort());
-    expect(diff.modified.sort()).toEqual([
+    ].toSorted());
+    expect(diff.modified.toSorted()).toEqual([
       'angular.json',
       'libs/test-lib/package.json',
       'package.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json'
-    ].sort());
+    ].toSorted());
 
     [applicationPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {
       expect(diff.all.some((file) => file.startsWith(path.relative(workspacePath, untouchedProject).replace(/\\+/g, '/')))).toBe(false);

--- a/packages/@o3r/apis-manager/schematics/index.it.spec.ts
+++ b/packages/@o3r/apis-manager/schematics/index.it.spec.ts
@@ -24,13 +24,13 @@ describe('new otter application with apis-manager', () => {
     expect(() => packageManagerRunOnProject(appName, isInWorkspace, { script: 'build' }, execAppOptions)).not.toThrow();
 
     const diff = getGitDiff(workspacePath);
-    expect(diff.modified.sort()).toEqual([
+    expect(diff.modified.toSorted()).toEqual([
       'apps/test-app/package.json',
       'apps/test-app/src/app/app.config.ts',
       'apps/test-app/tsconfig.app.json',
       'package.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json'
-    ].sort());
+    ].toSorted());
 
     [libraryPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {
       expect(diff.all.some((file) => file.startsWith(path.relative(workspacePath, untouchedProject).replace(/\\+/g, '/')))).toBe(false);

--- a/packages/@o3r/artifactory-tools/src/cli/pr-artifact-cleaner.cts
+++ b/packages/@o3r/artifactory-tools/src/cli/pr-artifact-cleaner.cts
@@ -76,7 +76,7 @@ const fetchOptions = {
             ]
         }
       ).include("name","repo","path","created")
-      .sort({"$desc" : ["path","name"]})
+      .toSorted({"$desc" : ["path","name"]})
       .limit(10000)`
 } as const satisfies RequestInit;
 
@@ -98,14 +98,14 @@ const run = async () => {
   const mapOfKeptItems = new Map<string, number[]>();
   const mapOfKeptResult = new Map<string, { repo: string; path: string; name: string }[]>();
   const resultToDelete: { repo: string; path: string; name: string }[] = [];
-  const sortedResult = responseSearchObj.results.sort((a, b) => b.name.localeCompare(a.name));
+  const sortedResult = responseSearchObj.results.toSorted((a, b) => b.name.localeCompare(a.name));
   for (const result of sortedResult) {
     const splitPath = result.name.split('.');
     const mapId = splitPath.slice(0, -2).join('.');
     const currentBuildNumber = +splitPath.at(-2)!;
     const buildNumbers = mapOfKeptItems.get(mapId);
     if (buildNumbers) {
-      buildNumbers.sort();
+      buildNumbers.toSorted();
       let isBuildNumberAlreadyInMap = false;
       let isBuildNumberHigherThanExisting = true;
       buildNumbers.forEach((value) => {
@@ -126,7 +126,7 @@ const run = async () => {
             }
           }
           buildNumbers.push(currentBuildNumber);
-          buildNumbers.sort();
+          buildNumbers.toSorted();
           mapOfKeptItems.set(mapId, buildNumbers);
           const keptBuildNumbers = mapOfKeptResult.get(`${mapId}${currentBuildNumber}`);
           if (keptBuildNumbers) {

--- a/packages/@o3r/components/schematics/index.it.spec.ts
+++ b/packages/@o3r/components/schematics/index.it.spec.ts
@@ -23,19 +23,19 @@ describe('ng add components', () => {
       '--skip-confirmation', '--enable-metadata-extract', '--project-name', appName] }, execAppOptions)).not.toThrow();
 
     const diff = getGitDiff(workspacePath);
-    expect(diff.modified.sort()).toEqual([
+    expect(diff.modified.toSorted()).toEqual([
       '.gitignore',
       'angular.json',
       'apps/test-app/package.json',
       'apps/test-app/src/main.ts',
       isYarnTest ? 'yarn.lock' : 'package-lock.json',
       'package.json'
-    ].sort());
-    expect(diff.added.sort()).toEqual([
+    ].toSorted());
+    expect(diff.added.toSorted()).toEqual([
       'apps/test-app/placeholders.metadata.json',
       'apps/test-app/tsconfig.cms.json',
       'apps/test-app/migration-scripts/README.md'
-    ].sort());
+    ].toSorted());
 
     [libraryPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {
       expect(diff.all.some((file) => file.startsWith(path.relative(workspacePath, untouchedProject).replace(/\\+/g, '/')))).toBe(false);
@@ -64,11 +64,11 @@ describe('ng add components', () => {
     const packageJson = JSON.parse(fs.readFileSync(`${workspacePath}/package.json`, 'utf8'));
     expect(packageJson.dependencies['@o3r/components']).toBeDefined();
 
-    expect(diff.added.sort()).toEqual([
+    expect(diff.added.toSorted()).toEqual([
       'libs/test-lib/placeholders.metadata.json',
       'libs/test-lib/tsconfig.cms.json',
       'libs/test-lib/migration-scripts/README.md'
-    ].sort());
+    ].toSorted());
 
     [applicationPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {
       expect(diff.all.some((file) => file.startsWith(path.relative(workspacePath, untouchedProject).replace(/\\+/g, '/')))).toBe(false);

--- a/packages/@o3r/components/src/devkit/highlight/highlight.ts
+++ b/packages/@o3r/components/src/devkit/highlight/highlight.ts
@@ -172,7 +172,7 @@ export class HighlightService {
 
     Object.values(overlayData).forEach((chips) => {
       chips
-        .sort(({ depth: depthA }, { depth: depthB }) => depthA - depthB)
+        .toSorted(({ depth: depthA }, { depth: depthB }) => depthA - depthB)
         .forEach(({ chip, overlay }, index, array) => {
           if (index !== 0) {
             // In case of overlap,

--- a/packages/@o3r/components/src/stores/placeholder-template/placeholder-template.selectors.ts
+++ b/packages/@o3r/components/src/stores/placeholder-template/placeholder-template.selectors.ts
@@ -64,7 +64,7 @@ export const selectSortedTemplates = (placeholderId: string) => createSelector(
       return { orderedTemplates: undefined, isPending };
     }
     // Sort templates by priority
-    const orderedTemplates = templates.sort((template1, template2) => {
+    const orderedTemplates = templates.toSorted((template1, template2) => {
       return (template2.priority - template1.priority) || 1;
     }).filter((templateData) => !!templateData.renderedTemplate);
 

--- a/packages/@o3r/configuration/schematics/configuration-to-component/index.ts
+++ b/packages/@o3r/configuration/schematics/configuration-to-component/index.ts
@@ -285,7 +285,7 @@ export function ngAddConfigFn(options: NgAddConfigSchematicsSchema): Rule {
                       ts.isConstructorDeclaration(classElement) || isNgOnChangesMethod(classElement)
                     ))
                     .concat(propertiesToAdd, newContructorDeclaration, newNgOnChanges)
-                    .sort(sortClassElement);
+                    .toSorted(sortClassElement);
 
                   addCommentsOnClassProperties(
                     newMembers,

--- a/packages/@o3r/configuration/schematics/index.it.spec.ts
+++ b/packages/@o3r/configuration/schematics/index.it.spec.ts
@@ -36,7 +36,7 @@ describe('new otter application with configuration', () => {
     await addImportToAppModule(applicationPath, 'TestSignal', 'src/components/test-signal');
 
     const diff = getGitDiff(workspacePath);
-    expect(diff.added.sort()).toEqual([
+    expect(diff.added.toSorted()).toEqual([
       path.join(relativeApplicationPath, 'src/components/test-signal/README.md').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, 'src/components/test-signal/index.ts').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, 'src/components/test-signal/test-signal.ts').replace(/[/\\]+/g, '/'),
@@ -53,15 +53,15 @@ describe('new otter application with configuration', () => {
       path.join(relativeApplicationPath, 'src/components/test/test.spec.ts').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, 'src/components/test/test.scss').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, 'src/components/test/test.html').replace(/[/\\]+/g, '/')
-    ].sort());
-    expect(diff.modified.sort()).toEqual([
+    ].toSorted());
+    expect(diff.modified.toSorted()).toEqual([
       path.join(relativeApplicationPath, 'package.json').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, 'src/app/app.ts').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, 'src/main.ts').replace(/[/\\]+/g, '/'),
       'angular.json',
       'package.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json'
-    ].sort());
+    ].toSorted());
 
     [libraryPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {
       expect(diff.all.some((file) => file.startsWith(path.relative(workspacePath, untouchedProject).replace(/\\+/g, '/')))).toBe(false);
@@ -95,7 +95,7 @@ describe('new otter application with configuration', () => {
 
     const packageJson = JSON.parse(fs.readFileSync(`${workspacePath}/package.json`, 'utf8'));
     expect(packageJson.dependencies['@o3r/configuration']).toBeDefined();
-    expect(diff.added.sort()).toEqual([
+    expect(diff.added.toSorted()).toEqual([
       path.join(relativeLibraryPath, 'src/components/test/test.scss').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'src/components/test/test-context.ts').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'src/components/test/test.html').replace(/[/\\]+/g, '/'),
@@ -112,13 +112,13 @@ describe('new otter application with configuration', () => {
       path.join(relativeLibraryPath, 'src/components/test-signal/test-signal-config.ts').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'src/components/test-signal/index.ts').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'src/components/test-signal/README.md').replace(/[/\\]+/g, '/')
-    ].sort());
-    expect(diff.modified.sort()).toEqual([
+    ].toSorted());
+    expect(diff.modified.toSorted()).toEqual([
       path.join(relativeLibraryPath, 'package.json').replace(/[/\\]+/g, '/'),
       'angular.json',
       'package.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json'
-    ].sort());
+    ].toSorted());
 
     [applicationPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {
       expect(diff.all.some((file) => file.startsWith(path.relative(workspacePath, untouchedProject).replace(/\\+/g, '/')))).toBe(false);

--- a/packages/@o3r/core/schematics/component/container/index.spec.ts
+++ b/packages/@o3r/core/schematics/component/container/index.spec.ts
@@ -86,8 +86,8 @@ describe('Component container', () => {
       'index.ts'
     ];
 
-    expect(tree.files.filter((file) => /test-component-cont/.test(file)).sort()).toEqual(
-      expectedFileNamesWithType.map((fileName) => getGeneratedComponentPath(componentName, fileName, 'container')).sort()
+    expect(tree.files.filter((file) => /test-component-cont/.test(file)).toSorted()).toEqual(
+      expectedFileNamesWithType.map((fileName) => getGeneratedComponentPath(componentName, fileName, 'container')).toSorted()
     );
     expect(tree.readContent(getGeneratedComponentPath(componentName, 'index.ts', 'container'))).toContain('export * from \'./test-component-cont.test-type\';');
     const componentFileContent = tree.readContent(getGeneratedComponentPath(componentName, 'test-component-cont.test-type.ts', 'container'));

--- a/packages/@o3r/core/schematics/component/presenter/index.spec.ts
+++ b/packages/@o3r/core/schematics/component/presenter/index.spec.ts
@@ -87,8 +87,8 @@ describe('Component presenter', () => {
       'index.ts'
     ];
 
-    expect(tree.files.filter((file) => /test-component-pres/.test(file)).sort()).toEqual(
-      expectedFileNamesWithType.map((fileName) => getGeneratedComponentPath(componentName, fileName, 'presenter')).sort()
+    expect(tree.files.filter((file) => /test-component-pres/.test(file)).toSorted()).toEqual(
+      expectedFileNamesWithType.map((fileName) => getGeneratedComponentPath(componentName, fileName, 'presenter')).toSorted()
     );
     expect(tree.readContent(getGeneratedComponentPath(componentName, 'index.ts', 'presenter'))).toContain('export * from \'./test-component-pres.test-type\';');
     const componentFileContent = tree.readContent(getGeneratedComponentPath(componentName, 'test-component-pres.test-type.ts', 'presenter'));

--- a/packages/@o3r/core/schematics/page/index.spec.ts
+++ b/packages/@o3r/core/schematics/page/index.spec.ts
@@ -81,7 +81,7 @@ describe('Page', () => {
         'README.md',
         'index.ts'
       ];
-      expect(tree.files.filter((file) => /test-page/.test(file)).sort()).toEqual(expectedFileNames.map((fileName) => `/src/app/test-page/${fileName}`).sort());
+      expect(tree.files.filter((file) => /test-page/.test(file)).toSorted()).toEqual(expectedFileNames.map((fileName) => `/src/app/test-page/${fileName}`).toSorted());
       expect(tree.readContent('/src/app/test-page/index.ts')).toContain('export * from \'./test-page.test-type\';');
     });
 

--- a/packages/@o3r/design/src/core/design-token/renderers/design-token-style-renderer.ts
+++ b/packages/@o3r/design/src/core/design-token/renderers/design-token-style-renderer.ts
@@ -77,7 +77,7 @@ export const getFileToUpdatePath = async (root?: string, defaultFile = 'styles.s
  */
 export const getTokenSorterByName: DesignTokenListTransform = (_variables, options) => {
   const splitNameRegExp = /^(.*?)(\d+)$/;
-  return (tokens) => tokens.sort((a, b) => {
+  return (tokens) => tokens.toSorted((a, b) => {
     const keyA = a.getKey(options?.tokenVariableNameRenderer);
     const keyB = b.getKey(options?.tokenVariableNameRenderer);
     const splitA = splitNameRegExp.exec(keyA);
@@ -156,7 +156,7 @@ export const getTokenSorterFromRegExpList: (regExps: RegExp[], applyRendererName
   return (tokens) =>
     tokens
       .map((token) => ({ index: regExps.findIndex((regExp) => applyRegExp(token, regExp)), token }))
-      .sort((a, b) => {
+      .toSorted((a, b) => {
         if (a.index === -1) {
           if (b.index === -1) {
             return 0;

--- a/packages/@o3r/extractors/builders/aggregate-migration-scripts/index.ts
+++ b/packages/@o3r/extractors/builders/aggregate-migration-scripts/index.ts
@@ -90,7 +90,7 @@ const getLibrariesVersions = (migrationFiles: MigrationFileEntry[]): LibraryVers
   }
   // Sort and dedupe versions
   Object.entries(libraries).forEach(([libName, libVersions]) => {
-    libVersions.sort((a, b) => semver.compare(a.appVersion, b.appVersion));
+    libVersions.toSorted((a, b) => semver.compare(a.appVersion, b.appVersion));
     libraries[libName] = libVersions.filter((libVersion, index) =>
       index < 1 || libVersions[index - 1].libVersion !== libVersion.libVersion);
   });

--- a/packages/@o3r/extractors/schematics/index.it.spec.ts
+++ b/packages/@o3r/extractors/schematics/index.it.spec.ts
@@ -21,18 +21,18 @@ describe('ng add extractors', () => {
     expect(() => packageManagerExec({ script: 'ng', args: ['add', `@o3r/extractors@${o3rVersion}`, '--skip-confirmation', '--project-name', appName] }, execAppOptions)).not.toThrow();
 
     const diff = getGitDiff(workspacePath);
-    expect(diff.modified.sort()).toEqual([
+    expect(diff.modified.toSorted()).toEqual([
       'angular.json',
       '.gitignore',
       'package.json',
       'apps/test-app/package.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json'
-    ].sort());
-    expect(diff.added.sort()).toEqual([
+    ].toSorted());
+    expect(diff.added.toSorted()).toEqual([
       'apps/test-app/placeholders.metadata.json',
       'apps/test-app/tsconfig.cms.json',
       'apps/test-app/migration-scripts/README.md'
-    ].sort());
+    ].toSorted());
 
     [libraryPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {
       expect(diff.all.some((file) => file.startsWith(path.relative(workspacePath, untouchedProject).replace(/\\+/g, '/')))).toBe(false);
@@ -48,18 +48,18 @@ describe('ng add extractors', () => {
     expect(() => packageManagerExec({ script: 'ng', args: ['add', `@o3r/extractors@${o3rVersion}`, '--skip-confirmation', '--project-name', libName] }, execAppOptions)).not.toThrow();
 
     const diff = getGitDiff(workspacePath);
-    expect(diff.modified.sort()).toEqual([
+    expect(diff.modified.toSorted()).toEqual([
       'angular.json',
       '.gitignore',
       'package.json',
       'libs/test-lib/package.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json'
-    ].sort());
-    expect(diff.added.sort()).toEqual([
+    ].toSorted());
+    expect(diff.added.toSorted()).toEqual([
       'libs/test-lib/placeholders.metadata.json',
       'libs/test-lib/tsconfig.cms.json',
       'libs/test-lib/migration-scripts/README.md'
-    ].sort());
+    ].toSorted());
 
     [applicationPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {
       expect(diff.all.some((file) => file.startsWith(path.relative(workspacePath, untouchedProject).replace(/\\+/g, '/')))).toBe(false);

--- a/packages/@o3r/extractors/src/core/comparator/package-managers-extractors/custom-npm-semver-resolver.ts
+++ b/packages/@o3r/extractors/src/core/comparator/package-managers-extractors/custom-npm-semver-resolver.ts
@@ -53,7 +53,7 @@ export class CustomNpmSemverResolver extends NpmSemverResolver {
       ? noDeprecatedCandidates
       : candidates;
 
-    finalCandidates.sort((a, b) => -a.compare(b));
+    finalCandidates.toSorted((a, b) => -a.compare(b));
 
     return finalCandidates.map((version) => {
       const versionLocator = structUtils.makeLocator(descriptor, `${PROTOCOL}${version.raw}`);

--- a/packages/@o3r/extractors/src/core/comparator/package-managers-extractors/npm-file-extractor-helper.ts
+++ b/packages/@o3r/extractors/src/core/comparator/package-managers-extractors/npm-file-extractor-helper.ts
@@ -61,7 +61,7 @@ export async function getFilesFromRegistry(packageDescriptor: string, paths: str
         const range = new semver.Range(packageRange, { includePrerelease: true });
         versions = versions.filter((v) => range.test(v));
       }
-      versions.sort((a, b) => semver.compare(b, a));
+      versions.toSorted((a, b) => semver.compare(b, a));
     }
     const latestVersion = typeof versions === 'string' ? versions : versions[0];
 

--- a/packages/@o3r/localization/builders/helpers/localization-generator.ts
+++ b/packages/@o3r/localization/builders/helpers/localization-generator.ts
@@ -408,6 +408,6 @@ export class LocalizationExtractor {
       throw new O3rCliError('Unknown referenced key');
     }
 
-    return options.sortKeys ? localizationMetadata.sort((a, b) => this.compareKeys(a, b)) : localizationMetadata;
+    return options.sortKeys ? localizationMetadata.toSorted((a, b) => this.compareKeys(a, b)) : localizationMetadata;
   }
 }

--- a/packages/@o3r/localization/builders/i18n/index.ts
+++ b/packages/@o3r/localization/builders/i18n/index.ts
@@ -27,7 +27,7 @@ export default createBuilder(createBuilderWithMetricsIfInstalled<I18nBuilderSche
       const newContent = JSON.stringify(
         Object.entries(localizationJson)
           .filter(([, value]) => !value.dictionary && !value.$ref && value.defaultValue !== undefined)
-          .sort((a, b) => a[0] < b[0] ? -1 : 1)
+          .toSorted((a, b) => a[0] < b[0] ? -1 : 1)
           .reduce((acc: { [key: string]: string }, [key, { defaultValue }]) => {
             acc[key] = defaultValue;
             return acc;

--- a/packages/@o3r/localization/builders/localization/index.ts
+++ b/packages/@o3r/localization/builders/localization/index.ts
@@ -421,7 +421,7 @@ export default createBuilder(createBuilderWithMetricsIfInstalled<LocalizationBui
       Object.entries(bundles).forEach(([language, bundle]) => {
         const filePath = path.resolve(writingFolder, `${language}.json`);
         context.logger.info(`Writing file to disk ${filePath}`);
-        fs.writeFileSync(filePath, JSON.stringify(bundle, Object.keys(bundle).sort(), 2));
+        fs.writeFileSync(filePath, JSON.stringify(bundle, Object.keys(bundle).toSorted(), 2));
       });
 
       return {

--- a/packages/@o3r/localization/schematics/index.it.spec.ts
+++ b/packages/@o3r/localization/schematics/index.it.spec.ts
@@ -39,8 +39,8 @@ describe('ng add otter localization', () => {
       path.join(relativeApplicationPath, 'src/app/app.spec.ts').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, 'src/app/app.ts').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, 'src/main.ts').replace(/[/\\]+/g, '/')
-    ].sort();
-    expect(diff.modified.sort()).toEqual(modifiedFiles);
+    ].toSorted();
+    expect(diff.modified.toSorted()).toEqual(modifiedFiles);
 
     const newFiles = [
       path.join(relativeApplicationPath, 'src/components/test/test-translation.ts').replace(/[/\\]+/g, '/'),
@@ -56,8 +56,8 @@ describe('ng add otter localization', () => {
       path.join(relativeApplicationPath, 'migration-scripts/README.md').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, 'tsconfig.cms.json').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, '.gitignore').replace(/[/\\]+/g, '/')
-    ].sort();
-    expect(diff.added.sort()).toEqual(newFiles);
+    ].toSorted();
+    expect(diff.added.toSorted()).toEqual(newFiles);
 
     [libraryPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {
       expect(diff.all.some((file) => file.startsWith(path.relative(workspacePath, untouchedProject).replace(/\\+/g, '/')))).toBe(false);
@@ -85,8 +85,8 @@ describe('ng add otter localization', () => {
       'angular.json',
       'package.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json'
-    ].sort();
-    expect(diff.modified.sort()).toEqual(modifiedFiles);
+    ].toSorted();
+    expect(diff.modified.toSorted()).toEqual(modifiedFiles);
 
     const addedFiles = [
       path.join(relativeLibraryPath, 'src/components/test/test-translation.ts').replace(/[/\\]+/g, '/'),
@@ -100,8 +100,8 @@ describe('ng add otter localization', () => {
       path.join(relativeLibraryPath, 'src/components/test/README.md').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'migration-scripts/README.md').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'tsconfig.cms.json').replace(/[/\\]+/g, '/')
-    ].sort();
-    expect(diff.added.sort()).toEqual(addedFiles);
+    ].toSorted();
+    expect(diff.added.toSorted()).toEqual(addedFiles);
 
     [applicationPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {
       expect(diff.all.some((file) => file.startsWith(path.relative(workspacePath, untouchedProject).replace(/\\+/g, '/')))).toBe(false);

--- a/packages/@o3r/localization/schematics/localization-to-component/index.ts
+++ b/packages/@o3r/localization/schematics/localization-to-component/index.ts
@@ -180,7 +180,7 @@ export function ngAddLocalizationFn(options: NgAddLocalizationSchematicsSchema):
                   const newMembers = node.members
                     .filter((classElement) => !ts.isConstructorDeclaration(classElement))
                     .concat(propertiesToAdd, newContructorDeclaration)
-                    .sort(sortClassElement);
+                    .toSorted(sortClassElement);
 
                   addCommentsOnClassProperties(
                     newMembers,

--- a/packages/@o3r/new-version/src/index.ts
+++ b/packages/@o3r/new-version/src/index.ts
@@ -139,7 +139,7 @@ export class NewVersion {
     let parsedSortedTags = tags
       .map((tag) => semver.parse(tag.replace('V', 'v')))
       .filter((tag): tag is semver.SemVer => !!tag && !!regexpVersionMask.test(tag.raw))
-      .sort((v1, v2) => semver.compare(v2, v1));
+      .toSorted((v1, v2) => semver.compare(v2, v1));
 
     this.options.logger.debug('Parsed and sorted tags:');
     this.options.logger.debug(JSON.stringify(parsedSortedTags));

--- a/packages/@o3r/pipeline/schematics/index.it.spec.ts
+++ b/packages/@o3r/pipeline/schematics/index.it.spec.ts
@@ -33,11 +33,11 @@ describe('new otter project', () => {
     const diff = getGitDiff(workspacePath);
     const yamlFiles = ['.github/actions/setup/action.yml', '.github/workflows/main.yml'];
 
-    expect(diff.added.sort()).toEqual(yamlFiles.sort());
-    expect(diff.modified.sort()).toEqual([
+    expect(diff.added.toSorted()).toEqual(yamlFiles.toSorted());
+    expect(diff.modified.toSorted()).toEqual([
       'package.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json'
-    ].sort());
+    ].toSorted());
     expect(diff.deleted.length).toBe(0);
 
     const packageJson = JSON.parse(readFileSync(path.join(workspacePath, 'package.json'), { encoding: 'utf8' })) as PackageJson;
@@ -69,12 +69,12 @@ describe('new otter project', () => {
     const diff = getGitDiff(workspacePath);
     const yamlFiles = ['.github/actions/setup/action.yml', '.github/workflows/main.yml'];
 
-    expect(diff.added.sort()).toEqual(yamlFiles.sort());
-    expect(diff.modified.sort()).toEqual([
+    expect(diff.added.toSorted()).toEqual(yamlFiles.toSorted());
+    expect(diff.modified.toSorted()).toEqual([
       'package.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json',
       isYarnTest ? '.yarnrc.yml' : '.npmrc'
-    ].sort());
+    ].toSorted());
     expect(diff.deleted.length).toBe(0);
     yamlFiles.forEach((yamlFile) => {
       execSync(`npx -p @action-validator/cli action-validator ${yamlFile}`, execAppOptions);

--- a/packages/@o3r/rules-engine/schematics/index.it.spec.ts
+++ b/packages/@o3r/rules-engine/schematics/index.it.spec.ts
@@ -40,7 +40,7 @@ describe('ng add rules-engine', () => {
       path.join(relativeApplicationPath, 'placeholders.metadata.json').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, 'tsconfig.cms.json').replace(/[/\\]+/g, '/')
     ];
-    expect(diff.added.sort()).toEqual(expectedAddedFiles.sort());
+    expect(diff.added.toSorted()).toEqual(expectedAddedFiles.toSorted());
     const expectedModifiedFiles = [
       path.join(relativeApplicationPath, 'package.json').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, 'src/app/app.ts').replace(/[/\\]+/g, '/'),
@@ -51,7 +51,7 @@ describe('ng add rules-engine', () => {
       'package.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json'
     ];
-    expect(diff.modified.sort()).toEqual(expectedModifiedFiles.sort());
+    expect(diff.modified.toSorted()).toEqual(expectedModifiedFiles.toSorted());
     [libraryPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {
       expect(diff.all.some((file) => file.startsWith(path.relative(workspacePath, untouchedProject).replace(/\\+/g, '/')))).toBe(false);
     });
@@ -70,7 +70,7 @@ describe('ng add rules-engine', () => {
     packageManagerExec({ script: 'ng', args: ['g', '@o3r/rules-engine:rules-engine-to-component', '--path', componentPath] }, execAppOptions);
 
     const diff = getGitDiff(workspacePath);
-    expect(diff.added.sort()).toEqual([
+    expect(diff.added.toSorted()).toEqual([
       path.join(relativeLibraryPath, 'src/components/test/test.scss').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'src/components/test/test-context.ts').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'src/components/test/test.html').replace(/[/\\]+/g, '/'),
@@ -81,14 +81,14 @@ describe('ng add rules-engine', () => {
       path.join(relativeLibraryPath, 'migration-scripts/README.md').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'placeholders.metadata.json').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'tsconfig.cms.json').replace(/[/\\]+/g, '/')
-    ].sort());
-    expect(diff.modified.sort()).toEqual([
+    ].toSorted());
+    expect(diff.modified.toSorted()).toEqual([
       path.join(relativeLibraryPath, 'package.json').replace(/[/\\]+/g, '/'),
       '.gitignore',
       'angular.json',
       'package.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json'
-    ].sort());
+    ].toSorted());
 
     [applicationPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {
       expect(diff.all.some((file) => file.startsWith(path.relative(workspacePath, untouchedProject).replace(/\\+/g, '/')))).toBe(false);

--- a/packages/@o3r/rules-engine/schematics/rules-engine-to-component/index.ts
+++ b/packages/@o3r/rules-engine/schematics/rules-engine-to-component/index.ts
@@ -160,7 +160,7 @@ function ngGenerateRulesEngineToComponentFn(options: NgGenerateRulesEngineToComp
                     findMethodByName('ngOnInit')(classElement) || findMethodByName('ngOnDestroy')(classElement)
                   ))
                   .concat(propertiesToAdd, newNgOnInit, newNgOnDestroy)
-                  .sort(sortClassElement);
+                  .toSorted(sortClassElement);
 
                 return factory.updateClassDeclaration(
                   node,

--- a/packages/@o3r/rules-engine/src/components/rules-engine/shared/ruleset-history-helper.ts
+++ b/packages/@o3r/rules-engine/src/components/rules-engine/shared/ruleset-history-helper.ts
@@ -45,7 +45,7 @@ export const rulesetReportToHistory = (events: DebugEvent[], rulesetMap: Record<
       }
       return acc;
     }, [])
-    .sort((execA, execB) => execB.timestamp - execA.timestamp)
+    .toSorted((execA, execB) => execB.timestamp - execA.timestamp)
     .map((rulesetExecution) => {
       const rulesetInformation = rulesetMap[rulesetExecution.rulesetId];
       const isActive = lastActiveRulesets.find((r) => r.id === rulesetExecution.rulesetId);
@@ -54,7 +54,7 @@ export const rulesetReportToHistory = (events: DebugEvent[], rulesetMap: Record<
         status: getStatus(rulesetExecution, !!isActive),
         isActive: !!isActive,
         rulesetInformation,
-        rulesEvaluations: (rulesetExecution.rulesEvaluations || []).sort((evalA, evalB) =>
+        rulesEvaluations: (rulesetExecution.rulesEvaluations || []).toSorted((evalA, evalB) =>
           (rulesetInformation?.rules.findIndex((r) => r.id === evalA.rule.id) || -1)
           - (rulesetInformation?.rules.findIndex((r) => r.id === evalB.rule.id) || -1)
         )

--- a/packages/@o3r/rules-engine/src/engine/debug/engine-debug.ts
+++ b/packages/@o3r/rules-engine/src/engine/debug/engine-debug.ts
@@ -146,7 +146,7 @@ export class EngineDebugger {
       rulesetName: ruleset.name,
       inputFacts,
       triggers: rulesetTriggers,
-      rulesEvaluations: flagCachedRules(rulesExecutions?.sort((a, b) => a.timestamp - b.timestamp) || [], rulesetTriggers),
+      rulesEvaluations: flagCachedRules(rulesExecutions?.toSorted((a, b) => a.timestamp - b.timestamp) || [], rulesetTriggers),
       temporaryFacts: runtimeFactValues
     };
     return baseRulesetOutputExecution;

--- a/packages/@o3r/schematics/src/rule-factories/ng-add/dependencies.ts
+++ b/packages/@o3r/schematics/src/rule-factories/ng-add/dependencies.ts
@@ -178,7 +178,7 @@ export const setupDependencies = (options: SetupDependenciesOptions): Rule => {
               context.logger.debug(`The dependency ${packageToInstall} (${depType}@${range}) will be added in ${packageJsonPath}`);
             }
             packageJsonContent[depType] = Object.keys(packageJsonContent[depType])
-              .sort()
+              .toSorted()
               .reduce((acc, key) => {
                 acc[key] = packageJsonContent[depType]![key];
                 return acc;

--- a/packages/@o3r/schematics/src/rule-factories/ng-add/ng-add-helpers.ts
+++ b/packages/@o3r/schematics/src/rule-factories/ng-add/ng-add-helpers.ts
@@ -49,7 +49,7 @@ const getNgAddSchema = (packageName: string, context: SchematicContext) => {
 
 const sortDependencies = (packageJson: PackageJson, depType: 'dependencies' | 'devDependencies' | 'peerDependencies') => {
   packageJson[depType] = packageJson[depType]
-    ? Object.fromEntries(Object.entries(packageJson[depType] || {}).sort(([key1, _val1], [key2, _val2]) => key1.localeCompare(key2)))
+    ? Object.fromEntries(Object.entries(packageJson[depType] || {}).toSorted(([key1, _val1], [key2, _val2]) => key1.localeCompare(key2)))
     : undefined;
 };
 

--- a/packages/@o3r/schematics/src/utility/collection.ts
+++ b/packages/@o3r/schematics/src/utility/collection.ts
@@ -51,7 +51,7 @@ export function getDefaultOptionsForSchematic<T extends WorkspaceSchematics['*:*
 
     return Object.entries<Record<string, string>>(schematics)
       .filter(([key, _]) => new RegExp(key.replace(/\*/g, '.*')).test(`${collection}:${schematicName}`))
-      .sort(([a], [b]) => (a.match(/\*/g)?.length || 0) - (b.match(/\*/g)?.length || 0))
+      .toSorted(([a], [b]) => (a.match(/\*/g)?.length || 0) - (b.match(/\*/g)?.length || 0))
       .map(([_, value]) => value)
       .reduce((config, value) => ({ ...config, ...value }), acc);
   }, {} as T);
@@ -68,7 +68,7 @@ export function getSchematicOptions<T extends WorkspaceSchematics['*:*'] = Works
 
   const options = config.schematics && Object.entries(config.schematics)
     .filter(([name]) => new RegExp(name.replace(/\*/g, '.*')).test(schematicName))
-    .sort(([a], [b]) => ((a.match(/\*/g)?.length || 0) - (b.match(/\*/g)?.length || 0)))
+    .toSorted(([a], [b]) => ((a.match(/\*/g)?.length || 0) - (b.match(/\*/g)?.length || 0)))
     .reduce((acc, [, opts]) => ({ ...acc, ...opts }), {} as any);
 
   return options && Object.keys(options).length > 0 ? options : config.schematics?.['*:*'] as T;

--- a/packages/@o3r/schematics/src/utility/dependencies.ts
+++ b/packages/@o3r/schematics/src/utility/dependencies.ts
@@ -97,7 +97,7 @@ export function getDependencyMaximumVersionRange(packageName: string, packageJso
     .filter((packageVersion): packageVersion is string => {
       return valid(packageVersion) !== null || validRange(packageVersion) !== null;
     })
-    .sort((rangeA, rangeB) =>
+    .toSorted((rangeA, rangeB) =>
       isRangeGreater(rangeB, rangeA) ? 1 : (isRangeGreater(rangeA, rangeB) ? -1 : 0)
     );
   return rangeSortedByHighestMinimum[0];

--- a/packages/@o3r/style-dictionary/schematics/index.it.spec.ts
+++ b/packages/@o3r/style-dictionary/schematics/index.it.spec.ts
@@ -27,15 +27,15 @@ describe('ng add otter style-dictionary hooks', () => {
 
     let diff = getGitDiff(workspacePath);
 
-    expect(diff.modified.sort()).toEqual([
+    expect(diff.modified.toSorted()).toEqual([
       path.join(relativeApplicationPath, 'package.json').replace(/[/\\]+/g, '/'),
       isYarnTest ? 'yarn.lock' : 'package-lock.json',
       'package.json'
-    ].sort());
-    expect(diff.added.sort()).toEqual([
+    ].toSorted());
+    expect(diff.added.toSorted()).toEqual([
       path.join(relativeApplicationPath, 'token.extensions.json').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, 'config.mjs').replace(/[/\\]+/g, '/')
-    ].sort());
+    ].toSorted());
 
     await fs.writeFile(path.join(applicationPath, 'test.tokens.json'), JSON.stringify({ colors: { primary: { $value: '#000' } } }));
 
@@ -62,15 +62,15 @@ describe('ng add otter style-dictionary hooks', () => {
 
     let diff = getGitDiff(workspacePath);
 
-    expect(diff.modified.sort()).toEqual([
+    expect(diff.modified.toSorted()).toEqual([
       path.join(relativeLibraryPath, 'package.json').replace(/[/\\]+/g, '/'),
       isYarnTest ? 'yarn.lock' : 'package-lock.json',
       'package.json'
-    ].sort());
-    expect(diff.added.sort()).toEqual([
+    ].toSorted());
+    expect(diff.added.toSorted()).toEqual([
       path.join(relativeLibraryPath, 'token.extensions.json').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'config.mjs').replace(/[/\\]+/g, '/')
-    ].sort());
+    ].toSorted());
 
     await fs.writeFile(path.join(libraryPath, 'test.tokens.json'), JSON.stringify({ colors: { primary: { $value: '#000' } } }));
 

--- a/packages/@o3r/style-dictionary/src/formats/css-format.mts
+++ b/packages/@o3r/style-dictionary/src/formats/css-format.mts
@@ -51,8 +51,8 @@ export const cssFormat: Format = {
       const propertyFormatter = getDefaultCssFormatter(baseFormatterOptions);
 
       return [...allTokens]
-        .sort(sortByPath)
-        .sort(outputReferences ? sortByReference(tokens, { unfilteredTokens, usesDtcg }) : () => 0)
+        .toSorted(sortByPath)
+        .toSorted(outputReferences ? sortByReference(tokens, { unfilteredTokens, usesDtcg }) : () => 0)
         .filter(({ attributes }) => !attributes?.private)
         .map((token) => ({
           token,

--- a/packages/@o3r/style-dictionary/src/formats/metadata-format.mts
+++ b/packages/@o3r/style-dictionary/src/formats/metadata-format.mts
@@ -53,7 +53,7 @@ export const metadataFormat: Format = {
     let allTokens = dictionary.allTokens;
     const tokens = dictionary.tokens;
     if (outputReferences) {
-      allTokens = [...allTokens].sort(
+      allTokens = [...allTokens].toSorted(
         sortByReference(tokens, { unfilteredTokens: dictionary.unfilteredTokens, usesDtcg })
       );
     }

--- a/packages/@o3r/style-dictionary/src/helpers/sort-by-path-sort-helpers.spec.ts
+++ b/packages/@o3r/style-dictionary/src/helpers/sort-by-path-sort-helpers.spec.ts
@@ -18,7 +18,7 @@ describe('sortByPath', () => {
       }
     ] as TransformedToken[];
 
-    const res = tokens.sort(sortByPath);
+    const res = tokens.toSorted(sortByPath);
     expect(res.length).toBe(2);
     expect(res[0].name).toBe('my.var.a');
     expect(res[1].name).toBe('my.var.z');
@@ -40,7 +40,7 @@ describe('sortByPath', () => {
       }
     ] as TransformedToken[];
 
-    const res = tokens.sort(sortByPath);
+    const res = tokens.toSorted(sortByPath);
     expect(res.length).toBe(3);
     expect(res[0].name).toBe('my.var');
     expect(res[1].name).toBe('my.var.a');
@@ -67,7 +67,7 @@ describe('sortByPath', () => {
       }
     ] as TransformedToken[];
 
-    const res = tokens.sort(sortByPath);
+    const res = tokens.toSorted(sortByPath);
     expect(res.length).toBe(4);
     expect(res[0].name).toBe('my.var');
     expect(res[1].name).toBe('my.var.00');
@@ -95,7 +95,7 @@ describe('sortByPath', () => {
       }
     ] as TransformedToken[];
 
-    const res = tokens.sort(sortByPath);
+    const res = tokens.toSorted(sortByPath);
     expect(res.length).toBe(4);
     expect(res[0].name).toBe('my.var');
     expect(res[1].name).toBe('my.var.00');

--- a/packages/@o3r/stylelint-plugin/schematics/index.it.spec.ts
+++ b/packages/@o3r/stylelint-plugin/schematics/index.it.spec.ts
@@ -26,11 +26,11 @@ describe('ng add stylelint-plugin', () => {
     packageManagerExec({ script: 'ng', args: ['add', `@o3r/stylelint-plugin@${o3rVersion}`, '--enable-metadata-extract', '--skip-confirmation', '--project-name', appName] }, execAppOptions);
     const diff = getGitDiff(workspacePath);
 
-    expect(diff.modified.sort()).toEqual([
+    expect(diff.modified.toSorted()).toEqual([
       'apps/test-app/package.json',
       'package.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json'
-    ].sort());
+    ].toSorted());
     expect(diff.added.length).toBe(0);
 
     [libraryPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {
@@ -63,11 +63,11 @@ describe('ng add stylelint-plugin', () => {
     packageManagerExec({ script: 'ng', args: ['add', `@o3r/stylelint-plugin@${o3rVersion}`, '--enable-metadata-extract', '--skip-confirmation', '--project-name', libName] }, execAppOptions);
     const diff = getGitDiff(workspacePath);
 
-    expect(diff.modified.sort()).toEqual([
+    expect(diff.modified.toSorted()).toEqual([
       'libs/test-lib/package.json',
       'package.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json'
-    ].sort());
+    ].toSorted());
     expect(diff.added.length).toBe(0);
 
     [applicationPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {

--- a/packages/@o3r/styling/schematics/index.it.spec.ts
+++ b/packages/@o3r/styling/schematics/index.it.spec.ts
@@ -45,9 +45,9 @@ describe('ng add styling', () => {
       path.join(relativeApplicationPath, 'migration-scripts/README.md').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, 'placeholders.metadata.json').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, 'tsconfig.cms.json').replace(/[/\\]+/g, '/')
-    ].sort();
-    expect(diff.added.sort()).toEqual(expectedAddedFiles);
-    expect(diff.modified.sort()).toEqual([
+    ].toSorted();
+    expect(diff.added.toSorted()).toEqual(expectedAddedFiles);
+    expect(diff.modified.toSorted()).toEqual([
       path.join(relativeApplicationPath, 'package.json').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, 'src/app/app.ts').replace(/[/\\]+/g, '/'),
       path.join(relativeApplicationPath, 'src/styles.scss').replace(/[/\\]+/g, '/'),
@@ -55,7 +55,7 @@ describe('ng add styling', () => {
       'angular.json',
       'package.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json'
-    ].sort());
+    ].toSorted());
 
     [libraryPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {
       expect(diff.all.some((file) => file.startsWith(path.relative(workspacePath, untouchedProject).replace(/\\+/g, '/')))).toBe(false);
@@ -77,7 +77,7 @@ describe('ng add styling', () => {
     packageManagerExec({ script: 'ng', args: ['g', '@o3r/styling:add-theming', '--path', filePath] }, execAppOptions);
 
     const diff = getGitDiff(execAppOptions.cwd);
-    expect(diff.added.sort()).toEqual([
+    expect(diff.added.toSorted()).toEqual([
       path.join(relativeLibraryPath, 'src/components/test/test-theme.scss').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'src/components/test/test.scss').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'src/components/test/test-context.ts').replace(/[/\\]+/g, '/'),
@@ -89,15 +89,15 @@ describe('ng add styling', () => {
       path.join(relativeLibraryPath, 'migration-scripts/README.md').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'placeholders.metadata.json').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'tsconfig.cms.json').replace(/[/\\]+/g, '/')
-    ].sort());
+    ].toSorted());
 
-    expect(diff.modified.sort()).toEqual([
+    expect(diff.modified.toSorted()).toEqual([
       path.join(relativeLibraryPath, 'package.json').replace(/[/\\]+/g, '/'),
       '.gitignore',
       'angular.json',
       'package.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json'
-    ].sort());
+    ].toSorted());
 
     [applicationPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {
       expect(diff.all.some((file) => file.startsWith(path.relative(workspacePath, untouchedProject).replace(/\\+/g, '/')))).toBe(false);

--- a/packages/@o3r/testing/schematics/index.it.spec.ts
+++ b/packages/@o3r/testing/schematics/index.it.spec.ts
@@ -81,22 +81,22 @@ describe('ng add testing', () => {
     packageManagerExec({ script: 'ng', args: ['add', `@o3r/testing@${o3rVersion}`, '--testing-framework', 'jest', '--skip-confirmation', '--project-name', libName] }, execAppOptions);
 
     const diff = getGitDiff(execAppOptions.cwd);
-    expect(diff.modified.sort()).toEqual([
+    expect(diff.modified.toSorted()).toEqual([
       'angular.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json',
       'package.json',
       '.vscode/extensions.json',
       'libs/test-lib/package.json',
       'libs/test-lib/tsconfig.spec.json'
-    ].sort());
+    ].toSorted());
 
-    expect(diff.added.sort()).toEqual([
+    expect(diff.added.toSorted()).toEqual([
       'jest.config.js',
       'jest.config.ut.js',
       'tsconfig.jest.json',
       'libs/test-lib/jest.config.js',
       'libs/test-lib/testing/setup-jest.ts'
-    ].sort());
+    ].toSorted());
 
     [applicationPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {
       expect(diff.all.some((file) => file.startsWith(path.relative(workspacePath, untouchedProject).replace(/\\+/g, '/')))).toBe(false);
@@ -141,8 +141,8 @@ describe('ng add testing', () => {
       path.join(relativeLibraryPath, 'src/components/test-component/presenter/test-component-pres.spec.ts').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'src/components/test-component/presenter/test-component-pres.scss').replace(/[/\\]+/g, '/'),
       path.join(relativeLibraryPath, 'src/components/test-component/presenter/test-component-pres.html').replace(/[/\\]+/g, '/')
-    ].sort();
-    expect(diff.added.sort()).toEqual(addedFiles);
+    ].toSorted();
+    expect(diff.added.toSorted()).toEqual(addedFiles);
     const modifiedFiles = [
       'angular.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json',
@@ -150,8 +150,8 @@ describe('ng add testing', () => {
       '.vscode/extensions.json',
       'libs/test-lib/package.json',
       'libs/test-lib/tsconfig.spec.json'
-    ].sort();
-    expect(diff.modified.sort()).toEqual(modifiedFiles);
+    ].toSorted();
+    expect(diff.modified.toSorted()).toEqual(modifiedFiles);
 
     [applicationPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {
       expect(diff.all.some((file) => file.startsWith(path.relative(workspacePath, untouchedProject).replace(/\\+/g, '/')))).toBe(false);

--- a/packages/@o3r/third-party/schematics/iframe-to-component/index.ts
+++ b/packages/@o3r/third-party/schematics/iframe-to-component/index.ts
@@ -160,7 +160,7 @@ export function ngAddIframeFn(options: NgAddIframeSchematicsSchema): Rule {
                       propertiesToAdd,
                       newNgAfterViewInit
                     )
-                    .sort(sortClassElement);
+                    .toSorted(sortClassElement);
 
                   addCommentsOnClassProperties(
                     newMembers,

--- a/packages/@o3r/third-party/schematics/index.it.spec.ts
+++ b/packages/@o3r/third-party/schematics/index.it.spec.ts
@@ -26,12 +26,12 @@ describe('new Angular application', () => {
 
     const diff = getGitDiff(workspacePath);
 
-    expect(diff.modified.sort()).toEqual([
+    expect(diff.modified.toSorted()).toEqual([
       'package.json',
       'angular.json',
       'apps/test-app/package.json',
       isYarnTest ? 'yarn.lock' : 'package-lock.json'
-    ].sort());
+    ].toSorted());
     expect(diff.added.length).toBe(0);
 
     const componentPath = path.normalize(path.posix.join(relativeApplicationPath, 'src/components/test/test.ts'));

--- a/tools/@o3r/workspace-helpers/scripts/report-deprecates.mjs
+++ b/tools/@o3r/workspace-helpers/scripts/report-deprecates.mjs
@@ -187,11 +187,11 @@ The following items are **deprecated** and **will be removed** in the version **
     }, {});
 
   Object.entries(changeMap)
-    .sort(([pck1], [pck2]) => pck1.localeCompare(pck2))
+    .toSorted(([pck1], [pck2]) => pck1.localeCompare(pck2))
     .forEach(([pck, reports]) => {
       template += `\n### From [${pck}](https://npmjs.com/package/${pck})\n\n`;
       reports
-        .sort(({ node }, report) => node.localeCompare(report.node))
+        .toSorted(({ node }, report) => node.localeCompare(report.node))
         .forEach(({ node, deprecationInfo }) => {
           const message = deprecationInfo.replace(new RegExp(`[, ]*(?:it |this module )?will be removed in (:?otter ?)?v${removalTargetVersion}[,.\\s]*`, 'i'), '').trim();
           template += `- \`${node}\` is deprecated.` + (message ? `</br>Note: *${formatNoteMessage(message)}*` : '') + '\n';

--- a/tools/github-actions/audit/src/main.ts
+++ b/tools/github-actions/audit/src/main.ts
@@ -89,7 +89,7 @@ ${reportData.errors.length > 0
 
 ${reportData.errors
     .filter((vul) => isVulnerabilityWithKnownSeverity(vul))
-    .sort(sortVulnerabilityBySeverity)
+    .toSorted(sortVulnerabilityBySeverity)
     .map((vul) => formatVulnerability(vul))
     .join(os.EOL)
 }
@@ -105,7 +105,7 @@ Vulnerabilities below the threshold: ${severityConfig}
 
 ${reportData.warnings
     .filter((vul) => isVulnerabilityWithKnownSeverity(vul))
-    .sort(sortVulnerabilityBySeverity)
+    .toSorted(sortVulnerabilityBySeverity)
     .map((vul) => formatVulnerability(vul))
     .join(os.EOL)
     .replaceAll('${', '&#36;{')

--- a/tools/github-actions/get-npm-tag/src/main.ts
+++ b/tools/github-actions/get-npm-tag/src/main.ts
@@ -30,7 +30,7 @@ async function run(): Promise<void> {
       .map((release) => release.tag_name.replace(/^v/i, ''))
       .map((tagWithoutV) => clean(tagWithoutV))
       .filter((cleanedTag): cleanedTag is string => cleanedTag !== null)
-      .sort(compare)
+      .toSorted(compare)
       .pop();
     const isLatest = latestVersion ? compare(latestVersion, version) <= 0 : true;
 


### PR DESCRIPTION
## Proposed change

Preserve immutability of arrays by using `Array.toSorted` instead of `Array.sort` so a copy is created instead of modifying the input

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
