### PR TITLE
feat: transloco package - builders

### DIFF
--- a/packages/@o3r/transloco/builders.json
+++ b/packages/@o3r/transloco/builders.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular_devkit/architect/src/builders-schema.json",
+  "builders": {
+    "i18n": {
+      "implementation": "./builders/i18n/",
+      "schema": "./builders/i18n/schema.json",
+      "description": "Generate the i18n"
+    },
+    "extractor": {
+      "implementation": "./builders/localization-extractor/",
+      "schema": "./builders/localization-extractor/schema.json",
+      "description": "Extract the localization keys from an Otter project"
+    },
+    "localization": {
+      "implementation": "./builders/localization/",
+      "schema": "./builders/localization/schema.json",
+      "description": "Generate the localizations"
+    },
+    "check-localization-migration-metadata": {
+      "implementation": "./builders/metadata-check/",
+      "schema": "./builders/metadata-check/schema.json",
+      "description": "Check for localization metadata breaking changes"
+    }
+  }
+}

--- a/packages/@o3r/transloco/builders/helpers/localization-generator.ts
+++ b/packages/@o3r/transloco/builders/helpers/localization-generator.ts
@@ -1,0 +1,417 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  logging,
+} from '@angular-devkit/core';
+import {
+  getLibraryCmsMetadata,
+  getLocalizationFileFromAngularElement,
+} from '@o3r/extractors';
+import {
+  O3rCliError,
+} from '@o3r/schematics';
+import {
+  sync as globbySync,
+} from 'globby';
+import * as ts from 'typescript';
+import type {
+  LocalizationExtractorBuilderSchema,
+} from '../localization-extractor/schema';
+import type {
+  JSONLocalization,
+  LocalizationMetadata,
+} from '@o3r/transloco';
+
+/** List of Angular decorator to look for */
+const ANGULAR_ANNOTATION = ['Component', 'Injectable', 'Pipe'] as const;
+
+/** Regular expression to match Angular decorators */
+const ANGULAR_DECORATOR_REGEXP = new RegExp('^@' + ANGULAR_ANNOTATION.map((e) => `(${e})`).join('|'));
+
+/** Map of Localization Metadata base on localization key */
+export interface LocalizationMetadataAsMap {
+  [key: string]: JSONLocalization;
+}
+
+/** Localization structure */
+export interface LocalizationJsonValue {
+  /** Localization Description */
+  description: string;
+  /** Determine if the item can have multiple extensions */
+  dictionary?: boolean;
+  /** Determine if the value has to be overridden */
+  referenceData?: boolean;
+  /** Localization default value */
+  defaultValue?: string;
+  /** Tags used for filtering/categorizing */
+  tags?: string[];
+  /** Reference to other localization */
+  $ref?: string;
+}
+
+/** Localization file structure */
+export interface LocalizationJsonFile {
+  [key: string]: LocalizationJsonValue;
+}
+
+type LocalizationJsonFileContent = LocalizationJsonFile & {
+  $schema?: string;
+};
+
+/** Localization file mapping */
+export interface LocalizationFileMap {
+  [file: string]: {
+    data: LocalizationJsonFile;
+    isDependency: boolean;
+  };
+}
+
+/** Metadata file mapping */
+export interface LibraryMetadataMap {
+  [libraryMetadataFile: string]: LocalizationMetadata;
+}
+
+/**
+ * Localization extractor
+ */
+export class LocalizationExtractor {
+  /** TsConfig of the file to base on */
+  private readonly tsconfigPath: string;
+
+  private readonly logger: logging.LoggerApi;
+
+  constructor(tsconfigPath: string, logger: logging.LoggerApi, private readonly options?: Partial<LocalizationExtractorBuilderSchema>) {
+    this.tsconfigPath = tsconfigPath;
+    this.logger = logger;
+  }
+
+  /** Get the list of file from tsconfig.json */
+  private getFilesFromTsConfig() {
+    const { include, exclude, cwd } = this.getPatternsFromTsConfig();
+    return globbySync(include, { ignore: exclude, cwd });
+  }
+
+  /**
+   * Return the class node if the class is an angular element
+   * @param source Ts file source
+   */
+  private getAngularClassNode(source: ts.SourceFile): ts.ClassDeclaration[] | undefined {
+    const angularItems: ts.ClassDeclaration[] = [];
+    source.forEachChild((item) => {
+      if (!ts.isClassDeclaration(item)) {
+        return;
+      }
+
+      let isAngularItem = false;
+      item.forEachChild((classItem) => {
+        if (isAngularItem || !ts.isDecorator(classItem)) {
+          return;
+        }
+        const text = classItem.getText(source);
+        if (!ANGULAR_DECORATOR_REGEXP.test(text)) {
+          return;
+        }
+        isAngularItem = true;
+      });
+
+      if (isAngularItem) {
+        angularItems.push(item);
+      }
+    });
+
+    return angularItems.length > 0 ? angularItems : undefined;
+  }
+
+  /**
+   * Get the list of referenced translation files
+   * @param localizationFileContent JSON content of a location file
+   * @param localizationFilePath Path of the localization file
+   */
+  private getReferencedFiles(localizationFileContent: LocalizationJsonFile, localizationFilePath?: string): string[] | undefined {
+    const folder = localizationFilePath ? path.dirname(localizationFilePath) : undefined;
+    const referencedFiles = Object.keys(localizationFileContent)
+      .filter((key) => !!localizationFileContent[key].$ref)
+      .map((key) => ({ key, ref: localizationFileContent[key].$ref!.split('#/')[0] }))
+      .filter(({ key, ref }) => {
+        const res = !!ref;
+        if (!res) {
+          this.logger.error(`The reference (${ref}) of the key ${key} is invalid, it will be ignored`);
+        }
+        return res;
+      })
+      .map(({ ref }) => {
+        if (!ref.startsWith('.')) {
+          if (this.options?.libraries?.length && this.options.libraries.every((lib) => !ref.startsWith(lib))) {
+            try {
+              return require.resolve(ref);
+            } catch (err: any) {
+              this.logger.debug(`Could not resolve reference ${ref}, treating as local file: ${err}`);
+            }
+          }
+          return undefined;
+        }
+        return folder ? path.resolve(folder, ref) : ref;
+      })
+      .filter((ref): ref is string => !!ref);
+
+    return referencedFiles.length > 0 ? referencedFiles : undefined;
+  }
+
+  /**
+   * Read a localization file
+   * @param locFile Path to the localization file
+   */
+  private async readLocalizationFile(locFile: string): Promise<LocalizationJsonFile> {
+    const content: LocalizationJsonFileContent = JSON.parse(await fs.promises.readFile(locFile, { encoding: 'utf8' }));
+    if (content.$schema) {
+      delete content.$schema;
+    }
+    return content;
+  }
+
+  /**
+   * Read a metadata file
+   * @param metadataFile Path to the metadata file
+   */
+  private async readMetadataFile(metadataFile: string): Promise<LocalizationMetadata> {
+    return JSON.parse(await fs.promises.readFile(metadataFile, { encoding: 'utf8' }));
+  }
+
+  /**
+   * Generate a metadata item from a localization item
+   * @param loc Localization item
+   * @param key Key of the localization
+   */
+  private generateMetadataItemFromLocalization(loc: LocalizationJsonValue, key: string): JSONLocalization {
+    const res: JSONLocalization = {
+      description: loc.description,
+      dictionary: !!loc.dictionary,
+      referenceData: !!loc.referenceData,
+      key
+    };
+
+    if (loc.defaultValue || loc.defaultValue === '') {
+      res.value = loc.defaultValue;
+    }
+
+    if (loc.tags) {
+      res.tags = loc.tags;
+    }
+
+    if (loc.$ref) {
+      const [refPath, refKey] = loc.$ref.split('#/', 2);
+      res.ref = refPath.startsWith('.') || this.options?.libraries?.some((lib) => refPath.startsWith(lib)) ? refKey : loc.$ref;
+    }
+
+    if (typeof loc.defaultValue === 'undefined' && typeof loc.$ref === 'undefined' && !loc.dictionary) {
+      this.logger.error(`${key} has no default value or $ref defined`);
+      throw new O3rCliError(`${key} has no default value or $ref defined`);
+    }
+
+    return res;
+  }
+
+  /**
+   * Compares two JSONLocalization object by their keys and returns the result of the string comparison
+   * @param a JSONLocalization
+   * @param b JSONLocalization
+   */
+  private compareKeys(a: JSONLocalization, b: JSONLocalization): number {
+    const keyA = a.key.toUpperCase();
+    const keyB = b.key.toUpperCase();
+    if (keyA < keyB) {
+      return -1;
+    }
+    if (keyA > keyB) {
+      return 1;
+    }
+    return 0;
+  }
+
+  /** Get the list of patterns from tsconfig.json */
+  public getPatternsFromTsConfig() {
+    const tsconfigResult = ts.readConfigFile(this.tsconfigPath, (p) => ts.sys.readFile(p));
+
+    if (tsconfigResult.error) {
+      const stringError = typeof tsconfigResult.error.messageText === 'string'
+        ? tsconfigResult.error.messageText
+        : tsconfigResult.error.messageText.messageText;
+      this.logger.error(stringError);
+      throw new O3rCliError(stringError);
+    }
+
+    const include: string[] = [...(tsconfigResult.config.files || []), ...(tsconfigResult.config.include || [])];
+    const exclude: string[] = tsconfigResult.config.exclude || [];
+    const cwd = path.resolve(path.dirname(this.tsconfigPath), tsconfigResult.config.rootDir || '.');
+    return { include, exclude, cwd };
+  }
+
+  /**
+   * Generate the localization mapping for a list of files
+   * @param localizationFiles Localization files to load
+   * @param alreadyLoadedFiles List of localization files already loadded
+   * @param isDependency Determine if the list of files are dependencies of others
+   */
+  public async getLocalizationMap(localizationFiles: string[], alreadyLoadedFiles: string[] = [], isDependency = false): Promise<LocalizationFileMap> {
+    const mapLocalization: LocalizationFileMap = {};
+    for (const file of localizationFiles) {
+      mapLocalization[file] = {
+        data: await this.readLocalizationFile(file),
+        isDependency
+      };
+    }
+
+    const references = localizationFiles
+      .map((file) => this.getReferencedFiles(mapLocalization[file].data, file))
+      .filter((refs): refs is string[] => !!refs)
+      .reduce((acc, refs) => {
+        acc.push(...refs.filter((ref) => !localizationFiles.includes(ref) && !alreadyLoadedFiles.includes(ref)));
+        return acc;
+      }, []);
+
+    if (references.length > 0) {
+      return {
+        ...mapLocalization,
+        ...await this.getLocalizationMap(references, [...localizationFiles, ...alreadyLoadedFiles], true)
+      };
+    }
+
+    return mapLocalization;
+  }
+
+  /**
+   * Extract the localization mapping from a tsconfig file
+   * @param extraLocalizationFiles Additional translations to add
+   */
+  public async extractLocalizationFromTsConfig(extraLocalizationFiles: string[] = []): Promise<LocalizationFileMap> {
+    const files = this.getFilesFromTsConfig();
+    const tsFiles = files
+      .filter((file) => /\.ts$/.test(file))
+      .map((file) => path.join(path.dirname(this.tsconfigPath), file));
+
+    const program = ts.createProgram(tsFiles, {});
+    const localizationFiles = tsFiles
+      .map((file) => ({ file, source: program.getSourceFile(file) }))
+      .map(({ file, source }) => ({ file, classes: source && this.getAngularClassNode(source), source }))
+      .filter(({ classes }) => !!classes)
+      .map(({ file, classes }) => classes!
+        .map((classItem) => getLocalizationFileFromAngularElement(classItem))
+        .filter((locFiles): locFiles is string[] => !!locFiles)
+        .reduce((acc: string[], locFiles) => {
+          acc.push(...locFiles.filter((f) => !acc.includes(f)));
+          return acc;
+        }, [])
+        .map((locFile) => path.resolve(path.dirname(file), locFile))
+      )
+      .reduce((acc: string[], locFiles) => {
+        acc.push(...locFiles.filter((f) => !acc.includes(f)));
+        return acc;
+      }, []);
+
+    localizationFiles.push(...extraLocalizationFiles.filter((file) => !localizationFiles.includes(file)));
+
+    this.logger.debug(`Found ${localizationFiles.length} localization file(s) to process`);
+
+    return this.getLocalizationMap(localizationFiles);
+  }
+
+  /**
+   * Retrieve metadata from libraries
+   * @param libraries Libraries on which the project depend
+   */
+  public async getMetadataFromLibraries(libraries: string[]) {
+    const metadataFiles = libraries
+      .map((lib) => getLibraryCmsMetadata(lib).localizationFilePath)
+      .filter((localizationFilePath): localizationFilePath is string => !!localizationFilePath);
+
+    return this.getMetadataFromFiles(metadataFiles);
+  }
+
+  /**
+   * Retrieve metadata from metadata files
+   * @param metadataFiles Metadata files
+   */
+  public async getMetadataFromFiles(metadataFiles: string[]) {
+    const metadataMap: LibraryMetadataMap = {};
+    for (const file of metadataFiles) {
+      metadataMap[file] = await this.readMetadataFile(file);
+    }
+
+    return metadataMap;
+  }
+
+  /**
+   * Generate metadata from localization and library metadata mappings
+   * @param localizationMap Map of localization files
+   * @param options Option of generation
+   * @param options.ignoreDuplicateKeys
+   * @param options.libraryMetadata
+   * @param options.outputFile
+   * @param options.sortKeys
+   */
+  public generateMetadata(localizationMap: LocalizationFileMap, options: {
+    ignoreDuplicateKeys: boolean;
+    libraryMetadata: LibraryMetadataMap;
+    outputFile: string;
+    sortKeys: boolean;
+  }): LocalizationMetadata {
+    const metadata: LocalizationMetadataAsMap = {};
+    let hasDuplicateKey = false;
+    const addMetadata = (data: JSONLocalization, origin?: string, libraries: string[] = []) => {
+      if (metadata[data.key]) {
+        hasDuplicateKey = true;
+        if (options.ignoreDuplicateKeys) {
+          this.logger.warn(
+            `The key ${data.key} from ${origin!} will override the previous value (${metadata[data.key].value || 'ref ' + metadata[data.key].ref!} -> ${data.value || 'ref ' + data.ref!})`
+          );
+        } else {
+          this.logger.error(
+            `The key ${data.key} from ${origin!} try to override the previous value (${metadata[data.key].value || 'ref ' + metadata[data.key].ref!} -> ${data.value || 'ref ' + data.ref!})`
+          );
+        }
+      }
+
+      metadata[data.key] = data.ref && data.ref.includes('#/') && libraries.some((lib) => data.ref!.startsWith(lib))
+        ? {
+          ...data,
+          ref: data.ref.split('#/')[1]
+        }
+        : data;
+    };
+
+    Object.keys(options.libraryMetadata)
+      .forEach((lib) =>
+        options.libraryMetadata[lib].forEach((dataLoc) => addMetadata(dataLoc, lib, this.options?.libraries))
+      );
+
+    Object.keys(localizationMap)
+      .forEach((locFile) =>
+        Object.keys(localizationMap[locFile].data)
+          .forEach((locKey) => addMetadata(this.generateMetadataItemFromLocalization(localizationMap[locFile].data[locKey], locKey), locFile))
+      );
+
+    if (hasDuplicateKey && !options.ignoreDuplicateKeys) {
+      throw new O3rCliError('Duplicate key');
+    }
+
+    const localizationMetadata = Object.values(metadata);
+    let hasUnknownRef = false;
+
+    localizationMetadata.forEach((data) => {
+      if (data.ref && !data.ref.includes('#/')) {
+        if (!metadata[data.ref]) {
+          hasUnknownRef = true;
+          this.logger.error(`The key ${data.ref} is unknown but referenced by ${data.key}.`);
+        } else if (typeof data.description === 'undefined') {
+          data.description = metadata[data.ref].description;
+        }
+      }
+    });
+
+    if (hasUnknownRef) {
+      throw new O3rCliError('Unknown referenced key');
+    }
+
+    return options.sortKeys ? localizationMetadata.toSorted((a, b) => this.compareKeys(a, b)) : localizationMetadata;
+  }
+}

