### PR TITLE
feat: transloco package - tools and tests

### DIFF
--- a/packages/@o3r/transloco/src/public_api.ts
+++ b/packages/@o3r/transloco/src/public_api.ts
@@ -2,3 +2,4 @@ export type { Translation } from '@o3r/core';
 export * from './annotations/index';
 export * from './core/index';
 export * from './stores/index';
+export * from './tools/index';

--- a/packages/@o3r/transloco/src/tools/index.ts
+++ b/packages/@o3r/transloco/src/tools/index.ts
@@ -1,0 +1,12 @@
+export * from './localization-helpers';
+export * from './localization-module';
+export * from './localization-provider';
+export { LocalizationService } from './localization-service';
+export * from './localization-token';
+export * from './localization-translate-directive';
+export * from './localization-translate-pipe';
+export * from './localized-currency-pipe';
+export * from './localized-date-pipe';
+export * from './localized-decimal-pipe';
+export { TextDirectionService } from './text-direction-service';
+export * from './translations-loader';

--- a/packages/@o3r/transloco/src/tools/localization-helpers.spec.ts
+++ b/packages/@o3r/transloco/src/tools/localization-helpers.spec.ts
@@ -1,0 +1,23 @@
+import {
+  getDebugKey,
+} from './localization-helpers';
+
+describe('localization helpers', () => {
+  describe('getDebugKey', () => {
+    it('should format key and value with a dash separator', () => {
+      expect(getDebugKey('my.key', 'My Value')).toBe('my.key - My Value');
+    });
+
+    it('should handle empty key', () => {
+      expect(getDebugKey('', 'My Value')).toBe(' - My Value');
+    });
+
+    it('should handle empty value', () => {
+      expect(getDebugKey('my.key', '')).toBe('my.key - ');
+    });
+
+    it('should handle both empty key and value', () => {
+      expect(getDebugKey('', '')).toBe(' - ');
+    });
+  });
+});

--- a/packages/@o3r/transloco/src/tools/localization-helpers.ts
+++ b/packages/@o3r/transloco/src/tools/localization-helpers.ts
@@ -1,0 +1,9 @@
+/**
+ * Formats a debug key string combining the translation key and its value.
+ * Used across the localization service, pipe, and directive when debugMode is enabled.
+ * @param key The translation key
+ * @param value The translated value
+ */
+export function getDebugKey(key: string, value: string): string {
+  return `${key} - ${value}`;
+}

--- a/packages/@o3r/transloco/src/tools/localization-module.ts
+++ b/packages/@o3r/transloco/src/tools/localization-module.ts
@@ -1,0 +1,110 @@
+import {
+  BidiModule,
+} from '@angular/cdk/bidi';
+import {
+  CommonModule,
+  CurrencyPipe,
+  DatePipe,
+  DecimalPipe,
+} from '@angular/common';
+import {
+  InjectionToken,
+  LOCALE_ID,
+  ModuleWithProviders,
+  NgModule,
+  Optional,
+} from '@angular/core';
+import {
+  TranslocoModule,
+} from '@jsverse/transloco';
+import {
+  DEFAULT_LOCALIZATION_CONFIGURATION,
+  LocalizationConfiguration,
+} from '../core';
+import {
+  LocalizationService,
+} from './localization-service';
+import {
+  LOCALIZATION_CONFIGURATION_TOKEN,
+} from './localization-token';
+import {
+  LocalizationTranslateDirective,
+} from './localization-translate-directive';
+import {
+  O3rLocalizationTranslatePipe,
+} from './localization-translate-pipe';
+import {
+  LocalizedCurrencyPipe,
+} from './localized-currency-pipe';
+import {
+  LocalizedDatePipe,
+} from './localized-date-pipe';
+import {
+  LocalizedDecimalPipe,
+} from './localized-decimal-pipe';
+import {
+  TextDirectionService,
+} from './text-direction-service';
+
+/**
+ * creates LocalizationConfiguration, which is used if the application
+ * @param configuration Localization configuration
+ */
+export function createLocalizationConfiguration(configuration?: Partial<LocalizationConfiguration>): LocalizationConfiguration {
+  return {
+    ...DEFAULT_LOCALIZATION_CONFIGURATION,
+    ...configuration
+  };
+}
+
+/**
+ * Factory to inject the LOCALE_ID token with the current language into Angular context
+ * @param localizationService Localization service
+ */
+export function localeIdNgBridge(localizationService: LocalizationService) {
+  return localizationService.getCurrentLanguage();
+}
+
+/** Custom Localization Configuration Token to override default localization configuration */
+export const CUSTOM_LOCALIZATION_CONFIGURATION_TOKEN = new InjectionToken<Partial<LocalizationConfiguration>>('Partial Localization configuration');
+
+@NgModule({
+  declarations: [O3rLocalizationTranslatePipe, LocalizationTranslateDirective, LocalizedDatePipe, LocalizedDecimalPipe, LocalizedCurrencyPipe],
+  imports: [TranslocoModule, BidiModule, CommonModule],
+  exports: [TranslocoModule, O3rLocalizationTranslatePipe, LocalizationTranslateDirective, LocalizedDatePipe, LocalizedDecimalPipe, LocalizedCurrencyPipe],
+  providers: [
+    { provide: LOCALIZATION_CONFIGURATION_TOKEN, useFactory: createLocalizationConfiguration, deps: [[new Optional(), CUSTOM_LOCALIZATION_CONFIGURATION_TOKEN]] },
+    { provide: LOCALE_ID, useFactory: localeIdNgBridge, deps: [LocalizationService] },
+    { provide: DatePipe, useClass: LocalizedDatePipe },
+    { provide: DecimalPipe, useClass: LocalizedDecimalPipe },
+    { provide: CurrencyPipe, useClass: LocalizedCurrencyPipe },
+    TextDirectionService
+  ]
+})
+export class LocalizationModule {
+  /**
+   * forRoot method should be called only once from the application index.ts
+   * It will do several things:
+   * - provide the configuration for the whole application
+   * - register all locales specified in the LocalizationConfiguration
+   * - configure TranslocoService
+   * - inject LOCALE_ID token
+   * @param configuration LocalizationConfiguration
+   */
+  public static forRoot(
+    configuration?: () => Partial<LocalizationConfiguration>
+  ): ModuleWithProviders<LocalizationModule> {
+    return {
+      ngModule: LocalizationModule,
+      providers: [
+        LocalizationService,
+        ...(configuration
+          ? [{
+            provide: CUSTOM_LOCALIZATION_CONFIGURATION_TOKEN,
+            useFactory: configuration
+          }]
+          : [])
+      ]
+    };
+  }
+}

--- a/packages/@o3r/transloco/src/tools/localization-provider.ts
+++ b/packages/@o3r/transloco/src/tools/localization-provider.ts
@@ -1,0 +1,54 @@
+import {
+  FactoryProvider,
+  Injector,
+  Optional,
+} from '@angular/core';
+import {
+  TRANSLOCO_LOADER,
+} from '@jsverse/transloco';
+import {
+  DynamicContentService,
+} from '@o3r/dynamic-content';
+import {
+  LoggerService,
+} from '@o3r/logger';
+import {
+  LocalizationConfiguration,
+} from '../core';
+import {
+  LOCALIZATION_CONFIGURATION_TOKEN,
+} from './localization-token';
+import {
+  TranslationsLoader,
+} from './translations-loader';
+
+/**
+ * Creates a loader of translations bundles based on the configuration
+ * (endPointUrl and language determine which bundle we load and where do we fetch it from)
+ * @param localizationConfiguration
+ * @param logger service to handle the log of warning and errors
+ * @param dynamicContentService (optional)
+ */
+export function createTranslateLoader(localizationConfiguration: LocalizationConfiguration, logger?: LoggerService, dynamicContentService?: DynamicContentService) {
+  const injector = Injector.create({
+    providers: [
+      { provide: LOCALIZATION_CONFIGURATION_TOKEN, useValue: localizationConfiguration },
+      { provide: LoggerService, useValue: logger },
+      { provide: DynamicContentService, useValue: dynamicContentService },
+      {
+        provide: TranslationsLoader,
+        deps: [[LoggerService, new Optional()], [DynamicContentService, new Optional()], LOCALIZATION_CONFIGURATION_TOKEN]
+      }
+    ]
+  });
+  return injector.get(TranslationsLoader);
+}
+
+/**
+ * TranslocoLoader provider, using framework's TranslationsLoader class
+ */
+export const translateLoaderProvider: Readonly<FactoryProvider> = {
+  provide: TRANSLOCO_LOADER,
+  useFactory: createTranslateLoader,
+  deps: [LOCALIZATION_CONFIGURATION_TOKEN, [new Optional(), LoggerService], [new Optional(), DynamicContentService]]
+} as const;

