### PR TITLE
ci(renovate): disable separateMinorPatch to avoid timeout

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -25,6 +25,7 @@
     "main",
     "/^release\\/.*-next$/"
   ],
+  "separateMinorPatch": false,
   "minimumReleaseAge": "5 days",
   "internalChecksFilter": "strict",
   "packageRules": [

--- a/packages/@ama-sdk/schematics/package.json
+++ b/packages/@ama-sdk/schematics/package.json
@@ -141,7 +141,7 @@
     "@swc/cli": "~0.7.9",
     "@swc/core": "~1.15.3",
     "@swc/helpers": "~0.5.17",
-    "@typescript-eslint/eslint-plugin": "~8.50.0",
+    "@typescript-eslint/eslint-plugin": "~8.51.0",
     "jest-junit": "~16.0.0",
     "lint-staged": "^16.0.0",
     "minimist": "^1.2.6",

--- a/packages/@o3r/core/package.json
+++ b/packages/@o3r/core/package.json
@@ -166,8 +166,8 @@
     "@o3r/store-sync": "workspace:~",
     "@stylistic/eslint-plugin": "~5.6.0",
     "@types/jest": "~30.0.0",
-    "@typescript-eslint/eslint-plugin": "~8.50.0",
-    "@typescript-eslint/parser": "~8.50.0",
+    "@typescript-eslint/eslint-plugin": "~8.51.0",
+    "@typescript-eslint/parser": "~8.51.0",
     "angular-eslint": "~20.6.0",
     "cpy-cli": "^6.0.0",
     "eslint": "~9.39.0",
@@ -175,7 +175,7 @@
     "eslint-import-resolver-typescript": "~4.4.0",
     "eslint-plugin-import": "~2.32.0",
     "eslint-plugin-import-newlines": "~1.4.0",
-    "eslint-plugin-jest": "~29.10.0",
+    "eslint-plugin-jest": "~29.11.0",
     "eslint-plugin-jsdoc": "~54.7.0",
     "eslint-plugin-prefer-arrow": "~1.2.3",
     "eslint-plugin-unicorn": "~60.0.0",
@@ -189,7 +189,7 @@
     "jsonc-eslint-parser": "~2.4.0",
     "nx": "~21.6.0",
     "ts-jest": "~29.4.0",
-    "typescript-eslint": "~8.50.0",
+    "typescript-eslint": "~8.51.0",
     "zone.js": "~0.15.0"
   },
   "engines": {


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