--- a/packages/@o3r/transloco/builders/i18n/index.spec.ts
+++ b/packages/@o3r/transloco/builders/i18n/index.spec.ts
@@ -1,0 +1,62 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  Architect,
+} from '@angular-devkit/architect';
+import {
+  TestingArchitectHost,
+} from '@angular-devkit/architect/testing';
+import {
+  schema,
+} from '@angular-devkit/core';
+import {
+  cleanVirtualFileSystem,
+  useVirtualFileSystem,
+} from '@o3r/test-helpers';
+import {
+  I18nBuilderSchema,
+} from './schema';
+
+describe('Localization i18n Builder', () => {
+  const workspaceRoot = path.join('..', '..', '..', '..', '..');
+  let architect: Architect;
+  let architectHost: TestingArchitectHost;
+  let virtualFileSystem: typeof fs;
+
+  beforeEach(() => {
+    virtualFileSystem = useVirtualFileSystem();
+
+    const registry = new schema.CoreSchemaRegistry();
+    registry.addPostTransform(schema.transforms.addUndefinedDefaults);
+    architectHost = new TestingArchitectHost(path.resolve(__dirname, workspaceRoot), __dirname);
+    architect = new Architect(architectHost, registry);
+    architectHost.addBuilder('.:i18n', require('./index').default);
+  });
+  afterEach(() => {
+    cleanVirtualFileSystem();
+  });
+
+  it('should generate the i18n', async () => {
+    const i18nFolder = path.resolve(__dirname, `${workspaceRoot}/apps/showcase/src/components/showcase/localization/i18n`);
+    await virtualFileSystem.promises.mkdir(i18nFolder, { recursive: true });
+    const options: I18nBuilderSchema = {
+      localizationConfigs: [
+        {
+          localizationFiles: [
+            'apps/showcase/src/!(i18n)/**/*-localization.json'
+          ],
+          i18nFolderPath: 'i18n'
+        }
+      ],
+      defaultLanguageFile: 'en-GB.json'
+    };
+    const run = await architect.scheduleBuilder('.:i18n', options);
+    const output = await run.result;
+    expect(output.error).toBeUndefined();
+    await run.stop();
+
+    const i18nOutput = JSON.parse(virtualFileSystem.readFileSync(path.join(i18nFolder, 'en-GB.json'), { encoding: 'utf8' }));
+    expect(typeof i18nOutput).toBe('object');
+    expect(Object.keys(i18nOutput)[0]).toMatch(/o3r-.*/);
+  });
+});

--- a/packages/@o3r/transloco/builders/i18n/index.ts
+++ b/packages/@o3r/transloco/builders/i18n/index.ts
@@ -1,0 +1,59 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  BuilderContext,
+  BuilderOutput,
+  createBuilder,
+} from '@angular-devkit/architect';
+import {
+  createBuilderWithMetricsIfInstalled,
+} from '@o3r/extractors';
+import {
+  sync as globbySync,
+} from 'globby';
+import type {
+  I18nBuilderSchema,
+} from './schema';
+
+/**
+ * Builder to generate i18n files from localization JSON files
+ */
+export default createBuilder(createBuilderWithMetricsIfInstalled<I18nBuilderSchema>((options: I18nBuilderSchema, context: BuilderContext): BuilderOutput => {
+  const posixWorkspaceRoot = context.workspaceRoot.split(path.sep).join(path.posix.sep);
+
+  options.localizationConfigs.forEach((config) => {
+    const fileNames = globbySync(config.localizationFiles.map((files: string) => path.posix.join(posixWorkspaceRoot, files)));
+
+    fileNames.forEach((filePath) => {
+      const localizationJson: Record<string, any> = JSON.parse(fs.readFileSync(filePath, { encoding: 'utf8' }));
+
+      const newContent = JSON.stringify(
+        Object.entries(localizationJson)
+          .filter(([, value]) => !value.dictionary && !value.$ref && value.defaultValue !== undefined)
+          .toSorted((a, b) => a[0] < b[0] ? -1 : 1)
+          .reduce((acc: { [key: string]: string }, [key, { defaultValue }]) => {
+            acc[key] = defaultValue;
+            return acc;
+          }, {}),
+        null,
+        2
+      );
+
+      const dir = path.dirname(filePath);
+      const i18nPath = path.join(dir, config.i18nFolderPath);
+
+      if (!fs.existsSync(i18nPath)) {
+        fs.mkdirSync(i18nPath, {
+          recursive: true
+        });
+      }
+
+      const defaultLanguageFile = path.join(i18nPath, options.defaultLanguageFile);
+      fs.writeFileSync(defaultLanguageFile, newContent + '\n');
+    });
+  });
+
+  return {
+    success: true
+  };
+}));

--- a/packages/@o3r/transloco/builders/i18n/schema.json
+++ b/packages/@o3r/transloco/builders/i18n/schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "I18nBuilderSchema",
+  "title": "I18n builder",
+  "description": "I18n builder options",
+  "properties": {
+    "localizationConfigs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "localizationFiles": {
+            "type": "array",
+            "description": "Glob to define how to find localization json files",
+            "items": {
+              "type": "string"
+            }
+          },
+          "i18nFolderPath": {
+            "type": "string",
+            "description": "Folder path for the i18n folder relative to the localization json file",
+            "default": "i18n"
+          }
+        }
+      }
+    },
+    "defaultLanguageFile": {
+      "type": "string",
+      "description": "Name of the file for the default language",
+      "default": "en-GB.json"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["localizationConfigs"]
+}

--- a/packages/@o3r/transloco/builders/i18n/schema.ts
+++ b/packages/@o3r/transloco/builders/i18n/schema.ts
@@ -1,0 +1,35 @@
+import type {
+  JsonObject,
+} from '@angular-devkit/core';
+
+/**
+ * Configuration for localization files
+ */
+export interface LocalizationConfig extends JsonObject {
+  /**
+   * Glob to define how to find localization json files
+   */
+  localizationFiles: string[];
+
+  /**
+   * Folder path for the i18n folder relative to the localization json file
+   * @default 'i18n'
+   */
+  i18nFolderPath: string;
+}
+
+/**
+ * Schema for the i18n builder
+ */
+export interface I18nBuilderSchema extends JsonObject {
+  /**
+   * List of LocalizationConfig
+   */
+  localizationConfigs: LocalizationConfig[];
+
+  /**
+   * Name of the file for the default language
+   * @default 'en-GB.json'
+   */
+  defaultLanguageFile: string;
+}

--- a/packages/@o3r/transloco/builders/localization-extractor/index.spec.ts
+++ b/packages/@o3r/transloco/builders/localization-extractor/index.spec.ts
@@ -1,0 +1,63 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  Architect,
+} from '@angular-devkit/architect';
+import {
+  TestingArchitectHost,
+} from '@angular-devkit/architect/testing';
+import {
+  schema,
+} from '@angular-devkit/core';
+import {
+  cleanVirtualFileSystem,
+  useVirtualFileSystem,
+} from '@o3r/test-helpers';
+import {
+  LocalizationExtractorBuilderSchema,
+} from './schema';
+
+describe('Localization Extractor Builder', () => {
+  const workspaceRoot = path.join('..', '..', '..', '..', '..');
+  let architect: Architect;
+  let architectHost: TestingArchitectHost;
+  let virtualFileSystem: typeof fs;
+
+  beforeEach(() => {
+    virtualFileSystem = useVirtualFileSystem();
+
+    const registry = new schema.CoreSchemaRegistry();
+    registry.addPostTransform(schema.transforms.addUndefinedDefaults);
+    architectHost = new TestingArchitectHost(path.resolve(__dirname, workspaceRoot), __dirname);
+    architect = new Architect(architectHost, registry);
+    architectHost.addBuilder('.:extractor', require('./index').default);
+  });
+  afterEach(() => {
+    cleanVirtualFileSystem();
+  });
+
+  it('should extract the localizations', async () => {
+    const options: LocalizationExtractorBuilderSchema = {
+      tsConfig: 'apps/showcase/tsconfig.app.json',
+      outputFile: path.resolve(__dirname, workspaceRoot, 'apps/showcase/localisation.metadata.json'),
+      libraries: [],
+      extraFilePatterns: [
+        'src/i18n/*-localization.json'
+      ],
+      watch: false,
+      ignoreDuplicateKeys: false,
+      inline: false,
+      sortKeys: false,
+      strictMode: false
+    };
+    const run = await architect.scheduleBuilder('.:extractor', options);
+    const output = await run.result;
+    expect(output.error).toBeUndefined();
+    await run.stop();
+
+    const localizationOutput = JSON.parse(virtualFileSystem.readFileSync(options.outputFile, { encoding: 'utf8' }));
+    expect(typeof localizationOutput).toBe('object');
+    expect(typeof localizationOutput.length).toBe('number');
+    expect(localizationOutput[0].key).toMatch(/o3r-.*/);
+  });
+});

