### PR TITLE
fix: plugin name should not contains space

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "plugins": [
     {
-      "name": "Otter MCP servers recommendations",
+      "name": "otter",
       "source": "./tools/llm/plugins/otter",
       "tags": [
         "otter",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "plugins": [
     {
-      "name": "Otter MCP servers recommendations",
+      "name": "otter",
       "source": "./tools/llm/plugins/otter",
       "tags": [
         "otter",


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
