### PR TITLE
feat: add user activity tracking for embedded apps

### DIFF
--- a/packages/@ama-mfe/messages/src/messages/user-activity/base.ts
+++ b/packages/@ama-mfe/messages/src/messages/user-activity/base.ts
@@ -1,0 +1,14 @@
+/** The user activity message type used for communication between shell and iframes */
+export const USER_ACTIVITY_MESSAGE_TYPE = 'user_activity';
+
+/**
+ * Types of user activity events that can be tracked
+ */
+export type UserActivityEventType =
+  | 'click'
+  | 'keydown'
+  | 'scroll'
+  | 'touchstart'
+  | 'focus'
+  | 'visibilitychange'
+  | 'iframeinteraction';

--- a/packages/@ama-mfe/messages/src/messages/user-activity/index.ts
+++ b/packages/@ama-mfe/messages/src/messages/user-activity/index.ts
@@ -1,0 +1,8 @@
+import type {
+  UserActivityMessageV1_0,
+} from './user-activity-versions';
+
+/** The versions of user activity messages */
+export type UserActivityMessage = UserActivityMessageV1_0;
+export * from './user-activity-versions';
+export { USER_ACTIVITY_MESSAGE_TYPE, type UserActivityEventType } from './base';

--- a/packages/@ama-mfe/messages/src/messages/user-activity/user-activity-versions.ts
+++ b/packages/@ama-mfe/messages/src/messages/user-activity/user-activity-versions.ts
@@ -1,0 +1,22 @@
+import type {
+  VersionedMessage,
+} from '@amadeus-it-group/microfrontends';
+import type {
+  USER_ACTIVITY_MESSAGE_TYPE,
+  UserActivityEventType,
+} from './base';
+
+/**
+ * User activity message version 1.0
+ * Sent from embedded modules to the shell to indicate user interaction
+ */
+export interface UserActivityMessageV1_0 extends VersionedMessage {
+  /** @inheritdoc */
+  type: typeof USER_ACTIVITY_MESSAGE_TYPE;
+  /** @inheritdoc */
+  version: '1.0';
+  /** The type of activity event that occurred */
+  eventType: UserActivityEventType;
+  /** Timestamp when the activity occurred */
+  timestamp: number;
+}

--- a/packages/@ama-mfe/messages/src/public_api.ts
+++ b/packages/@ama-mfe/messages/src/public_api.ts
@@ -2,3 +2,4 @@ export * from './messages/history/index';
 export * from './messages/navigation/index';
 export * from './messages/resize/index';
 export * from './messages/theme/index';
+export * from './messages/user-activity/index';

--- a/packages/@ama-mfe/ng-utils/src/messages/index.ts
+++ b/packages/@ama-mfe/ng-utils/src/messages/index.ts
@@ -1,3 +1,4 @@
 export * from './available-sender';
 export * from './error-sender';
 export * from './error/index';
+export * from './user-activity';

--- a/packages/@ama-mfe/ng-utils/src/messages/user-activity.spec.ts
+++ b/packages/@ama-mfe/ng-utils/src/messages/user-activity.spec.ts
@@ -1,0 +1,87 @@
+import {
+  USER_ACTIVITY_MESSAGE_TYPE,
+  type UserActivityMessageV1_0,
+} from '@ama-mfe/messages';
+import {
+  isUserActivityMessage,
+} from './user-activity';
+
+describe('isUserActivityMessage', () => {
+  it('should return true for valid UserActivityMessageV1_0', () => {
+    const message: UserActivityMessageV1_0 = {
+      type: USER_ACTIVITY_MESSAGE_TYPE,
+      version: '1.0',
+      eventType: 'click',
+      timestamp: Date.now()
+    };
+
+    expect(isUserActivityMessage(message)).toBe(true);
+  });
+
+  it('should return true for all valid event types', () => {
+    const eventTypes = ['click', 'keydown', 'scroll', 'touchstart', 'focus', 'visibilitychange', 'iframeinteraction'] as const;
+
+    eventTypes.forEach((eventType) => {
+      const message: UserActivityMessageV1_0 = {
+        type: USER_ACTIVITY_MESSAGE_TYPE,
+        version: '1.0',
+        eventType,
+        timestamp: Date.now()
+      };
+
+      expect(isUserActivityMessage(message)).toBe(true);
+    });
+  });
+
+  it('should return false for null', () => {
+    expect(isUserActivityMessage(null)).toBe(false);
+  });
+
+  it('should return false for undefined', () => {
+    expect(isUserActivityMessage(undefined)).toBe(false);
+  });
+
+  it('should return false for non-object values', () => {
+    expect(isUserActivityMessage('string')).toBe(false);
+    expect(isUserActivityMessage(123)).toBe(false);
+    expect(isUserActivityMessage(true)).toBe(false);
+  });
+
+  it('should return false for object without type property', () => {
+    const message = {
+      version: '1.0',
+      eventType: 'click',
+      timestamp: Date.now()
+    };
+
+    expect(isUserActivityMessage(message)).toBe(false);
+  });
+
+  it('should return false for object with wrong type', () => {
+    const message = {
+      type: 'wrong_type',
+      version: '1.0',
+      eventType: 'click',
+      timestamp: Date.now()
+    };
+
+    expect(isUserActivityMessage(message)).toBe(false);
+  });
+
+  it('should return false for empty object', () => {
+    expect(isUserActivityMessage({})).toBe(false);
+  });
+
+  it('should return false for array', () => {
+    expect(isUserActivityMessage([])).toBe(false);
+  });
+
+  it('should return true even if other properties are missing (only checks type)', () => {
+    // The type guard only checks for the type property
+    const message = {
+      type: USER_ACTIVITY_MESSAGE_TYPE
+    };
+
+    expect(isUserActivityMessage(message)).toBe(true);
+  });
+});

--- a/packages/@ama-mfe/ng-utils/src/messages/user-activity.ts
+++ b/packages/@ama-mfe/ng-utils/src/messages/user-activity.ts
@@ -1,0 +1,17 @@
+import {
+  USER_ACTIVITY_MESSAGE_TYPE,
+  type UserActivityMessage,
+} from '@ama-mfe/messages';
+
+/**
+ * Type guard to check if a message is a user activity message
+ * @param message The message to check
+ */
+export function isUserActivityMessage(message: unknown): message is UserActivityMessage {
+  return (
+    typeof message === 'object'
+    && message !== null
+    && 'type' in message
+    && message.type === USER_ACTIVITY_MESSAGE_TYPE
+  );
+}

--- a/packages/@ama-mfe/ng-utils/src/public_api.ts
+++ b/packages/@ama-mfe/ng-utils/src/public_api.ts
@@ -6,4 +6,5 @@ export * from './messages/index';
 export * from './navigation/index';
 export * from './resize/index';
 export * from './theme/index';
+export * from './user-activity/index';
 export * from './utils';