--- a/packages/@o3r/transloco/builders/localization-extractor/index.ts
+++ b/packages/@o3r/transloco/builders/localization-extractor/index.ts
@@ -1,0 +1,231 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  BuilderOutput,
+  createBuilder,
+} from '@angular-devkit/architect';
+import {
+  createBuilderWithMetricsIfInstalled,
+  validateJson,
+} from '@o3r/extractors';
+import {
+  O3rCliError,
+} from '@o3r/schematics';
+import * as chokidar from 'chokidar';
+import {
+  sync as globbySync,
+} from 'globby';
+import {
+  LibraryMetadataMap,
+  LocalizationExtractor,
+  LocalizationFileMap,
+} from '../helpers/localization-generator';
+import type {
+  LocalizationExtractorBuilderSchema,
+} from './schema';
+import {
+  validators,
+} from './validations';
+
+export type * from './schema';
+
+/**
+ * Builder to extract localization keys from an Otter project
+ */
+export default createBuilder(createBuilderWithMetricsIfInstalled<LocalizationExtractorBuilderSchema>(async (options, context): Promise<BuilderOutput> => {
+  context.reportRunning();
+
+  const localizationExtractor = new LocalizationExtractor(path.resolve(context.workspaceRoot, options.tsConfig), context.logger, options);
+  const cache: { libs: LibraryMetadataMap; locs: LocalizationFileMap } = { libs: {}, locs: {} };
+
+  const execute = async (isFirstLoad = true, files?: { libs?: string[]; locs?: string[]; extraFiles?: string[] }): Promise<BuilderOutput> => {
+    /** Maximum number of steps */
+    const STEP_NUMBER = !isFirstLoad && files ? (files.libs && files.libs.length > 0 ? 1 : 0) + (files.locs && files.locs.length > 0 ? 1 : 0) + 2 : 4;
+    let stepValue = 0;
+
+    try {
+      // load everything from TSConfig
+      if (isFirstLoad) {
+        context.reportProgress(STEP_NUMBER, stepValue++, 'Load localization');
+        cache.locs = await localizationExtractor.extractLocalizationFromTsConfig(files && files.extraFiles);
+
+        context.reportProgress(STEP_NUMBER, stepValue++, 'Load metadata');
+        cache.libs = files && files.libs ? await localizationExtractor.getMetadataFromLibraries(files.libs) : {};
+
+      // Load specific files that have changed
+      } else {
+        if (files && files.locs) {
+          context.reportProgress(STEP_NUMBER, stepValue++, 'reload localization');
+          const newLocs = await localizationExtractor.getLocalizationMap([...files.locs, ...(files.extraFiles || [])], Object.keys(cache.locs));
+          Object.keys(newLocs)
+            .forEach((key) => {
+              if (cache.locs[key]) {
+                newLocs[key].isDependency = cache.locs[key].isDependency;
+              }
+            });
+          cache.locs = {
+            ...cache.locs,
+            ...newLocs
+          };
+        }
+        if (files && files.libs) {
+          context.reportProgress(STEP_NUMBER, stepValue++, 'reload library metadata');
+          const newLibs = await localizationExtractor.getMetadataFromFiles(files.libs);
+          cache.libs = {
+            ...cache.libs,
+            ...newLibs
+          };
+        }
+      }
+
+      const metadata = localizationExtractor.generateMetadata(cache.locs, {
+        ignoreDuplicateKeys: options.ignoreDuplicateKeys,
+        libraryMetadata: cache.libs,
+        outputFile: options.outputFile,
+        sortKeys: options.sortKeys
+      });
+
+      context.reportProgress(STEP_NUMBER, stepValue++, 'Check translations string validation');
+      const translationsWithIssue = metadata
+        .filter((metadataItem) =>
+          !!metadataItem.value
+          && validators.reduce<boolean>((isInvalid, validator) => isInvalid || !validator(metadataItem.value!), false)
+        );
+      if (translationsWithIssue.length > 0) {
+        throw new O3rCliError(`The following translations are invalid: ${translationsWithIssue.map((translation) => translation.key).join(', ')}`);
+      }
+
+      validateJson(
+        metadata,
+        JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../schemas/localization.metadata.schema.json'), { encoding: 'utf8' })),
+        'The output of localization metadata is not valid regarding the json schema, please check the details below : \n',
+        options.strictMode
+      );
+
+      context.reportProgress(STEP_NUMBER, STEP_NUMBER, 'Generating metadata');
+
+      // Create output folder if does not exist
+      const localizationMetadataFolder = path.dirname(path.resolve(context.workspaceRoot, options.outputFile));
+      if (!fs.existsSync(localizationMetadataFolder)) {
+        fs.mkdirSync(localizationMetadataFolder, {
+          recursive: true
+        });
+      }
+      // Write metadata file
+      try {
+        await fs.promises.mkdir(path.dirname(path.resolve(context.workspaceRoot, options.outputFile)), { recursive: true });
+      } catch {}
+      await new Promise<void>((resolve, reject) =>
+        fs.writeFile(
+          path.resolve(context.workspaceRoot, options.outputFile),
+          options.inline ? JSON.stringify(metadata) : JSON.stringify(metadata, null, 2),
+          (err) => err ? reject(err) : resolve()
+        )
+      );
+    } catch (e: any) {
+      if (e.stack) {
+        context.logger.error(e.stack);
+      }
+
+      return {
+        success: false,
+        error: e.message || e.toString()
+
+      };
+    }
+
+    context.logger.info(`Localization metadata bundle extracted in ${options.outputFile}.`);
+
+    return {
+      success: true
+    };
+  };
+
+  /**
+   * Run a translation generation and report the result
+   * @param execution Execution process
+   */
+  const generateWithReport = async (execution: Promise<BuilderOutput>) => {
+    const result = await execution;
+
+    if (result.success) {
+      context.logger.info('Localization metadata updated');
+    } else if (result.error) {
+      context.logger.error(result.error);
+    }
+    context.reportStatus('Waiting for changes...');
+    return result;
+  };
+
+  const initialExtraLocs = options.extraFilePatterns.length > 0 ? globbySync(options.extraFilePatterns, { cwd: context.currentDirectory }) : [];
+
+  if (options.watch) {
+    let currentProcess: Promise<unknown> | undefined = generateWithReport(execute(true, { extraFiles: initialExtraLocs, libs: options.libraries }))
+      .then(() => {
+        currentProcess = undefined;
+      });
+
+    await currentProcess;
+
+    /** SCSS file watcher */
+    const watcher = chokidar.watch([...Object.keys(cache.locs), ...(options.extraFilePatterns || [])], { ignoreInitial: true });
+    const metadataWatcher = chokidar.watch(Object.keys(cache.libs), { ignoreInitial: true });
+    const { include, exclude, cwd } = localizationExtractor.getPatternsFromTsConfig();
+    const tsWatcher = chokidar.watch(include, { ignoreInitial: true, ignored: exclude, cwd });
+
+    tsWatcher
+      .on('add', async (filePath, fileStat) => {
+        if (!fileStat || !fileStat.isFile || !/\.ts$/.test(filePath)) {
+          return;
+        }
+        if (currentProcess) {
+          await currentProcess;
+        }
+        context.logger.info('Refreshed full metadata');
+        currentProcess = generateWithReport(execute(true, { extraFiles: initialExtraLocs, libs: options.libraries }));
+        await currentProcess;
+        currentProcess = undefined;
+        watcher.add(Object.keys(cache.locs));
+      });
+
+    metadataWatcher
+      .on('all', async (eventName, filePath) => {
+        if (currentProcess) {
+          context.logger.debug(`Ignored action ${eventName} on ${filePath}`);
+        } else {
+          context.logger.debug(`Refreshed for action ${eventName} on ${filePath}`);
+          currentProcess = generateWithReport(execute(false, { libs: [filePath] }));
+          await currentProcess;
+          currentProcess = undefined;
+        }
+      });
+
+    watcher
+      .on('all', async (eventName, filePath) => {
+        if (currentProcess) {
+          context.logger.debug(`Ignored action ${eventName} on ${filePath}`);
+        } else {
+          context.logger.debug(`Refreshed for action ${eventName} on ${filePath}`);
+          currentProcess = generateWithReport(execute(false, { locs: [filePath] }));
+          await currentProcess;
+          currentProcess = undefined;
+        }
+      });
+
+    context.addTeardown(async () => {
+      await watcher.close();
+      await metadataWatcher.close();
+      await tsWatcher.close();
+    });
+
+    // Exit on watcher failure
+    return new Promise<BuilderOutput>((_resolve, reject) => {
+      // TODO remove cast after https://github.com/paulmillr/chokidar/issues/1392
+      watcher.on('error', (err) => reject(err as Error));
+      metadataWatcher.on('error', (err) => reject(err as Error));
+      tsWatcher.on('error', (err) => reject(err as Error));
+    });
+  } else {
+    return execute(true, { extraFiles: initialExtraLocs, libs: options.libraries });
+  }
+}));

--- a/packages/@o3r/transloco/builders/localization-extractor/schema.json
+++ b/packages/@o3r/transloco/builders/localization-extractor/schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "$id": "LocalizationExtractorBuilderSchema",
+  "title": "Localization builder",
+  "description": "Localization builder options",
+  "properties": {
+    "tsConfig": {
+      "type": "string",
+      "description": "Typescript configuration file to build the application",
+      "default": "tsconfig.json"
+    },
+    "extraFilePatterns": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Path patterns of files to add to the generated metadata",
+      "default": []
+    },
+    "ignoreDuplicateKeys": {
+      "type": "boolean",
+      "description": "If true, extraction process is not interrupted in case of duplicate keys",
+      "default": false
+    },
+    "libraries": {
+      "type": "array",
+      "description": "List of libraries imported",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "outputFile": {
+      "type": "string",
+      "description": "Path to the output file",
+      "default": "localisation.metadata.json"
+    },
+    "watch": {
+      "type": "boolean",
+      "description": "Enable watch mode",
+      "default": false
+    },
+    "inline": {
+      "type": "boolean",
+      "description": "Write metadata inline",
+      "default": false
+    },
+    "sortKeys": {
+      "type": "boolean",
+      "description": "Sort metadata alphabetically by keys",
+      "default": false
+    },
+    "strictMode": {
+      "type": "boolean",
+      "description": "If activated, this option will fail when any property not supported by the CMS is found, it will be ignored if not activated",
+      "default": false
+    }
+  },
+  "additionalProperties": false,
+  "required": []
+}

--- a/packages/@o3r/transloco/builders/localization-extractor/schema.ts
+++ b/packages/@o3r/transloco/builders/localization-extractor/schema.ts
@@ -1,0 +1,36 @@
+import type {
+  JsonObject,
+} from '@angular-devkit/core';
+
+/**
+ * Schema for the localization extractor builder
+ */
+export interface LocalizationExtractorBuilderSchema extends JsonObject {
+
+  /** Typescript configuration file to build the application */
+  tsConfig: string;
+
+  /** If true, extraction process is not interrupted in case of duplicate keys */
+  ignoreDuplicateKeys: boolean;
+
+  /** List of libraries imported */
+  libraries: string[];
+
+  /** Path to the output file */
+  outputFile: string;
+
+  /** Enable watch mode */
+  watch: boolean;
+
+  /** Write metadata inline */
+  inline: boolean;
+
+  /** Path patterns of files to add to the generated metadata */
+  extraFilePatterns: string[];
+
+  /** If true, metadata objects are sorted by keys */
+  sortKeys: boolean;
+
+  /** If activated, this option will fail when any property not supported by the CMS is found, it will be ignored if not activated */
+  strictMode: boolean;
+}

--- a/packages/@o3r/transloco/builders/localization-extractor/validations.ts
+++ b/packages/@o3r/transloco/builders/localization-extractor/validations.ts
@@ -1,0 +1,56 @@
+/** Translation Validator */
+export type ValidatorType = (str: string) => boolean;
+
+/** Map of opening brackets to their closing counterparts */
+const MAP_BRACKETS = {
+  '[': ']',
+  '{': '}',
+  '(': ')'
+} as const;
+
+/** List of closing brackets */
+const CLOSURE_BRACKETS: string[] = Object.values(MAP_BRACKETS);
+
+/**
+ * Check that the opened parentheses are correctly closed
+ * @param str translation
+ */
+export function checkParentheses(str: string) {
+  const stack: string[] = [];
+
+  for (const ch of str) {
+    if (MAP_BRACKETS[ch as keyof typeof MAP_BRACKETS]) {
+      stack.push(ch);
+    } else if (CLOSURE_BRACKETS.includes(ch)) {
+      const tail = stack.pop();
+      if (!tail) {
+        return false;
+      }
+      const closure = MAP_BRACKETS[tail as keyof typeof MAP_BRACKETS];
+      if (closure !== ch) {
+        return false;
+      }
+    }
+  }
+
+  return stack.length === 0;
+}
+
+/**
+ * Check if the plural instruction always include an "other" case
+ * @param str translation
+ */
+export function checkOtherInPlural(str: string) {
+  if (/{[^,]*, *plural *, *.*}/.test(str)) {
+    return /{.*other.*}/.test(str);
+  }
+  return true;
+}
+
+/**
+ * List of validators to apply to the translations
+ */
+export const validators: ValidatorType[] = [
+  checkParentheses,
+  checkOtherInPlural
+];