--- a/packages/@o3r/transloco/src/tools/localization-service.spec.ts
+++ b/packages/@o3r/transloco/src/tools/localization-service.spec.ts
@@ -1,0 +1,271 @@
+import {
+  TestBed,
+} from '@angular/core/testing';
+import {
+  provideTransloco,
+} from '@jsverse/transloco';
+import {
+  firstValueFrom,
+  of,
+} from 'rxjs';
+import {
+  DEFAULT_LOCALIZATION_CONFIGURATION,
+  LocalizationConfiguration,
+  LocalizationModule,
+  LocalizationService,
+} from '@o3r/transloco';
+
+describe('LocalizationService', () => {
+  describe('default configuration', () => {
+    const configurationFactory: () => LocalizationConfiguration = () => ({
+      ...DEFAULT_LOCALIZATION_CONFIGURATION
+    });
+
+    let localizationService: LocalizationService;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [
+          LocalizationModule.forRoot(configurationFactory)
+        ],
+        providers: [provideTransloco({ config: {} }), LocalizationService]
+      }).compileComponents();
+      localizationService = TestBed.inject(LocalizationService);
+
+      await localizationService.configure();
+    });
+
+    it('should be used for translations (en)', () => {
+      const expectedLanguage = 'en';
+
+      expect(localizationService.getCurrentLanguage()).toEqual(expectedLanguage);
+    });
+  });
+
+  describe('fallbackLocalesMap configuration unavailable', () => {
+    const configurationFactory: () => LocalizationConfiguration = () => ({
+      ...DEFAULT_LOCALIZATION_CONFIGURATION,
+      supportedLocales: ['en-GB', 'fr-FR', 'fr-CA', 'ar-AR'],
+      fallbackLanguage: 'en-GB'
+    });
+
+    let localizationService: LocalizationService;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [
+          LocalizationModule.forRoot(configurationFactory)
+        ],
+        providers: [provideTransloco({ config: {} }), LocalizationService]
+      }).compileComponents();
+      localizationService = TestBed.inject(LocalizationService);
+
+      await localizationService.configure();
+    });
+
+    it('should translate to the same language, when supported language provided', () => {
+      localizationService.useLanguage('en-GB');
+
+      expect(localizationService.getCurrentLanguage()).toEqual('en-GB');
+
+      localizationService.useLanguage('ar-AR');
+
+      expect(localizationService.getCurrentLanguage()).toEqual('ar-AR');
+
+      localizationService.useLanguage('fr-CA');
+
+      expect(localizationService.getCurrentLanguage()).toEqual('fr-CA');
+
+      localizationService.useLanguage('fr-FR');
+
+      expect(localizationService.getCurrentLanguage()).toEqual('fr-FR');
+    });
+
+    it('should translate to the nearest supported language, when un-supported language provided', () => {
+      localizationService.useLanguage('fr-BE');
+
+      expect(localizationService.getCurrentLanguage()).toEqual('fr-FR');
+
+      localizationService.useLanguage('ar-EG');
+
+      expect(localizationService.getCurrentLanguage()).toEqual('ar-AR');
+    });
+
+    it(`should translate to the default fallback language, when un-supported language provided and
+        no nearest supportedLocales language available`, () => {
+      const actualLanguage = 'de-AT';
+      const expectedLanguage = 'en-GB';
+
+      localizationService.useLanguage(actualLanguage);
+
+      expect(localizationService.getCurrentLanguage()).toEqual(expectedLanguage);
+    });
+  });
+
+  describe('language to use is specified in the configuration and supported', () => {
+    const configurationFactory: () => LocalizationConfiguration = () => ({
+      ...DEFAULT_LOCALIZATION_CONFIGURATION,
+      supportedLocales: ['en-GB', 'fr-FR', 'fr-CA', 'ar-AR'],
+      fallbackLanguage: 'en-GB',
+      language: 'fr-FR'
+    });
+
+    let translateServiceSpy: jest.SpyInstance;
+    let localizationService: LocalizationService;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [
+          LocalizationModule.forRoot(configurationFactory)
+        ],
+        providers: [provideTransloco({ config: {} }), LocalizationService]
+      }).compileComponents();
+      localizationService = TestBed.inject(LocalizationService);
+      const translateService = localizationService.getTranslateService();
+      translateServiceSpy = jest.spyOn(translateService, 'setDefaultLang');
+      await localizationService.configure();
+    });
+
+    it('should translate to the language provided in the configuration, when a supported language is provided', () => {
+      expect(translateServiceSpy).toHaveBeenCalledWith('fr-FR');
+      expect(localizationService.getCurrentLanguage()).toEqual('fr-FR');
+    });
+  });
+
+  describe('language to use is specified in the configuration and not supported', () => {
+    const configurationFactory: () => LocalizationConfiguration = () => ({
+      ...DEFAULT_LOCALIZATION_CONFIGURATION,
+      supportedLocales: ['en-GB', 'fr-FR', 'fr-CA', 'ar-AR'],
+      fallbackLanguage: 'en-GB',
+      language: 'es-ES'
+    });
+
+    let translateServiceSpy: jest.SpyInstance;
+    let localizationService: LocalizationService;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [
+          LocalizationModule.forRoot(configurationFactory)
+        ],
+        providers: [provideTransloco({ config: {} }), LocalizationService]
+      }).compileComponents();
+      localizationService = TestBed.inject(LocalizationService);
+      const translateService = localizationService.getTranslateService();
+      translateServiceSpy = jest.spyOn(translateService, 'setDefaultLang');
+      await localizationService.configure();
+    });
+
+    it('should translate to the fallback language provided in the configuration, when a non supported language is provided', () => {
+      expect(translateServiceSpy).toHaveBeenCalledWith('en-GB');
+      expect(localizationService.getCurrentLanguage()).toEqual('en-GB');
+    });
+  });
+
+  describe('fallbackLocalesMap configuration available', () => {
+    const configurationFactory: () => LocalizationConfiguration = () => ({
+      ...DEFAULT_LOCALIZATION_CONFIGURATION,
+      supportedLocales: ['en-GB', 'en-US', 'fr-FR', 'ar-AR'],
+      fallbackLocalesMap: {
+        'en-CA': 'en-US',
+        'fr-CA': 'fr-FR',
+        'de-CH': 'ar-AR',
+        de: 'fr-FR',
+        it: 'fr-FR',
+        hi: 'en-GB',
+        zh: 'en-GB'
+      },
+      fallbackLanguage: 'fr-FR'
+    });
+
+    let localizationService: LocalizationService;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [
+          LocalizationModule.forRoot(configurationFactory)
+        ],
+        providers: [provideTransloco({ config: {} }), LocalizationService]
+      }).compileComponents();
+      localizationService = TestBed.inject(LocalizationService);
+
+      await localizationService.configure();
+    });
+
+    it('should translate to the same language, when supported language provided', () => {
+      localizationService.useLanguage('en-GB');
+
+      expect(localizationService.getCurrentLanguage()).toEqual('en-GB');
+
+      localizationService.useLanguage('ar-AR');
+
+      expect(localizationService.getCurrentLanguage()).toEqual('ar-AR');
+    });
+
+    it('should translate to the fallback locale map language, when un-supported language provided', () => {
+      localizationService.useLanguage('en-CA');
+
+      expect(localizationService.getCurrentLanguage()).toEqual('en-US');
+
+      localizationService.useLanguage('fr-CA');
+
+      expect(localizationService.getCurrentLanguage()).toEqual('fr-FR');
+
+      localizationService.useLanguage('de-CH');
+
+      expect(localizationService.getCurrentLanguage()).toEqual('ar-AR');
+
+      localizationService.useLanguage('de-DE');
+
+      expect(localizationService.getCurrentLanguage()).toEqual('fr-FR');
+
+      localizationService.useLanguage('de-AT');
+
+      expect(localizationService.getCurrentLanguage()).toEqual('fr-FR');
+
+      localizationService.useLanguage('it-IT');
+
+      expect(localizationService.getCurrentLanguage()).toEqual('fr-FR');
+
+      localizationService.useLanguage('zh-TW');
+
+      expect(localizationService.getCurrentLanguage()).toEqual('en-GB');
+
+      localizationService.useLanguage('zh-CN');
+
+      expect(localizationService.getCurrentLanguage()).toEqual('en-GB');
+    });
+
+    it(`should translate to the nearest supported language, when un-supported language provided,
+        fallback locale map doesn't have the mapped language`, () => {
+      const actualLanguage = 'en-AU';
+      const expectedLanguage = 'en-GB';
+
+      localizationService.useLanguage(actualLanguage);
+
+      expect(localizationService.getCurrentLanguage()).toEqual(expectedLanguage);
+    });
+
+    it(`should fallback to the default language, when un-supported language provided,
+        no nearest supportedLocales, fallbackLocalesMap language available`, () => {
+      const actualLanguage = 'bn-BD';
+      const expectedLanguage = 'fr-FR';
+
+      localizationService.useLanguage(actualLanguage);
+
+      expect(localizationService.getCurrentLanguage()).toEqual(expectedLanguage);
+    });
+
+    it('should return the translated value for a given key', async () => {
+      const key = 'HELLO';
+      const value = 'Hello world';
+
+      const translateService = localizationService.getTranslateService();
+      const selectTranslateSpy = jest.spyOn(translateService, 'selectTranslate').mockReturnValue(of(value));
+
+      const result = await firstValueFrom(localizationService.translate(key));
+      expect(selectTranslateSpy).toHaveBeenCalledWith(key, undefined);
+      expect(result).toBe(value);
+    });
+  });
+});

