### PR TITLE
fix: renovate - exclude peer dependencies from range bump for otter p…

### DIFF
--- a/tools/renovate/group/otter.json
+++ b/tools/renovate/group/otter.json
@@ -31,6 +31,9 @@
         "/^@ama-styling/",
         "/^@ama-openapi/"
       ],
+      "matchDepTypes": [
+        "!peerDependencies"
+      ],
       "rangeStrategy": "bump"
     },
     {


### PR DESCRIPTION
…ackages

## Proposed change

Update of renovate config to avoid bumping minor/patch versions of otter packages as peer dependencies.

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