--- a/packages/@ama-mfe/ng-utils/src/user-activity/activity-consumer.service.spec.ts
+++ b/packages/@ama-mfe/ng-utils/src/user-activity/activity-consumer.service.spec.ts
@@ -1,0 +1,186 @@
+import {
+  USER_ACTIVITY_MESSAGE_TYPE,
+  type UserActivityMessageV1_0,
+} from '@ama-mfe/messages';
+import type {
+  RoutedMessage,
+} from '@amadeus-it-group/microfrontends';
+import {
+  TestBed,
+} from '@angular/core/testing';
+import {
+  ActivityConsumerService,
+} from './activity-consumer.service';
+import {
+  ConsumerManagerService,
+} from '@ama-mfe/ng-utils';
+
+describe('ActivityConsumerService', () => {
+  let service: ActivityConsumerService;
+  let consumerManagerServiceMock: jest.Mocked<ConsumerManagerService>;
+
+  beforeEach(() => {
+    consumerManagerServiceMock = {
+      register: jest.fn(),
+      unregister: jest.fn()
+    } as unknown as jest.Mocked<ConsumerManagerService>;
+
+    TestBed.configureTestingModule({
+      providers: [
+        ActivityConsumerService,
+        { provide: ConsumerManagerService, useValue: consumerManagerServiceMock }
+      ]
+    });
+
+    service = TestBed.inject(ActivityConsumerService);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('initialization', () => {
+    it('should be created', () => {
+      expect(service).toBeDefined();
+      expect(service instanceof ActivityConsumerService).toBe(true);
+    });
+
+    it('should have the correct message type', () => {
+      expect(service.type).toBe(USER_ACTIVITY_MESSAGE_TYPE);
+    });
+
+    it('should have supported version 1.0', () => {
+      expect(service.supportedVersions['1.0']).toBeDefined();
+      expect(typeof service.supportedVersions['1.0']).toBe('function');
+    });
+
+    it('should have undefined latestReceivedActivity initially', () => {
+      expect(service.latestReceivedActivity()).toBeUndefined();
+    });
+  });
+
+  describe('start', () => {
+    it('should register with consumer manager service', () => {
+      service.start();
+
+      expect(consumerManagerServiceMock.register).toHaveBeenCalledWith(service);
+      expect(consumerManagerServiceMock.register).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('stop', () => {
+    it('should unregister from consumer manager service', () => {
+      service.stop();
+
+      expect(consumerManagerServiceMock.unregister).toHaveBeenCalledWith(service);
+      expect(consumerManagerServiceMock.unregister).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('supportedVersions["1.0"]', () => {
+    it('should update latestReceivedActivity signal with message data', () => {
+      const mockMessage: RoutedMessage<UserActivityMessageV1_0> = {
+        from: 'test-channel-id',
+        to: ['consumer'],
+        payload: {
+          type: USER_ACTIVITY_MESSAGE_TYPE,
+          version: '1.0',
+          eventType: 'click',
+          timestamp: 1_234_567_890
+        }
+      };
+
+      service.supportedVersions['1.0'](mockMessage);
+
+      const activity = service.latestReceivedActivity();
+      expect(activity).toBeDefined();
+      expect(activity?.channelId).toBe('test-channel-id');
+      expect(activity?.eventType).toBe('click');
+      expect(activity?.timestamp).toBe(1_234_567_890);
+    });
+
+    it('should use "unknown" as channelId when from is undefined', () => {
+      const mockMessage: RoutedMessage<UserActivityMessageV1_0> = {
+        from: undefined,
+        to: ['consumer'],
+        payload: {
+          type: USER_ACTIVITY_MESSAGE_TYPE,
+          version: '1.0',
+          eventType: 'keydown',
+          timestamp: 9_876_543_210
+        }
+      };
+
+      service.supportedVersions['1.0'](mockMessage);
+
+      const activity = service.latestReceivedActivity();
+      expect(activity?.channelId).toBe('unknown');
+    });
+
+    it('should update latestReceivedActivity on subsequent messages', () => {
+      const firstMessage: RoutedMessage<UserActivityMessageV1_0> = {
+        from: 'channel-1',
+        to: ['consumer'],
+        payload: {
+          type: USER_ACTIVITY_MESSAGE_TYPE,
+          version: '1.0',
+          eventType: 'click',
+          timestamp: 1000
+        }
+      };
+
+      const secondMessage: RoutedMessage<UserActivityMessageV1_0> = {
+        from: 'channel-2',
+        to: ['consumer'],
+        payload: {
+          type: USER_ACTIVITY_MESSAGE_TYPE,
+          version: '1.0',
+          eventType: 'scroll',
+          timestamp: 2000
+        }
+      };
+
+      service.supportedVersions['1.0'](firstMessage);
+      expect(service.latestReceivedActivity()?.channelId).toBe('channel-1');
+      expect(service.latestReceivedActivity()?.eventType).toBe('click');
+
+      service.supportedVersions['1.0'](secondMessage);
+      expect(service.latestReceivedActivity()?.channelId).toBe('channel-2');
+      expect(service.latestReceivedActivity()?.eventType).toBe('scroll');
+      expect(service.latestReceivedActivity()?.timestamp).toBe(2000);
+    });
+
+    it('should handle all event types', () => {
+      const eventTypes = ['click', 'keydown', 'scroll', 'touchstart', 'focus', 'visibilitychange'] as const;
+
+      eventTypes.forEach((eventType) => {
+        const mockMessage: RoutedMessage<UserActivityMessageV1_0> = {
+          from: 'test-channel',
+          to: ['consumer'],
+          payload: {
+            type: USER_ACTIVITY_MESSAGE_TYPE,
+            version: '1.0',
+            eventType,
+            timestamp: Date.now()
+          }
+        };
+
+        service.supportedVersions['1.0'](mockMessage);
+        expect(service.latestReceivedActivity()?.eventType).toBe(eventType);
+      });
+    });
+  });
+
+  describe('latestReceivedActivity signal', () => {
+    it('should be read-only', () => {
+      // The signal should be a readonly signal (no set method exposed)
+      expect(service.latestReceivedActivity).toBeDefined();
+      expect(typeof service.latestReceivedActivity).toBe('function');
+      // Verify it's not a WritableSignal by checking it doesn't have set/update methods
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- testing signal type
+      expect((service.latestReceivedActivity as any).set).toBeUndefined();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- testing signal type
+      expect((service.latestReceivedActivity as any).update).toBeUndefined();
+    });
+  });
+});

--- a/packages/@ama-mfe/ng-utils/src/user-activity/activity-consumer.service.ts
+++ b/packages/@ama-mfe/ng-utils/src/user-activity/activity-consumer.service.ts
@@ -1,0 +1,74 @@
+import {
+  USER_ACTIVITY_MESSAGE_TYPE,
+  type UserActivityMessageV1_0,
+} from '@ama-mfe/messages';
+import type {
+  RoutedMessage,
+} from '@amadeus-it-group/microfrontends';
+import {
+  inject,
+  Injectable,
+  signal,
+} from '@angular/core';
+import {
+  type BasicMessageConsumer,
+  ConsumerManagerService,
+} from '../managers';
+import {
+  ActivityInfo,
+} from './interfaces';
+
+/**
+ * Generic service that consumes user activity messages.
+ * Can be used in both shell (to receive from modules) and modules (to receive from shell).
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class ActivityConsumerService implements BasicMessageConsumer<UserActivityMessageV1_0> {
+  private readonly consumerManagerService = inject(ConsumerManagerService);
+
+  /**
+   * Signal containing the latest activity info
+   */
+  private readonly latestReceivedActivityWritable = signal<ActivityInfo | undefined>(undefined);
+
+  /**
+   * Read-only signal containing the latest activity info received from other peers via the message protocol.
+   * Access the timestamp via latestReceivedActivity()?.timestamp
+   */
+  public readonly latestReceivedActivity = this.latestReceivedActivityWritable.asReadonly();
+
+  /**
+   * @inheritdoc
+   */
+  public readonly type = USER_ACTIVITY_MESSAGE_TYPE;
+
+  /**
+   * @inheritdoc
+   */
+  public readonly supportedVersions: Record<string, (message: RoutedMessage<UserActivityMessageV1_0>) => void> = {
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- Version keys follow message versioning convention
+    '1.0': (message) => {
+      this.latestReceivedActivityWritable.set({
+        channelId: message.from || 'unknown',
+        eventType: message.payload.eventType,
+        timestamp: message.payload.timestamp
+      });
+    }
+  };
+
+  /**
+   * Starts the activity consumer service by registering it with the consumer manager.
+   */
+  public start(): void {
+    this.consumerManagerService.register(this);
+  }
+
+  /**
+   * Stops the activity consumer service by unregistering it from the consumer manager.
+   */
+  public stop(): void {
+    this.consumerManagerService.unregister(this);
+  }
+}

--- a/packages/@ama-mfe/ng-utils/src/user-activity/activity-producer.service.spec.ts
+++ b/packages/@ama-mfe/ng-utils/src/user-activity/activity-producer.service.spec.ts
@@ -1,0 +1,534 @@
+import {
+  USER_ACTIVITY_MESSAGE_TYPE,
+} from '@ama-mfe/messages';
+import {
+  createEnvironmentInjector,
+  EnvironmentInjector,
+} from '@angular/core';
+import {
+  fakeAsync,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
+import {
+  LoggerService,
+} from '@o3r/logger';
+import {
+  ConnectionService,
+} from '../connect';
+import {
+  registerProducer,
+} from '../managers';
+import {
+  ActivityProducerService,
+} from './activity-producer.service';
+import type {
+  ActivityProducerConfig,
+} from './interfaces';
+
+let afterNextRenderCallback: (() => void) | null = null;
+
+jest.mock('../managers', () => ({
+  ...jest.requireActual('../managers'),
+  registerProducer: jest.fn()
+}));
+
+// Mock afterNextRender at module level
+jest.mock('@angular/core', () => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- mocking the module
+  const actual = jest.requireActual('@angular/core');
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- mocking the module
+  return {
+    ...actual,
+    afterNextRender: jest.fn((callback: () => void) => {
+      afterNextRenderCallback = callback;
+    })
+  };
+});
+
+describe('ActivityProducerService', () => {
+  let service: ActivityProducerService;
+  let connectionServiceMock: jest.Mocked<ConnectionService<any>>;
+  let loggerServiceMock: jest.Mocked<LoggerService>;
+
+  beforeEach(() => {
+    afterNextRenderCallback = null;
+
+    connectionServiceMock = {
+      send: jest.fn(),
+      id: 'test-module',
+      knownPeers: new Map([
+        ['host-app', [{ type: USER_ACTIVITY_MESSAGE_TYPE, version: '1.0' }]],
+        ['test-module', [{ type: USER_ACTIVITY_MESSAGE_TYPE, version: '1.0' }]]
+      ])
+    } as unknown as jest.Mocked<ConnectionService<any>>;
+
+    loggerServiceMock = {
+      warn: jest.fn(),
+      error: jest.fn()
+    } as unknown as jest.Mocked<LoggerService>;
+
+    TestBed.configureTestingModule({
+      providers: [
+        ActivityProducerService,
+        { provide: ConnectionService, useValue: connectionServiceMock },
+        { provide: LoggerService, useValue: loggerServiceMock }
+      ]
+    });
+
+    service = TestBed.inject(ActivityProducerService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    // Clean up any event listeners
+    service?.stop();
+  });
+
+  describe('initialization', () => {
+    it('should be created', () => {
+      expect(service).toBeDefined();
+      expect(service instanceof ActivityProducerService).toBe(true);
+    });
+
+    it('should have the correct message type', () => {
+      expect(service.types).toBe(USER_ACTIVITY_MESSAGE_TYPE);
+    });
+
+    it('should register as a producer on construction', () => {
+      expect(registerProducer).toHaveBeenCalledWith(service);
+    });
+
+    it('should call stop when the injector is destroyed', () => {
+      const parentInjector = TestBed.inject(EnvironmentInjector);
+      const childInjector = createEnvironmentInjector([
+        ActivityProducerService,
+        { provide: ConnectionService, useValue: connectionServiceMock }
+      ], parentInjector);
+
+      const childService = childInjector.get(ActivityProducerService);
+      const stopSpy = jest.spyOn(childService, 'stop');
+
+      childInjector.destroy();
+
+      expect(stopSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should have undefined localActivity initially', () => {
+      expect(service.localActivity()).toBeUndefined();
+    });
+  });
+
+  describe('handleError', () => {
+    it('should log warning for error messages', () => {
+      const errorContent = {
+        type: USER_ACTIVITY_MESSAGE_TYPE,
+        version: '1.0',
+        error: 'Test error'
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- test mock
+      service.handleError(errorContent as any);
+
+      expect(loggerServiceMock.error).toHaveBeenCalledWith('Error in user activity service message', errorContent);
+    });
+  });
+
+  describe('start', () => {
+    const config: ActivityProducerConfig = {
+      throttleMs: 100
+    };
+
+    it('should start with default config when no config is provided', fakeAsync(() => {
+      service.start();
+      afterNextRenderCallback?.();
+
+      // First event should send
+      document.dispatchEvent(new Event('click'));
+      tick(0);
+      expect(connectionServiceMock.send).toHaveBeenCalledTimes(1);
+
+      // Second event should not send (default throttle is 1000ms)
+      document.dispatchEvent(new Event('click'));
+      tick(0);
+      expect(connectionServiceMock.send).toHaveBeenCalledTimes(1);
+
+      // After default throttle window passes, it should send again
+      tick(1000);
+      document.dispatchEvent(new Event('click'));
+      tick(0);
+      expect(connectionServiceMock.send).toHaveBeenCalledTimes(2);
+    }));
+
+    it('should not start twice', () => {
+      service.start(config);
+      const firstCallback = afterNextRenderCallback;
+
+      service.start(config);
+
+      // afterNextRender should only be called once
+      expect(afterNextRenderCallback).toBe(firstCallback);
+    });
+
+    it('should schedule event listener setup via afterNextRender', () => {
+      service.start(config);
+
+      expect(afterNextRenderCallback).not.toBeNull();
+    });
+
+    it('should add event listeners when afterNextRender callback executes', () => {
+      const addEventListenerSpy = jest.spyOn(document, 'addEventListener');
+
+      service.start(config);
+      afterNextRenderCallback?.();
+
+      // Should add listeners for: click, keydown, scroll, touchstart, focus, visibilitychange
+      expect(addEventListenerSpy).toHaveBeenCalledTimes(6);
+      expect(addEventListenerSpy).toHaveBeenCalledWith('click', expect.any(Function), { passive: true, capture: true });
+      expect(addEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function), { passive: true, capture: true });
+      expect(addEventListenerSpy).toHaveBeenCalledWith('scroll', expect.any(Function), { passive: true, capture: true });
+      expect(addEventListenerSpy).toHaveBeenCalledWith('touchstart', expect.any(Function), { passive: true, capture: true });
+      expect(addEventListenerSpy).toHaveBeenCalledWith('focus', expect.any(Function), { passive: true, capture: true });
+      expect(addEventListenerSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function), { passive: true, capture: true });
+
+      addEventListenerSpy.mockRestore();
+    });
+  });
+
+  describe('stop', () => {
+    const config: ActivityProducerConfig = {
+      throttleMs: 100
+    };
+
+    it('should remove all event listeners', () => {
+      const removeEventListenerSpy = jest.spyOn(document, 'removeEventListener');
+
+      service.start(config);
+      afterNextRenderCallback?.();
+      service.stop();
+
+      expect(removeEventListenerSpy).toHaveBeenCalledTimes(6);
+      removeEventListenerSpy.mockRestore();
+    });
+  });
+
+  describe('activity detection', () => {
+    const config: ActivityProducerConfig = {
+      throttleMs: 100
+    };
+
+    beforeEach(() => {
+      service.start(config);
+      afterNextRenderCallback?.();
+    });
+
+    it('should send message on click event', fakeAsync(() => {
+      document.dispatchEvent(new Event('click'));
+      tick(0);
+
+      expect(connectionServiceMock.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: USER_ACTIVITY_MESSAGE_TYPE,
+          version: '1.0',
+          eventType: 'click',
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- jest matcher
+          timestamp: expect.any(Number)
+        }),
+        { to: ['host-app'] }
+      );
+    }));
+
+    it('should update localActivity signal on activity', fakeAsync(() => {
+      document.dispatchEvent(new Event('click'));
+      tick(0);
+
+      const activity = service.localActivity();
+      expect(activity).toBeDefined();
+      expect(activity?.channelId).toBe('local');
+      expect(activity?.eventType).toBe('click');
+      expect(activity?.timestamp).toBeGreaterThan(0);
+    }));
+
+    it('should throttle messages', fakeAsync(() => {
+      // First event should send
+      document.dispatchEvent(new Event('click'));
+      tick(0);
+      expect(connectionServiceMock.send).toHaveBeenCalledTimes(1);
+
+      // Second event within throttle window should not send
+      document.dispatchEvent(new Event('click'));
+      tick(50);
+      expect(connectionServiceMock.send).toHaveBeenCalledTimes(1);
+
+      // Event after throttle window should send
+      tick(100);
+      document.dispatchEvent(new Event('click'));
+      tick(0);
+      expect(connectionServiceMock.send).toHaveBeenCalledTimes(2);
+    }));
+
+    it('should always update localActivity signal even when throttled', fakeAsync(() => {
+      document.dispatchEvent(new Event('click'));
+      tick(0);
+      const firstTimestamp = service.localActivity()?.timestamp;
+
+      tick(50);
+      document.dispatchEvent(new Event('keydown'));
+      tick(0);
+
+      // localActivity should be updated even though message was throttled
+      expect(service.localActivity()?.eventType).toBe('keydown');
+      expect(service.localActivity()?.timestamp).toBeGreaterThanOrEqual(firstTimestamp);
+    }));
+
+    it('should handle keydown events', fakeAsync(() => {
+      document.dispatchEvent(new Event('keydown'));
+      tick(0);
+
+      expect(connectionServiceMock.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'keydown'
+        }),
+        { to: ['host-app'] }
+      );
+    }));
+
+    it('should ignore repeated keydown events', fakeAsync(() => {
+      const repeatedKeydownEvent = new KeyboardEvent('keydown', { repeat: true });
+
+      document.dispatchEvent(repeatedKeydownEvent);
+      tick(0);
+
+      expect(connectionServiceMock.send).not.toHaveBeenCalled();
+    }));
+
+    it('should handle scroll events with throttling', fakeAsync(() => {
+      document.dispatchEvent(new Event('scroll'));
+      tick(300); // Wait for throttle interval (default 300ms)
+
+      expect(connectionServiceMock.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'scroll'
+        }),
+        { to: ['host-app'] }
+      );
+    }));
+
+    it('should throttle high-frequency scroll events', fakeAsync(() => {
+      // First scroll event should send immediately
+      document.dispatchEvent(new Event('scroll'));
+      tick(0);
+      expect(connectionServiceMock.send).toHaveBeenCalledTimes(1);
+
+      // Second scroll within throttle window (300ms) should not send
+      document.dispatchEvent(new Event('scroll'));
+      tick(100);
+      expect(connectionServiceMock.send).toHaveBeenCalledTimes(1);
+
+      // Third scroll still within throttle window should not send
+      document.dispatchEvent(new Event('scroll'));
+      tick(100);
+      expect(connectionServiceMock.send).toHaveBeenCalledTimes(1);
+
+      // After throttle window passes, next scroll should send
+      tick(200); // Total 400ms since first event
+      document.dispatchEvent(new Event('scroll'));
+      tick(0);
+      expect(connectionServiceMock.send).toHaveBeenCalledTimes(2);
+    }));
+
+    it('should handle touchstart events', fakeAsync(() => {
+      document.dispatchEvent(new Event('touchstart'));
+      tick(0);
+
+      expect(connectionServiceMock.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'touchstart'
+        }),
+        { to: ['host-app'] }
+      );
+    }));
+
+    it('should handle focus events', fakeAsync(() => {
+      document.dispatchEvent(new Event('focus'));
+      tick(0);
+
+      expect(connectionServiceMock.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'focus'
+        }),
+        { to: ['host-app'] }
+      );
+    }));
+
+    it('should handle visibilitychange when document becomes visible', fakeAsync(() => {
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'visible',
+        configurable: true
+      });
+
+      document.dispatchEvent(new Event('visibilitychange'));
+      tick(0);
+
+      expect(connectionServiceMock.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'visibilitychange'
+        }),
+        { to: ['host-app'] }
+      );
+    }));
+  });
+
+  describe('peer filtering', () => {
+    it('should not send message when no peers have registered for user activity', fakeAsync(() => {
+      const localConnectionMock = {
+        send: jest.fn(),
+        id: 'test-module',
+        knownPeers: new Map([
+          ['test-module', [{ type: 'other_message', version: '1.0' }]]
+        ])
+      } as unknown as jest.Mocked<ConnectionService<any>>;
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          ActivityProducerService,
+          { provide: ConnectionService, useValue: localConnectionMock }
+        ]
+      });
+      const localService = TestBed.inject(ActivityProducerService);
+
+      localService.start({ throttleMs: 100 });
+      afterNextRenderCallback?.();
+
+      document.dispatchEvent(new Event('click'));
+      tick(0);
+
+      expect(localConnectionMock.send).not.toHaveBeenCalled();
+      localService.stop();
+    }));
+
+    it('should not send message when only self has registered for user activity', fakeAsync(() => {
+      const localConnectionMock = {
+        send: jest.fn(),
+        id: 'test-module',
+        knownPeers: new Map([
+          ['test-module', [{ type: USER_ACTIVITY_MESSAGE_TYPE, version: '1.0' }]]
+        ])
+      } as unknown as jest.Mocked<ConnectionService<any>>;
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          ActivityProducerService,
+          { provide: ConnectionService, useValue: localConnectionMock }
+        ]
+      });
+      const localService = TestBed.inject(ActivityProducerService);
+
+      localService.start({ throttleMs: 100 });
+      afterNextRenderCallback?.();
+
+      document.dispatchEvent(new Event('click'));
+      tick(0);
+
+      expect(localConnectionMock.send).not.toHaveBeenCalled();
+      localService.stop();
+    }));
+
+    it('should send to multiple peers that have registered for user activity', fakeAsync(() => {
+      const localConnectionMock = {
+        send: jest.fn(),
+        id: 'test-module',
+        knownPeers: new Map([
+          ['host-app', [{ type: USER_ACTIVITY_MESSAGE_TYPE, version: '1.0' }]],
+          ['other-module', [{ type: USER_ACTIVITY_MESSAGE_TYPE, version: '1.0' }]],
+          ['test-module', [{ type: USER_ACTIVITY_MESSAGE_TYPE, version: '1.0' }]]
+        ])
+      } as unknown as jest.Mocked<ConnectionService<any>>;
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          ActivityProducerService,
+          { provide: ConnectionService, useValue: localConnectionMock }
+        ]
+      });
+      const localService = TestBed.inject(ActivityProducerService);
+
+      localService.start({ throttleMs: 100 });
+      afterNextRenderCallback?.();
+
+      document.dispatchEvent(new Event('click'));
+      tick(0);
+
+      expect(localConnectionMock.send).toHaveBeenCalled();
+      const callArgs = localConnectionMock.send.mock.calls[0][1] as { to: string[] };
+      expect(callArgs.to).toContain('host-app');
+      expect(callArgs.to).toContain('other-module');
+      expect(callArgs.to).not.toContain('test-module');
+      localService.stop();
+    }));
+  });
+
+  describe('shouldBroadcast filter', () => {
+    it('should not send message when shouldBroadcast returns false', fakeAsync(() => {
+      const config: ActivityProducerConfig = {
+        throttleMs: 100,
+        shouldBroadcast: () => false
+      };
+
+      service.start(config);
+      afterNextRenderCallback?.();
+
+      document.dispatchEvent(new Event('click'));
+      tick(0);
+
+      expect(connectionServiceMock.send).not.toHaveBeenCalled();
+    }));
+
+    it('should send message when shouldBroadcast returns true', fakeAsync(() => {
+      const config: ActivityProducerConfig = {
+        throttleMs: 100,
+        shouldBroadcast: () => true
+      };
+
+      service.start(config);
+      afterNextRenderCallback?.();
+
+      document.dispatchEvent(new Event('click'));
+      tick(0);
+
+      expect(connectionServiceMock.send).toHaveBeenCalled();
+    }));
+
+    it('should pass event to shouldBroadcast filter', fakeAsync(() => {
+      const shouldBroadcastMock = jest.fn().mockReturnValue(true);
+      const config: ActivityProducerConfig = {
+        throttleMs: 100,
+        shouldBroadcast: shouldBroadcastMock
+      };
+
+      service.start(config);
+      afterNextRenderCallback?.();
+
+      const clickEvent = new Event('click');
+      document.dispatchEvent(clickEvent);
+      tick(0);
+
+      expect(shouldBroadcastMock).toHaveBeenCalledWith(expect.any(Event));
+    }));
+  });
+
+  describe('localActivity signal', () => {
+    it('should be read-only', () => {
+      expect(service.localActivity).toBeDefined();
+      expect(typeof service.localActivity).toBe('function');
+      // Verify it's not a WritableSignal
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- testing signal type
+      expect((service.localActivity as any).set).toBeUndefined();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- testing signal type
+      expect((service.localActivity as any).update).toBeUndefined();
+    });
+  });
+});

