### PR TITLE
fix(ama-sdk): missing enums from barrel file

### DIFF
--- a/packages/@ama-sdk/create/src/index.it.spec.ts
+++ b/packages/@ama-sdk/create/src/index.it.spec.ts
@@ -68,6 +68,11 @@ describe('Create new sdk command', () => {
     ).not.toThrow();
     expect(() => packageManagerRun({ script: 'build' }, { ...execAppOptions, cwd: sdkPackagePath })).not.toThrow();
     expect(existsSync(path.join(sdkPackagePath, 'src', 'models', 'base', 'pet', 'pet.reviver.ts'))).toBeFalsy();
+
+    // Verify enums exports are generated correctly
+    const enumsContent = fs.readFileSync(path.join(sdkPackagePath, 'src', 'models', 'base', 'enums.ts'), 'utf8');
+    expect(enumsContent).toContain('LIST_STATUS');
+    expect(enumsContent).toMatch(/export type \{.*Status.*\}/);
   });
 
   test('should generate a full SDK when the specification is provided', () => {

--- a/packages/@ama-sdk/create/testing/mocks/MOCK_DATE_UTILS_swagger.yaml
+++ b/packages/@ama-sdk/create/testing/mocks/MOCK_DATE_UTILS_swagger.yaml
@@ -73,6 +73,12 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 definitions:
+  Status:
+    type: string
+    enum:
+      - available
+      - pending
+      - sold
   Pet:
     type: "object"
     required:
@@ -95,6 +101,8 @@ definitions:
         type: string
       tag:
         type: string
+      status:
+        $ref: '#/definitions/Status'
   Pets:
     type: array
     items:

--- a/packages/@ama-sdk/create/testing/mocks/MOCK_swagger.yaml
+++ b/packages/@ama-sdk/create/testing/mocks/MOCK_swagger.yaml
@@ -73,6 +73,12 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 definitions:
+  Status:
+    type: string
+    enum:
+      - available
+      - pending
+      - sold
   Pet:
     type: "object"
     required:
@@ -86,6 +92,8 @@ definitions:
         type: string
       tag:
         type: string
+      status:
+        $ref: '#/definitions/Status'
   Pets:
     type: array
     items:

--- a/packages/@ama-sdk/create/testing/mocks/MOCK_swagger_updated.yaml
+++ b/packages/@ama-sdk/create/testing/mocks/MOCK_swagger_updated.yaml
@@ -73,6 +73,12 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 definitions:
+  Status:
+    type: string
+    enum:
+      - available
+      - pending
+      - sold
   Pet:
     type: "object"
     required:
@@ -87,6 +93,8 @@ definitions:
         type: string
       tag:
         type: string
+      status:
+        $ref: '#/definitions/Status'
   Pets:
     type: array
     items:

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/model/enums.mustache
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/model/enums.mustache
@@ -1,7 +1,11 @@
 {{#replaceWithEmptyExportIfNeeded}}
 {{#noEmptyExport}}
+{{#models}}{{#model}}{{#isEnum}}export { {{#upperSnakeCase}}list{{classname}}{{/upperSnakeCase}} } from './{{#kebabCase}}{{classname}}{{/kebabCase}}/{{#kebabCase}}{{classname}}{{/kebabCase}}';
+{{/isEnum}}{{/model}}{{/models}}
 {{#models}}{{#model}}{{#hasEnums}}{{#removeBrackets}}export { {{#trimComma}}{{#vars}}{{#isEnum}}{{#upperSnakeCase}}list{{{datatypeWithEnum}}}{{/upperSnakeCase}} as {{#upperSnakeCase}}{{vendorExtensions.x-exposed-classname}}List{{{datatypeWithEnum}}}{{/upperSnakeCase}}, {{/isEnum}}{{/vars}}{{/trimComma}} } from './{{#kebabCase}}{{classname}}{{/kebabCase}}/{{#kebabCase}}{{classname}}{{/kebabCase}}';
 {{/removeBrackets}}{{/hasEnums}}{{/model}}{{/models}}
+{{#models}}{{#model}}{{#isEnum}}export type { {{classname}} } from './{{#kebabCase}}{{classname}}{{/kebabCase}}/{{#kebabCase}}{{classname}}{{/kebabCase}}';
+{{/isEnum}}{{/model}}{{/models}}
 {{#models}}{{#model}}{{#hasEnums}}{{#removeBrackets}}export type { {{#trimComma}}{{#vars}}{{#isEnum}}{{{datatypeWithEnum}}} as {{vendorExtensions.x-exposed-classname}}{{{datatypeWithEnum}}}, {{/isEnum}}{{/vars}}{{/trimComma}} } from './{{#kebabCase}}{{classname}}{{/kebabCase}}/{{#kebabCase}}{{classname}}{{/kebabCase}}';
 {{/removeBrackets}}{{/hasEnums}}{{/model}}{{/models}}{{/noEmptyExport}}
 {{/replaceWithEmptyExportIfNeeded}}


### PR DESCRIPTION
## Proposed change

When enums are defined directly in the `/components/schema` of the openapi spec, they are missing from the `enums.ts` file.

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