--- a/packages/@o3r/transloco/src/tools/localization-service.ts
+++ b/packages/@o3r/transloco/src/tools/localization-service.ts
@@ -1,0 +1,257 @@
+import {
+  inject,
+  Injectable,
+  signal,
+} from '@angular/core';
+import {
+  toObservable,
+} from '@angular/core/rxjs-interop';
+import {
+  TranslocoService,
+} from '@jsverse/transloco';
+import {
+  select,
+  Store,
+} from '@ngrx/store';
+import {
+  LoggerService,
+} from '@o3r/logger';
+import {
+  combineLatest,
+  distinctUntilChanged,
+  firstValueFrom,
+  map,
+  Observable,
+  of,
+  shareReplay,
+  startWith,
+  switchMap,
+} from 'rxjs';
+import {
+  LocalizationConfiguration,
+} from '../core/localization-configuration';
+import {
+  LocalizationOverrideStore,
+  selectLocalizationOverride,
+} from '../stores/index';
+import {
+  getDebugKey,
+} from './localization-helpers';
+import {
+  LOCALIZATION_CONFIGURATION_TOKEN,
+} from './localization-token';
+
+/**
+ * Service which is wrapping the configuration logic of TranslocoService from JSVerse Transloco.
+ * Any application willing to use localization just needs to inject LocalizationService
+ * in the root component and call its configure() method.
+ */
+@Injectable()
+export class LocalizationService {
+  private readonly translateService = inject(TranslocoService);
+  private readonly logger = inject(LoggerService, { optional: true });
+  private readonly configuration = inject<LocalizationConfiguration>(LOCALIZATION_CONFIGURATION_TOKEN);
+  private readonly store = inject<Store<LocalizationOverrideStore>>(Store, { optional: true });
+
+  private readonly localeSplitIdentifier = '-';
+
+  /**
+   * Internal signal that we use to track changes between keys only and translation mode
+   */
+  private readonly _showKeys = signal(false);
+
+  /**
+   * Map of localization keys to replace a key to another
+   */
+  private readonly keyMapping$?: Observable<Record<string, any>>;
+
+  /**
+   * _showKeys exposed as an Observable
+   */
+  public readonly showKeys$ = toObservable(this._showKeys);
+
+  /**
+   * Return the current value of debug show/hide translation keys.
+   */
+  public readonly showKeys = this._showKeys.asReadonly();
+
+  constructor() {
+    this.configure().catch((err) => {
+      this.logger?.error(`Failed to configure LocalizationService: ${err}`);
+    });
+    if (this.store) {
+      this.keyMapping$ = this.store.pipe(
+        select(selectLocalizationOverride)
+      );
+    } else {
+      this.logger?.debug('Store not available: localization key overrides via rules engine will not be active.');
+    }
+  }
+
+  /**
+   * This will handle the fallback language hierarchy to find out fallback language.
+   * supportedLocales language has highest priority, next priority goes to fallbackLocalesMap and default would be
+   * fallbackLanguage.
+   * @param language Selected language.
+   * @returns selected language if supported, fallback language otherwise.
+   */
+  private checkFallbackLocalesMap<T extends string | undefined>(language: T) {
+    if (language && !this.configuration.supportedLocales.includes(language)) {
+      const closestSupportedLanguageCode = this.getFirstClosestSupportedLanguageCode(language);
+      const fallbackForLanguage = this.getFallbackMapLangCode(language);
+      const fallbackStrategyDebug = (fallbackForLanguage && ' associated fallback language ')
+        || (closestSupportedLanguageCode && ' closest supported language ')
+        || (this.configuration.fallbackLanguage && ' configured default language ');
+      const fallbackLang = fallbackForLanguage || closestSupportedLanguageCode || this.configuration.fallbackLanguage || language;
+      if (language !== fallbackLang) {
+        this.logger?.debug(`Non supported languages ${language} will fallback to ${fallbackStrategyDebug} ${fallbackLang}`);
+      }
+      return fallbackLang;
+    } else if (!language) {
+      this.logger?.debug('Language is not defined');
+    }
+    return language;
+  }
+
+  /**
+   * This function checks if fallback language can be provided from fallbackLocalesMap.
+   * supportedLocales: ['en-GB', 'en-US', 'fr-FR'], fallbackLocalesMap: {'en-CA': 'en-US', 'de': 'fr-FR'}
+   * translate to en-CA -> fallback to en-US, translate to de-DE -> fallback to fr-FR
+   * translate to en-NZ -> fallback to en-GB
+   * @param language Selected language.
+   * @returns Fallback language if available, undefined otherwise.
+   */
+  private getFallbackMapLangCode(language: string): string | undefined {
+    const fallbackLocalesMap = this.configuration.fallbackLocalesMap;
+    const [locale] = language.split(this.localeSplitIdentifier);
+
+    return fallbackLocalesMap && (fallbackLocalesMap[language] || fallbackLocalesMap[locale]);
+  }
+
+  /**
+   * This function checks if closest supported language available incase of selected language is not
+   * supported language.
+   * supportedLocales: ['en-GB', 'en-US', 'fr-FR']
+   * translate to en-CA -> fallback to en-GB
+   * @param language Selected language.
+   * @returns Closest supported language if available, undefined otherwise.
+   */
+  private getFirstClosestSupportedLanguageCode(language: string): string | undefined {
+    const [locale] = language.split(this.localeSplitIdentifier);
+    const firstClosestRegx = new RegExp(`^${locale}${this.localeSplitIdentifier}?`, 'i');
+
+    return this.configuration.supportedLocales.find((supportedLang) => firstClosestRegx.test(supportedLang));
+  }
+
+  /**
+   * Returns a stream of translated values of a key which updates whenever the language changes.
+   * @param translationKey Key to translate
+   * @param interpolateParams Object to use in translation binding
+   * @returns A stream of the translated key
+   */
+  private getTranslationStream(translationKey: string, interpolateParams?: object) {
+    const translation$ = this.translateService.events$.pipe(
+      startWith(undefined),
+      switchMap(() => this.translateService.selectTranslate(translationKey, interpolateParams)),
+      map((value) => this.configuration.debugMode ? getDebugKey(translationKey, value) : value),
+      distinctUntilChanged()
+    );
+
+    if (!this.configuration.enableTranslationDeactivation) {
+      return translation$;
+    }
+
+    return combineLatest([
+      translation$,
+      this.showKeys$
+    ]).pipe(
+      map(([value, showKeys]) => showKeys ? translationKey : value)
+    );
+  }
+
+  /**
+   * Configures TranslocoService and registers locales. This method is called from the application level.
+   */
+  public async configure() {
+    const language = this.checkFallbackLocalesMap(this.configuration.language || this.configuration.fallbackLanguage);
+    this.translateService.setAvailableLangs(this.configuration.supportedLocales);
+    this.translateService.setDefaultLang(language);
+    await firstValueFrom(this.useLanguage(language));
+  }
+
+  /**
+   * Is the translation deactivation enabled
+   */
+  public isTranslationDeactivationEnabled() {
+    return this.configuration.enableTranslationDeactivation;
+  }
+
+  /**
+   * Wrapper to call the TranslocoService method getAvailableLangs().
+   */
+  public getLanguages() {
+    return this.translateService.getAvailableLangs().map((l) => (typeof l === 'string' ? l : l.id));
+  }
+
+  /**
+   * Wrapper to call the TranslocoService method setActiveLang(language).
+   * @param language
+   */
+  public useLanguage(language: string): Observable<any> {
+    language = this.checkFallbackLocalesMap(language);
+    this.translateService.setActiveLang(language);
+    return this.translateService.load(language);
+  }
+
+  /**
+   * Wrapper to get the TranslocoService getActiveLang.
+   */
+  public getCurrentLanguage() {
+    return this.translateService.getActiveLang();
+  }
+
+  /**
+   * Get the instance of the TranslocoService used by LocalizationService.
+   */
+  public getTranslateService() {
+    return this.translateService;
+  }
+
+  /**
+   * Toggle the ShowKeys mode between active and inactive.
+   * @param value if specified, set the ShowKeys mode to value. If not specified, toggle the ShowKeys mode.
+   */
+  public toggleShowKeys(value?: boolean) {
+    if (!this.configuration.enableTranslationDeactivation) {
+      throw new Error('Translation deactivation is not enabled. Please set the LocalizationConfiguration property "enableTranslationDeactivation" accordingly.');
+    }
+    const newValue = value === undefined ? !this.showKeys() : value;
+    this._showKeys.set(newValue);
+  }
+
+  /**
+   * Get an observable of translation key after global mapping
+   * @param requestedKey Original translation key
+   */
+  public getKey(requestedKey: string) {
+    return this.keyMapping$
+      ? this.keyMapping$.pipe(
+        map((keyMapping) => keyMapping[requestedKey] || requestedKey),
+        distinctUntilChanged()
+      )
+      : of(requestedKey);
+  }
+
+  /**
+   * Returns a stream of translated values of a key which updates whenever the language changes.
+   * @param key Key to translate
+   * @param interpolateParams Object to use in translation binding
+   * @returns A stream of the translated key
+   */
+  public translate(key: string, interpolateParams?: object) {
+    return this.getKey(key).pipe(
+      switchMap((translationKey) => this.getTranslationStream(translationKey, interpolateParams)),
+      shareReplay({ refCount: true, bufferSize: 1 })
+    );
+  }
+}

--- a/packages/@o3r/transloco/src/tools/localization-token.ts
+++ b/packages/@o3r/transloco/src/tools/localization-token.ts
@@ -1,0 +1,9 @@
+import {
+  InjectionToken,
+} from '@angular/core';
+import {
+  LocalizationConfiguration,
+} from '../core';
+
+/** Localization Configuration Token */
+export const LOCALIZATION_CONFIGURATION_TOKEN = new InjectionToken<LocalizationConfiguration>('Localization Configuration injection token');