--- a/packages/@ama-mfe/ng-utils/src/user-activity/activity-producer.service.ts
+++ b/packages/@ama-mfe/ng-utils/src/user-activity/activity-producer.service.ts
@@ -1,0 +1,238 @@
+import {
+  USER_ACTIVITY_MESSAGE_TYPE,
+  type UserActivityEventType,
+  type UserActivityMessage,
+  type UserActivityMessageV1_0,
+} from '@ama-mfe/messages';
+import {
+  afterNextRender,
+  DestroyRef,
+  inject,
+  Injectable,
+  signal,
+} from '@angular/core';
+import {
+  LoggerService,
+} from '@o3r/logger';
+import {
+  ConnectionService,
+} from '../connect/index';
+import {
+  type MessageProducer,
+  registerProducer,
+} from '../managers';
+import type {
+  ErrorContent,
+} from '../messages';
+import {
+  ACTIVITY_EVENTS,
+  DEFAULT_ACTIVITY_PRODUCER_CONFIG,
+  HIGH_FREQUENCY_EVENTS,
+  IFRAME_INTERACTION_EVENT,
+  VISIBILITY_CHANGE_EVENT,
+} from './config';
+import {
+  IframeActivityTrackerService,
+} from './iframe-activity-tracker.service';
+import type {
+  ActivityInfo,
+  ActivityProducerConfig,
+} from './interfaces';
+
+/**
+ * Generic service that tracks user activity and sends messages.
+ * Can be configured for different contexts (cockpit or modules) via start() method parameter.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class ActivityProducerService implements MessageProducer<UserActivityMessage> {
+  private readonly messageService = inject(ConnectionService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly iframeActivityTracker = inject(IframeActivityTrackerService);
+  private readonly logger = inject(LoggerService);
+
+  /**
+   * Timestamp of the last sent activity message
+   */
+  private lastSentTimestamp = 0;
+
+  /**
+   * Bound event listeners for cleanup
+   */
+  private readonly boundListeners = new Map<UserActivityEventType, EventListener>();
+
+  /**
+   * Last emission timestamps for throttled high-frequency events
+   */
+  private readonly lastEmitTimestamps = new Map<UserActivityEventType, number>();
+
+  /**
+   * Whether the service has been started
+   */
+  private started = false;
+
+  /**
+   * Signal that emits local activity information.
+   * This allows consumers to react to activity detected by this producer.
+   */
+  private readonly localActivityWritable = signal<ActivityInfo | undefined>(undefined);
+
+  /**
+   * Read-only signal containing the latest local activity info.
+   * Use this signal to react to locally detected activity.
+   */
+  public readonly localActivity = this.localActivityWritable.asReadonly();
+
+  /**
+   * @inheritdoc
+   */
+  public readonly types = USER_ACTIVITY_MESSAGE_TYPE;
+
+  constructor() {
+    registerProducer(this);
+    this.destroyRef.onDestroy(() => this.stop());
+  }
+
+  /**
+   * Handles high-frequency events by applying a per-eventType throttle before calling onActivity.
+   *
+   * Difference with onActivity:
+   * - onActivityThrottled limits how often a given high-frequency event type (e.g. scroll) is processed
+   *   (based on highFrequencyThrottleMs and lastEmitTimestamps)
+   * - onActivity updates the local activity signal and applies the global message throttle
+   *   (based on global throttleMs and lastSentTimestamp)
+   * @param eventType The type of activity event that occurred
+   * @param configObject
+   */
+  private onActivityThrottled(eventType: UserActivityEventType, configObject: ActivityProducerConfig): void {
+    const now = Date.now();
+    const lastEmit = this.lastEmitTimestamps.get(eventType) ?? 0;
+    const throttleMs = configObject.highFrequencyThrottleMs!;
+
+    if (now - lastEmit >= throttleMs) {
+      this.lastEmitTimestamps.set(eventType, now);
+      this.onActivity(eventType, configObject);
+    }
+  }
+
+  /**
+   * Handles activity by sending a throttled message and emitting to local signal.
+   * @param eventType The type of activity event that occurred
+   * @param configObject
+   */
+  private onActivity(eventType: UserActivityEventType, configObject: ActivityProducerConfig): void {
+    const now = Date.now();
+
+    // Always emit local activity signal (not throttled for local detection)
+    this.localActivityWritable.set({
+      channelId: 'local',
+      eventType,
+      timestamp: now
+    });
+
+    // Send message with throttling
+    if (now - this.lastSentTimestamp >= configObject.throttleMs) {
+      this.lastSentTimestamp = now;
+      this.sendActivityMessage(eventType, now);
+    }
+  }
+
+  /**
+   * Sends an activity message.
+   * @param eventType The type of activity event
+   * @param timestamp The timestamp of the event
+   */
+  private sendActivityMessage(eventType: UserActivityEventType, timestamp: number): void {
+    const message: UserActivityMessageV1_0 = {
+      type: USER_ACTIVITY_MESSAGE_TYPE,
+      version: '1.0',
+      eventType,
+      timestamp
+    };
+    const registeredPeersIdsForUserActivity = [...this.messageService.knownPeers.entries()]
+      .filter(([peerId]) => peerId !== this.messageService.id)
+      .filter(([, messages]) => messages.some((msg) => msg.type === USER_ACTIVITY_MESSAGE_TYPE))
+      .map((peer) => peer[0]);
+    // send messages to the peers waiting for user activity
+    // avoids sending the message to modules which are not using it
+    if (registeredPeersIdsForUserActivity.length > 0) {
+      this.messageService.send(message, { to: registeredPeersIdsForUserActivity });
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public handleError(message: ErrorContent<UserActivityMessage>): void {
+    this.logger.error('Error in user activity service message', message);
+  }
+
+  /**
+   * Starts observing user activity events.
+   * When activity is detected, it sends a throttled message.
+   * Event listeners are attached after the next render to ensure DOM is ready.
+   * @param config Configuration for the activity producer
+   */
+  public start(config?: Partial<ActivityProducerConfig>): void {
+    if (this.started) {
+      return;
+    }
+    this.started = true;
+    const configObject: ActivityProducerConfig = { ...DEFAULT_ACTIVITY_PRODUCER_CONFIG, ...config };
+
+    // Always use afterNextRender to ensure DOM is ready in all contexts
+    afterNextRender(() => {
+      ACTIVITY_EVENTS.forEach((eventType) => {
+        const isHighFrequency = HIGH_FREQUENCY_EVENTS.includes(eventType);
+        const listener = (event: Event) => {
+          // do nothing if the event is a key kept pressed
+          if (eventType === 'keydown' && event instanceof KeyboardEvent && event.repeat) {
+            return;
+          }
+          // Apply filter if provided
+          if (configObject.shouldBroadcast?.(event) === false) {
+            return;
+          }
+          if (isHighFrequency) {
+            this.onActivityThrottled(eventType, configObject);
+          } else {
+            this.onActivity(eventType, configObject);
+          }
+        };
+        this.boundListeners.set(eventType, listener);
+        document.addEventListener(eventType, listener, { passive: true, capture: true });
+      });
+
+      // Also listen for visibility changes
+      const visibilityListener = () => {
+        if (document.visibilityState === 'visible') {
+          this.onActivity(VISIBILITY_CHANGE_EVENT, configObject);
+        }
+      };
+      this.boundListeners.set(VISIBILITY_CHANGE_EVENT, visibilityListener);
+      document.addEventListener(VISIBILITY_CHANGE_EVENT, visibilityListener, { passive: true, capture: true });
+
+      // Set up nested iframe tracking if enabled
+      if (configObject.trackNestedIframes) {
+        this.iframeActivityTracker.start({
+          pollIntervalMs: configObject.nestedIframePollIntervalMs,
+          activityIntervalMs: configObject.nestedIframeActivityEmitIntervalMs,
+          onActivity: () => this.onActivity(IFRAME_INTERACTION_EVENT, configObject)
+        });
+      }
+    });
+  }
+
+  /**
+   * Stops observing user activity events.
+   */
+  public stop(): void {
+    this.boundListeners.forEach((listener, eventType) => {
+      document.removeEventListener(eventType, listener, { capture: true });
+    });
+    this.boundListeners.clear();
+    this.lastEmitTimestamps.clear();
+    this.iframeActivityTracker.stop();
+  }
+}

--- a/packages/@ama-mfe/ng-utils/src/user-activity/config.spec.ts
+++ b/packages/@ama-mfe/ng-utils/src/user-activity/config.spec.ts
@@ -1,0 +1,63 @@
+import {
+  ACTIVITY_EVENTS,
+  DEFAULT_ACTIVITY_PRODUCER_CONFIG,
+  HIGH_FREQUENCY_EVENTS,
+} from './config';
+
+describe('user-activity config', () => {
+  describe('ACTIVITY_EVENTS', () => {
+    it('should contain expected event types', () => {
+      expect(ACTIVITY_EVENTS).toContain('click');
+      expect(ACTIVITY_EVENTS).toContain('keydown');
+      expect(ACTIVITY_EVENTS).toContain('scroll');
+      expect(ACTIVITY_EVENTS).toContain('touchstart');
+      expect(ACTIVITY_EVENTS).toContain('focus');
+    });
+
+    it('should have 5 event types', () => {
+      expect(ACTIVITY_EVENTS.length).toBe(5);
+    });
+
+    it('should be an array', () => {
+      expect(Array.isArray(ACTIVITY_EVENTS)).toBe(true);
+    });
+  });
+
+  describe('HIGH_FREQUENCY_EVENTS', () => {
+    it('should contain scroll', () => {
+      expect(HIGH_FREQUENCY_EVENTS).toContain('scroll');
+    });
+
+    it('should have 1 event type', () => {
+      expect(HIGH_FREQUENCY_EVENTS.length).toBe(1);
+    });
+
+    it('should be a subset of ACTIVITY_EVENTS', () => {
+      HIGH_FREQUENCY_EVENTS.forEach((event) => {
+        expect(ACTIVITY_EVENTS).toContain(event);
+      });
+    });
+  });
+
+  describe('DEFAULT_ACTIVITY_PRODUCER_CONFIG', () => {
+    it('should have throttleMs set to 1000ms', () => {
+      expect(DEFAULT_ACTIVITY_PRODUCER_CONFIG.throttleMs).toBe(1000);
+    });
+
+    it('should have trackNestedIframes set to false', () => {
+      expect(DEFAULT_ACTIVITY_PRODUCER_CONFIG.trackNestedIframes).toBe(false);
+    });
+
+    it('should have highFrequencyThrottleMs set to 300ms', () => {
+      expect(DEFAULT_ACTIVITY_PRODUCER_CONFIG.highFrequencyThrottleMs).toBe(300);
+    });
+
+    it('should have nestedIframeActivityEmitIntervalMs set to 30000ms', () => {
+      expect(DEFAULT_ACTIVITY_PRODUCER_CONFIG.nestedIframeActivityEmitIntervalMs).toBe(30_000);
+    });
+
+    it('should have nestedIframePollIntervalMs set to 1000ms', () => {
+      expect(DEFAULT_ACTIVITY_PRODUCER_CONFIG.nestedIframePollIntervalMs).toBe(1000);
+    });
+  });
+});

--- a/packages/@ama-mfe/ng-utils/src/user-activity/config.ts
+++ b/packages/@ama-mfe/ng-utils/src/user-activity/config.ts
@@ -1,0 +1,52 @@
+import type {
+  UserActivityEventType,
+} from '@ama-mfe/messages';
+import type {
+  ActivityProducerConfig,
+} from './interfaces';
+
+/**
+ * DOM events that indicate user activity
+ */
+export const ACTIVITY_EVENTS: readonly Exclude<UserActivityEventType, 'visibilitychange'>[] = [
+  'click',
+  'keydown',
+  'scroll',
+  'touchstart',
+  'focus'
+];
+
+/**
+ * Custom activity event type for iframe interactions.
+ * Emitted programmatically when an iframe gains focus, not from a DOM event listener.
+ */
+export const IFRAME_INTERACTION_EVENT: UserActivityEventType = 'iframeinteraction';
+
+/**
+ * Custom activity event type for visibility changes.
+ * Emitted programmatically when the document becomes visible, not from a DOM event listener.
+ */
+export const VISIBILITY_CHANGE_EVENT: UserActivityEventType = 'visibilitychange';
+
+/**
+ * High-frequency events that require throttling to avoid performance issues
+ */
+export const HIGH_FREQUENCY_EVENTS: readonly UserActivityEventType[] = [
+  'scroll'
+];
+
+/**
+ * Default configuration values for the ActivityProducerService
+ */
+export const DEFAULT_ACTIVITY_PRODUCER_CONFIG: Readonly<ActivityProducerConfig> = {
+  /** Default throttle time in milliseconds between activity messages */
+  throttleMs: 1000,
+  /** Default throttle time in milliseconds for high-frequency events */
+  highFrequencyThrottleMs: 300,
+  /** Whether to track nested iframes by default */
+  trackNestedIframes: false,
+  /** Default interval for iframe activity signals (30 seconds) */
+  nestedIframeActivityEmitIntervalMs: 30_000,
+  /** Default polling interval for detecting iframe focus changes (1 second) */
+  nestedIframePollIntervalMs: 1000
+};

--- a/packages/@ama-mfe/ng-utils/src/user-activity/iframe-activity-tracker.service.spec.ts
+++ b/packages/@ama-mfe/ng-utils/src/user-activity/iframe-activity-tracker.service.spec.ts
@@ -1,0 +1,382 @@
+import {
+  fakeAsync,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
+import {
+  DEFAULT_ACTIVITY_PRODUCER_CONFIG,
+} from './config';
+import {
+  IframeActivityTrackerService,
+} from './iframe-activity-tracker.service';
+
+describe('IframeActivityTrackerService', () => {
+  let service: IframeActivityTrackerService;
+  let onActivityMock: jest.Mock;
+
+  // Use a short poll interval for tests
+  const TEST_POLL_INTERVAL = 100;
+  const TEST_ACTIVITY_INTERVAL = 1000;
+
+  // Helper to set activeElement to an iframe
+  const setActiveElementToIframe = (iframe: HTMLIFrameElement) => {
+    Object.defineProperty(document, 'activeElement', {
+      value: iframe,
+      configurable: true
+    });
+  };
+
+  // Helper to set activeElement to body (not iframe)
+  const setActiveElementToBody = () => {
+    Object.defineProperty(document, 'activeElement', {
+      value: document.body,
+      configurable: true
+    });
+  };
+
+  beforeEach(() => {
+    onActivityMock = jest.fn();
+
+    TestBed.configureTestingModule({
+      providers: [IframeActivityTrackerService]
+    });
+
+    service = TestBed.inject(IframeActivityTrackerService);
+
+    // Reset activeElement mock
+    setActiveElementToBody();
+  });
+
+  afterEach(() => {
+    service.stop();
+    jest.clearAllMocks();
+    // Clean up any iframes added during tests
+    document.querySelectorAll('iframe').forEach((iframe) => iframe.remove());
+  });
+
+  describe('initialization', () => {
+    it('should be created', () => {
+      expect(service).toBeDefined();
+      expect(service instanceof IframeActivityTrackerService).toBe(true);
+    });
+  });
+
+  describe('start', () => {
+    it('should not start twice', fakeAsync(() => {
+      const iframe = document.createElement('iframe');
+      document.body.append(iframe);
+      setActiveElementToIframe(iframe);
+
+      service.start({ onActivity: onActivityMock, pollIntervalMs: TEST_POLL_INTERVAL, activityIntervalMs: TEST_ACTIVITY_INTERVAL });
+      service.start({ onActivity: onActivityMock, pollIntervalMs: TEST_POLL_INTERVAL, activityIntervalMs: TEST_ACTIVITY_INTERVAL });
+
+      // First poll detects focus and emits immediately
+      tick(TEST_POLL_INTERVAL);
+      expect(onActivityMock).toHaveBeenCalledTimes(1);
+
+      // Activity interval emits again
+      tick(TEST_ACTIVITY_INTERVAL);
+      expect(onActivityMock).toHaveBeenCalledTimes(2);
+    }));
+
+    it('should use default poll interval when not specified', () => {
+      expect(DEFAULT_ACTIVITY_PRODUCER_CONFIG.nestedIframePollIntervalMs).toBe(1000);
+    });
+
+    it('should use custom poll interval', fakeAsync(() => {
+      const iframe = document.createElement('iframe');
+      document.body.append(iframe);
+      setActiveElementToIframe(iframe);
+
+      service.start({
+        onActivity: onActivityMock,
+        pollIntervalMs: 500,
+        activityIntervalMs: TEST_ACTIVITY_INTERVAL
+      });
+
+      // Poll at 500ms detects focus
+      tick(500);
+      expect(onActivityMock).toHaveBeenCalledTimes(1);
+    }));
+
+    it('should use custom activity interval', fakeAsync(() => {
+      const iframe = document.createElement('iframe');
+      document.body.append(iframe);
+      setActiveElementToIframe(iframe);
+
+      service.start({
+        onActivity: onActivityMock,
+        pollIntervalMs: TEST_POLL_INTERVAL,
+        activityIntervalMs: 2000
+      });
+
+      // Poll detects focus
+      tick(TEST_POLL_INTERVAL);
+      expect(onActivityMock).toHaveBeenCalledTimes(1);
+
+      // Activity interval at 2000ms
+      tick(2000);
+      expect(onActivityMock).toHaveBeenCalledTimes(2);
+
+      tick(2000);
+      expect(onActivityMock).toHaveBeenCalledTimes(3);
+    }));
+  });
+
+  describe('stop', () => {
+    it('should not throw when stopping without starting', () => {
+      expect(() => service.stop()).not.toThrow();
+    });
+
+    it('should stop all intervals after stop', fakeAsync(() => {
+      const iframe = document.createElement('iframe');
+      document.body.append(iframe);
+      setActiveElementToIframe(iframe);
+
+      service.start({
+        onActivity: onActivityMock,
+        pollIntervalMs: TEST_POLL_INTERVAL,
+        activityIntervalMs: TEST_ACTIVITY_INTERVAL
+      });
+
+      // Poll detects focus and emits
+      tick(TEST_POLL_INTERVAL);
+      expect(onActivityMock).toHaveBeenCalledTimes(1);
+
+      service.stop();
+
+      tick(5000);
+      // Should still be 1 - no more calls after stop
+      expect(onActivityMock).toHaveBeenCalledTimes(1);
+    }));
+
+    it('should allow restart after stop', fakeAsync(() => {
+      const iframe = document.createElement('iframe');
+      document.body.append(iframe);
+      setActiveElementToIframe(iframe);
+
+      service.start({ onActivity: onActivityMock, pollIntervalMs: TEST_POLL_INTERVAL, activityIntervalMs: TEST_ACTIVITY_INTERVAL });
+      tick(TEST_POLL_INTERVAL);
+      expect(onActivityMock).toHaveBeenCalledTimes(1);
+
+      service.stop();
+
+      service.start({ onActivity: onActivityMock, pollIntervalMs: TEST_POLL_INTERVAL, activityIntervalMs: TEST_ACTIVITY_INTERVAL });
+      tick(TEST_POLL_INTERVAL);
+      expect(onActivityMock).toHaveBeenCalledTimes(2);
+    }));
+  });
+
+  describe('polling behavior', () => {
+    it('should emit immediately when poll detects iframe focus', fakeAsync(() => {
+      const iframe = document.createElement('iframe');
+      document.body.append(iframe);
+      setActiveElementToIframe(iframe);
+
+      service.start({ onActivity: onActivityMock, pollIntervalMs: TEST_POLL_INTERVAL, activityIntervalMs: TEST_ACTIVITY_INTERVAL });
+
+      // First poll detects focus and emits immediately
+      tick(TEST_POLL_INTERVAL);
+      expect(onActivityMock).toHaveBeenCalledTimes(1);
+
+      // Activity interval emits again
+      tick(TEST_ACTIVITY_INTERVAL);
+      expect(onActivityMock).toHaveBeenCalledTimes(2);
+
+      tick(TEST_ACTIVITY_INTERVAL);
+      expect(onActivityMock).toHaveBeenCalledTimes(3);
+    }));
+
+    it('should not emit activity when iframe does not have focus', fakeAsync(() => {
+      service.start({ onActivity: onActivityMock, pollIntervalMs: TEST_POLL_INTERVAL, activityIntervalMs: TEST_ACTIVITY_INTERVAL });
+
+      // activeElement is body, not iframe
+      tick(3000);
+      expect(onActivityMock).not.toHaveBeenCalled();
+    }));
+
+    it('should stop emitting when focus leaves iframe', fakeAsync(() => {
+      const iframe = document.createElement('iframe');
+      document.body.append(iframe);
+      setActiveElementToIframe(iframe);
+
+      service.start({ onActivity: onActivityMock, pollIntervalMs: TEST_POLL_INTERVAL, activityIntervalMs: TEST_ACTIVITY_INTERVAL });
+
+      // Poll detects focus
+      tick(TEST_POLL_INTERVAL);
+      expect(onActivityMock).toHaveBeenCalledTimes(1);
+
+      // Activity interval
+      tick(TEST_ACTIVITY_INTERVAL);
+      expect(onActivityMock).toHaveBeenCalledTimes(2);
+
+      // Focus leaves iframe
+      setActiveElementToBody();
+
+      // Next poll detects focus loss and stops activity interval
+      tick(TEST_POLL_INTERVAL);
+
+      tick(TEST_ACTIVITY_INTERVAL);
+      // Should still be 2 - no more calls after focus left
+      expect(onActivityMock).toHaveBeenCalledTimes(2);
+    }));
+
+    it('should resume emitting when focus returns to iframe', fakeAsync(() => {
+      const iframe = document.createElement('iframe');
+      document.body.append(iframe);
+      setActiveElementToIframe(iframe);
+
+      service.start({ onActivity: onActivityMock, pollIntervalMs: TEST_POLL_INTERVAL, activityIntervalMs: TEST_ACTIVITY_INTERVAL });
+
+      // Poll detects focus
+      tick(TEST_POLL_INTERVAL);
+      expect(onActivityMock).toHaveBeenCalledTimes(1);
+
+      // Focus leaves iframe
+      setActiveElementToBody();
+      tick(TEST_POLL_INTERVAL); // Poll detects loss
+      expect(onActivityMock).toHaveBeenCalledTimes(1);
+
+      // Focus returns to iframe
+      setActiveElementToIframe(iframe);
+      tick(TEST_POLL_INTERVAL); // Poll detects focus again, emits immediately
+      expect(onActivityMock).toHaveBeenCalledTimes(2);
+
+      // Activity interval continues
+      tick(TEST_ACTIVITY_INTERVAL);
+      expect(onActivityMock).toHaveBeenCalledTimes(3);
+    }));
+
+    it('should detect any iframe (including dynamically added)', fakeAsync(() => {
+      service.start({ onActivity: onActivityMock, pollIntervalMs: TEST_POLL_INTERVAL, activityIntervalMs: TEST_ACTIVITY_INTERVAL });
+
+      // No iframe focus on start
+      tick(TEST_POLL_INTERVAL);
+      expect(onActivityMock).not.toHaveBeenCalled();
+
+      // Create a new iframe after start and focus it
+      const dynamicIframe = document.createElement('iframe');
+      document.body.append(dynamicIframe);
+      setActiveElementToIframe(dynamicIframe);
+
+      // Next poll detects focus
+      tick(TEST_POLL_INTERVAL);
+      expect(onActivityMock).toHaveBeenCalledTimes(1);
+    }));
+  });
+
+  describe('visibility behavior', () => {
+    // Helper to simulate visibility change
+    const setDocumentVisibility = (state: 'visible' | 'hidden') => {
+      Object.defineProperty(document, 'visibilityState', {
+        value: state,
+        configurable: true
+      });
+      document.dispatchEvent(new Event('visibilitychange'));
+    };
+
+    afterEach(() => {
+      // Reset visibility to visible
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'visible',
+        configurable: true
+      });
+    });
+
+    it('should not start polling when document is hidden', fakeAsync(() => {
+      const iframe = document.createElement('iframe');
+      document.body.append(iframe);
+      setActiveElementToIframe(iframe);
+
+      // Set document as hidden before starting
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'hidden',
+        configurable: true
+      });
+
+      service.start({ onActivity: onActivityMock, pollIntervalMs: TEST_POLL_INTERVAL, activityIntervalMs: TEST_ACTIVITY_INTERVAL });
+
+      // Even with iframe focused, no activity should be emitted when hidden
+      tick(TEST_POLL_INTERVAL * 10);
+      expect(onActivityMock).not.toHaveBeenCalled();
+    }));
+
+    it('should stop emitting activity when tab becomes hidden', fakeAsync(() => {
+      const iframe = document.createElement('iframe');
+      document.body.append(iframe);
+      setActiveElementToIframe(iframe);
+
+      service.start({ onActivity: onActivityMock, pollIntervalMs: TEST_POLL_INTERVAL, activityIntervalMs: TEST_ACTIVITY_INTERVAL });
+
+      // Poll detects focus and emits
+      tick(TEST_POLL_INTERVAL);
+      expect(onActivityMock).toHaveBeenCalledTimes(1);
+
+      // Activity interval emits
+      tick(TEST_ACTIVITY_INTERVAL);
+      expect(onActivityMock).toHaveBeenCalledTimes(2);
+
+      // Tab becomes hidden
+      setDocumentVisibility('hidden');
+
+      // No more activity should be emitted
+      tick(TEST_ACTIVITY_INTERVAL * 5);
+      expect(onActivityMock).toHaveBeenCalledTimes(2);
+    }));
+
+    it('should resume emitting activity when tab becomes visible again', fakeAsync(() => {
+      const iframe = document.createElement('iframe');
+      document.body.append(iframe);
+      setActiveElementToIframe(iframe);
+
+      service.start({ onActivity: onActivityMock, pollIntervalMs: TEST_POLL_INTERVAL, activityIntervalMs: TEST_ACTIVITY_INTERVAL });
+
+      // Poll detects focus and emits
+      tick(TEST_POLL_INTERVAL);
+      expect(onActivityMock).toHaveBeenCalledTimes(1);
+
+      // Tab becomes hidden
+      setDocumentVisibility('hidden');
+      tick(TEST_ACTIVITY_INTERVAL * 2);
+      expect(onActivityMock).toHaveBeenCalledTimes(1);
+
+      // Tab becomes visible again
+      setDocumentVisibility('visible');
+
+      // Polling resumes and detects iframe focus
+      tick(TEST_POLL_INTERVAL);
+      expect(onActivityMock).toHaveBeenCalledTimes(2);
+
+      // Activity interval continues
+      tick(TEST_ACTIVITY_INTERVAL);
+      expect(onActivityMock).toHaveBeenCalledTimes(3);
+    }));
+
+    it('should not emit activity when tab is hidden even if iframe has focus', fakeAsync(() => {
+      const iframe = document.createElement('iframe');
+      document.body.append(iframe);
+
+      // Start with document hidden
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'hidden',
+        configurable: true
+      });
+
+      service.start({ onActivity: onActivityMock, pollIntervalMs: TEST_POLL_INTERVAL, activityIntervalMs: TEST_ACTIVITY_INTERVAL });
+
+      // Focus iframe while hidden
+      setActiveElementToIframe(iframe);
+      tick(TEST_POLL_INTERVAL * 5);
+
+      // No activity emitted while hidden
+      expect(onActivityMock).not.toHaveBeenCalled();
+
+      // Tab becomes visible
+      setDocumentVisibility('visible');
+
+      // Now polling starts and detects iframe focus
+      tick(TEST_POLL_INTERVAL);
+      expect(onActivityMock).toHaveBeenCalledTimes(1);
+    }));
+  });
+});