--- a/packages/@o3r/transloco/builders/localization/builder.spec.ts
+++ b/packages/@o3r/transloco/builders/localization/builder.spec.ts
@@ -1,0 +1,40 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as builder from './index';
+
+const filesPerLanguage = {
+  en_US: [path.join(__dirname, '../../testing/mocks', 'test-resources', 'en_US.json')],
+  fr_FR: [path.join(__dirname, '../../testing/mocks', 'test-resources', 'fr_FR.json')],
+  en_GB: [path.join(__dirname, '../../testing/mocks', 'test-resources', 'en_GB.json')]
+};
+
+const languageFilesContent = Object.entries(filesPerLanguage).reduce((acc, [language, files]) => {
+  acc[language] = JSON.parse(fs.readFileSync(files[0]).toString());
+  return acc;
+}, {} as Record<string, Record<string, string>>);
+
+describe('Localization builder', () => {
+  beforeEach(() => {});
+
+  describe('getTranslationsForLanguage', () => {
+    it('No override should not merge files', () => {
+      const result = builder.getTranslationsForLanguage('en_GB', filesPerLanguage, {}, {});
+
+      expect(result).toEqual(languageFilesContent.en_GB);
+    });
+
+    it('Override should only merge specified files', () => {
+      const resultEnGb = builder.getTranslationsForLanguage('en_GB', filesPerLanguage, { en_GB: 'en_US' }, {});
+
+      expect(resultEnGb).toEqual({ ...languageFilesContent.en_US, ...languageFilesContent.en_GB });
+
+      const resultFrFr = builder.getTranslationsForLanguage('fr_FR', filesPerLanguage, { en_GB: 'en_US' }, {});
+
+      expect(resultFrFr).toEqual(languageFilesContent.fr_FR);
+    });
+
+    it('Circular override should throw', () => {
+      expect(() => builder.getTranslationsForLanguage('en_GB', filesPerLanguage, { en_GB: 'en_US', en_US: 'en_GB' }, {})).toThrow();
+    });
+  });
+});

--- a/packages/@o3r/transloco/builders/localization/index.spec.ts
+++ b/packages/@o3r/transloco/builders/localization/index.spec.ts
@@ -1,0 +1,80 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  Architect,
+  createBuilder,
+} from '@angular-devkit/architect';
+import {
+  TestingArchitectHost,
+} from '@angular-devkit/architect/testing';
+import {
+  schema,
+} from '@angular-devkit/core';
+import {
+  cleanVirtualFileSystem,
+  useVirtualFileSystem,
+} from '@o3r/test-helpers';
+import {
+  LocalizationBuilderSchema,
+} from './schema';
+
+describe('Localization Builder', () => {
+  const workspaceRoot = path.join('..', '..', '..', '..', '..');
+  let architect: Architect;
+  let architectHost: TestingArchitectHost;
+  let virtualFileSystem: typeof fs;
+
+  beforeEach(async () => {
+    virtualFileSystem = useVirtualFileSystem();
+
+    const registry = new schema.CoreSchemaRegistry();
+    registry.addPostTransform(schema.transforms.addUndefinedDefaults);
+    architectHost = new TestingArchitectHost(path.resolve(__dirname, workspaceRoot), __dirname);
+    architect = new Architect(architectHost, registry);
+    architectHost.addBuilder('.:localization', require('./index').default);
+    architectHost.addBuilder('noop', createBuilder(() => ({ success: true })));
+    architectHost.addTarget({ project: 'showcase', target: 'compile' }, 'noop', {
+      outputPath: path.resolve(__dirname, `${workspaceRoot}/apps/showcase/dist`)
+    });
+    architectHost.addTarget({ project: 'showcase', target: 'extract-translations' }, 'noop', {
+      outputFile: path.resolve(__dirname, `${workspaceRoot}/apps/showcase/localisation.metadata.json`)
+    });
+    await virtualFileSystem.promises.mkdir(path.resolve(__dirname, `${workspaceRoot}/apps/showcase`), { recursive: true });
+    await virtualFileSystem.promises.writeFile(path.resolve(__dirname, `${workspaceRoot}/apps/showcase/localisation.metadata.json`), '[]');
+  });
+  afterEach(() => {
+    cleanVirtualFileSystem();
+  });
+
+  it('should generate the localizations', async () => {
+    const options: LocalizationBuilderSchema = {
+      browserTarget: 'showcase:compile',
+      localizationExtracterTarget: 'showcase:extract-translations',
+      locales: [
+        'en-GB',
+        'fr-FR'
+      ],
+      assets: [
+        'apps/showcase/src/assets/locales',
+        'apps/showcase/src/assets/locales/*',
+        'apps/showcase/src/components/**/i18n'
+      ],
+      outputPath: path.resolve(__dirname, `${workspaceRoot}/apps/showcase/dev-resources/localizations`),
+      checkUnusedTranslation: true,
+      defaultLanguageMapping: {},
+      failIfMissingMetadata: false,
+      watch: false,
+      ignoreReferencesIfNotDefault: false,
+      useMetadataAsDefault: true
+    };
+    await virtualFileSystem.promises.mkdir(options.outputPath, { recursive: true });
+    const run = await architect.scheduleBuilder('.:localization', options);
+    const output = await run.result;
+    expect(output.error).toBeUndefined();
+    await run.stop();
+
+    const localizationOutput = virtualFileSystem.readdirSync(options.outputPath);
+    expect(localizationOutput).toContain('en-GB.json');
+    expect(localizationOutput).toContain('fr-FR.json');
+  });
+});