--- a/packages/@o3r/transloco/src/tools/localization-translate-directive.ts
+++ b/packages/@o3r/transloco/src/tools/localization-translate-directive.ts
@@ -1,0 +1,151 @@
+import {
+  ChangeDetectorRef,
+  DestroyRef,
+  Directive,
+  ElementRef,
+  inject,
+  Input,
+  OnChanges,
+  OnInit,
+  Renderer2,
+  SimpleChange,
+  SimpleChanges,
+  TemplateRef,
+} from '@angular/core';
+import {
+  takeUntilDestroyed,
+} from '@angular/core/rxjs-interop';
+import {
+  TranslocoDirective,
+} from '@jsverse/transloco';
+import {
+  Subscription,
+} from 'rxjs';
+import {
+  LocalizationConfiguration,
+} from '../core';
+import {
+  getDebugKey,
+} from './localization-helpers';
+import {
+  LocalizationService,
+} from './localization-service';
+import {
+  LOCALIZATION_CONFIGURATION_TOKEN,
+} from './localization-token';
+
+/**
+ * TranslocoDirective class adding debug functionality.
+ *
+ * Extends the TranslocoDirective from Transloco to add:
+ * - Key mapping via LocalizationService (override store)
+ * - Show keys mode (display raw keys instead of translations)
+ * - Debug mode (display key alongside translation)
+ *
+ * For the structural strategy (`*transloco`), the debug/showKeys behavior is handled
+ * by overriding `getTranslateFn`.
+ *
+ * For the attribute strategy (`[transloco]="key"`), the parent's private `attributeStrategy()`
+ * sets `innerText` directly. Since we cannot override this private method, we apply
+ * debug/showKeys transformations by overwriting `innerText` immediately after calling
+ * `super.ngOnInit()` and `super.ngOnChanges()`, in the same call stack.
+ */
+@Directive({
+  selector: '[transloco]',
+  standalone: false
+})
+export class LocalizationTranslateDirective extends TranslocoDirective implements OnInit, OnChanges {
+  private readonly localizationService = inject(LocalizationService);
+  private readonly localizationConfig = inject<LocalizationConfiguration>(LOCALIZATION_CONFIGURATION_TOKEN);
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+  private readonly hostElement = inject(ElementRef);
+  private readonly hostRenderer = inject(Renderer2);
+  private readonly isAttributeStrategy = inject(TemplateRef, { optional: true }) === null;
+  private readonly o3rDestroyRef = inject(DestroyRef);
+
+  /**
+   * Should we display keys instead of translations
+   */
+  private showKeys = false;
+
+  /**
+   * Internal subscription to the LocalizationService key mapping
+   */
+  private onKeyChange?: Subscription;
+
+  /** @inheritdoc */
+  @Input()
+  public set transloco(key: string) {
+    if (key && key !== this.key) {
+      this.onKeyChange?.unsubscribe();
+      this.onKeyChange = this.localizationService.getKey(key)
+        .pipe(takeUntilDestroyed(this.o3rDestroyRef))
+        .subscribe((newKey) => {
+          const previousKey = this.key;
+          this.key = newKey;
+          this.changeDetectorRef.markForCheck();
+          super.ngOnChanges({ transloco: new SimpleChange(previousKey, newKey, !previousKey) });
+        });
+    }
+  }
+
+  constructor() {
+    super();
+    if (this.localizationConfig.enableTranslationDeactivation) {
+      this.localizationService.showKeys$.pipe(takeUntilDestroyed(this.o3rDestroyRef)).subscribe((showKeys) => {
+        this.showKeys = showKeys;
+        this.changeDetectorRef.markForCheck();
+      });
+    }
+  }
+
+  /**
+   * For the attribute strategy, overwrites `innerText` with the debug/showKeys value
+   * immediately after the parent has set it.
+   */
+  private applyAttributeDebug() {
+    if (!this.isAttributeStrategy || !this.key) {
+      return;
+    }
+    if (this.showKeys) {
+      this.hostRenderer.setProperty(this.hostElement.nativeElement, 'innerText', this.key);
+    } else if (this.localizationConfig.debugMode) {
+      this.hostRenderer.setProperty(
+        this.hostElement.nativeElement,
+        'innerText',
+        getDebugKey(this.key, this.hostElement.nativeElement.innerText as string)
+      );
+    }
+  }
+
+  /**
+   * Override getTranslateFn to plug debug/showKeys for the structural strategy.
+   * @param lang Current language
+   * @param prefix Scope prefix
+   */
+  protected override getTranslateFn(lang: string, prefix: string | undefined): (key: string, params?: Record<string, unknown>) => any {
+    const parentTranslateFn = super.getTranslateFn(lang, prefix);
+    return (key: string, params?: Record<string, unknown>) => {
+      if (this.showKeys) {
+        return key;
+      }
+      const value = parentTranslateFn(key, params);
+      if (this.localizationConfig.debugMode) {
+        return getDebugKey(key, value as string);
+      }
+      return value;
+    };
+  }
+
+  /** @inheritdoc */
+  public override ngOnInit() {
+    super.ngOnInit();
+    this.applyAttributeDebug();
+  }
+
+  /** @inheritdoc */
+  public override ngOnChanges(changes: SimpleChanges) {
+    super.ngOnChanges(changes);
+    this.applyAttributeDebug();
+  }
+}

--- a/packages/@o3r/transloco/src/tools/localization-translate-pipe.spec.ts
+++ b/packages/@o3r/transloco/src/tools/localization-translate-pipe.spec.ts
@@ -1,0 +1,155 @@
+import {
+  ChangeDetectorRef,
+} from '@angular/core';
+import {
+  TestBed,
+} from '@angular/core/testing';
+import {
+  provideTransloco,
+  Translation,
+  TRANSLOCO_LOADER,
+  TranslocoLoader,
+  TranslocoService,
+} from '@jsverse/transloco';
+import {
+  firstValueFrom,
+  Observable,
+  of,
+} from 'rxjs';
+import {
+  ChangeDetectorRefFixture,
+} from '../../testing/change-detector-ref-fixture';
+import {
+  createLocalizationConfiguration,
+  LOCALIZATION_CONFIGURATION_TOKEN,
+  LocalizationModule,
+  LocalizationService,
+  O3rLocalizationTranslatePipe,
+} from '@o3r/transloco';
+
+const translations: Record<string, Translation> = {
+  en: {
+    test: 'This is a test',
+    testParams: 'This is a test {{param1}} {{param2}}'
+  }
+};
+
+class FakeLoader implements TranslocoLoader {
+  public getTranslation(lang: string): Observable<Translation> {
+    return of(translations[lang] || {});
+  }
+}
+
+describe('LocalizationTranslatePipe', () => {
+  let localizationService: LocalizationService;
+  let pipe: O3rLocalizationTranslatePipe;
+
+  describe('enableTranslationDeactivation OFF', () => {
+    it('should throw when trying to deactivate the translation', async () => {
+      await TestBed.configureTestingModule({
+        imports: [
+          LocalizationModule.forRoot(() => ({ language: 'en', supportedLocales: ['en'] }))
+        ],
+        providers: [
+          provideTransloco({ config: {} }),
+          LocalizationService,
+          { provide: TRANSLOCO_LOADER, useClass: FakeLoader },
+          { provide: ChangeDetectorRef, useClass: ChangeDetectorRefFixture },
+          { provide: O3rLocalizationTranslatePipe, deps: [LocalizationService, TranslocoService, ChangeDetectorRef, LOCALIZATION_CONFIGURATION_TOKEN] }
+        ]
+      }).compileComponents();
+
+      localizationService = TestBed.inject(LocalizationService);
+      // initialize TranslocoService via configure of LocalizationService
+      await localizationService.configure();
+      pipe = TestBed.inject(O3rLocalizationTranslatePipe);
+
+      expect(() => localizationService.toggleShowKeys()).toThrow();
+    });
+  });
+
+  describe('enableTranslationDeactivation ON', () => {
+    describe('debug mode OFF', () => {
+      beforeEach(async () => {
+        await TestBed.configureTestingModule({
+          imports: [
+            LocalizationModule.forRoot(() => ({ language: 'en', supportedLocales: ['en'] }))
+          ],
+          providers: [
+            provideTransloco({ config: { defaultLang: 'en', prodMode: true } }),
+            LocalizationService,
+            { provide: TRANSLOCO_LOADER, useClass: FakeLoader },
+            {
+              provide: LOCALIZATION_CONFIGURATION_TOKEN,
+              useFactory: () => createLocalizationConfiguration({ supportedLocales: ['en'], enableTranslationDeactivation: true })
+            },
+            { provide: ChangeDetectorRef, useClass: ChangeDetectorRefFixture },
+            { provide: O3rLocalizationTranslatePipe, deps: [LocalizationService, TranslocoService, ChangeDetectorRef, LOCALIZATION_CONFIGURATION_TOKEN] }
+          ]
+        }).compileComponents();
+
+        localizationService = TestBed.inject(LocalizationService);
+        // initialize TranslocoService via configure of LocalizationService
+        await localizationService.configure();
+        // Load translations via loader so they are cached for _loadDependencies
+        const translateService = TestBed.inject(TranslocoService);
+        await firstValueFrom(translateService.load('en'));
+        pipe = TestBed.inject(O3rLocalizationTranslatePipe);
+      });
+
+      it('Should not translate if ShowKeys is activated', () => {
+        localizationService.toggleShowKeys();
+
+        expect(pipe.transform('test')).toEqual('test');
+        expect(pipe.transform('testParams', { param1: 'with param-1', param2: 'and param-2' })).toEqual('testParams');
+      });
+
+      it('Should translate if ShowKeys is not activated', () => {
+        expect(pipe.transform('test')).toEqual('This is a test');
+
+        expect(pipe.transform('testParams', { param1: 'with param-1', param2: 'and param-2' })).toEqual('This is a test with param-1 and param-2');
+      });
+    });
+
+    describe('debug mode ON', () => {
+      beforeEach(async () => {
+        await TestBed.configureTestingModule({
+          imports: [
+            LocalizationModule.forRoot(() => ({ language: 'en', supportedLocales: ['en'] }))
+          ],
+          providers: [
+            provideTransloco({ config: { defaultLang: 'en', prodMode: true } }),
+            LocalizationService,
+            { provide: TRANSLOCO_LOADER, useClass: FakeLoader },
+            {
+              provide: LOCALIZATION_CONFIGURATION_TOKEN,
+              useFactory: () => createLocalizationConfiguration({ supportedLocales: ['en'], debugMode: true, enableTranslationDeactivation: true })
+            },
+            { provide: ChangeDetectorRef, useClass: ChangeDetectorRefFixture },
+            { provide: O3rLocalizationTranslatePipe, deps: [LocalizationService, TranslocoService, ChangeDetectorRef, LOCALIZATION_CONFIGURATION_TOKEN] }
+          ]
+        }).compileComponents();
+        localizationService = TestBed.inject(LocalizationService);
+        // initialize TranslocoService via configure of LocalizationService
+        await localizationService.configure();
+        // Load translations via loader so they are cached for _loadDependencies
+        const translateService = TestBed.inject(TranslocoService);
+        await firstValueFrom(translateService.load('en'));
+        pipe = TestBed.inject(O3rLocalizationTranslatePipe);
+      });
+
+      it('Should not translate if ShowKeys is activated', () => {
+        localizationService.toggleShowKeys();
+
+        expect(pipe.transform('test')).toEqual('test');
+        expect(pipe.transform('testParams', { param1: 'with param-1', param2: 'and param-2' })).toEqual('testParams');
+      });
+
+      it('Should display both key and value if ShowKeys is not activated', () => {
+        expect(pipe.transform('test')).toEqual('test - This is a test');
+
+        expect(pipe.transform('testParams', { param1: 'with param-1', param2: 'and param-2' })).toEqual('testParams - This is a test with param-1 and param-2');
+      });
+    });
+  });
+});