--- a/packages/@ama-mfe/ng-utils/src/user-activity/iframe-activity-tracker.service.ts
+++ b/packages/@ama-mfe/ng-utils/src/user-activity/iframe-activity-tracker.service.ts
@@ -1,0 +1,163 @@
+import {
+  Injectable,
+} from '@angular/core';
+import type {
+  IframeActivityTrackerConfig,
+} from './interfaces';
+
+/**
+ * Service that tracks user activity within nested iframes.
+ *
+ * Polls document.activeElement frequently to detect when an iframe has focus.
+ * When an iframe gains focus, emits immediately and then at the configured interval.
+ * When focus leaves the iframe, it stops emitting.
+ *
+ * This is needed because cross-origin iframes don't fire focus/blur events
+ * that bubble to the parent, and the regular activity tracker can't detect
+ * user interactions inside iframes.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class IframeActivityTrackerService {
+  /**
+   * Interval ID for polling activeElement
+   */
+  private pollIntervalId?: ReturnType<typeof setInterval>;
+
+  /**
+   * Interval ID for emitting activity at configured interval
+   */
+  private activityIntervalId?: ReturnType<typeof setInterval>;
+
+  /**
+   * Current configuration
+   */
+  private config?: IframeActivityTrackerConfig;
+
+  /**
+   * Bound visibility change handler for cleanup
+   */
+  private readonly visibilityChangeHandler = () => this.handleVisibilityChange();
+
+  /**
+   * Whether the service has been started
+   */
+  private get started() {
+    return this.config !== undefined;
+  }
+
+  /**
+   * Whether we are currently tracking iframe activity (iframe had focus on last poll)
+   */
+  private get isTrackingIframeActivity() {
+    return this.activityIntervalId !== undefined;
+  }
+
+  /**
+   * Polls document.activeElement to detect iframe focus changes.
+   * When iframe gains focus: emit immediately and start activity interval.
+   * When iframe loses focus: stop activity interval.
+   */
+  private checkActiveElement(): void {
+    const activeElement = document.activeElement;
+    const iframeFocused = activeElement instanceof HTMLIFrameElement;
+
+    if (iframeFocused && !this.isTrackingIframeActivity) {
+      // Iframe just gained focus - emit immediately and start activity interval
+      this.config?.onActivity();
+      this.startActivityInterval();
+    } else if (!iframeFocused && this.isTrackingIframeActivity) {
+      // Focus left the iframe - stop activity interval
+      this.stopActivityInterval();
+    }
+  }
+
+  /**
+   * Handles visibility change events to pause/resume polling when tab visibility changes.
+   */
+  private handleVisibilityChange(): void {
+    if (document.visibilityState === 'visible') {
+      this.startPolling();
+    } else {
+      this.stopPolling();
+      this.stopActivityInterval();
+    }
+  }
+
+  /**
+   * Starts polling for active element changes.
+   */
+  private startPolling(): void {
+    if (this.pollIntervalId) {
+      return;
+    }
+    this.pollIntervalId = setInterval(
+      () => this.checkActiveElement(),
+      this.config!.pollIntervalMs
+    );
+  }
+
+  /**
+   * Stops polling for active element changes.
+   */
+  private stopPolling(): void {
+    if (this.pollIntervalId) {
+      clearInterval(this.pollIntervalId);
+      this.pollIntervalId = undefined;
+    }
+  }
+
+  /**
+   * Starts the activity emission interval.
+   */
+  private startActivityInterval(): void {
+    this.stopActivityInterval();
+    this.activityIntervalId = setInterval(() => {
+      this.config?.onActivity();
+    }, this.config!.activityIntervalMs);
+  }
+
+  /**
+   * Stops the activity emission interval.
+   */
+  private stopActivityInterval(): void {
+    if (this.activityIntervalId) {
+      clearInterval(this.activityIntervalId);
+      this.activityIntervalId = undefined;
+    }
+  }
+
+  /**
+   * Starts tracking nested iframes within the document.
+   * @param config Configuration for the tracker
+   */
+  public start(config: IframeActivityTrackerConfig): void {
+    if (this.started) {
+      return;
+    }
+    this.config = config;
+
+    // Listen for visibility changes to pause/resume polling
+    document.addEventListener('visibilitychange', this.visibilityChangeHandler);
+
+    // Only start polling if document is currently visible
+    if (document.visibilityState === 'visible') {
+      this.startPolling();
+    }
+  }
+
+  /**
+   * Stops tracking nested iframes and cleans up resources.
+   */
+  public stop(): void {
+    if (!this.started) {
+      return;
+    }
+
+    document.removeEventListener('visibilitychange', this.visibilityChangeHandler);
+    this.stopPolling();
+    this.stopActivityInterval();
+    this.config = undefined;
+  }
+}