--- a/packages/@o3r/transloco/builders/localization/index.ts
+++ b/packages/@o3r/transloco/builders/localization/index.ts
@@ -1,0 +1,536 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  BuilderContext,
+  BuilderOutput,
+  createBuilder,
+  Target,
+} from '@angular-devkit/architect';
+import {
+  logging,
+} from '@angular-devkit/core';
+import {
+  createBuilderWithMetricsIfInstalled,
+} from '@o3r/extractors';
+import {
+  O3rCliError,
+} from '@o3r/schematics';
+import {
+  sync as globbySync,
+} from 'globby';
+import {
+  firstValueFrom,
+  from,
+  merge,
+} from 'rxjs';
+import {
+  filter,
+} from 'rxjs/operators';
+import type {
+  LocalizationExtractorBuilderSchema,
+} from '../localization-extractor/schema';
+import type {
+  LocalizationBuilderSchema,
+} from './schema';
+import type {
+  JSONLocalization,
+} from '@o3r/transloco';
+
+/** Maximum number of steps */
+const STEP_NUMBER = 5;
+/** File System debounce time */
+const FS_DEBOUNCE_TIME = 200;
+
+/**
+ * Get the list of translation files provided in the current package
+ * @param languages List of languages
+ * @param assets Folder containing the package override translations bundles
+ * @param context Ng Builder context
+ */
+function getAppTranslationFiles(languages: string[], assets: string | string[], context: BuilderContext): Record<string, string[]> {
+  const assetsList = (typeof assets === 'string' ? [assets] : assets);
+  const posixWorkspaceRoot = context.workspaceRoot.split(path.sep).join(path.posix.sep);
+
+  const languageFileEntries = globbySync(assetsList.map((asset) => path.posix.join(posixWorkspaceRoot, asset, '*.json')), {
+    objectMode: true
+  });
+
+  const filesPerLanguage = languageFileEntries.reduce<Record<string, string[]>>((acc, languageFileEntry) => {
+    const language = languageFileEntry.name.slice(0, -5); // Remove .json extension from the name
+    acc[language] = acc[language] || [];
+    acc[language].push(languageFileEntry.path);
+    return acc;
+  }, {});
+
+  const languagesToDelete = Object.keys(filesPerLanguage).filter((language) => !languages.includes(language));
+  languagesToDelete.forEach((language) => delete filesPerLanguage[language]);
+  return filesPerLanguage;
+}
+
+/**
+ * Check if a translation has been overridden at application level but not defined in the metadata
+ * @param language Language
+ * @param defaultBundle Default translation bundle
+ * @param customTranslations Override of translations provided by assets
+ * @param context ng Builder context
+ * @param metaData
+ * @param failIfMissingMetadata
+ */
+function checkUnusedTranslation(
+  language: string,
+  defaultBundle: { [k: string]: string },
+  customTranslations: { [k: string]: string },
+  context: BuilderContext,
+  metaData: JSONLocalization[],
+  failIfMissingMetadata: boolean
+) {
+  const dictionaryKeysPatterns = metaData
+    .filter((metadataItem) => metadataItem.dictionary)
+    .map((metadataItem) => metadataItem.key)
+    .map((key) => `${key}.`);
+
+  const missingMetadata = Object.keys(customTranslations)
+    .filter((key) => defaultBundle[key] === undefined)
+    .filter((key) => !dictionaryKeysPatterns.some((dictionaryKeyPattern) => key.startsWith(dictionaryKeyPattern)));
+
+  missingMetadata.forEach((key) => context.logger[failIfMissingMetadata ? 'error' : 'warn'](`The key "${key}" from "${language}" is not part of the MetaData`));
+
+  if (missingMetadata.length > 0 && failIfMissingMetadata) {
+    throw new O3rCliError(`There is missing metadata for ${language}`);
+  }
+}
+
+/**
+ * Clean localization json file.
+ * Note: it is used to remove $schema potentially added by the customization
+ * @param translationBundle Translation bundle
+ */
+function sanitizeLocalization(translationBundle: { [k: string]: string }) {
+  delete translationBundle.$schema;
+  return translationBundle;
+}
+
+/**
+ * Load all the translation files in the given array and created a single Object that associated to each key its localized value.
+ * @param files
+ */
+export function loadTranslations(files: string[]): { [k: string]: string } {
+  const translationList = files.map((file) => sanitizeLocalization(JSON.parse(fs.readFileSync(file).toString())));
+  return translationList.reduce<{ [k: string]: string }>((acc, translation) => Object.assign(acc, translation), {});
+}
+
+/**
+ * Computes the translation bundle for a given language, by resolving overrides specified in defaultLanguageMapping
+ * @param language
+ * @param filesPerLanguage
+ * @param defaultLanguageMapping
+ * @param memory
+ * @param dependencyPath
+ */
+export function getTranslationsForLanguage(
+  language: string,
+  filesPerLanguage: Record<string, string[]>,
+  defaultLanguageMapping: Record<string, string>,
+  memory: Record<string, Record<string, string>>,
+  dependencyPath: Set<string> = new Set()): Record<string, string> {
+  if (memory[language]) {
+    return memory[language];
+  }
+
+  dependencyPath.add(language);
+  const files = filesPerLanguage[language];
+
+  let translations: Record<string, string> = files ? loadTranslations(files) : {};
+
+  const defaultLanguage = defaultLanguageMapping[language];
+  // If a default language has been configured for this language
+  if (defaultLanguage) {
+    // Throw an error if we find a circular dependency
+    if (dependencyPath.has(defaultLanguage)) {
+      throw new O3rCliError(`Circular dependency found: ${[...Array.from(dependencyPath), defaultLanguage].join('->')}`);
+    } else {
+      // Else, recursively resolve its bundle and use it as a base for the current language
+      const defaultTranslations = getTranslationsForLanguage(defaultLanguage, filesPerLanguage, defaultLanguageMapping, memory, dependencyPath);
+
+      translations = {
+        ...defaultTranslations,
+        ...translations
+      };
+    }
+  }
+
+  memory[language] = translations;
+  return translations;
+}
+
+/**
+ * Get the translation bundle for each languages
+ * @param languages List of languages
+ * @param defaultBundle Default translation bundle
+ * @param fileMapping Mapping of translations per languages
+ * @param mapReferencesDictionary mapReferencesDictionary
+ * @param shouldCheckUnusedTranslation Specify if we need to check the translation not in metadata file
+ * @param context Ng Builder context
+ * @param metadata metadata
+ * @param refKeysMapping mapping for referencing towards referenced keys
+ * @param defaultLanguageMapping
+ * @param useMetadataAsDefault
+ * @param ignoreReferenceIfNotDefault
+ * @param failIfMissingMetadata
+ */
+function getBundlesPerLanguages(
+  languages: string[],
+  defaultBundle: Record<string, string>,
+  fileMapping: Record<string, string[]>,
+  mapReferencesDictionary: Record<string, string>,
+  shouldCheckUnusedTranslation: boolean,
+  context: BuilderContext,
+  metadata: JSONLocalization[] = [],
+  refKeysMapping: Record<string, string>,
+  defaultLanguageMapping: Record<string, string>,
+  useMetadataAsDefault: boolean,
+  ignoreReferenceIfNotDefault: boolean,
+  failIfMissingMetadata: boolean
+) {
+  const bundles: Record<string, Record<string, string>> = {};
+  const memory: Record<string, Record<string, string>> = {};
+  for (const language of languages) {
+    const translations = getTranslationsForLanguage(language, fileMapping, defaultLanguageMapping, memory);
+
+    if (shouldCheckUnusedTranslation) {
+      checkUnusedTranslation(language, defaultBundle, translations, context, metadata, failIfMissingMetadata);
+    }
+
+    const bundle = useMetadataAsDefault
+      ? {
+        ...defaultBundle,
+        ...translations
+      }
+      : translations;
+    bundles[language] = bundle;
+
+    Object.keys(mapReferencesDictionary)
+      .forEach((key) =>
+        Object.keys(bundles[language])
+          .filter((k) => k.startsWith(mapReferencesDictionary[key]))
+          .forEach((k) => {
+            const newKey = k.replace(mapReferencesDictionary[key], key);
+            if (!bundle[newKey]) {
+              bundle[newKey] = bundle[k];
+            }
+          })
+      );
+
+    Object.entries(refKeysMapping)
+      .forEach(([key, mappedKey]) => {
+        if (bundle[mappedKey] && (!ignoreReferenceIfNotDefault || bundle[key] === undefined || bundle[key] === defaultBundle[key])) {
+          bundle[key] = bundle[mappedKey];
+        }
+      });
+  }
+  return bundles;
+}
+
+/**
+ * Extract localization referred in metadata
+ * @param metaData Localization metadata
+ * @param key Translation key
+ */
+function getExtractReferredTranslationValue(metaData: JSONLocalization[], key: string): string {
+  const translationObj = metaData.find((data) => data.key === key);
+  if (translationObj) {
+    return translationObj.ref ? getExtractReferredTranslationValue(metaData, translationObj.ref) : translationObj.value || key;
+  } else {
+    return key;
+  }
+}
+
+/**
+ * Extract localization key referred in metadata
+ * @param metaData Localization metadata
+ * @param key Translation key
+ */
+function getExtractReferredTranslationKey(metaData: JSONLocalization[], key: string): string {
+  const translationObj = metaData.find((data) => data.key === key);
+  return (translationObj && !!translationObj.ref) ? getExtractReferredTranslationKey(metaData, translationObj.ref) : key;
+}
+
+/**
+ * Extract some data from the provided localization metadata:
+ * - The bundle containing default translations
+ * - The map that associates to every key containing a reference, the key it resolves to
+ * - The map that associated to every key being a dictionary reference, the key it resolves to
+ * @param metadata
+ */
+function processMetadata(metadata: JSONLocalization[]) {
+  const defaultTranslations: Record<string, string> = {};
+  const keyReferences: Record<string, string> = {};
+  const dictionaryReferences: Record<string, string> = {};
+
+  metadata.forEach((localization) => {
+    if (localization.value === undefined && localization.ref === undefined) {
+      return;
+    }
+    if (localization.ref) {
+      const extractedReference = getExtractReferredTranslationKey(metadata, localization.ref);
+      if (localization.dictionary) {
+        dictionaryReferences[localization.key] = extractedReference;
+      }
+      keyReferences[localization.key] = extractedReference;
+      defaultTranslations[localization.key] = getExtractReferredTranslationValue(metadata, localization.ref);
+    } else {
+      defaultTranslations[localization.key] = localization.value!;
+    }
+  });
+
+  return { defaultTranslations, keyReferences, dictionaryReferences };
+}
+
+/**
+ * Start the metadata generator in watch mode
+ * @param localizationExtractorTarget Target of the localization extractor builder
+ * @param context Builder context
+ */
+function startMetadataGenerator(localizationExtractorTarget: Target, context: BuilderContext) {
+  const logger = context.logger.createChild('Metadata Logger');
+  const extractorBuild = context.scheduleTarget(localizationExtractorTarget, { watch: true }, { logger });
+  return firstValueFrom(
+    merge(
+      logger.pipe(),
+      from(extractorBuild.then((build) => build.result))
+    ).pipe(
+      filter((entry) => !(entry as logging.LogEntry).message || /Localization metadata bundle extracted/.test((entry as logging.LogEntry).message))
+    )
+  );
+}
+
+/**
+ *  Regenerate the metadata if missing
+ * @param localizationMetaDataFile Path to the localization metadata file
+ * @param localizationExtractorTarget Localization Extractor target configured in the angular.json
+ * @param context Ng Builder context
+ */
+async function checkMetadata(localizationMetaDataFile: string, localizationExtractorTarget: Target, context: BuilderContext): Promise<BuilderOutput | undefined> {
+  let metaDataExists = fs.existsSync(localizationMetaDataFile);
+  if (!metaDataExists) {
+    context.logger.warn(`The file ${localizationMetaDataFile} does not exist, the extractor will be run`);
+    context.reportProgress(2, STEP_NUMBER, 'Generating Localization metadata file');
+    const extractorBuild = await context.scheduleTarget(localizationExtractorTarget, { watch: false });
+    const extractorBuildResult = await extractorBuild.result;
+    if (extractorBuildResult.success) {
+      metaDataExists = fs.existsSync(localizationMetaDataFile);
+      if (!metaDataExists) {
+        return {
+          success: false,
+          error: `The file ${localizationMetaDataFile} has not been generated`
+        };
+      }
+    } else {
+      return extractorBuildResult;
+    }
+  }
+}
+
+/**
+ * Builder to generate localization bundles
+ */
+export default createBuilder(createBuilderWithMetricsIfInstalled<LocalizationBuilderSchema>(async (options, context): Promise<BuilderOutput> => {
+  context.reportRunning();
+
+  // Load Targets to get build options
+  context.reportProgress(0, STEP_NUMBER, 'Checking required options');
+  let [project, target, configuration] = options.browserTarget.split(':');
+  const browserTarget = { project, target, configuration };
+
+  [project, target, configuration] = options.localizationExtracterTarget.split(':');
+  const localizationExtractorTarget = { project, target, configuration };
+
+  const [browserTargetRawOptions, localizationExtracterTargetRawOptions, browserTargetBuilder, localizationExtracterTargetBuilder] = await Promise.all([
+    context.getTargetOptions(browserTarget),
+    context.getTargetOptions(localizationExtractorTarget),
+    context.getBuilderNameForTarget(browserTarget),
+    context.getBuilderNameForTarget(localizationExtractorTarget)
+  ]);
+  const [browserTargetOptions, localizationExtracterTargetOptions] = await Promise.all([
+    context.validateOptions<{ outputPath?: string | { base: string; browser?: string } }>(browserTargetRawOptions, browserTargetBuilder),
+    context.validateOptions<LocalizationExtractorBuilderSchema>(localizationExtracterTargetRawOptions, localizationExtracterTargetBuilder)
+  ]);
+  let browserTargetOptionsOutputPath: string;
+  // Check the minimum of mandatory options to the builders
+  if (typeof browserTargetOptions.outputPath !== 'string' && typeof browserTargetOptions.outputPath?.base !== 'string') {
+    browserTargetOptionsOutputPath = path.join(context.workspaceRoot, 'dist', browserTarget.project); // outputPath became optional in Angular v20
+  } else if (typeof browserTargetOptions.outputPath === 'string') {
+    browserTargetOptionsOutputPath = browserTargetOptions.outputPath;
+  } else {
+    browserTargetOptionsOutputPath = path.join(browserTargetOptions.outputPath.base,
+      typeof browserTargetOptions.outputPath.browser === 'string' ? browserTargetOptions.outputPath.browser : '');
+  }
+  if (typeof localizationExtracterTargetOptions.outputFile !== 'string') {
+    return {
+      success: false,
+      error: `The targetLocalizationExtracter ${options.localizationExtracterTarget} does not provide 'outputFile' option`
+    };
+  }
+
+  /** Path to the build output folder */
+  const outputPath = path.resolve(context.workspaceRoot, browserTargetOptionsOutputPath);
+  /** Path to the metadata file */
+  const localizationMetaDataFile = path.resolve(context.workspaceRoot, localizationExtracterTargetOptions.outputFile);
+
+  /**
+   * Generate translation bundles
+   * @param languageToRegenerate language to focus on
+   */
+  const execute = (languageToRegenerate?: string): BuilderOutput => {
+    /** Localization metadata */
+    context.reportProgress(1, STEP_NUMBER, 'Checking Metadata');
+    const metaData = JSON.parse(fs.readFileSync(localizationMetaDataFile, { encoding: 'utf8' })) as JSONLocalization[];
+
+    context.reportProgress(3, STEP_NUMBER, 'Loading translation files');
+    /** List of translation files provided in the current package */
+    const appTranslationFiles = options.assets?.length ? getAppTranslationFiles(options.locales, options.assets, context) : {};
+
+    /** Mapping between the language and the custom translation of the package */
+    const fileMapping = languageToRegenerate ? { [languageToRegenerate]: appTranslationFiles[languageToRegenerate] } : appTranslationFiles;
+
+    const { defaultTranslations, keyReferences, dictionaryReferences } = processMetadata(metaData);
+
+    context.reportProgress(4, STEP_NUMBER, 'Merging translations');
+    try {
+      /** List of final translation bundles */
+      const bundles = getBundlesPerLanguages(
+        languageToRegenerate ? [languageToRegenerate] : options.locales,
+        defaultTranslations,
+        fileMapping,
+        dictionaryReferences,
+        options.checkUnusedTranslation,
+        context,
+        metaData,
+        keyReferences,
+        options.defaultLanguageMapping,
+        options.useMetadataAsDefault,
+        options.ignoreReferencesIfNotDefault,
+        options.failIfMissingMetadata
+      );
+
+      context.reportProgress(5, STEP_NUMBER, 'Writing translations');
+
+      // Write translation files
+      const writingFolder = options.outputPath || outputPath || '.';
+      if (!fs.existsSync(writingFolder)) {
+        fs.mkdirSync(writingFolder, { recursive: true });
+      }
+
+      Object.entries(bundles).forEach(([language, bundle]) => {
+        const filePath = path.resolve(writingFolder, `${language}.json`);
+        context.logger.info(`Writing file to disk ${filePath}`);
+        fs.writeFileSync(filePath, JSON.stringify(bundle, Object.keys(bundle).toSorted(), 2));
+      });
+
+      return {
+        success: true
+      };
+    } catch (error: any) {
+      return {
+        success: false,
+        error: typeof error === 'string' ? error : error.message
+      };
+    }
+  };
+
+  /** Timeout to handle nodejs issue (#1970) */
+  const fsTimeout: { [file: string]: NodeJS.Timeout | number | null } = {};
+
+  /**
+   * Run a translation generation and report the result
+   * @param language Language that has changed and requires a regeneration
+   */
+  const generateWithReport = (language?: string) => {
+    const result = execute(language);
+
+    if (result.success && language) {
+      context.logger.info(`Translations updated based on changes in ${language}`);
+    } else if (result.error) {
+      context.logger.error(result.error);
+    }
+    context.reportStatus('Waiting for changes');
+    return result;
+  };
+
+  /**
+   * Run a translation generation for metadata change
+   */
+  const generateForMetadataChange = () => {
+    const METADATA_LABEL = 'metadata';
+    if (fsTimeout[METADATA_LABEL]) {
+      return;
+    }
+
+    fsTimeout[METADATA_LABEL] = setTimeout(() => {
+      fsTimeout[METADATA_LABEL] = null;
+      const result = generateWithReport();
+      if (result.success) {
+        context.logger.info('Translations updated based on metadata');
+      }
+    }, FS_DEBOUNCE_TIME);
+  };
+
+  /**
+   * Run a translation generation for asset change
+   * @param filename File that has changed and requires a regeneration
+   * @param fullFilePath
+   */
+  const generateForAssetsChange = (filename: string, fullFilePath: string) => {
+    if (fsTimeout[filename]) {
+      return;
+    }
+
+    fsTimeout[filename] = setTimeout(() => {
+      fsTimeout[filename] = null;
+      context.logger.info(`Change triggered in ${fullFilePath}`);
+      generateWithReport(path.parse(filename).name);
+    }, FS_DEBOUNCE_TIME);
+  };
+
+  if (options.watch) {
+    const metaDataGeneration = await startMetadataGenerator(localizationExtractorTarget, context);
+    const metaDataGenerationResult = metaDataGeneration && metaDataGeneration.output && metaDataGeneration.result;
+    if (metaDataGenerationResult && !(metaDataGenerationResult as BuilderOutput).success) {
+      return metaDataGenerationResult as BuilderOutput;
+    }
+    // Execute the generation a first time
+    generateWithReport();
+
+    // Create file watchers
+    let assetsWatchers: fs.FSWatcher[] = [];
+    if (options.assets) {
+      const assetsList = (typeof options.assets === 'string' ? [options.assets] : options.assets);
+      const posixWorkspaceRoot = context.workspaceRoot.split(path.sep).join(path.posix.sep);
+      const filenamesToInclude = `(${options.locales.join('|')}).json`;
+      const assets = globbySync(assetsList.map((asset) => path.posix.join(posixWorkspaceRoot, asset, filenamesToInclude)));
+      assetsWatchers = assetsWatchers.concat(
+        assets.map((asset) => fs.watch(asset, (_eventType, filename) => generateForAssetsChange(filename as string, asset)))
+      );
+    }
+
+    const metadataWatcher = fs.watch(localizationMetaDataFile, () => generateForMetadataChange());
+
+    context.addTeardown(() => {
+      assetsWatchers.forEach((assetsWatcher) => assetsWatcher.close());
+      metadataWatcher.close();
+    });
+
+    // Exit on watcher failure
+    return new Promise<BuilderOutput>((_resolve, reject) => {
+      assetsWatchers.forEach((assetsWatcher) => assetsWatcher.once('error', (err) => reject(err)));
+      metadataWatcher.once('error', (err) => reject(err));
+    });
+  } else {
+    // Execute the generation only once if not watch mode
+    const metaDataGeneration = await checkMetadata(localizationMetaDataFile, localizationExtractorTarget, context);
+    if (metaDataGeneration && !metaDataGeneration.success) {
+      return metaDataGeneration;
+    }
+    return execute();
+  }
+}));