--- a/packages/@o3r/transloco/src/tools/localization-translate-pipe.ts
+++ b/packages/@o3r/transloco/src/tools/localization-translate-pipe.ts
@@ -1,0 +1,112 @@
+import {
+  ChangeDetectorRef,
+  DestroyRef,
+  inject,
+  Pipe,
+  PipeTransform,
+} from '@angular/core';
+import {
+  takeUntilDestroyed,
+} from '@angular/core/rxjs-interop';
+import {
+  TRANSLOCO_LANG,
+  TRANSLOCO_SCOPE,
+  TranslocoPipe,
+  TranslocoService,
+} from '@jsverse/transloco';
+import {
+  Subscription,
+} from 'rxjs';
+import {
+  LocalizationConfiguration,
+} from '../core';
+import {
+  getDebugKey,
+} from './localization-helpers';
+import {
+  LocalizationService,
+} from './localization-service';
+import {
+  LOCALIZATION_CONFIGURATION_TOKEN,
+} from './localization-token';
+
+/**
+ * TranslocoPipe class adding debug functionality
+ */
+@Pipe({
+  name: 'o3rTranslate',
+  pure: false,
+  standalone: false
+})
+export class O3rLocalizationTranslatePipe extends TranslocoPipe implements PipeTransform {
+  /** Localization service instance */
+  protected readonly localizationService = inject(LocalizationService);
+  /** Change detector service instance */
+  protected readonly changeDetector = inject(ChangeDetectorRef);
+  /** Localization config token */
+  protected readonly localizationConfig: LocalizationConfiguration = inject(LOCALIZATION_CONFIGURATION_TOKEN);
+  /** Destroy reference */
+  protected readonly destroyRef = inject(DestroyRef);
+
+  /**
+   * Internal subscription to the LocalizationService key mapping
+   */
+  protected onKeyChange?: Subscription;
+
+  /**
+   * Should we display keys instead of translations
+   */
+  protected showKeys = false;
+
+  /** last key queried */
+  protected lastQueryKey?: string;
+
+  /** last key resolved */
+  protected lastResolvedKey?: string;
+
+  constructor() {
+    super(
+      inject(TranslocoService),
+      inject(TRANSLOCO_SCOPE, { optional: true }) ?? undefined,
+      inject(TRANSLOCO_LANG, { optional: true }) ?? undefined,
+      inject(ChangeDetectorRef)
+    );
+    if (this.localizationConfig.enableTranslationDeactivation) {
+      this.localizationService.showKeys$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((showKeys) => {
+        this.showKeys = showKeys;
+        this.changeDetector.markForCheck();
+      });
+    }
+  }
+
+  /**
+   * Calls original transform method and eventually outputs the key if debugMode (in LocalizationConfiguration) is enabled
+   * @inheritdoc
+   */
+  public transform(query: string, ...args: any[]): any {
+    if (!query || this.localizationService.showKeys()) {
+      return query;
+    }
+
+    if (query !== this.lastQueryKey) {
+      this.lastQueryKey = query;
+      if (this.onKeyChange) {
+        this.onKeyChange.unsubscribe();
+      }
+      this.onKeyChange = this.localizationService.getKey(query)
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((key) => {
+          this.lastResolvedKey = key;
+          this.changeDetector.markForCheck();
+        });
+    }
+
+    const value = super.transform(this.lastResolvedKey, ...args);
+
+    if (this.localizationConfig.debugMode) {
+      return getDebugKey(this.lastResolvedKey!, value);
+    }
+
+    return value;
+  }
+}

--- a/packages/@o3r/transloco/src/tools/localized-currency-pipe.spec.ts
+++ b/packages/@o3r/transloco/src/tools/localized-currency-pipe.spec.ts
@@ -1,0 +1,54 @@
+import {
+  ChangeDetectorRef,
+  signal,
+} from '@angular/core';
+import {
+  TestBed,
+} from '@angular/core/testing';
+import {
+  BehaviorSubject,
+} from 'rxjs';
+import {
+  ChangeDetectorRefFixture,
+} from '../../testing/change-detector-ref-fixture';
+import {
+  LocalizationService,
+  LocalizedCurrencyPipe,
+} from '@o3r/transloco';
+
+describe('LocalizedCurrencyPipe', () => {
+  let localizedCurrencyPipe: LocalizedCurrencyPipe;
+  let changeDetectorRef: ChangeDetectorRef;
+  const currentLanguage = new BehaviorSubject('fr');
+  const showKeysSignal = signal(false);
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        LocalizedCurrencyPipe,
+        { provide: ChangeDetectorRef, useClass: ChangeDetectorRefFixture },
+        {
+          provide: LocalizationService,
+          useValue: {
+            getCurrentLanguage: () => currentLanguage.getValue(),
+            getTranslateService: () => ({
+              langChanges$: currentLanguage
+            }),
+            showKeys: showKeysSignal.asReadonly()
+          }
+        }
+      ]
+    });
+    localizedCurrencyPipe = TestBed.inject(LocalizedCurrencyPipe);
+    changeDetectorRef = TestBed.inject(ChangeDetectorRef);
+  });
+
+  it('should create an instance', () => {
+    expect(localizedCurrencyPipe).toBeTruthy();
+  });
+
+  it('should mark for check when the language changes', () => {
+    currentLanguage.next('en');
+    expect(changeDetectorRef.markForCheck).toHaveBeenCalled();
+  });
+});

--- a/packages/@o3r/transloco/src/tools/localized-currency-pipe.ts
+++ b/packages/@o3r/transloco/src/tools/localized-currency-pipe.ts
@@ -1,0 +1,50 @@
+import {
+  CurrencyPipe,
+} from '@angular/common';
+import {
+  ChangeDetectorRef,
+  inject,
+  Pipe,
+  PipeTransform,
+} from '@angular/core';
+import {
+  takeUntilDestroyed,
+} from '@angular/core/rxjs-interop';
+import {
+  LocalizationService,
+} from './localization-service';
+
+/**
+ * Native angular CurrencyPipe taking the current lang into consideration
+ */
+@Pipe({
+  name: 'currency',
+  pure: false,
+  standalone: false
+})
+export class LocalizedCurrencyPipe extends CurrencyPipe implements PipeTransform {
+  private readonly localizationService = inject(LocalizationService);
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+
+  constructor() {
+    super(inject(LocalizationService).getCurrentLanguage());
+    this.localizationService.getTranslateService().langChanges$
+      .pipe(takeUntilDestroyed())
+      .subscribe(() =>
+        this.changeDetectorRef.markForCheck()
+      );
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public transform(value: number | string, currencyCode?: string, display?: string | boolean, digitsInfo?: string, locale?: string): string | null;
+  public transform(value: null | undefined, currencyCode?: string, display?: string | boolean, digitsInfo?: string, locale?: string): null;
+  public transform(
+    // eslint-disable-next-line @typescript-eslint/unified-signatures -- Expose same signatures as angular CurrencyPipe
+    value: number | string | null | undefined, currencyCode?: string, display?: string | boolean, digitsInfo?: string, locale?: string): string | null;
+  public transform(
+    value: number | string | null | undefined, currencyCode?: string, display?: string | boolean, digitsInfo?: string, locale?: string): string | null {
+    return this.localizationService.showKeys() ? '' : super.transform(value, currencyCode, display, digitsInfo, locale || this.localizationService.getCurrentLanguage());
+  }
+}

--- a/packages/@o3r/transloco/src/tools/localized-date-pipe.spec.ts
+++ b/packages/@o3r/transloco/src/tools/localized-date-pipe.spec.ts
@@ -1,0 +1,64 @@
+import {
+  ChangeDetectorRef,
+  signal,
+} from '@angular/core';
+import {
+  TestBed,
+} from '@angular/core/testing';
+import {
+  BehaviorSubject,
+} from 'rxjs';
+import {
+  ChangeDetectorRefFixture,
+} from '../../testing/change-detector-ref-fixture';
+import {
+  LocalizationService,
+  LocalizedDatePipe,
+} from '@o3r/transloco';
+
+const currentLanguage = new BehaviorSubject('fr');
+const showKeysSignal = signal(true);
+
+describe('LocalizedDatePipe', () => {
+  let pipe: LocalizedDatePipe;
+  let changeDetectorRef: ChangeDetectorRef;
+
+  beforeEach(() => {
+    showKeysSignal.set(true);
+    TestBed.configureTestingModule({
+      providers: [
+        LocalizedDatePipe,
+        {
+          provide: ChangeDetectorRef, useClass: ChangeDetectorRefFixture
+        },
+        {
+          provide: LocalizationService,
+          useValue: {
+            getCurrentLanguage: () => currentLanguage.getValue(),
+            getTranslateService: () => ({
+              langChanges$: currentLanguage
+            }),
+            showKeys: showKeysSignal.asReadonly()
+          }
+        }
+      ]
+    });
+    pipe = TestBed.inject(LocalizedDatePipe);
+    changeDetectorRef = TestBed.inject(ChangeDetectorRef);
+  });
+
+  it('should display the format on showKeys mode', () => {
+    expect(pipe.transform(new Date(2018, 11, 24), 'EEE, d MMM')).toBe('EEE, d MMM');
+  });
+
+  it('should format the date when showKeys is false', () => {
+    showKeysSignal.set(false);
+    currentLanguage.next('en');
+    expect(pipe.transform(new Date(2018, 11, 24), 'EEE, d MMM')).toBe('Mon, 24 Dec');
+  });
+
+  it('should mark for check when the language changes', () => {
+    currentLanguage.next('en');
+    expect(changeDetectorRef.markForCheck).toHaveBeenCalled();
+  });
+});

--- a/packages/@o3r/transloco/src/tools/localized-date-pipe.ts
+++ b/packages/@o3r/transloco/src/tools/localized-date-pipe.ts
@@ -1,0 +1,52 @@
+import {
+  DatePipe,
+} from '@angular/common';
+import {
+  ChangeDetectorRef,
+  inject,
+  Pipe,
+  PipeTransform,
+} from '@angular/core';
+import {
+  takeUntilDestroyed,
+} from '@angular/core/rxjs-interop';
+import {
+  LocalizationService,
+} from './localization-service';
+
+/**
+ * Native angular DatePipe taking the current lang into consideration
+ */
+@Pipe({
+  name: 'date',
+  pure: false,
+  standalone: false
+})
+export class LocalizedDatePipe extends DatePipe implements PipeTransform {
+  private readonly localizationService = inject(LocalizationService);
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+
+  constructor() {
+    super(inject(LocalizationService).getCurrentLanguage());
+    this.localizationService.getTranslateService().langChanges$
+      .pipe(takeUntilDestroyed())
+      .subscribe(() =>
+        this.changeDetectorRef.markForCheck()
+      );
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public transform(value: Date | string | number, format?: string, timezone?: string, locale?: string): string
+    | null;
+  public transform(value: null | undefined, format?: string, timezone?: string, locale?: string): null;
+  public transform(
+    value: Date | string | number | null | undefined, format?: string, timezone?: string,
+    locale?: string): string | null;
+  public transform(
+    value: Date | string | number | null | undefined, format = 'mediumDate', timezone?: string,
+    locale?: string): string | null {
+    return this.localizationService.showKeys() ? format : super.transform(value, format, timezone, locale || this.localizationService.getCurrentLanguage());
+  }
+}

--- a/packages/@o3r/transloco/src/tools/localized-decimal-pipe.spec.ts
+++ b/packages/@o3r/transloco/src/tools/localized-decimal-pipe.spec.ts
@@ -1,0 +1,54 @@
+import {
+  ChangeDetectorRef,
+  signal,
+} from '@angular/core';
+import {
+  TestBed,
+} from '@angular/core/testing';
+import {
+  BehaviorSubject,
+} from 'rxjs';
+import {
+  ChangeDetectorRefFixture,
+} from '../../testing/change-detector-ref-fixture';
+import {
+  LocalizationService,
+  LocalizedDecimalPipe,
+} from '@o3r/transloco';
+
+const currentLanguage = new BehaviorSubject('fr');
+const showKeysSignal = signal(false);
+
+describe('LocalizedDecimalPipe', () => {
+  let changeDetectorRef: ChangeDetectorRef;
+  let pipe: LocalizedDecimalPipe;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        LocalizedDecimalPipe,
+        { provide: ChangeDetectorRef, useClass: ChangeDetectorRefFixture },
+        {
+          provide: LocalizationService, useValue: {
+            getCurrentLanguage: () => currentLanguage.getValue(),
+            getTranslateService: () => ({
+              langChanges$: currentLanguage
+            }),
+            showKeys: showKeysSignal.asReadonly()
+          }
+        }
+      ]
+    });
+    changeDetectorRef = TestBed.inject(ChangeDetectorRef);
+    pipe = TestBed.inject(LocalizedDecimalPipe);
+  });
+
+  it('should create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should mark for check when the language changes', () => {
+    currentLanguage.next('en');
+    expect(changeDetectorRef.markForCheck).toHaveBeenCalled();
+  });
+});