--- a/packages/@ama-mfe/ng-utils/src/user-activity/index.ts
+++ b/packages/@ama-mfe/ng-utils/src/user-activity/index.ts
@@ -1,0 +1,5 @@
+export * from './interfaces';
+export * from './config';
+export * from './activity-producer.service';
+export * from './activity-consumer.service';
+export * from './iframe-activity-tracker.service';

--- a/packages/@ama-mfe/ng-utils/src/user-activity/interfaces.ts
+++ b/packages/@ama-mfe/ng-utils/src/user-activity/interfaces.ts
@@ -1,0 +1,76 @@
+/**
+ * Information about user activity received from another context
+ */
+export interface ActivityInfo {
+  /** The channel ID (source ID) that sent the activity */
+  channelId: string;
+  /** The type of activity event */
+  eventType: string;
+  /** Timestamp when the activity occurred */
+  timestamp: number;
+}
+
+/**
+ * Configuration options for the activity producer service
+ */
+export interface ActivityProducerConfig {
+  /**
+   * Minimum interval in milliseconds between activity messages sent to the consumer.
+   * When multiple events occur within this interval, only the first one triggers a message.
+   * This prevents flooding the communication channel with too many messages.
+   */
+  throttleMs: number;
+  /**
+   * Optional filter function to determine if an event should be broadcast to the host(shell) app.
+   * Return true to broadcast the event, false to ignore it.
+   * Useful for filtering out events that occur on specific elements (e.g., iframes handled separately).
+   * @param event The DOM event that triggered the activity
+   * @returns Whether the event should be broadcast
+   */
+  shouldBroadcast?: (event: Event) => boolean;
+  /**
+   * Enable tracking of nested iframes. When enabled, the service will detect when focus
+   * moves to an iframe within the document and send periodic activity signals while
+   * the iframe has focus. This is useful for modules that contain iframes whose content
+   * cannot be modified to include activity tracking.
+   */
+  trackNestedIframes?: boolean;
+  /**
+   * Interval in milliseconds for polling document.activeElement to detect iframe focus.
+   * Only used when trackNestedIframes is true.
+   * @default 1000
+   */
+  nestedIframePollIntervalMs?: number;
+  /**
+   * Interval in milliseconds for sending activity signals to the host(shell) app while a nested iframe has focus.
+   * Only used when trackNestedIframes is true.
+   * @default 30000
+   */
+  nestedIframeActivityEmitIntervalMs?: number;
+  /**
+   * Throttle time in milliseconds for high-frequency events (scroll, mousemove).
+   * These events are throttled to avoid performance issues.
+   * @default 300
+   */
+  highFrequencyThrottleMs?: number;
+}
+
+/**
+ * Configuration for the iframe activity tracker
+ */
+export interface IframeActivityTrackerConfig {
+  /**
+   * Interval in milliseconds for polling document.activeElement to detect iframe focus.
+   * @default 1000
+   */
+  pollIntervalMs?: number;
+  /**
+   * Interval in milliseconds for sending activity signals to the host(shell) app while an iframe has focus.
+   * @default 30000
+   */
+  activityIntervalMs?: number;
+  /**
+   * Callback to invoke when activity is detected
+   */
+  onActivity: () => void;
+}