--- a/packages/@o3r/transloco/builders/localization/schema.json
+++ b/packages/@o3r/transloco/builders/localization/schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "LocalizationBuilderSchema",
+  "title": "Localization builder",
+  "description": "Localization builder options",
+  "properties": {
+    "browserTarget": {
+      "type": "string",
+      "description": "Target to build."
+    },
+    "localizationExtracterTarget": {
+      "type": "string",
+      "description": "Target translation extracter."
+    },
+    "outputPath": {
+      "type": "string",
+      "description": "Output path to localization bundles"
+    },
+    "locales": {
+      "type": "array",
+      "description": "List of languages to generate",
+      "default": ["en-GB"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "defaultLanguageMapping": {
+      "type": "object",
+      "description": "Map that associates to a locale, the other locale / language that should be used as default values",
+      "default": {},
+      "additionalProperties": { "type":  "string" }
+    },
+    "useMetadataAsDefault": {
+      "type": "boolean",
+      "description": "Should missing translations for a given language be filled from the default values from the metadata or not",
+      "default": true
+    },
+    "ignoreReferencesIfNotDefault": {
+      "type": "boolean",
+      "description": "Do not resolve references when the value of the child key has been customized (eg. is neither undefined or the default value)",
+      "default": false
+    },
+    "assets": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ],
+      "description": "Asset folder containing the package translations"
+    },
+    "checkUnusedTranslation": {
+      "type": "boolean",
+      "description": "Check if a translation from the asset folder is not a registered translation",
+      "default": true
+    },
+    "watch": {
+      "type": "boolean",
+      "description": "Enable watch mode",
+      "default": false
+    },
+    "failIfMissingMetadata": {
+      "type": "boolean",
+      "description": "Throws an error if there is missing metadata",
+      "default": false
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "localizationExtracterTarget",
+    "browserTarget"
+  ]
+}

--- a/packages/@o3r/transloco/builders/localization/schema.ts
+++ b/packages/@o3r/transloco/builders/localization/schema.ts
@@ -1,0 +1,42 @@
+import type {
+  JsonObject,
+} from '@angular-devkit/core';
+
+/**
+ * Schema for the localization builder
+ */
+export interface LocalizationBuilderSchema extends JsonObject {
+
+  /** Target to build */
+  browserTarget: string;
+
+  /** Target translation extracter */
+  localizationExtracterTarget: string;
+
+  /** Output path to localization bundles */
+  outputPath: string;
+
+  /** List of languages to generate */
+  locales: string[];
+
+  /** Map that associates to a locale, the other locale / language that should be used as default values */
+  defaultLanguageMapping: Record<string, string>;
+
+  /** Should missing translations for a given language be filled from the default values from the metadata or not */
+  useMetadataAsDefault: boolean;
+
+  /** Do not resolve references when the value of the child key has been customized (eg. is neither undefined or the default value) */
+  ignoreReferencesIfNotDefault: boolean;
+
+  /** Asset folder containing the package translations */
+  assets: string[] | string | null;
+
+  /** Check if a translation from the asset folder is not a registered translation */
+  checkUnusedTranslation: boolean;
+
+  /** Enable watch mode */
+  watch: boolean;
+
+  /** Throws an error if there is missing metadata */
+  failIfMissingMetadata: boolean;
+}

--- a/packages/@o3r/transloco/builders/metadata-check/helpers/index.ts
+++ b/packages/@o3r/transloco/builders/metadata-check/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './localization-metadata-comparison-helper';

--- a/packages/@o3r/transloco/builders/metadata-check/helpers/localization-metadata-comparison-helper.ts
+++ b/packages/@o3r/transloco/builders/metadata-check/helpers/localization-metadata-comparison-helper.ts
@@ -1,0 +1,51 @@
+import type {
+  MetadataComparator,
+} from '@o3r/extractors';
+import type {
+  JSONLocalization,
+  LocalizationMetadata,
+} from '@o3r/transloco';
+
+/**
+ * Interface describing a localization migration element
+ */
+export interface MigrationLocalizationMetadata {
+  /** Localization key */
+  key: string;
+}
+
+/**
+ * Returns an array of localization metadata from a metadata file.
+ * @param content Content of a migration metadata file
+ */
+const getLocalizationArray = (content: LocalizationMetadata) => content;
+
+/**
+ * Returns the localization key identifier
+ * @param localization Localization metadata object
+ */
+const getLocalizationName = (localization: JSONLocalization) => localization.key;
+
+/**
+ * Checks if the content type is relevant for localization metadata
+ * @param contentType Content type to check
+ */
+const isRelevantContentType = (contentType: string) => contentType === 'LOCALIZATION';
+
+/**
+ * Checks if a localization matches the migration data
+ * @param localization Localization metadata object
+ * @param migrationData Migration metadata to match against
+ */
+const isMigrationLocalizationDataMatch = (localization: JSONLocalization, migrationData: MigrationLocalizationMetadata) =>
+  getLocalizationName(localization) === migrationData.key;
+
+/**
+ * Comparator used to compare one version of localization metadata with another
+ */
+export const localizationMetadataComparator: Readonly<MetadataComparator<JSONLocalization, MigrationLocalizationMetadata, LocalizationMetadata>> = {
+  getArray: getLocalizationArray,
+  getIdentifier: getLocalizationName,
+  isRelevantContentType,
+  isMigrationDataMatch: isMigrationLocalizationDataMatch
+} as const;

--- a/packages/@o3r/transloco/builders/metadata-check/index.it.spec.ts
+++ b/packages/@o3r/transloco/builders/metadata-check/index.it.spec.ts
@@ -1,0 +1,326 @@
+/**
+ * Test environment exported by O3rEnvironment, must be first line of the file
+ * @jest-environment @o3r/test-helpers/jest-environment
+ * @jest-environment-o3r-app-folder test-app-localization-metadata-check
+ */
+const o3rEnvironment = globalThis.o3rEnvironment;
+
+import {
+  existsSync,
+  promises,
+  readFileSync,
+} from 'node:fs';
+import {
+  dirname,
+  join,
+} from 'node:path';
+import type {
+  MigrationFile,
+} from '@o3r/extractors';
+import {
+  getExternalDependenciesVersionRange,
+  getPackageManager,
+} from '@o3r/schematics';
+import {
+  getDefaultExecSyncOptions,
+  getLatestPackageVersion,
+  packageManagerAdd,
+  packageManagerExec,
+  packageManagerVersion,
+  publishToVerdaccio,
+} from '@o3r/test-helpers';
+import {
+  inc,
+} from 'semver';
+import type {
+  MigrationLocalizationMetadata,
+} from './helpers/localization-metadata-comparison-helper';
+import type {
+  JSONLocalization,
+  LocalizationMetadata,
+} from '@o3r/transloco';
+
+const baseVersion = '1.2.0';
+const version = '1.3.0';
+const migrationDataFileName = `migration-scripts/MIGRATION-${version}.json`;
+const metadataFileName = 'localisation.metadata.json';
+
+const defaultMigrationData: MigrationFile<MigrationLocalizationMetadata> = {
+  version,
+  changes: [
+    { // Rename key name
+      contentType: 'LOCALIZATION',
+      before: {
+        key: 'localization.key1'
+      },
+      after: {
+        key: 'new-localization.key1'
+      }
+    }
+  ]
+};
+
+const createLoc = (key: string): JSONLocalization => ({
+  key,
+  description: '',
+  dictionary: false,
+  referenceData: false
+});
+
+const previousLocalizationMetadata: LocalizationMetadata = [
+  createLoc('localization.key0'),
+  createLoc('localization.key1')
+];
+
+const newLocalizationMetadata: LocalizationMetadata = [
+  previousLocalizationMetadata[0],
+  createLoc('new-localization.key1')
+];
+
+async function writeFileAsJSON(path: string, content: object) {
+  if (!existsSync(dirname(path))) {
+    await promises.mkdir(dirname(path), { recursive: true });
+  }
+  await promises.writeFile(path, JSON.stringify(content), { encoding: 'utf8' });
+}
+
+const initTest = async (
+  newMetadata: LocalizationMetadata,
+  migrationData: MigrationFile<MigrationLocalizationMetadata>,
+  packageNameSuffix: string,
+  options?: {
+    allowBreakingChanges?: boolean;
+    shouldCheckUnusedMigrationData?: boolean;
+    prerelease?: string;
+  }
+) => {
+  const {
+    allowBreakingChanges = false,
+    shouldCheckUnusedMigrationData = false,
+    prerelease
+  } = options || {};
+  const { workspacePath, appName, applicationPath, o3rVersion, isYarnTest } = o3rEnvironment.testEnvironment;
+  const execAppOptions = { ...getDefaultExecSyncOptions(), cwd: applicationPath };
+  const execAppOptionsWorkspace = { ...getDefaultExecSyncOptions(), cwd: workspacePath };
+  packageManagerExec({ script: 'ng', args: ['add', `@o3r/extractors@${o3rVersion}`, '--skip-confirmation', '--project-name', appName] }, execAppOptionsWorkspace);
+  packageManagerExec({ script: 'ng', args: ['add', `@o3r/transloco@${o3rVersion}`, '--skip-confirmation', '--project-name', appName] }, execAppOptionsWorkspace);
+  const versions = getExternalDependenciesVersionRange([
+    'semver',
+    ...(isYarnTest
+      ? [
+        '@yarnpkg/core',
+        '@yarnpkg/fslib',
+        '@yarnpkg/plugin-npm',
+        '@yarnpkg/plugin-pack',
+        '@yarnpkg/cli'
+      ]
+      : [])
+  ], join(__dirname, '..', '..', 'package.json'), {
+    warn: jest.fn()
+  } as any);
+  Object.entries(versions).forEach(([pkgName, pkgVersion]) => packageManagerAdd(`${pkgName}@${pkgVersion}`, execAppOptionsWorkspace));
+  const npmIgnorePath = join(applicationPath, '.npmignore');
+  const packageJsonPath = join(applicationPath, 'package.json');
+  const angularJsonPath = join(workspacePath, 'angular.json');
+  const metadataPath = join(applicationPath, metadataFileName);
+  const migrationDataPath = join(applicationPath, migrationDataFileName);
+
+  // Add builder options
+  const angularJson = JSON.parse(readFileSync(angularJsonPath, { encoding: 'utf8' }).toString());
+  const builderConfig = {
+    builder: '@o3r/transloco:check-localization-migration-metadata',
+    options: {
+      allowBreakingChanges,
+      shouldCheckUnusedMigrationData,
+      migrationDataPath: `apps/test-app/migration-scripts/MIGRATION-*.json`
+    }
+  };
+  angularJson.projects[appName].architect['check-metadata'] = builderConfig;
+  await writeFileAsJSON(angularJsonPath, angularJson);
+
+  // Add scope to project for registry management
+  let packageJson = JSON.parse(readFileSync(packageJsonPath, { encoding: 'utf8' }).toString());
+  const packageName = `@o3r/${o3rEnvironment.testEnvironment.folderName}-${packageNameSuffix}`;
+  packageJson = {
+    ...packageJson,
+    name: packageName,
+    private: false
+  };
+  await writeFileAsJSON(packageJsonPath, packageJson);
+  await promises.writeFile(npmIgnorePath, '');
+
+  // Set old metadata and publish to registry
+  await writeFileAsJSON(metadataPath, previousLocalizationMetadata);
+
+  let latestVersion;
+  try {
+    latestVersion = getLatestPackageVersion(packageName, execAppOptionsWorkspace);
+  } catch {
+    latestVersion = baseVersion;
+  }
+
+  const prereleaseSuffix = prerelease ? `-${prerelease}.0` : '';
+  const bumpedVersion = inc(latestVersion.replace(/-.*$/, ''), 'patch') + prereleaseSuffix;
+
+  const args = getPackageManager() === 'yarn' ? [] : ['--no-git-tag-version', '-f'];
+  packageManagerVersion(bumpedVersion, args, execAppOptions);
+
+  await publishToVerdaccio(execAppOptions);
+
+  // Override with new metadata for comparison
+  await writeFileAsJSON(metadataPath, newMetadata);
+
+  // Add migration data file
+  await writeFileAsJSON(migrationDataPath, migrationData);
+};
+
+describe('check metadata migration', () => {
+  test('should not throw', async () => {
+    await initTest(
+      newLocalizationMetadata,
+      defaultMigrationData,
+      'allow-breaking-changes',
+      { allowBreakingChanges: true, shouldCheckUnusedMigrationData: false }
+    );
+    const { workspacePath, appName } = o3rEnvironment.testEnvironment;
+    const execAppOptionsWorkspace = { ...getDefaultExecSyncOptions(), cwd: workspacePath };
+
+    expect(() => packageManagerExec({ script: 'ng', args: ['run', `${appName}:check-metadata`] }, execAppOptionsWorkspace)).not.toThrow();
+  });
+
+  test('should not throw on prerelease', async () => {
+    await initTest(
+      newLocalizationMetadata,
+      defaultMigrationData,
+      'allow-breaking-changes-prerelease',
+      { allowBreakingChanges: true, shouldCheckUnusedMigrationData: false, prerelease: 'rc' }
+    );
+    const { workspacePath, appName } = o3rEnvironment.testEnvironment;
+    const execAppOptionsWorkspace = { ...getDefaultExecSyncOptions(), cwd: workspacePath };
+
+    expect(() => packageManagerExec({ script: 'ng', args: ['run', `${appName}:check-metadata`] }, execAppOptionsWorkspace)).not.toThrow();
+  });
+
+  test('should throw because no migration data', async () => {
+    await initTest(
+      newLocalizationMetadata,
+      {
+        ...defaultMigrationData,
+        changes: []
+      },
+      'no-migration-data',
+      { allowBreakingChanges: true, shouldCheckUnusedMigrationData: false }
+    );
+    const { workspacePath, appName } = o3rEnvironment.testEnvironment;
+    const execAppOptionsWorkspace = { ...getDefaultExecSyncOptions(), cwd: workspacePath };
+
+    try {
+      packageManagerExec({ script: 'ng', args: ['run', `${appName}:check-metadata`] }, execAppOptionsWorkspace);
+      throw new Error('should have thrown before');
+    } catch (e: any) {
+      /* eslint-disable jest/no-conditional-expect -- catch block always reached */
+      expect(e.message).not.toBe('should have thrown before');
+      previousLocalizationMetadata.slice(1).forEach(({ key: id }) => {
+        expect(e.message).toContain(`Property ${id} has been modified but is not documented in the migration document`);
+        expect(e.message).not.toContain(`Property ${id} has been modified but the new property is not present in the new metadata`);
+        expect(e.message).not.toContain(`Property ${id} is not present in the new metadata and breaking changes are not allowed`);
+      });
+      /* eslint-enable jest/no-conditional-expect */
+    }
+  });
+
+  test('should throw because migration data invalid', async () => {
+    await initTest(
+      [newLocalizationMetadata[0]],
+      {
+        ...defaultMigrationData,
+        changes: defaultMigrationData.changes.map((change) => ({
+          ...change,
+          after: {
+            ...change.after,
+            key: 'invalid.key'
+          }
+        }))
+      },
+      'invalid-data',
+      { allowBreakingChanges: true, shouldCheckUnusedMigrationData: false }
+    );
+    const { workspacePath, appName } = o3rEnvironment.testEnvironment;
+    const execAppOptionsWorkspace = { ...getDefaultExecSyncOptions(), cwd: workspacePath };
+
+    try {
+      packageManagerExec({ script: 'ng', args: ['run', `${appName}:check-metadata`] }, execAppOptionsWorkspace);
+      throw new Error('should have thrown before');
+    } catch (e: any) {
+      /* eslint-disable jest/no-conditional-expect -- catch block always reached */
+      expect(e.message).not.toBe('should have thrown before');
+      previousLocalizationMetadata.slice(1).forEach(({ key: id }) => {
+        expect(e.message).not.toContain(`Property ${id} has been modified but is not documented in the migration document`);
+        expect(e.message).toContain(`Property ${id} has been modified but the new property is not present in the new metadata`);
+        expect(e.message).not.toContain(`Property ${id} is not present in the new metadata and breaking changes are not allowed`);
+      });
+      /* eslint-enable jest/no-conditional-expect */
+    }
+  });
+
+  test('should throw because breaking changes are not allowed', async () => {
+    await initTest(
+      newLocalizationMetadata,
+      {
+        ...defaultMigrationData,
+        changes: []
+      },
+      'breaking-changes',
+      { allowBreakingChanges: false, shouldCheckUnusedMigrationData: false }
+    );
+    const { workspacePath, appName } = o3rEnvironment.testEnvironment;
+    const execAppOptionsWorkspace = { ...getDefaultExecSyncOptions(), cwd: workspacePath };
+
+    try {
+      packageManagerExec({ script: 'ng', args: ['run', `${appName}:check-metadata`] }, execAppOptionsWorkspace);
+      throw new Error('should have thrown before');
+    } catch (e: any) {
+      /* eslint-disable jest/no-conditional-expect -- catch block always reached */
+      expect(e.message).not.toBe('should have thrown before');
+      previousLocalizationMetadata.slice(1).forEach(({ key: id }) => {
+        expect(e.message).not.toContain(`Property ${id} has been modified but is not documented in the migration document`);
+        expect(e.message).not.toContain(`Property ${id} has been modified but the new property is not present in the new metadata`);
+        expect(e.message).toContain(`Property ${id} is not present in the new metadata and breaking changes are not allowed`);
+      });
+      /* eslint-enable jest/no-conditional-expect */
+    }
+  });
+
+  test('should throw because of unused migration data', async () => {
+    const unusedMigrationItem = {
+      contentType: 'LOCALIZATION',
+      before: {
+        key: 'fake-remove'
+      }
+    };
+    await initTest(
+      newLocalizationMetadata,
+      {
+        ...defaultMigrationData,
+        changes: [
+          ...defaultMigrationData.changes,
+          unusedMigrationItem
+        ]
+      },
+      'unused-migration-data',
+      { allowBreakingChanges: true, shouldCheckUnusedMigrationData: true }
+    );
+    const { workspacePath, appName } = o3rEnvironment.testEnvironment;
+    const execAppOptionsWorkspace = { ...getDefaultExecSyncOptions(), cwd: workspacePath };
+
+    try {
+      packageManagerExec({ script: 'ng', args: ['run', `${appName}:check-metadata`] }, execAppOptionsWorkspace);
+      throw new Error('should have thrown before');
+    } catch (e: any) {
+      /* eslint-disable jest/no-conditional-expect -- catch block always called */
+      expect(e.message).not.toBe('should have thrown before');
+      expect(e.message).toContain(`The following migration data has been documented but no corresponding metadata change was found: ${JSON.stringify(unusedMigrationItem, null, 2)}`);
+      /* eslint-enable jest/no-conditional-expect */
+    }
+  });
+});

