### PR TITLE
feat: transloco package - devkit

### DIFF
--- a/packages/@o3r/transloco/src/devkit/index.ts
+++ b/packages/@o3r/transloco/src/devkit/index.ts
@@ -1,0 +1,6 @@
+export * from './localization-devkit-interface';
+export * from './localization-devtools';
+export * from './localization-devtools-console-service';
+export * from './localization-devtools-message-service';
+export * from './localization-devtools-module';
+export * from './localization-devtools-token';

--- a/packages/@o3r/transloco/src/devkit/localization-devkit-interface.ts
+++ b/packages/@o3r/transloco/src/devkit/localization-devkit-interface.ts
@@ -1,0 +1,142 @@
+import type {
+  ConnectContentMessage,
+  ContextualizationDevtoolsCommonOptions,
+  DevtoolsCommonOptions,
+  MessageDataTypes,
+  OtterMessageContent,
+  RequestMessagesContentMessage,
+} from '@o3r/core';
+import type {
+  LocalizationMetadata,
+} from '../core';
+
+/**
+ * Configuration options for the Localization Devtools service
+ */
+export interface LocalizationDevtoolsServiceOptions extends DevtoolsCommonOptions, ContextualizationDevtoolsCommonOptions {
+  /** Path to the localization metadata file */
+  metadataFilePath: string;
+}
+
+/** Localizations message content */
+export interface LocalizationsContentMessage extends OtterMessageContent<'localizations'> {
+  /** Localizations metadata */
+  localizations: LocalizationMetadata;
+}
+
+/** Languages message content */
+export interface LanguagesContentMessage extends OtterMessageContent<'languages'> {
+  /** Languages available */
+  languages: string[];
+}
+
+/** Switch languages message content */
+export interface SwitchLanguageContentMessage extends OtterMessageContent<'switchLanguage'> {
+  /** Language */
+  language: string;
+}
+
+/** Display localization key message content */
+export interface DisplayLocalizationKeysContentMessage extends OtterMessageContent<'displayLocalizationKeys'> {
+  /** Toggle the display of the localization keys */
+  toggle?: boolean;
+}
+
+/** Update localization message content */
+export interface UpdateLocalizationContentMessage extends OtterMessageContent<'updateLocalization'> {
+  /** Localization key */
+  key: string;
+  /** Localization value */
+  value: string;
+  /** Lang */
+  lang?: string;
+}
+
+/** Reload localization Keys message content */
+export interface ReloadLocalizationKeysContentMessage extends OtterMessageContent<'reloadLocalizationKeys'> {
+  /** Lang */
+  lang?: string;
+}
+
+/** Is translation deactivation enabled message content */
+export interface IsTranslationDeactivationEnabledContentMessage extends OtterMessageContent<'isTranslationDeactivationEnabled'> {
+  /** Whether translation deactivation is enabled */
+  enabled: boolean;
+}
+
+/** Get translation values message content */
+export interface GetTranslationValuesContentMessage extends OtterMessageContent<'getTranslationValuesContentMessage'> {
+  /** Translation key-value pairs */
+  translations: { [localizationKey: string]: string };
+}
+
+/** Union type of all localization message contents */
+type LocalizationMessageContents = LanguagesContentMessage
+  | ReloadLocalizationKeysContentMessage
+  | SwitchLanguageContentMessage
+  | LocalizationsContentMessage
+  | DisplayLocalizationKeysContentMessage
+  | UpdateLocalizationContentMessage
+  | IsTranslationDeactivationEnabledContentMessage
+  | GetTranslationValuesContentMessage;
+
+/** List of possible DataTypes for Localization messages */
+export type LocalizationMessageDataTypes = MessageDataTypes<LocalizationMessageContents>;
+
+/** List of all messages for Localization purpose */
+export type AvailableLocalizationMessageContents = LocalizationMessageContents
+  | ConnectContentMessage
+  | RequestMessagesContentMessage<LocalizationMessageDataTypes>;
+
+/**
+ * Contextualization devtools exposed for localization in CMS integration
+ */
+export interface LocalizationContextualizationDevtools {
+  /**
+   * Is the translation deactivation enabled
+   */
+  isTranslationDeactivationEnabled(): boolean | Promise<boolean>;
+
+  /**
+   * Show localization keys
+   * @param value value enforced by the DevTools extension
+   */
+  showLocalizationKeys: (value?: boolean) => void | Promise<void>;
+
+  /**
+   * Returns the current language
+   */
+  getCurrentLanguage: () => string | Promise<string>;
+
+  /**
+   * Switch the current language to the specified value
+   * @param language new language to switch to
+   */
+  switchLanguage: (language: string) => Promise<{ previous: string; requested: string; current: string }>;
+
+  /**
+   * Set up a listener on language change
+   * @param fn called when the language is changed in the app
+   * @returns Object with unsubscribe() method to prevent memory leaks
+   */
+  onLanguageChange: (fn: (language: string) => any) => { unsubscribe: () => void };
+
+  /**
+   * Clear all language change listeners
+   */
+  clearLanguageChangeListeners: () => void;
+
+  /**
+   * Updates the specified localization key/values for the current language
+   * @param keyValues key/values to update
+   * @param language if not provided, the current language value
+   */
+  updateLocalizationKeys: (keyValues: { [key: string]: string }, language?: string) => void | Promise<void>;
+
+  /**
+   * Reload a language from the language file
+   * @see https://github.com/jsverse/transloco
+   * @param language language to reload
+   */
+  reloadLocalizationKeys: (language?: string) => Promise<void>;
+}