### PR DESCRIPTION
## Description

This PR introduces a User Activity Tracking feature for micro-frontend architectures, enabling host applications (shells) to monitor user interactions across embedded modules.

### Features

- **ActivityProducerService**: Listens for DOM events (click, keydown, scroll, touchstart, focus) and:
  - Exposes a `localActivity` signal for consumers within the same application
  - Sends throttled activity messages via the communication protocol to connected peers

- **ActivityConsumerService**: Receives activity messages from connected peers and exposes them via the `latestReceivedActivity` signal

- **Nested Iframe Tracking**: Detects when focus moves to an iframe and simulates activity by emitting periodic `iframeinteraction` events, solving the problem of cross-origin restrictions and focus isolation

- **Configurable Throttling**: Prevents flooding the communication channel with configurable throttle intervals

- **Event Filtering**: `shouldBroadcast` option allows filtering which events trigger activity messages (e.g., exclude iframe events in shell since embedded module activity comes via the communication protocol)

### Configuration Options

| Option | Default | Description |
|--------|---------|-------------|
| `throttleMs` | `1000` | Minimum interval between activity messages |
| `trackNestedIframes` | `false` | Enable tracking of nested iframes |
| `nestedIframePollIntervalMs` | `1000` | Polling interval for iframe focus detection |
| `nestedIframeActivityEmitIntervalMs` | `30000` | Activity signal interval while iframe has focus |
| `highFrequencyThrottleMs` | `300` | Throttle time for high-frequency events (scroll) |
| `shouldBroadcast` | - | Optional filter function for events |

### Use Cases

- Session timeout functionality
- User analytics
- Any feature requiring awareness of user activity across micro-frontends

### Changes

- Added [ActivityProducerService](cci:2://file:///c:/git_clones/github/opensource/otter/packages/@ama-mfe/ng-utils/src/user-activity/activity-producer.service.ts:42:0-229:1) and [ActivityConsumerService](cci:2://file:///c:/git_clones/github/opensource/otter/packages/@ama-mfe/ng-utils/src/user-activity/activity-consumer.service.ts:24:0-73:1)
- Added [IframeActivityTrackerService](cci:2://file:///c:/git_clones/github/opensource/otter/packages/@ama-mfe/ng-utils/src/user-activity/iframe-activity-tracker.service.ts:18:0-124:1) for nested iframe detection
- Added `DEFAULT_ACTIVITY_PRODUCER_CONFIG` with sensible defaults
- Added comprehensive tests
- Added documentation in README.md