### PR TITLE
fix: remote cache for SDK schematics

### DIFF
--- a/packages/@ama-sdk/schematics/project.json
+++ b/packages/@ama-sdk/schematics/project.json
@@ -22,18 +22,14 @@
         "script": "prepare:build:builders"
       },
       "inputs": [
-        "schematics",
-        "builders",
+        "schematics-only",
         "^cli",
         "{projectRoot}/schematics/**/*.jar"
       ],
       "outputs": [
         "{projectRoot}/dist/package.json",
-        "{projectRoot}/dist/builders.json",
         "{projectRoot}/dist/migration.json",
         "{projectRoot}/dist/collection.json",
-        "{projectRoot}/dist/builders/**/*.json",
-        "{projectRoot}/dist/schemas/**/*.json",
         "{projectRoot}/dist/schematics/**/*.json",
         "{projectRoot}/dist/schematics/**/*.jar",
         "{projectRoot}/dist/schematics/**/templates/**"
@@ -53,10 +49,6 @@
         "{projectRoot}/dist/src/**/*.js",
         "{projectRoot}/dist/src/**/*.d.ts",
         "{projectRoot}/dist/src/**/*.map",
-        "{projectRoot}/dist/builders/package.json",
-        "{projectRoot}/dist/builders/**/*.js",
-        "{projectRoot}/dist/builders/**/*.d.ts",
-        "{projectRoot}/dist/builders/**/*.map",
         "{projectRoot}/dist/schematics/package.json",
         "{projectRoot}/dist/schematics/**/*.js",
         "{projectRoot}/dist/schematics/**/*.d.ts",


### PR DESCRIPTION
## Proposed change

fix: remote cache for SDK schematics

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