--- a/packages/@o3r/transloco/src/tools/localized-decimal-pipe.ts
+++ b/packages/@o3r/transloco/src/tools/localized-decimal-pipe.ts
@@ -1,0 +1,46 @@
+import {
+  DecimalPipe,
+} from '@angular/common';
+import {
+  ChangeDetectorRef,
+  inject,
+  Pipe,
+  PipeTransform,
+} from '@angular/core';
+import {
+  takeUntilDestroyed,
+} from '@angular/core/rxjs-interop';
+import {
+  LocalizationService,
+} from './localization-service';
+
+/**
+ * Native angular DecimalPipe taking the current lang into consideration
+ */
+@Pipe({
+  name: 'number',
+  pure: false,
+  standalone: false
+})
+export class LocalizedDecimalPipe extends DecimalPipe implements PipeTransform {
+  private readonly localizationService = inject(LocalizationService);
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+
+  constructor() {
+    super(inject(LocalizationService).getCurrentLanguage());
+    this.localizationService.getTranslateService().langChanges$
+      .pipe(takeUntilDestroyed())
+      .subscribe(() =>
+        this.changeDetectorRef.markForCheck()
+      );
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public transform(value: number | string, digitsInfo?: string, locale?: string): string | null;
+  public transform(value: null | undefined, digitsInfo?: string, locale?: string): null;
+  public transform(value: number | string | null | undefined, digitsInfo?: string, locale?: string): string | null {
+    return this.localizationService.showKeys() ? '' : super.transform(value, digitsInfo, locale || this.localizationService.getCurrentLanguage());
+  }
+}

--- a/packages/@o3r/transloco/src/tools/text-direction-service.ts
+++ b/packages/@o3r/transloco/src/tools/text-direction-service.ts
@@ -1,0 +1,60 @@
+import {
+  Directionality,
+} from '@angular/cdk/bidi';
+import {
+  inject,
+  Injectable,
+  OnDestroy,
+  Renderer2,
+  RendererFactory2,
+} from '@angular/core';
+import {
+  TranslocoService,
+} from '@jsverse/transloco';
+import {
+  Subscription,
+} from 'rxjs';
+import {
+  LocalizationConfiguration,
+} from '../core';
+import {
+  LOCALIZATION_CONFIGURATION_TOKEN,
+} from './localization-token';
+
+/**
+ * Service for handling the text direction based on the LocalizationConfiguration
+ */
+@Injectable()
+export class TextDirectionService implements OnDestroy {
+  private readonly translateService = inject(TranslocoService);
+  private readonly configuration = inject<LocalizationConfiguration>(LOCALIZATION_CONFIGURATION_TOKEN);
+  private readonly rendererFactory = inject(RendererFactory2);
+  private readonly directionality = inject(Directionality);
+
+  private subscription?: Subscription;
+  private readonly renderer: Renderer2;
+
+  constructor() {
+    this.renderer = this.rendererFactory.createRenderer(null, null);
+  }
+
+  /**
+   * Updates the dir attribute on body HTML tag.
+   * @returns a subscription that updates the dir attribute
+   */
+  public onLangChangeSubscription() {
+    if (this.subscription && !this.subscription.closed) {
+      return this.subscription;
+    }
+    this.subscription = this.translateService.langChanges$.subscribe((lang: string) => {
+      const direction = this.configuration.rtlLanguages.includes(lang.split('-')[0]) ? 'rtl' : 'ltr';
+      this.renderer.setAttribute(document.body, 'dir', direction);
+      this.directionality.change.emit(direction);
+    });
+    return this.subscription;
+  }
+
+  public ngOnDestroy() {
+    this.subscription?.unsubscribe();
+  }
+}

--- a/packages/@o3r/transloco/src/tools/translations-loader.spec.ts
+++ b/packages/@o3r/transloco/src/tools/translations-loader.spec.ts
@@ -1,0 +1,417 @@
+/* eslint-disable jest/no-done-callback -- test made with observables */
+/* eslint-disable @typescript-eslint/naming-convention -- localization keys are not following the naming convention */
+import {
+  TestBed,
+} from '@angular/core/testing';
+import {
+  LOCALIZATION_CONFIGURATION_TOKEN,
+  LocalizationConfiguration,
+  TranslationsLoader,
+} from '@o3r/transloco';
+
+function mockSuccessApiResponse(body = {}) {
+  return Response.json(body, {
+    status: 200,
+    headers: { 'Content-type': 'application/json' }
+  });
+}
+
+function mockFailApiResponse(body = {}) {
+  return Response.json(body, {
+    status: 404,
+    headers: { 'Content-type': 'application/json' }
+  });
+}
+
+interface TranslationsDictionary {
+  'good.morning': string;
+  'good.evening': string;
+}
+
+const responseEN: TranslationsDictionary = {
+  'good.morning': 'Good Morning',
+  'good.evening': 'Good Evening'
+};
+
+const responseFR: TranslationsDictionary = {
+  'good.morning': 'Bonjour',
+  'good.evening': 'Bonsoir'
+};
+
+/**
+ * Resolves a relative URL against window.location.origin, matching the behavior of the URL API used in TranslationsLoader.
+ * @param url relative or absolute URL
+ */
+function resolveUrl(url: string): string {
+  return new URL(url, window.location.origin).href;
+}
+
+const configuration: LocalizationConfiguration = {
+  bundlesOutputPath: '',
+  debugMode: false,
+  enableTranslationDeactivation: false,
+  endPointUrl: '',
+  useDynamicContent: false,
+  fallbackLanguage: 'en',
+  language: 'fr',
+  rtlLanguages: ['ar'],
+  supportedLocales: [],
+  mergeWithLocalTranslations: false
+};
+
+describe('TranslationsLoader - no endPointUrl', () => {
+  describe('language !== fallback language', () => {
+    let translationsLoader: TranslationsLoader;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: LOCALIZATION_CONFIGURATION_TOKEN, useValue: configuration },
+          { provide: TranslationsLoader, deps: [LOCALIZATION_CONFIGURATION_TOKEN] }
+        ]
+      });
+      translationsLoader = TestBed.inject(TranslationsLoader);
+    });
+
+    it('OK ' + configuration.language + '.json from local', (done) => {
+      let countCall = 0;
+      const latestUrls: string[] = [];
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        countCall++;
+        latestUrls.push(url);
+        return Promise.resolve(mockSuccessApiResponse(responseFR));
+      });
+
+      jest.spyOn(translationsLoader, 'getTranslationFromLocal');
+
+      const subscription = translationsLoader.getTranslation(configuration.language).subscribe((res) => {
+        // 1 call
+        expect(countCall).toBe(1);
+        // fetch from /fr.json
+        expect(latestUrls[0]).toBe(resolveUrl('fr.json'));
+        // gets french bundle
+        expect(res).toEqual(responseFR);
+
+        subscription.unsubscribe();
+        done();
+      });
+    });
+
+    it('KO ' + configuration.language + '.json from local, fallback OK to local ' + configuration.fallbackLanguage + '.json', (done) => {
+      let countCall = 0;
+      const latestUrls: string[] = [];
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        const lang = url
+          .split('/')
+          .at(-1)
+          .split('.')[0];
+        countCall++;
+        latestUrls.push(url);
+        if (lang === configuration.language) {
+          // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- reject with a 404 response
+          return Promise.reject(mockFailApiResponse());
+        }
+        return Promise.resolve(mockSuccessApiResponse(responseEN));
+      });
+
+      jest.spyOn(translationsLoader, 'getTranslationFromLocal');
+
+      const subscription = translationsLoader.getTranslation(configuration.language).subscribe((res) => {
+        // 2 calls
+        expect(countCall).toBe(2);
+        // fetch from /fr.json
+        expect(latestUrls[0]).toBe(resolveUrl('fr.json'));
+        // fetch from /en.json
+        expect(latestUrls[1]).toBe(resolveUrl('en.json'));
+        // response is OK
+        expect(res).toBeDefined();
+        // gets english response
+        expect(res).toEqual(responseEN);
+
+        subscription.unsubscribe();
+        done();
+      });
+    });
+  });
+
+  describe('language === fallback language', () => {
+    const configuration2: LocalizationConfiguration = Object.assign({}, configuration, { fallbackLanguage: 'fr' });
+    let translationsLoader: TranslationsLoader;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: LOCALIZATION_CONFIGURATION_TOKEN, useValue: configuration2 },
+          { provide: TranslationsLoader, deps: [LOCALIZATION_CONFIGURATION_TOKEN] }
+        ]
+      });
+      translationsLoader = TestBed.inject(TranslationsLoader);
+    });
+
+    it('KO ' + configuration2.language + '.json from local, but no second call', (done) => {
+      let countCall = 0;
+      global.fetch = jest.fn().mockImplementation(() => {
+        countCall++;
+        // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- reject with a 404 response
+        return Promise.reject(mockFailApiResponse({}));
+      });
+
+      const subscription = translationsLoader.getTranslation(configuration2.language).subscribe(
+        () => {},
+        () => {},
+        () => {
+          // just one call done
+          expect(countCall).toBe(1);
+
+          subscription.unsubscribe();
+          done();
+        }
+      );
+    });
+  });
+});
+
+describe('TranslationsLoader - with endPointUrl', () => {
+  let translationsLoader: TranslationsLoader;
+  const configuration3 = Object.assign({}, configuration, { endPointUrl: 'http://myUrl/' });
+
+  describe('local translation merging', () => {
+    let translationsBundleSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      translationsBundleSpy = global.fetch = jest.fn().mockImplementation((url: string) => {
+        const isDynamicTransaltions = new RegExp(configuration3.endPointUrl, 'i').test(url);
+        return Promise.resolve(mockSuccessApiResponse(isDynamicTransaltions ? responseFR : { localOnly: 'test' }));
+      });
+    });
+
+    it('should merge local and dynamic translations', (done) => {
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: LOCALIZATION_CONFIGURATION_TOKEN, useValue: { ...configuration3, mergeWithLocalTranslations: true } },
+          { provide: TranslationsLoader, deps: [LOCALIZATION_CONFIGURATION_TOKEN] }
+        ]
+      });
+      translationsLoader = TestBed.inject(TranslationsLoader);
+      const subscription = translationsLoader.getTranslation(configuration3.language).subscribe((res) => {
+        expect(res.localOnly).toBeDefined();
+        expect(res.localOnly).toMatch(/^\[local] /);
+        expect(translationsBundleSpy).toHaveBeenCalledTimes(2);
+        subscription.unsubscribe();
+        done();
+      });
+    });
+
+    it('should get dynamic translations only', (done) => {
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: LOCALIZATION_CONFIGURATION_TOKEN, useValue: { ...configuration3, mergeWithLocalTranslations: false } },
+          { provide: TranslationsLoader, deps: [LOCALIZATION_CONFIGURATION_TOKEN] }
+        ]
+      });
+      translationsLoader = TestBed.inject(TranslationsLoader);
+      const subscription = translationsLoader.getTranslation(configuration3.language).subscribe((res) => {
+        expect(res.localOnly).not.toBeDefined();
+        expect(translationsBundleSpy).toHaveBeenCalledTimes(1);
+        subscription.unsubscribe();
+        done();
+      });
+    });
+  });
+
+  describe('language !== fallback language', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: LOCALIZATION_CONFIGURATION_TOKEN, useValue: configuration3 },
+          { provide: TranslationsLoader, deps: [LOCALIZATION_CONFIGURATION_TOKEN] }
+        ]
+      });
+      translationsLoader = TestBed.inject(TranslationsLoader);
+    });
+
+    it('OK ' + configuration3.language + '.json from endPointUrl', (done) => {
+      let countCall = 0;
+      const latestUrls: string[] = [];
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        countCall++;
+        latestUrls.push(url);
+        return Promise.resolve(mockSuccessApiResponse(responseFR));
+      });
+
+      jest.spyOn(translationsLoader, 'getTranslationFromLocal');
+
+      const subscription = translationsLoader.getTranslation(configuration3.language).subscribe((res) => {
+        // get the fr.json
+        expect(res).toEqual(responseFR);
+        // 1 call
+        expect(countCall).toBe(1);
+        // fetch from endPointUrl
+        expect(latestUrls[0]).toBe(resolveUrl(configuration3.endPointUrl + configuration3.language + '.json'));
+        // get the fr.json
+        expect(res).toEqual(responseFR);
+
+        subscription.unsubscribe();
+        done();
+      });
+    });
+
+    it('KO ' + configuration3.language + '.json from endPointUrl, fallback OK to local ' + configuration3.language + '.json', (done) => {
+      let countCall = 0;
+      const latestUrls: string[] = [];
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        const endPointUrl = resolveUrl(configuration3.endPointUrl + configuration3.language + '.json');
+        countCall++;
+        latestUrls.push(url);
+        if (endPointUrl === url) {
+          // fail with fr on endPoint
+          // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- reject with a 404 response
+          return Promise.reject(mockFailApiResponse());
+        }
+        return Promise.resolve(mockSuccessApiResponse(responseFR));
+      });
+
+      jest.spyOn(translationsLoader, 'getTranslationFromLocal');
+
+      const subscription = translationsLoader.getTranslation(configuration3.language).subscribe((res) => {
+        // 2 calls (1 for endPoint which fails + 1 local that is OK)
+        expect(countCall).toBe(2);
+        // endPoint URL was called
+        expect(latestUrls[0]).toBe(resolveUrl(configuration3.endPointUrl + configuration3.language + '.json'));
+        // local URL was called
+        expect(latestUrls[1]).toBe(resolveUrl(configuration3.language + '.json'));
+        // get the fr.json
+        expect(res).toEqual(responseFR);
+
+        subscription.unsubscribe();
+        done();
+      });
+    });
+
+    it('KO ' + configuration3.language + '.json from endPointUrl, fallback KO to local ' + configuration3.language + '.json, fallback OK to ' + configuration.fallbackLanguage + '.json', (done) => {
+      let countCall = 0;
+      const latestUrls: string[] = [];
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        const endPointUrl = resolveUrl(configuration3.endPointUrl + configuration3.language + '.json');
+        const localLangUrl = resolveUrl(configuration3.language + '.json');
+        countCall++;
+        latestUrls.push(url);
+        if (endPointUrl === url) {
+          // fail with fr on endPoint
+          // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- reject with a 404 response
+          return Promise.reject(mockFailApiResponse());
+        } else if (localLangUrl === url) {
+          // success if fr local
+          // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- reject with a 404 response
+          return Promise.reject(mockFailApiResponse());
+        }
+        return Promise.resolve(mockSuccessApiResponse(responseEN));
+      });
+
+      jest.spyOn(translationsLoader, 'getTranslationFromLocal');
+
+      const subscription = translationsLoader.getTranslation(configuration3.language).subscribe((res) => {
+        expect(countCall).toBe(3);
+
+        expect(latestUrls[0]).toEqual(resolveUrl(configuration3.endPointUrl + configuration3.language + '.json'));
+
+        expect(latestUrls[1]).toEqual(resolveUrl(configuration3.language + '.json'));
+
+        expect(latestUrls[2]).toEqual(resolveUrl(configuration3.fallbackLanguage + '.json'));
+
+        expect(res).toBeDefined();
+
+        expect(res).toEqual(responseEN);
+
+        subscription.unsubscribe();
+        done();
+      });
+    });
+  });
+
+  describe('With queryParams', () => {
+    it('performs fetch with one parameter', (done) => {
+      let countCall = 0;
+      const latestUrls: string[] = [];
+      const configWithParams = Object.assign({}, configuration3, { queryParams: { SITECODE: 'XDEFXDEF' } });
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: LOCALIZATION_CONFIGURATION_TOKEN, useValue: configWithParams },
+          { provide: TranslationsLoader, deps: [LOCALIZATION_CONFIGURATION_TOKEN] }
+        ]
+      });
+      translationsLoader = TestBed.inject(TranslationsLoader);
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        countCall++;
+        latestUrls.push(url);
+        return Promise.resolve(mockSuccessApiResponse(responseFR));
+      });
+      const subscription = translationsLoader.getTranslation(configWithParams.language).subscribe((res) => {
+        // get the fr.json
+        expect(res).toEqual(responseFR);
+        // 1 call
+        expect(countCall).toBe(1);
+        // check the query URL
+        expect(latestUrls[0]).toBe(resolveUrl(configWithParams.endPointUrl + configWithParams.language + '.json') + '?SITECODE=XDEFXDEF');
+        subscription.unsubscribe();
+        done();
+      });
+    });
+
+    it('performs fetch with several parameters', (done) => {
+      let countCall = 0;
+      const latestUrls: string[] = [];
+      const configWithParams = Object.assign({}, configuration3, { queryParams: { SITECODE: 'XDEFXDEF', OFFICEID: 'ANNCEPAR29MAY' } });
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: LOCALIZATION_CONFIGURATION_TOKEN, useValue: configWithParams },
+          { provide: TranslationsLoader, deps: [LOCALIZATION_CONFIGURATION_TOKEN] }
+        ]
+      });
+      translationsLoader = TestBed.inject(TranslationsLoader);
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        countCall++;
+        latestUrls.push(url);
+        return Promise.resolve(mockSuccessApiResponse(responseFR));
+      });
+      const subscription = translationsLoader.getTranslation(configWithParams.language).subscribe((res) => {
+        // get the fr.json
+        expect(res).toEqual(responseFR);
+        // 1 call
+        expect(countCall).toBe(1);
+        // check the query URL
+        expect(latestUrls[0]).toBe(resolveUrl(configWithParams.endPointUrl + configWithParams.language + '.json') + '?SITECODE=XDEFXDEF&OFFICEID=ANNCEPAR29MAY');
+        subscription.unsubscribe();
+        done();
+      });
+    });
+
+    it('performs fetch with encoded parameters', (done) => {
+      let countCall = 0;
+      const latestUrls: string[] = [];
+      const configWithParams = Object.assign({}, configuration3, { queryParams: { 'SITE CODE': 'XDEF DEF' } });
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: LOCALIZATION_CONFIGURATION_TOKEN, useValue: configWithParams },
+          { provide: TranslationsLoader, deps: [LOCALIZATION_CONFIGURATION_TOKEN] }
+        ]
+      });
+      translationsLoader = TestBed.inject(TranslationsLoader);
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        countCall++;
+        latestUrls.push(url);
+        return Promise.resolve(mockSuccessApiResponse(responseFR));
+      });
+      const subscription = translationsLoader.getTranslation(configWithParams.language).subscribe((res) => {
+        // get the fr.json
+        expect(res).toEqual(responseFR);
+        // 1 call
+        expect(countCall).toBe(1);
+        // check the query URL
+        expect(latestUrls[0]).toBe(resolveUrl(configWithParams.endPointUrl + configWithParams.language + '.json') + '?SITE+CODE=XDEF+DEF');
+        subscription.unsubscribe();
+        done();
+      });
+    });
+  });
+});