--- a/packages/@o3r/transloco/src/devkit/localization-devtools-console-service.ts
+++ b/packages/@o3r/transloco/src/devkit/localization-devtools-console-service.ts
@@ -1,0 +1,120 @@
+/* eslint-disable no-console -- This is the purpose of this service */
+import {
+  inject,
+  Injectable,
+} from '@angular/core';
+import type {
+  ContextualizationDataset,
+  DevtoolsServiceInterface,
+  WindowWithDevtools,
+} from '@o3r/core';
+import {
+  LocalizationContextualizationDevtools,
+  LocalizationDevtoolsServiceOptions,
+} from './localization-devkit-interface';
+import {
+  OtterLocalizationDevtools,
+} from './localization-devtools';
+import {
+  OTTER_LOCALIZATION_DEVTOOLS_DEFAULT_OPTIONS,
+  OTTER_LOCALIZATION_DEVTOOLS_OPTIONS,
+} from './localization-devtools-token';
+
+/**
+ * Service that exposes localization devtools functionality via the browser console
+ */
+@Injectable()
+export class LocalizationDevtoolsConsoleService implements DevtoolsServiceInterface, LocalizationContextualizationDevtools {
+  /** Name of the Window property to access to the devtools */
+  public static readonly windowModuleName = 'localization';
+
+  private readonly localizationDevtools = inject(OtterLocalizationDevtools);
+  private readonly options = inject<LocalizationDevtoolsServiceOptions>(OTTER_LOCALIZATION_DEVTOOLS_OPTIONS, { optional: true }) ?? OTTER_LOCALIZATION_DEVTOOLS_DEFAULT_OPTIONS;
+
+  constructor() {
+    if (
+      this.options.isActivatedOnBootstrap
+      || (
+        this.options.isActivatedOnBootstrapWhenCMSContext
+        && (document.body.dataset as ContextualizationDataset).cmscontext === 'true'
+      )
+    ) {
+      this.activate();
+    }
+  }
+
+  /** @inheritDoc */
+  public activate() {
+    const windowWithDevtools: WindowWithDevtools = window;
+
+    windowWithDevtools._OTTER_DEVTOOLS_ ||= {};
+
+    windowWithDevtools._OTTER_DEVTOOLS_[LocalizationDevtoolsConsoleService.windowModuleName] = this;
+
+    console.info(`Otter localization Devtools is now accessible via the _OTTER_DEVTOOLS_.${LocalizationDevtoolsConsoleService.windowModuleName} variable`);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public isTranslationDeactivationEnabled(): boolean | Promise<boolean> {
+    return this.localizationDevtools.isTranslationDeactivationEnabled();
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public showLocalizationKeys(value?: boolean): void | Promise<void> {
+    this.localizationDevtools.showLocalizationKeys(value);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public getCurrentLanguage(): string | Promise<string> {
+    const currentLanguage = this.localizationDevtools.getCurrentLanguage();
+    return currentLanguage;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public async switchLanguage(language: string): Promise<{ previous: string; requested: string; current: string }> {
+    const previous = this.localizationDevtools.getCurrentLanguage();
+    await this.localizationDevtools.switchLanguage(language);
+    const current = this.localizationDevtools.getCurrentLanguage();
+    return {
+      requested: language,
+      previous,
+      current
+    };
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public onLanguageChange(fn: (language: string) => any): { unsubscribe: () => void } {
+    return this.localizationDevtools.onLanguageChange(fn);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public clearLanguageChangeListeners(): void {
+    this.localizationDevtools.clearLanguageChangeListeners();
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public updateLocalizationKeys(keyValues: { [key: string]: string }, language?: string): void | Promise<void> {
+    return this.localizationDevtools.updateLocalizationKeys(keyValues, language);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public reloadLocalizationKeys(language?: string) {
+    return this.localizationDevtools.reloadLocalizationKeys(language);
+  }
+}

--- a/packages/@o3r/transloco/src/devkit/localization-devtools-console.spec.ts
+++ b/packages/@o3r/transloco/src/devkit/localization-devtools-console.spec.ts
@@ -1,0 +1,48 @@
+import {
+  TestBed,
+} from '@angular/core/testing';
+import {
+  provideTransloco,
+} from '@jsverse/transloco';
+import {
+  LocalizationService,
+} from '../tools';
+import {
+  OtterLocalizationDevtools,
+} from './localization-devtools';
+import {
+  LocalizationDevtoolsConsoleService,
+} from './localization-devtools-console-service';
+import {
+  OTTER_LOCALIZATION_DEVTOOLS_DEFAULT_OPTIONS,
+  OTTER_LOCALIZATION_DEVTOOLS_OPTIONS,
+} from './localization-devtools-token';
+
+describe('Localization DevTools console', () => {
+  let service: LocalizationDevtoolsConsoleService;
+
+  beforeEach(async () => {
+    jest.spyOn(console, 'info').mockImplementation();
+    await TestBed.configureTestingModule({
+      providers: [
+        provideTransloco({
+          config: {
+            availableLangs: ['en'],
+            defaultLang: 'en'
+          }
+        }),
+        LocalizationDevtoolsConsoleService,
+        { provide: OtterLocalizationDevtools, useValue: {} },
+        { provide: LocalizationService, useValue: { getCurrentLanguage: () => 'en' } },
+        { provide: OTTER_LOCALIZATION_DEVTOOLS_OPTIONS, useValue: OTTER_LOCALIZATION_DEVTOOLS_DEFAULT_OPTIONS }
+      ]
+    }).compileComponents();
+    service = TestBed.inject(LocalizationDevtoolsConsoleService);
+  });
+
+  it('should be activated', () => {
+    service.activate();
+
+    expect((window as any)._OTTER_DEVTOOLS_?.[LocalizationDevtoolsConsoleService.windowModuleName]).toBeDefined();
+  });
+});

--- a/packages/@o3r/transloco/src/devkit/localization-devtools-message-service.ts
+++ b/packages/@o3r/transloco/src/devkit/localization-devtools-message-service.ts
@@ -1,0 +1,163 @@
+import {
+  DestroyRef,
+  inject,
+  Injectable,
+} from '@angular/core';
+import {
+  takeUntilDestroyed,
+} from '@angular/core/rxjs-interop';
+import {
+  filterMessageContent,
+  sendOtterMessage,
+} from '@o3r/core';
+import {
+  LoggerService,
+} from '@o3r/logger';
+import {
+  fromEvent,
+} from 'rxjs';
+import {
+  LocalizationService,
+} from '../tools';
+import {
+  type AvailableLocalizationMessageContents,
+  LocalizationDevtoolsServiceOptions,
+  type LocalizationMessageDataTypes,
+} from './localization-devkit-interface';
+import {
+  OtterLocalizationDevtools,
+} from './localization-devtools';
+import {
+  OTTER_LOCALIZATION_DEVTOOLS_DEFAULT_OPTIONS,
+  OTTER_LOCALIZATION_DEVTOOLS_OPTIONS,
+} from './localization-devtools-token';
+
+/**
+ * Type guard to check if a message is a localization message
+ * @param message Message to check
+ * @returns True if the message is a localization message
+ */
+const isLocalizationMessage = (message: any): message is AvailableLocalizationMessageContents => {
+  return message && (
+    message.dataType === 'displayLocalizationKeys'
+    || message.dataType === 'languages'
+    || message.dataType === 'switchLanguage'
+    || message.dataType === 'localizations'
+    || message.dataType === 'updateLocalization'
+    || message.dataType === 'requestMessages'
+    || message.dataType === 'connect'
+    || message.dataType === 'reloadLocalizationKeys'
+    || message.dataType === 'isTranslationDeactivationEnabled'
+    || message.dataType === 'getTranslationValuesContentMessage'
+  );
+};
+
+/**
+ * Service that handles localization devtools messages communication
+ */
+@Injectable()
+export class LocalizationDevtoolsMessageService {
+  private readonly logger = inject(LoggerService);
+  private readonly localizationDevTools = inject(OtterLocalizationDevtools);
+  private readonly localizationService = inject(LocalizationService);
+  private readonly options = inject<LocalizationDevtoolsServiceOptions>(OTTER_LOCALIZATION_DEVTOOLS_OPTIONS, { optional: true }) ?? OTTER_LOCALIZATION_DEVTOOLS_DEFAULT_OPTIONS;
+
+  private readonly sendMessage = sendOtterMessage<AvailableLocalizationMessageContents>;
+  private readonly destroyRef = inject(DestroyRef);
+
+  constructor() {
+    this.options = {
+      ...OTTER_LOCALIZATION_DEVTOOLS_DEFAULT_OPTIONS,
+      ...this.options
+    };
+    if (this.options.isActivatedOnBootstrap) {
+      this.activate();
+    }
+  }
+
+  private async sendLocalizationsMetadata() {
+    const metadata = await (await fetch(this.options.metadataFilePath)).json();
+    this.sendMessage('localizations', {
+      localizations: metadata
+    });
+  }
+
+  /**
+   * Function to trigger a re-send a requested messages to the Otter Chrome DevTools extension
+   * @param only restricted list of messages to re-send
+   */
+  private handleReEmitRequest(only?: LocalizationMessageDataTypes[]) {
+    if (!only || only.includes('localizations')) {
+      void this.sendLocalizationsMetadata();
+    }
+    if (!only || only.includes('switchLanguage')) {
+      this.sendMessage('switchLanguage', { language: this.localizationDevTools.getCurrentLanguage() });
+    }
+    if (!only || only.includes('languages')) {
+      this.sendMessage('languages', { languages: this.localizationService.getLanguages() });
+    }
+    if (!only || only.includes('getTranslationValuesContentMessage')) {
+      this.sendMessage('getTranslationValuesContentMessage', {
+        translations: this.localizationService.getTranslateService().getTranslation(this.localizationService.getCurrentLanguage())
+      });
+    }
+    if (!only || only.includes('isTranslationDeactivationEnabled')) {
+      this.sendMessage('isTranslationDeactivationEnabled', { enabled: this.localizationService.isTranslationDeactivationEnabled() });
+    }
+  }
+
+  /**
+   * Function to handle the incoming messages from Otter Chrome DevTools extension
+   * @param message Message coming from the Otter Chrome DevTools extension
+   */
+  private handleEvents(message: AvailableLocalizationMessageContents) {
+    this.logger.debug('Message handling by the localization service', message);
+
+    switch (message.dataType) {
+      case 'connect': {
+        this.connectPlugin();
+        break;
+      }
+      case 'displayLocalizationKeys': {
+        this.localizationDevTools.showLocalizationKeys(message.toggle);
+        break;
+      }
+      case 'requestMessages': {
+        void this.handleReEmitRequest(message.only);
+        break;
+      }
+      case 'switchLanguage': {
+        void this.localizationDevTools.switchLanguage(message.language);
+        break;
+      }
+      case 'updateLocalization': {
+        void this.localizationDevTools.updateLocalizationKeys({
+          [message.key]: message.value
+        }, message.lang);
+        break;
+      }
+      case 'reloadLocalizationKeys': {
+        void this.localizationDevTools.reloadLocalizationKeys(message.lang);
+        break;
+      }
+      default: {
+        this.logger.warn('Message ignored by the localization service', message);
+      }
+    }
+  }
+
+  /**
+   * Function to connect the plugin to the Otter Chrome DevTools extension
+   */
+  private connectPlugin() {
+    this.logger.debug('Otter DevTools is plugged to localization service of the application');
+  }
+
+  /** @inheritDoc */
+  public activate() {
+    fromEvent(window, 'message').pipe(
+      takeUntilDestroyed(this.destroyRef),
+      filterMessageContent(isLocalizationMessage)
+    ).subscribe((e) => this.handleEvents(e));
+  }
+}

--- a/packages/@o3r/transloco/src/devkit/localization-devtools-module.ts
+++ b/packages/@o3r/transloco/src/devkit/localization-devtools-module.ts
@@ -1,0 +1,55 @@
+import {
+  ModuleWithProviders,
+  NgModule,
+} from '@angular/core';
+import {
+  LocalizationModule,
+} from '../tools/index';
+import type {
+  LocalizationDevtoolsServiceOptions,
+} from './localization-devkit-interface';
+import {
+  OtterLocalizationDevtools,
+} from './localization-devtools';
+import {
+  LocalizationDevtoolsConsoleService,
+} from './localization-devtools-console-service';
+import {
+  LocalizationDevtoolsMessageService,
+} from './localization-devtools-message-service';
+import {
+  OTTER_LOCALIZATION_DEVTOOLS_DEFAULT_OPTIONS,
+  OTTER_LOCALIZATION_DEVTOOLS_OPTIONS,
+} from './localization-devtools-token';
+
+/**
+ * Module that provides localization devtools functionality
+ */
+@NgModule({
+  imports: [
+    LocalizationModule
+  ],
+  providers: [
+    { provide: OTTER_LOCALIZATION_DEVTOOLS_OPTIONS, useValue: OTTER_LOCALIZATION_DEVTOOLS_DEFAULT_OPTIONS },
+    LocalizationDevtoolsMessageService,
+    LocalizationDevtoolsConsoleService,
+    OtterLocalizationDevtools
+  ]
+})
+export class LocalizationDevtoolsModule {
+  /**
+   * Initialize Otter Devtools
+   * @param options
+   */
+  public static instrument(options: Partial<LocalizationDevtoolsServiceOptions>): ModuleWithProviders<LocalizationDevtoolsModule> {
+    return {
+      ngModule: LocalizationDevtoolsModule,
+      providers: [
+        { provide: OTTER_LOCALIZATION_DEVTOOLS_OPTIONS, useValue: { ...OTTER_LOCALIZATION_DEVTOOLS_DEFAULT_OPTIONS, ...options }, multi: false },
+        LocalizationDevtoolsMessageService,
+        LocalizationDevtoolsConsoleService,
+        OtterLocalizationDevtools
+      ]
+    };
+  }
+}

--- a/packages/@o3r/transloco/src/devkit/localization-devtools-token.ts
+++ b/packages/@o3r/transloco/src/devkit/localization-devtools-token.ts
@@ -1,0 +1,20 @@
+import {
+  InjectionToken,
+} from '@angular/core';
+import {
+  LocalizationDevtoolsServiceOptions,
+} from './localization-devkit-interface';
+
+/**
+ * Default configuration options for the Otter Localization Devtools
+ */
+export const OTTER_LOCALIZATION_DEVTOOLS_DEFAULT_OPTIONS: Readonly<LocalizationDevtoolsServiceOptions> = {
+  isActivatedOnBootstrap: false,
+  isActivatedOnBootstrapWhenCMSContext: true,
+  metadataFilePath: './metadata/localisation.metadata.json'
+} as const;
+
+/**
+ * Injection token for Otter Localization Devtools configuration options
+ */
+export const OTTER_LOCALIZATION_DEVTOOLS_OPTIONS = new InjectionToken<LocalizationDevtoolsServiceOptions>('Otter Localization Devtools options');

--- a/packages/@o3r/transloco/src/devkit/localization-devtools.ts
+++ b/packages/@o3r/transloco/src/devkit/localization-devtools.ts
@@ -1,0 +1,133 @@
+import {
+  ApplicationRef,
+  inject,
+  Injectable,
+  OnDestroy,
+} from '@angular/core';
+import {
+  TRANSLOCO_TRANSPILER,
+  type TranslocoTranspiler,
+} from '@jsverse/transloco';
+import {
+  lastValueFrom,
+  Subscription,
+} from 'rxjs';
+import {
+  LocalizationService,
+} from '../tools';
+
+/**
+ * Service that provides core localization devtools functionality
+ */
+@Injectable()
+export class OtterLocalizationDevtools implements OnDestroy {
+  private readonly localizationService = inject(LocalizationService);
+  private readonly translateTranspiler = inject<TranslocoTranspiler>(TRANSLOCO_TRANSPILER);
+  private readonly appRef = inject(ApplicationRef);
+  private readonly languageChangeSubscriptions = new Set<Subscription>();
+
+  /**
+   * Is the translation deactivation enabled
+   */
+  public isTranslationDeactivationEnabled() {
+    return this.localizationService.isTranslationDeactivationEnabled();
+  }
+
+  /**
+   * Show localization keys
+   * @param value value enforced by the DevTools extension
+   */
+  public showLocalizationKeys(value?: boolean): void {
+    this.localizationService.toggleShowKeys(value);
+    this.appRef.tick();
+  }
+
+  /**
+   * Returns the current language
+   */
+  public getCurrentLanguage() {
+    return this.localizationService.getCurrentLanguage();
+  }
+
+  /**
+   * Set up a listener on language change
+   * @param fn called when the language is changed in the app
+   * @returns Object with unsubscribe() method to prevent memory leaks
+   */
+  public onLanguageChange(fn: (language: string) => any): { unsubscribe: () => void } {
+    const subscription = this.localizationService
+      .getTranslateService()
+      .langChanges$
+      .subscribe((lang: string) => {
+        fn(lang);
+      });
+
+    this.languageChangeSubscriptions.add(subscription);
+
+    // Return custom object with unsubscribe method
+    return {
+      unsubscribe: () => {
+        subscription.unsubscribe();
+        this.languageChangeSubscriptions.delete(subscription);
+      }
+    };
+  }
+
+  /**
+   * Clear all language change listeners
+   */
+  public clearLanguageChangeListeners(): void {
+    this.languageChangeSubscriptions.forEach((sub) => sub.unsubscribe());
+    this.languageChangeSubscriptions.clear();
+  }
+
+  /**
+   * Cleanup subscriptions when service is destroyed
+   */
+  public ngOnDestroy(): void {
+    this.clearLanguageChangeListeners();
+  }
+
+  /**
+   * Switch the current language to the specified value
+   * @param language new language to switch to
+   */
+  public async switchLanguage(language: string | undefined) {
+    if (!language) {
+      return;
+    }
+    await lastValueFrom(this.localizationService.useLanguage(language));
+    this.appRef.tick();
+  }
+
+  /**
+   * Updates the specified localization key/values for the current language.
+   *
+   * Recommendation: To be used with a small number of keys to update to avoid performance issues.
+   * @param keyValues key/values to update
+   * @param language if not provided, the current language value
+   */
+  public updateLocalizationKeys(keyValues: { [key: string]: string }, language?: string): void | Promise<void> {
+    const lang = language || this.getCurrentLanguage();
+    const translateService = this.localizationService.getTranslateService();
+    Object.entries(keyValues).forEach(([key, value]) => {
+      translateService.setTranslationKey(key, value, { lang });
+    });
+    this.appRef.tick();
+  }
+
+  /**
+   * Reload a language from the language file
+   * @param language language to reload
+   */
+  public async reloadLocalizationKeys(language?: string) {
+    const lang = language || this.getCurrentLanguage();
+    if ((this.translateTranspiler as any).setLocale) {
+      (this.translateTranspiler as any).setLocale(null);
+    }
+    const translateService = this.localizationService.getTranslateService();
+    const translations = await lastValueFrom(translateService.load(lang));
+    translateService.setTranslation(translations, lang, { merge: false });
+    this.appRef.tick();
+  }
+}


### PR DESCRIPTION
## Proposed change

- Copy `src/devkit/` — replace `TranslateService` references with `TranslocoService` and `@ngx-translate/core` imports with `@jsverse/transloco`.
- Copy corresponding `*.spec.ts` files for devtools.

Copy `src/core/translate-message-format-lazy-compiler.ts` → `src/core/translate-message-format-lazy-transpiler.ts`:
- The old `TranslateMessageFormatLazyCompiler` (101 lines) was a full reimplementation of lazy ICU compilation because ngx-translate's ecosystem only offered eager compilation. It manually managed caching via a `Map<string, IntlMessageFormat>`, wrapped each key in a closure for lazy parsing, and directly depended on `intl-messageformat`.
- The new `TranslateMessageFormatLazyTranspiler` (30 lines) extends `MessageFormatTranspiler` from `@jsverse/transloco-messageformat`, which already provides lazy transpilation, built-in caching, and automatic locale management out of the box.
- The only addition is a `clearCache()` method (needed by devtools to force-reload translations at runtime), which calls the inherited `setLocale(null)` to recreate the internal `MessageFormat` instance and discard its cache.
- The file re-exports `MessageformatConfig` and `TRANSLOCO_MESSAGE_FORMAT_CONFIG` from `@jsverse/transloco-messageformat` so that consumers of `@o3r/transloco` can configure the transpiler without adding a direct dependency on `@jsverse/transloco-messageformat`.

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