--- a/packages/@o3r/transloco/builders/metadata-check/index.ts
+++ b/packages/@o3r/transloco/builders/metadata-check/index.ts
@@ -1,0 +1,21 @@
+import {
+  type BuilderOutput,
+  createBuilder,
+} from '@angular-devkit/architect';
+import {
+  checkMetadataBuilder,
+  createBuilderWithMetricsIfInstalled,
+} from '@o3r/extractors';
+import {
+  localizationMetadataComparator,
+} from './helpers';
+import type {
+  LocalizationMigrationMetadataCheckBuilderSchema,
+} from './schema';
+
+/**
+ * Builder to check for localization metadata breaking changes
+ */
+export default createBuilder<LocalizationMigrationMetadataCheckBuilderSchema>(createBuilderWithMetricsIfInstalled((options, context): Promise<BuilderOutput> => {
+  return checkMetadataBuilder({ ...options, packageJsonEntry: 'localizationFilePath' }, context, localizationMetadataComparator);
+}));

--- a/packages/@o3r/transloco/builders/metadata-check/schema.json
+++ b/packages/@o3r/transloco/builders/metadata-check/schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "$id": "LocalizationMigrationMetadataCheckBuilderSchema",
+  "title": "Check localization migration metadata builder",
+  "description": "Check localization migration metadata builder",
+  "properties": {
+    "migrationDataPath": {
+      "type": ["string", "array"],
+      "items": {
+        "type": "string"
+      },
+      "description": "Glob of the migration files to use."
+    },
+    "granularity": {
+      "type": "string",
+      "description": "Granularity of the migration check.",
+      "default": "minor",
+      "enum": [
+        "major",
+        "minor"
+      ]
+    },
+    "allowBreakingChanges": {
+      "type": "boolean",
+      "description": "Are breaking changes allowed.",
+      "default": false
+    },
+    "shouldCheckUnusedMigrationData": {
+      "type": "boolean",
+      "description": "Whether to throw an error in case of a migration item that is not used during metadata checks",
+      "default": false
+    },
+    "packageManager": {
+      "type": "string",
+      "description": "Override of the package manager, otherwise it will be determined from the project."
+    },
+    "metadataPath": {
+      "type": "string",
+      "description": "Path of the localization metadata file.",
+      "default": "./localisation.metadata.json"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["migrationDataPath"]
+}

--- a/packages/@o3r/transloco/builders/metadata-check/schema.ts
+++ b/packages/@o3r/transloco/builders/metadata-check/schema.ts
@@ -1,0 +1,7 @@
+import type {
+  MigrationMetadataCheckBuilderOptions,
+} from '@o3r/extractors';
+
+/** Migration metadata check builder schema */
+export interface LocalizationMigrationMetadataCheckBuilderSchema extends MigrationMetadataCheckBuilderOptions {
+}

--- a/packages/@o3r/transloco/jest.config.js
+++ b/packages/@o3r/transloco/jest.config.js
@@ -4,6 +4,7 @@ const { getJestProjectConfig } = require('@o3r/test-helpers');
 module.exports = {
   ...getJestProjectConfig(),
   projects: [
-    '<rootDir>/testing/jest.config.ut.js'
+    '<rootDir>/testing/jest.config.ut.js',
+    '<rootDir>/testing/jest.config.ut.builders.js'
   ]
 };

--- a/packages/@o3r/transloco/package.json
+++ b/packages/@o3r/transloco/package.json
@@ -18,17 +18,26 @@
     },
     "./schemas/*.json": {
       "default": "./schemas/*.json"
+    },
+    "./builders/*": {
+      "types": "./dist/builders/*.d.ts",
+      "default": "./dist/builders/*"
     }
   },
   "scripts": {
     "nx": "nx",
     "ng": "yarn nx",
     "copy:schemas": "yarn cpy 'schemas/*.json' dist/schemas",
+    "prepare:build:builders": "yarn cpy 'builders/**/*.json' dist/builders && yarn cpy 'builders.json' dist && yarn copy:schemas",
     "prepare:compile": "cp-package-json",
+    "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest",
     "build": "yarn nx build transloco",
     "test": "jest --passWithNoTests"
   },
   "peerDependencies": {
+    "@angular-devkit/architect": ">=0.2100.0 <0.2200.0-0",
+    "@angular-devkit/core": "^21.0.0",
+    "@angular-devkit/schematics": "^21.0.0",
     "@angular/cdk": "^21.0.0",
     "@angular/common": "^21.0.0",
     "@angular/core": "^21.0.0",
@@ -36,18 +45,47 @@
     "@ngrx/store": "^21.0.0",
     "@o3r/core": "workspace:~",
     "@o3r/dynamic-content": "workspace:~",
+    "@o3r/extractors": "workspace:~",
     "@o3r/logger": "workspace:~",
-    "intl-messageformat": "^11.0.0",
-    "rxjs": "^7.8.1"
+    "@o3r/schematics": "workspace:~",
+    "@schematics/angular": "^21.0.0",
+    "chokidar": "^4.0.0 || ^5.0.0",
+    "globby": "^11.1.0",
+    "rxjs": "^7.8.1",
+    "typescript": "^5.9.0"
   },
   "peerDependenciesMeta": {
+    "@angular-devkit/architect": {
+      "optional": true
+    },
+    "@angular-devkit/core": {
+      "optional": true
+    },
+    "@angular-devkit/schematics": {
+      "optional": true
+    },
     "@o3r/dynamic-content": {
+      "optional": true
+    },
+    "@o3r/extractors": {
       "optional": true
     },
     "@o3r/logger": {
       "optional": true
     },
-    "intl-messageformat": {
+    "@o3r/schematics": {
+      "optional": true
+    },
+    "@schematics/angular": {
+      "optional": true
+    },
+    "chokidar": {
+      "optional": true
+    },
+    "globby": {
+      "optional": true
+    },
+    "typescript": {
       "optional": true
     }
   },
@@ -56,7 +94,10 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
+    "@angular-devkit/architect": "0.2102.2",
     "@angular-devkit/build-angular": "~21.2.0",
+    "@angular-devkit/core": "~21.2.0",
+    "@angular-devkit/schematics": "~21.2.0",
     "@angular/animations": "~21.2.4",
     "@angular/cdk": "~21.2.0",
     "@angular/cli": "~21.2.0",
@@ -81,13 +122,16 @@
     "@o3r/dynamic-content": "workspace:~",
     "@o3r/eslint-config": "workspace:~",
     "@o3r/eslint-plugin": "workspace:~",
+    "@o3r/extractors": "workspace:~",
     "@o3r/logger": "workspace:~",
     "@o3r/test-helpers": "workspace:~",
+    "@schematics/angular": "~21.2.0",
     "@stylistic/eslint-plugin": "~5.10.0",
     "@types/jest": "~30.0.0",
     "@types/node": "~24.12.0",
     "@typescript-eslint/parser": "~8.57.0",
     "angular-eslint": "~21.3.0",
+    "chokidar": "~5.0.0",
     "cpy-cli": "^6.0.0",
     "eslint": "~9.39.0",
     "eslint-import-resolver-node": "~0.3.9",
@@ -100,7 +144,7 @@
     "eslint-plugin-unicorn": "~62.0.0",
     "eslint-plugin-unused-imports": "~4.4.0",
     "globals": "^16.0.0",
-    "intl-messageformat": "~11.1.0",
+    "globby": "^11.1.0",
     "isomorphic-fetch": "~3.0.0",
     "jest": "~30.3.0",
     "jest-environment-jsdom": "~30.3.0",
@@ -109,14 +153,18 @@
     "jest-util": "~30.3.0",
     "jsdom": "~27.4.0",
     "jsonc-eslint-parser": "~2.4.0",
+    "memfs": "~4.56.0",
     "nx": "~22.5.3",
     "rxjs": "^7.8.1",
+    "semver": "^7.5.2",
     "ts-jest": "~29.4.0",
     "typescript": "~5.9.2",
-    "typescript-eslint": "~8.57.0"
+    "typescript-eslint": "~8.57.0",
+    "unionfs": "~4.6.0"
   },
   "engines": {
     "node": "^22.17.0 || ^24.0.0"
   },