--- a/packages/@o3r/transloco/src/tools/translations-loader.ts
+++ b/packages/@o3r/transloco/src/tools/translations-loader.ts
@@ -1,0 +1,141 @@
+import {
+  inject,
+  Injectable,
+} from '@angular/core';
+import {
+  Translation,
+  TranslocoLoader,
+} from '@jsverse/transloco';
+import {
+  DynamicContentService,
+} from '@o3r/dynamic-content';
+import {
+  LoggerService,
+} from '@o3r/logger';
+import {
+  combineLatest,
+  from,
+  Observable,
+  of,
+} from 'rxjs';
+import {
+  catchError,
+  map,
+  switchMap,
+} from 'rxjs/operators';
+import {
+  LocalizationConfiguration,
+} from '../core';
+import {
+  LOCALIZATION_CONFIGURATION_TOKEN,
+} from './localization-token';
+
+const JSON_EXT = '.json';
+
+/**
+ * This class is responsible for loading translation bundles from remote or local endpoints depending on the LocalizationConfiguration.
+ * Fallback mechanism ensures that if a bundle in some language cannot be fetched remotely
+ * we try to fetch the same language bundle locally (bundles stored inside the application)
+ * and finally load the fallback language bundle (if all previous fetches failed)
+ */
+@Injectable()
+export class TranslationsLoader implements TranslocoLoader {
+  private readonly localizationConfiguration: LocalizationConfiguration = inject(LOCALIZATION_CONFIGURATION_TOKEN);
+  private readonly logger? = inject(LoggerService, { optional: true });
+  private readonly dynamicContentService? = inject(DynamicContentService, { optional: true });
+
+  /**
+   * Download a language bundle file
+   * @param  url Url to the bundle file
+   */
+  private downloadLanguageBundle$(url: string) {
+    const queryParams = this.localizationConfiguration.queryParams;
+    const parsedUrl = new URL(url, window.location.origin);
+    if (queryParams) {
+      Object.entries(queryParams).forEach(([key, value]) => parsedUrl.searchParams.append(key, value));
+    }
+    return from(fetch(parsedUrl.href, this.localizationConfiguration.fetchOptions)).pipe(
+      switchMap((response) => response.json() as Promise<Translation>)
+    );
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public getTranslation(lang: string): Observable<Translation> {
+    const fallback = this.localizationConfiguration.fallbackLanguage;
+    let localizationPath$ = of(this.localizationConfiguration.endPointUrl);
+
+    if (this.localizationConfiguration.useDynamicContent) {
+      if (!this.dynamicContentService) {
+        throw new Error('Dynamic Content is not available. Please verify you have provided the DynamicContent in your application');
+      }
+      localizationPath$ = this.dynamicContentService.getContentPathStream(this.localizationConfiguration.endPointUrl);
+    }
+
+    return localizationPath$.pipe(
+      switchMap((localizationPath: string) => {
+        if (localizationPath) {
+          const localizationBundle$ = this.downloadLanguageBundle$(localizationPath + lang + JSON_EXT);
+
+          if (this.localizationConfiguration.mergeWithLocalTranslations) {
+            return combineLatest([
+              localizationBundle$.pipe(catchError(() => {
+                this.logger?.warn(`Failed to load the localization resource from ${localizationPath + lang + JSON_EXT} during merge, falling back to local translations only`);
+                return of({});
+              })),
+              this.getTranslationFromLocal(lang, fallback).pipe(
+                map((translations) => {
+                  Object.entries(translations).forEach(([key, value]) => translations[key] = `[local] ${value as string}`);
+                  return translations;
+                })
+              )
+            ]).pipe(map(([dynamicTranslations, localTranslations]) => ({ ...localTranslations, ...dynamicTranslations })));
+          }
+
+          /*
+          * if endPointUrl is specified by the configuration then:
+          *   1. try to load lang from endPointUrl
+          *   2. if 1 fails then try to load from the app (local file)
+          */
+          return localizationBundle$.pipe(
+            catchError(() => {
+              this.logger?.warn(`Failed to load the localization resource from ${localizationPath + lang + JSON_EXT}, trying from the application resources`);
+              return this.getTranslationFromLocal(lang, fallback);
+            })
+          );
+        }
+        /*
+        * else if endPointUrl NOT specified by then configuration then:
+        *   1. try to load from the app (local file)
+        */
+        this.logger?.warn('No localization endpoint specified, localization fetch from application resources');
+        return this.getTranslationFromLocal(lang, fallback);
+      })
+    );
+  }
+
+  /**
+   *
+   *Fetches localization bundles from published folder (internal to application)
+   *
+   *1. try to load lang from local
+   *2. if 1 fails try to load fallback lang but only if it's different from lang in 1
+   * @param lang - language of the bundle
+   * @param fallbackLanguage - fallback language in case bundle in language not found
+   */
+  public getTranslationFromLocal(lang: string, fallbackLanguage: string): Observable<Translation> {
+    const pathPrefix: string = this.localizationConfiguration.bundlesOutputPath;
+    return this.downloadLanguageBundle$(pathPrefix + lang + JSON_EXT).pipe(
+      catchError(() => {
+        if (lang === fallbackLanguage) {
+          this.logger?.error(`Failed to load ${lang} from ${pathPrefix + lang + JSON_EXT}.`);
+          return of({});
+        } else {
+          this.logger?.warn(`Failed to load ${lang} from ${pathPrefix + lang + JSON_EXT}. Application will fallback to ${fallbackLanguage}`);
+          return this.getTranslationFromLocal(fallbackLanguage, fallbackLanguage);
+        }
+      })
+    );
+  }
+}

--- a/packages/@o3r/transloco/testing/change-detector-ref-fixture.ts
+++ b/packages/@o3r/transloco/testing/change-detector-ref-fixture.ts
@@ -1,0 +1,22 @@
+import {
+  ChangeDetectorRef,
+} from '@angular/core';
+
+/**
+ * Fixture for ChangeDetectorRef
+ */
+export class ChangeDetectorRefFixture implements Readonly<ChangeDetectorRef> {
+  public markForCheck: jest.Mock<any, any>;
+  public detach: jest.Mock<any, any>;
+  public detectChanges: jest.Mock<any, any>;
+  public checkNoChanges: jest.Mock<any, any>;
+  public reattach: jest.Mock<any, any>;
+
+  constructor() {
+    this.markForCheck = jest.fn();
+    this.detach = jest.fn();
+    this.detectChanges = jest.fn();
+    this.checkNoChanges = jest.fn();
+    this.reattach = jest.fn();
+  }
+}

--- a/packages/@o3r/transloco/testing/jest.config.ut.js
+++ b/packages/@o3r/transloco/testing/jest.config.ut.js
@@ -13,5 +13,8 @@ module.exports = {
       '<rootDir>/schematics/.*'
     ]
   }),
-  setupFilesAfterEnv: ['<rootDir>/testing/setup-jest.ts']
+  setupFilesAfterEnv: ['<rootDir>/testing/setup-jest.ts'],
+  transformIgnorePatterns: [
+    'node_modules/(?!.*\\.mjs$|@jsverse)'
+  ]
 };


### PR DESCRIPTION
## Proposed change

Migration of tools from ngx-translate to Transloco

`src/tools/` directory — the main runtime integration.
Each file has its corresponding `*.spec.ts` test file (using `TranslocoTestingModule` / `provideTranslocoTesting`)

| File | Changes |
|------|---------|
| `localization-service.ts` | Replace `TranslateService` → `TranslocoService` |
| `localization-module.ts` | Replace `TranslateModule` → `TranslocoModule` / `provideTransloco()` |
| `localization-provider.ts` | Replace `TranslateService` → `TranslocoService` |
| `translations-loader.ts` | Implement `TranslocoLoader` instead of `TranslateLoader` |
| `localization-translate-pipe.ts` | Wrap `TranslocoPipe` or `TranslocoService` |
| `localization-translate-directive.ts` | Wrap `TranslocoDirective` or `TranslocoService` |
| `text-direction-service.ts` | Replace `onLangChange` → `langChanges$` |
| `localization-token.ts` | Update injection tokens |
| Localized pipes | Adapt locale-change subscription |

`src/core/translate-message-format-lazy-compiler.ts` — replace `TranslateCompiler` with `TranslocoTranspiler`

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