+  "builders": "./builders.json",
   "sideEffects": false
 }

--- a/packages/@o3r/transloco/project.json
+++ b/packages/@o3r/transloco/project.json
@@ -8,6 +8,7 @@
     "build": {
       "executor": "nx:noop",
       "dependsOn": [
+        "build-builders",
         "compile",
         "expose-schemas"
       ],
@@ -16,6 +17,8 @@
       }
     },
     "prepare": {},
+    "prepare-build-builders": {},
+    "build-builders": {},
     "compile": {
       "executor": "@angular-devkit/build-angular:ng-packagr",
       "options": {

--- a/packages/@o3r/transloco/testing/jest.config.ut.builders.js
+++ b/packages/@o3r/transloco/testing/jest.config.ut.builders.js
@@ -1,21 +1,17 @@
 const path = require('node:path');
 const { getTsJestBaseConfig, getOtterJestBaseConfig, getJestUnitTestConfig } = require('@o3r/test-helpers');
-const { createCjsPreset } = require('jest-preset-angular/presets');
+const { createDefaultPreset } = require('ts-jest');
 
 const rootDir = path.join(__dirname, '..');
 
 /** @type {import('ts-jest/dist/types').JestConfigWithTsJest} */
 module.exports = {
-  ...createCjsPreset(getTsJestBaseConfig()),
+  ...createDefaultPreset(getTsJestBaseConfig()),
   ...getOtterJestBaseConfig(rootDir),
   ...getJestUnitTestConfig({
     testPathIgnorePatterns: [
-      '<rootDir>/builders/.*',
-      '<rootDir>/schematics/.*'
+      '<rootDir>/src/.*'
     ]
   }),
-  setupFilesAfterEnv: ['<rootDir>/testing/setup-jest.ts'],
-  transformIgnorePatterns: [
-    'node_modules/(?!.*\\.mjs$|@jsverse)'
-  ]
+  setupFilesAfterEnv: ['<rootDir>/testing/setup-jest.builders.ts']
 };

--- a/packages/@o3r/transloco/testing/mocks/test-resources/en_GB.json
+++ b/packages/@o3r/transloco/testing/mocks/test-resources/en_GB.json
@@ -1,0 +1,5 @@
+{
+  "color": "colour",
+  "soccer": "football",
+  "organize": "organise"
+}

--- a/packages/@o3r/transloco/testing/mocks/test-resources/en_US.json
+++ b/packages/@o3r/transloco/testing/mocks/test-resources/en_US.json
@@ -1,0 +1,8 @@
+{
+  "color": "color",
+  "number": "number",
+  "month": "month",
+  "soccer": "soccer",
+  "organize": "organize",
+  "flower": "flower"
+}

--- a/packages/@o3r/transloco/testing/mocks/test-resources/fr_FR.json
+++ b/packages/@o3r/transloco/testing/mocks/test-resources/fr_FR.json
@@ -1,0 +1,8 @@
+{
+  "color": "couleur",
+  "number": "numero",
+  "month": "mois",
+  "soccer": "football",
+  "organize": "organiser",
+  "flower": "fleur"
+}

--- a/packages/@o3r/transloco/testing/setup-jest.builders.ts
+++ b/packages/@o3r/transloco/testing/setup-jest.builders.ts
@@ -1,0 +1,1 @@
+import '@o3r/test-helpers/setup-jest-builders';

--- a/packages/@o3r/transloco/tsconfig.builders.json
+++ b/packages/@o3r/transloco/tsconfig.builders.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../tsconfig.build",
+  "compilerOptions": {
+    "incremental": true,
+    "composite": true,
+    "outDir": "./dist",
+    "module": "CommonJS",
+    "moduleResolution": "node10",
+    "rootDir": ".",
+    "types": ["node"],
+    "skipLibCheck": true,
+    "tsBuildInfoFile": "build/.tsbuildinfo.builders"
+  },
+  "include": [
+    "builders/**/*.ts"
+  ],
+  "exclude": [
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/@o3r/transloco/tsconfig.json
+++ b/packages/@o3r/transloco/tsconfig.json
@@ -6,6 +6,9 @@
       "path": "./tsconfig.build.composite.json"
     },
     {
+      "path": "./tsconfig.builders.json"
+    },
+    {
       "path": "./tsconfig.spec.json"
     },
     {

--- a/packages/@o3r/transloco/tsconfig.spec.json
+++ b/packages/@o3r/transloco/tsconfig.spec.json
@@ -6,7 +6,8 @@
     "rootDir": "."
   },
   "include": [
-    "./src/**/*.spec.ts"
+    "./src/**/*.spec.ts",
+    "./builders/**/*.spec.ts"
   ],
   "exclude": [],
   "references": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -12517,7 +12517,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@o3r/transloco@workspace:packages/@o3r/transloco"
   dependencies:
+    "@angular-devkit/architect": "npm:0.2102.2"
     "@angular-devkit/build-angular": "npm:~21.2.0"
+    "@angular-devkit/core": "npm:~21.2.0"
+    "@angular-devkit/schematics": "npm:~21.2.0"
     "@angular/animations": "npm:~21.2.4"
     "@angular/cdk": "npm:~21.2.0"
     "@angular/cli": "npm:~21.2.0"
@@ -12542,14 +12545,17 @@ __metadata:
     "@o3r/dynamic-content": "workspace:~"
     "@o3r/eslint-config": "workspace:~"
     "@o3r/eslint-plugin": "workspace:~"
+    "@o3r/extractors": "workspace:~"
     "@o3r/logger": "workspace:~"
     "@o3r/schematics": "workspace:~"
     "@o3r/test-helpers": "workspace:~"
+    "@schematics/angular": "npm:~21.2.0"
     "@stylistic/eslint-plugin": "npm:~5.10.0"
     "@types/jest": "npm:~30.0.0"
     "@types/node": "npm:~24.12.0"
     "@typescript-eslint/parser": "npm:~8.57.0"
     angular-eslint: "npm:~21.3.0"
+    chokidar: "npm:~5.0.0"
     cpy-cli: "npm:^6.0.0"
     eslint: "npm:~9.39.0"
     eslint-import-resolver-node: "npm:~0.3.9"
@@ -12562,7 +12568,7 @@ __metadata:
     eslint-plugin-unicorn: "npm:~62.0.0"
     eslint-plugin-unused-imports: "npm:~4.4.0"
     globals: "npm:^16.0.0"
-    intl-messageformat: "npm:~11.1.0"
+    globby: "npm:^11.1.0"
     isomorphic-fetch: "npm:~3.0.0"
     jest: "npm:~30.3.0"
     jest-environment-jsdom: "npm:~30.3.0"
@@ -12571,13 +12577,19 @@ __metadata:
     jest-util: "npm:~30.3.0"
     jsdom: "npm:~27.4.0"
     jsonc-eslint-parser: "npm:~2.4.0"
+    memfs: "npm:~4.56.0"
     nx: "npm:~22.5.3"
     rxjs: "npm:^7.8.1"
+    semver: "npm:^7.5.2"
     ts-jest: "npm:~29.4.0"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.9.2"
     typescript-eslint: "npm:~8.57.0"
+    unionfs: "npm:~4.6.0"
   peerDependencies:
+    "@angular-devkit/architect": ">=0.2100.0 <0.2200.0-0"
+    "@angular-devkit/core": ^21.0.0
+    "@angular-devkit/schematics": ^21.0.0
     "@angular/cdk": ^21.0.0
     "@angular/common": ^21.0.0
     "@angular/core": ^21.0.0
@@ -12585,15 +12597,36 @@ __metadata:
     "@ngrx/store": ^21.0.0
     "@o3r/core": "workspace:~"
     "@o3r/dynamic-content": "workspace:~"
+    "@o3r/extractors": "workspace:~"
     "@o3r/logger": "workspace:~"
-    intl-messageformat: ^11.0.0
+    "@o3r/schematics": "workspace:~"
+    "@schematics/angular": ^21.0.0
+    chokidar: ^4.0.0 || ^5.0.0
+    globby: ^11.1.0
     rxjs: ^7.8.1
+    typescript: ^5.9.0
   peerDependenciesMeta:
+    "@angular-devkit/architect":
+      optional: true
+    "@angular-devkit/core":
+      optional: true
+    "@angular-devkit/schematics":
+      optional: true
     "@o3r/dynamic-content":
+      optional: true
+    "@o3r/extractors":
       optional: true
     "@o3r/logger":
       optional: true
-    intl-messageformat:
+    "@o3r/schematics":
+      optional: true
+    "@schematics/angular":
+      optional: true
+    chokidar:
+      optional: true
+    globby:
+      optional: true
+    typescript:
       optional: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Proposed change


The builders are **entirely library-agnostic** — they operate on JSON metadata files, TypeScript ASTs, and the `JSONLocalization`/`LocalizationMetadata` types (which are identical in both packages). The only changes needed are replacing `from '@o3r/localization'` → `from '@o3r/transloco'` in type imports.

### Files copied from `@o3r/localization`

| Directory | Files | Changes |
|---|---|---|
| `builders/helpers/` | `localization-generator.ts` | `@o3r/localization` → `@o3r/transloco` import |
| `builders/i18n/` | `index.ts`, `schema.ts`, `schema.json`, `index.spec.ts` | None (no `@o3r/localization` refs) |
| `builders/localization/` | `index.ts`, `schema.ts`, `schema.json`, `builder.spec.ts`, `index.spec.ts` | `@o3r/localization` → `@o3r/transloco` import in `index.ts` |
| `builders/localization-extractor/` | `index.ts`, `schema.ts`, `schema.json`, `validations.ts`, `index.spec.ts` | None |
| `builders/metadata-check/` | `index.ts`, `schema.ts`, `schema.json`, `index.it.spec.ts`, `helpers/` | `@o3r/localization` → `@o3r/transloco` imports |

### Configuration files created

- **`builders.json`** — Registers all 4 builders (`i18n`, `extractor`, `localization`, `check-localization-migration-metadata`)
- **`tsconfig.builders.json`** — TypeScript config for CommonJS builder compilation
- **`testing/jest.config.ut.builders.js`** — Jest config for builder unit tests (with `setup-jest.builders.ts` for virtual filesystem support)
- **`testing/setup-jest.builders.ts`** — Builder test setup (imports `@o3r/test-helpers/setup-jest-builders`)
- **`testing/mocks/test-resources/`** — Test resource JSON files (`en_GB.json`, `en_US.json`, `fr_FR.json`)

### Configuration updates

- **`project.json`** — Added `prepare-build-builders` and `build-builders` targets, added `build-builders` to `build` dependencies
- **`package.json`** — Added `"builders": "./builders.json"`, builder export entry, `prepare:build:builders` / `build:builders` scripts, builder-related peer/dev dependencies (`@angular-devkit/architect`, `@angular-devkit/core`, `@o3r/extractors`, `@o3r/schematics`, `chokidar`, `globby`, `typescript`, etc.)
- **`jest.config.js`** — Added `jest.config.ut.builders.js` to projects list
- **`testing/jest.config.ut.js`** — Added `'<rootDir>/builders/.*'` to `testPathIgnorePatterns` to avoid running builder specs under the Angular preset


## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
