### PR TITLE
feat: transloco package - schematics

### DIFF
--- a/packages/@o3r/testing/package.json
+++ b/packages/@o3r/testing/package.json
@@ -56,6 +56,10 @@
       "types": "./localization/index.d.ts",
       "default": "./localization/index.js"
     },
+    "./transloco": {
+      "types": "./transloco/index.d.ts",
+      "default": "./transloco/index.js"
+    },
     "./mocks": {
       "types": "./mocks/index.d.ts",
       "default": "./mocks/index.js"
@@ -96,6 +100,7 @@
     "@angular/core": "^21.0.0",
     "@angular/forms": "^21.0.0",
     "@angular/platform-browser": "^21.0.0",
+    "@jsverse/transloco": "^8.0.0",
     "@material/slider": "^14.0.0",
     "@ngrx/store": "^21.0.0",
     "@ngx-translate/core": "^15.0.0 || ~16.0.4",
@@ -103,6 +108,7 @@
     "@o3r/eslint-config": "workspace:~",
     "@o3r/localization": "workspace:~",
     "@o3r/schematics": "workspace:~",
+    "@o3r/transloco": "workspace:~",
     "@playwright/test": "^1.49.0",
     "@schematics/angular": "^21.0.0",
     "eslint": "~9.39.0",
@@ -129,6 +135,9 @@
     "@angular/forms": {
       "optional": true
     },
+    "@jsverse/transloco": {
+      "optional": true
+    },
     "@material/slider": {
       "optional": true
     },
@@ -148,6 +157,9 @@
       "optional": true
     },
     "@o3r/schematics": {
+      "optional": true
+    },
+    "@o3r/transloco": {
       "optional": true
     },
     "@playwright/test": {
@@ -191,6 +203,7 @@
     "@babel/preset-typescript": "~7.28.0",
     "@compodoc/compodoc": "^1.1.32",
     "@eslint-community/eslint-plugin-eslint-comments": "^4.4.0",
+    "@jsverse/transloco": "~8.2.1",
     "@material/slider": "^14.0.0",
     "@ngrx/store": "~21.1.0",
     "@ngx-translate/core": "~16.0.4",
@@ -201,6 +214,7 @@
     "@o3r/eslint-plugin": "workspace:~",
     "@o3r/localization": "workspace:~",
     "@o3r/test-helpers": "workspace:~",
+    "@o3r/transloco": "workspace:~",
     "@playwright/test": "~1.59.0",
     "@schematics/angular": "~21.2.0",
     "@standard-schema/spec": "~1.1.0",

--- a/packages/@o3r/testing/src/transloco/index.ts
+++ b/packages/@o3r/testing/src/transloco/index.ts
@@ -1,0 +1,1 @@
+export * from './transloco-mock';

--- a/packages/@o3r/testing/src/transloco/transloco-mock.ts
+++ b/packages/@o3r/testing/src/transloco/transloco-mock.ts
@@ -1,0 +1,97 @@
+import {
+  EnvironmentProviders,
+  Pipe,
+  PipeTransform,
+  Provider,
+} from '@angular/core';
+import {
+  provideTransloco,
+  TRANSLOCO_LOADER,
+} from '@jsverse/transloco';
+import {
+  LocalizationConfiguration,
+  provideLocalization,
+} from '@o3r/transloco';
+import {
+  of,
+} from 'rxjs';
+
+/**
+ * Default localization configuration for testing
+ */
+const defaultLocalizationConfiguration = {
+  supportedLocales: ['en'],
+  language: 'en',
+  fallbackLanguage: 'en'
+} as const satisfies Partial<LocalizationConfiguration>;
+
+/**
+ * Mock translations interface to provide to the mock localization provider
+ */
+export interface MockTranslations {
+  [lang: string]: {
+    [key: string]: any;
+  };
+}
+
+/**
+ * Mock pipe for transloco (from \@jsverse/transloco)
+ */
+@Pipe({
+  name: 'transloco',
+  standalone: true
+})
+export class TranslocoPipeMock implements PipeTransform {
+  /**
+   * Transform method for the mock pipe
+   * @param args Arguments passed to the pipe
+   */
+  public transform(...args: any[]): string | undefined {
+    return args && args.map((arg) => JSON.stringify(arg)).join(', ');
+  }
+}
+
+/**
+ * Mock pipe for o3rTranslate
+ */
+@Pipe({
+  name: 'o3rTranslate',
+  standalone: true
+})
+export class O3rTranslatePipeMock implements PipeTransform {
+  /**
+   * Transform method for the mock pipe
+   * @param args Arguments passed to the pipe
+   */
+  public transform(...args: any[]): string | undefined {
+    return args && args.map((arg) => JSON.stringify(arg)).join(', ');
+  }
+}
+
+/**
+ * Provides mock localization configuration for testing
+ * @param localizationConfiguration Localization configuration
+ * @param translations Translations to use
+ * @returns List of providers for the TestBed
+ */
+export function provideLocalizationMock(
+  localizationConfiguration: Partial<LocalizationConfiguration> = defaultLocalizationConfiguration,
+  translations: MockTranslations = {}
+): (Provider | EnvironmentProviders)[] {
+  const providers: Provider[] = [
+    { provide: TRANSLOCO_LOADER, useValue: { getTranslation: (lang: string) => of(translations[lang]) } }
+  ];
+
+  return [
+    ...provideTransloco({
+      config: {
+        availableLangs: localizationConfiguration.supportedLocales || ['en'],
+        defaultLang: localizationConfiguration.language || localizationConfiguration.fallbackLanguage || 'en',
+        reRenderOnLangChange: true,
+        prodMode: true
+      }
+    }),
+    ...providers,
+    provideLocalization(localizationConfiguration)
+  ];
+}

--- a/packages/@o3r/testing/tsconfig.build.json
+++ b/packages/@o3r/testing/tsconfig.build.json
@@ -20,6 +20,7 @@
     "src/core/playwright/**/*.ts",
     "src/kassette/**/*.ts",
     "src/localization/**/*.ts",
+    "src/transloco/**/*.ts",
     "src/mocks/**/*.ts",
     "src/store/**/*.ts",
     "src/tools/**/*.ts",

--- a/packages/@o3r/transloco/.npmignore
+++ b/packages/@o3r/transloco/.npmignore
@@ -1,0 +1,1 @@
+# Nested package.json's in builders and schematics are needed for CommonJS compatibility

--- a/packages/@o3r/transloco/builders/metadata-check/index.it.spec.ts
+++ b/packages/@o3r/transloco/builders/metadata-check/index.it.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Test environment exported by O3rEnvironment, must be first line of the file
  * @jest-environment @o3r/test-helpers/jest-environment
- * @jest-environment-o3r-app-folder test-app-localization-metadata-check
+ * @jest-environment-o3r-app-folder test-app-transloco-metadata-check
  */
 const o3rEnvironment = globalThis.o3rEnvironment;
 

--- a/packages/@o3r/transloco/collection.json
+++ b/packages/@o3r/transloco/collection.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://raw.githubusercontent.com/angular/angular-cli/main/packages/angular_devkit/schematics/collection-schema.json",
+  "schematics": {
+    "ng-add": {
+      "description": "Add Otter Localization (Transloco) to the project.",
+      "factory": "./schematics/ng-add/index#ngAdd",
+      "schema": "./schematics/ng-add/schema.json",
+      "aliases": ["install", "i"]
+    },
+    "localization-to-component": {
+      "description": "[o3r] Add Otter Localization architecture to an existing component",
+      "factory": "./schematics/localization-to-component/index#ngAddLocalization",
+      "schema": "./schematics/localization-to-component/schema.json",
+      "aliases": ["o3r-localization-to-component", "add-localization"]
+    },
+    "localization-key-to-component": {
+      "description": "[o3r] Add Otter Localization key to an existing component",
+      "factory": "./schematics/add-localization-key/index#ngAddLocalizationKey",
+      "schema": "./schematics/add-localization-key/schema.json",
+      "aliases": ["o3r-localization-key-to-component", "add-localization-key"]
+    }
+  }
+}

--- a/packages/@o3r/transloco/package.json
+++ b/packages/@o3r/transloco/package.json
@@ -10,6 +10,7 @@
     "transloco",
     "otter",
     "otter-module",
+    "otter-cms",
     "experimental"
   ],
   "exports": {
@@ -27,21 +28,25 @@
   "scripts": {
     "nx": "nx",
     "ng": "yarn nx",
+    "copy:templates": "yarn cpy 'schematics/**/templates/**' dist/schematics",
     "copy:schemas": "yarn cpy 'schemas/*.json' dist/schemas",
-    "prepare:build:builders": "yarn cpy 'builders/**/*.json' dist/builders && yarn cpy 'builders.json' dist && yarn copy:schemas",
+    "prepare:build:builders": "yarn cpy 'builders/**/*.json' dist/builders && yarn cpy '{builders,collection}.json' dist && yarn cpy 'schematics/**/*.json' dist/schematics && yarn copy:templates && yarn copy:schemas",
     "prepare:compile": "cp-package-json",
     "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest",
-    "build": "yarn nx build transloco",
-    "test": "jest --passWithNoTests"
+    "build": "yarn nx build transloco"
   },
   "peerDependencies": {
     "@angular-devkit/architect": ">=0.2100.0 <0.2200.0-0",
     "@angular-devkit/core": "^21.0.0",
     "@angular-devkit/schematics": "^21.0.0",
     "@angular/cdk": "^21.0.0",
+    "@angular/cli": "^21.0.0",
     "@angular/common": "^21.0.0",
     "@angular/core": "^21.0.0",
+    "@angular/platform-browser-dynamic": "^21.0.0",
     "@jsverse/transloco": "^8.0.0",
+    "@jsverse/transloco-messageformat": "^8.0.0",
+    "@jsverse/utils": "1.0.0-beta.5",
     "@ngrx/store": "^21.0.0",
     "@o3r/core": "workspace:~",
     "@o3r/dynamic-content": "workspace:~",
@@ -49,9 +54,16 @@
     "@o3r/logger": "workspace:~",
     "@o3r/schematics": "workspace:~",
     "@schematics/angular": "^21.0.0",
+    "@yarnpkg/cli": "^4.3.1",
+    "@yarnpkg/core": "^4.1.1",
+    "@yarnpkg/fslib": "^3.1.0",
+    "@yarnpkg/plugin-npm": "^3.0.1",
+    "@yarnpkg/plugin-pack": "^4.0.0",
     "chokidar": "^4.0.0 || ^5.0.0",
     "globby": "^11.1.0",
     "rxjs": "^7.8.1",
+    "semver": "^7.5.2",
+    "type-fest": "^5.3.1",
     "typescript": "^5.9.0"
   },
   "peerDependenciesMeta": {
@@ -64,13 +76,7 @@
     "@angular-devkit/schematics": {
       "optional": true
     },
-    "@o3r/dynamic-content": {
-      "optional": true
-    },
-    "@o3r/extractors": {
-      "optional": true
-    },
-    "@o3r/logger": {
+    "@angular/cli": {
       "optional": true
     },
     "@o3r/schematics": {
@@ -79,10 +85,31 @@
     "@schematics/angular": {
       "optional": true
     },
+    "@yarnpkg/cli": {
+      "optional": true
+    },
+    "@yarnpkg/core": {
+      "optional": true
+    },
+    "@yarnpkg/fslib": {
+      "optional": true
+    },
+    "@yarnpkg/plugin-npm": {
+      "optional": true
+    },
+    "@yarnpkg/plugin-pack": {
+      "optional": true
+    },
     "chokidar": {
       "optional": true
     },
     "globby": {
+      "optional": true
+    },
+    "semver": {
+      "optional": true
+    },
+    "type-fest": {
       "optional": true
     },
     "typescript": {
@@ -94,7 +121,7 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@angular-devkit/architect": "0.2102.2",
+    "@angular-devkit/architect": "0.2102.7",
     "@angular-devkit/build-angular": "~21.2.0",
     "@angular-devkit/core": "~21.2.0",
     "@angular-devkit/schematics": "~21.2.0",
@@ -112,7 +139,9 @@
     "@compodoc/compodoc": "^1.1.32",
     "@eslint-community/eslint-plugin-eslint-comments": "^4.4.0",
     "@jsverse/transloco": "~8.2.1",
-    "@ngrx/store": "~21.0.0",
+    "@jsverse/transloco-messageformat": "~8.2.1",
+    "@jsverse/utils": "1.0.0-beta.5",
+    "@ngrx/store": "~21.1.0",
     "@nx/eslint": "~22.6.0",
     "@nx/eslint-plugin": "~22.6.0",
     "@nx/jest": "~22.6.0",
@@ -130,6 +159,11 @@
     "@types/jest": "~30.0.0",
     "@types/node": "~24.12.0",
     "@typescript-eslint/parser": "~8.58.0",
+    "@yarnpkg/cli": "^4.5.0",
+    "@yarnpkg/core": "^4.1.3",
+    "@yarnpkg/fslib": "^3.1.0",
+    "@yarnpkg/plugin-npm": "^3.0.1",
+    "@yarnpkg/plugin-pack": "^4.0.0",
     "angular-eslint": "~21.3.0",
     "chokidar": "~5.0.0",
     "cpy-cli": "^6.0.0",
@@ -153,11 +187,12 @@
     "jest-util": "~30.3.0",
     "jsdom": "~27.4.0",
     "jsonc-eslint-parser": "~2.4.0",
-    "memfs": "~4.56.0",
+    "memfs": "~4.57.0",
     "nx": "~22.6.0",
     "rxjs": "^7.8.1",
     "semver": "^7.5.2",
     "ts-jest": "~29.4.0",
+    "type-fest": "^5.3.1",
     "typescript": "~5.9.2",
     "typescript-eslint": "~8.58.0",
     "unionfs": "~4.6.0"
@@ -166,5 +201,6 @@
     "node": "^22.17.0 || ^24.0.0"
   },
   "builders": "./builders.json",
+  "schematics": "./collection.json",
   "sideEffects": false
 }

--- a/packages/@o3r/transloco/package.json
+++ b/packages/@o3r/transloco/package.json
@@ -10,6 +10,7 @@
     "transloco",
     "otter",
     "otter-module",
+    "otter-cms",
     "experimental"
   ],
   "exports": {
@@ -27,21 +28,25 @@
   "scripts": {
     "nx": "nx",
     "ng": "yarn nx",
+    "copy:templates": "yarn cpy 'schematics/**/templates/**' dist/schematics",
     "copy:schemas": "yarn cpy 'schemas/*.json' dist/schemas",
-    "prepare:build:builders": "yarn cpy 'builders/**/*.json' dist/builders && yarn cpy 'builders.json' dist && yarn copy:schemas",
+    "prepare:build:builders": "yarn cpy 'builders/**/*.json' dist/builders && yarn cpy '{builders,collection}.json' dist && yarn cpy 'schematics/**/*.json' dist/schematics && yarn copy:templates && yarn copy:schemas",
     "prepare:compile": "cp-package-json",
     "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest",
-    "build": "yarn nx build transloco",
-    "test": "jest --passWithNoTests"
+    "build": "yarn nx build transloco"
   },
   "peerDependencies": {
     "@angular-devkit/architect": ">=0.2100.0 <0.2200.0-0",
     "@angular-devkit/core": "^21.0.0",
     "@angular-devkit/schematics": "^21.0.0",
     "@angular/cdk": "^21.0.0",
+    "@angular/cli": "^21.0.0",
     "@angular/common": "^21.0.0",
     "@angular/core": "^21.0.0",
+    "@angular/platform-browser-dynamic": "^21.0.0",
     "@jsverse/transloco": "^8.0.0",
+    "@jsverse/transloco-messageformat": "^8.0.0",
+    "@jsverse/utils": "1.0.0-beta.5",
     "@ngrx/store": "^21.0.0",
     "@o3r/core": "workspace:~",
     "@o3r/dynamic-content": "workspace:~",
@@ -49,28 +54,26 @@
     "@o3r/logger": "workspace:~",
     "@o3r/schematics": "workspace:~",
     "@schematics/angular": "^21.0.0",
+    "@yarnpkg/cli": "^4.3.1",
+    "@yarnpkg/core": "^4.1.1",
+    "@yarnpkg/fslib": "^3.1.0",
+    "@yarnpkg/plugin-npm": "^3.0.1",
+    "@yarnpkg/plugin-pack": "^4.0.0",
     "chokidar": "^4.0.0 || ^5.0.0",
     "globby": "^11.1.0",
     "rxjs": "^7.8.1",
+    "semver": "^7.5.2",
+    "type-fest": "^5.3.1",
     "typescript": "^5.9.0"
   },
   "peerDependenciesMeta": {
-    "@angular-devkit/architect": {
-      "optional": true
-    },
     "@angular-devkit/core": {
       "optional": true
     },
     "@angular-devkit/schematics": {
       "optional": true
     },
-    "@o3r/dynamic-content": {
-      "optional": true
-    },
-    "@o3r/extractors": {
-      "optional": true
-    },
-    "@o3r/logger": {
+    "@angular/cli": {
       "optional": true
     },
     "@o3r/schematics": {
@@ -79,10 +82,31 @@
     "@schematics/angular": {
       "optional": true
     },
+    "@yarnpkg/cli": {
+      "optional": true
+    },
+    "@yarnpkg/core": {
+      "optional": true
+    },
+    "@yarnpkg/fslib": {
+      "optional": true
+    },
+    "@yarnpkg/plugin-npm": {
+      "optional": true
+    },
+    "@yarnpkg/plugin-pack": {
+      "optional": true
+    },
     "chokidar": {
       "optional": true
     },
     "globby": {
+      "optional": true
+    },
+    "semver": {
+      "optional": true
+    },
+    "type-fest": {
       "optional": true
     },
     "typescript": {
@@ -94,7 +118,7 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@angular-devkit/architect": "0.2102.2",
+    "@angular-devkit/architect": "0.2102.7",
     "@angular-devkit/build-angular": "~21.2.0",
     "@angular-devkit/core": "~21.2.0",
     "@angular-devkit/schematics": "~21.2.0",
@@ -112,7 +136,9 @@
     "@compodoc/compodoc": "^1.1.32",
     "@eslint-community/eslint-plugin-eslint-comments": "^4.4.0",
     "@jsverse/transloco": "~8.2.1",
-    "@ngrx/store": "~21.0.0",
+    "@jsverse/transloco-messageformat": "~8.2.1",
+    "@jsverse/utils": "1.0.0-beta.5",
+    "@ngrx/store": "~21.1.0",
     "@nx/eslint": "~22.6.0",
     "@nx/eslint-plugin": "~22.6.0",
     "@nx/jest": "~22.6.0",
@@ -130,6 +156,11 @@
     "@types/jest": "~30.0.0",
     "@types/node": "~24.12.0",
     "@typescript-eslint/parser": "~8.58.0",
+    "@yarnpkg/cli": "^4.5.0",
+    "@yarnpkg/core": "^4.1.3",
+    "@yarnpkg/fslib": "^3.1.0",
+    "@yarnpkg/plugin-npm": "^3.0.1",
+    "@yarnpkg/plugin-pack": "^4.0.0",
     "angular-eslint": "~21.3.0",
     "chokidar": "~5.0.0",
     "cpy-cli": "^6.0.0",
@@ -153,11 +184,12 @@
     "jest-util": "~30.3.0",
     "jsdom": "~27.4.0",
     "jsonc-eslint-parser": "~2.4.0",
-    "memfs": "~4.56.0",
+    "memfs": "~4.57.0",
     "nx": "~22.6.0",
     "rxjs": "^7.8.1",
     "semver": "^7.5.2",
     "ts-jest": "~29.4.0",
+    "type-fest": "^5.3.1",
     "typescript": "~5.9.2",
     "typescript-eslint": "~8.58.0",
     "unionfs": "~4.6.0"
@@ -166,5 +198,6 @@
     "node": "^22.17.0 || ^24.0.0"
   },
   "builders": "./builders.json",
+  "schematics": "./collection.json",
   "sideEffects": false
 }

--- a/packages/@o3r/transloco/project.json
+++ b/packages/@o3r/transloco/project.json
@@ -17,8 +17,6 @@
       }
     },
     "prepare": {},
-    "prepare-build-builders": {},
-    "build-builders": {},
     "compile": {
       "executor": "@angular-devkit/build-angular:ng-packagr",
       "options": {
@@ -30,13 +28,12 @@
         "^build"
       ]
     },
+    "prepare-build-builders": {},
+    "build-builders": {},
     "expose-schemas": {},
     "lint": {},
-    "test": {
-      "options": {
-        "passWithNoTests": true
-      }
-    },
+    "test": {},
+    "test-int": {},
     "prepare-publish": {},
     "publish": {},
     "documentation": {}

--- a/packages/@o3r/transloco/schematics/add-localization-key/index.spec.ts
+++ b/packages/@o3r/transloco/schematics/add-localization-key/index.spec.ts
@@ -1,0 +1,242 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  Tree,
+} from '@angular-devkit/schematics';
+import {
+  SchematicTestRunner,
+} from '@angular-devkit/schematics/testing';
+import {
+  firstValueFrom,
+} from 'rxjs';
+import {
+  ngAddLocalizationKeyFn,
+} from './index';
+
+jest.mock('node:readline', () => ({
+  createInterface: () => ({
+    question: jest.fn((_query, cb) => cb('mockInputUser')) as any,
+    close: jest.fn()
+  })
+}));
+
+const collectionPath = path.join(__dirname, '..', '..', 'collection.json');
+const emptyO3rComponentPath = '/src/components/empty/empty.ts';
+const o3rComponentPath = '/src/components/test/test.ts';
+const templatePath = '/src/components/test/test.html';
+const translationPath = '/src/components/test/test-translations.ts';
+const localizationPath = '/src/components/test/test-localization.json';
+const ngComponentPath = '/src/components/ng/ng.ts';
+
+describe('Add Localization', () => {
+  let initialTree: Tree;
+
+  describe('Otter standalone component', () => {
+    beforeEach(() => {
+      initialTree = Tree.empty();
+      initialTree.create(o3rComponentPath, `
+        import {CommonModule} from '@angular/common';
+        import {ChangeDetectionStrategy, Component, OnDestroy, OnInit, ViewEncapsulation} from '@angular/core';
+        import {O3rComponent} from '@o3r/core';
+        import {Localization, Translatable} from '@o3r/transloco';
+        import {translations, TestTranslation} from './test-translations';
+
+        @O3rComponent({
+          componentType: 'Component'
+        })
+        @Component({
+          selector: 'o3r-test-pres',
+          imports: [CommonModule],
+          styleUrls: ['./test.scss'],
+          templateUrl: './test.html',
+          changeDetection: ChangeDetectionStrategy.OnPush,
+          encapsulation: ViewEncapsulation.None
+        })
+        export class Test implements Translatable<TestTranslation> {
+          @Input()
+          @Localization('./test-localization.json')
+          public translations: TestTranslation;
+
+          constructor() {
+            this.translations = translations;
+          }
+        }
+      `);
+      initialTree.create(emptyO3rComponentPath, `
+        import {CommonModule} from '@angular/common';
+        import {ChangeDetectionStrategy, Component, OnDestroy, OnInit, ViewEncapsulation} from '@angular/core';
+        import {O3rComponent} from '@o3r/core';
+        import {translations, TestTranslation} from './test-translations';
+
+        @O3rComponent({
+          componentType: 'Component'
+        })
+        @Component({
+          selector: 'o3r-test-pres',
+          imports: [CommonModule],
+          styleUrls: ['./test.scss'],
+          templateUrl: './test.html',
+          changeDetection: ChangeDetectionStrategy.OnPush,
+          encapsulation: ViewEncapsulation.None
+        })
+        export class Test {}
+      `);
+      initialTree.create(templatePath, '<div>Dummy 1</div>');
+      initialTree.create(localizationPath, '{}');
+      initialTree.create(translationPath, `
+        import { Translation } from '@o3r/core';
+
+        export interface TestTranslation extends Translation {}
+
+        export const translations: Readonly<TestTranslation> = {} as const;
+      `);
+      initialTree.create('.eslintrc.json', fs.readFileSync(path.resolve(__dirname, '..', '..', 'testing', 'mocks', '__dot__eslintrc.mocks.json')));
+    });
+
+    it('should update the localization files and the template', async () => {
+      const runner = new SchematicTestRunner('schematics', collectionPath);
+      const tree = await runner.runSchematic('add-localization-key', {
+        path: o3rComponentPath,
+        key: 'dummyLoc1',
+        description: 'Dummy 1 description',
+        value: 'Dummy 1',
+        updateTemplate: true
+      }, initialTree);
+
+      const templateFileContent = tree.readText(templatePath);
+      expect(templateFileContent).toBe('<div>{{ translations.dummyLoc1 | o3rTranslate }}</div>');
+
+      const translationFileContent = tree.readText(translationPath);
+      expect(translationFileContent).toContain('dummyLoc1: string;');
+      expect(translationFileContent).toContain('dummyLoc1: \'o3r-test-pres.dummyLoc1\'');
+
+      const localizationFileContent: any = tree.readJson(localizationPath);
+      expect(localizationFileContent['o3r-test-pres.dummyLoc1'].description).toBe('Dummy 1 description');
+      expect(localizationFileContent['o3r-test-pres.dummyLoc1'].defaultValue).toBe('Dummy 1');
+    });
+
+    it('should ask user for another key name if we add a localization key to a component that already has it', async () => {
+      const runner = new SchematicTestRunner('schematics', collectionPath);
+      let tree = await runner.runSchematic('add-localization-key', {
+        path: o3rComponentPath,
+        key: 'dummyLoc1',
+        description: 'Dummy 1 description',
+        value: 'Dummy 1'
+      }, initialTree);
+      tree = await runner.runSchematic('add-localization-key', {
+        path: o3rComponentPath,
+        key: 'dummyLoc1',
+        description: 'Dummy 1 description',
+        value: 'Dummy 1'
+      }, tree);
+      const localizationFileContent: any = tree.readJson(localizationPath);
+      expect(localizationFileContent['o3r-test-pres.mockInputUser']).toBeDefined();
+    });
+
+    it('should throw if we add localization key to a component that is not localized', async () => {
+      const runner = new SchematicTestRunner('schematics', collectionPath);
+      await expect(runner.runSchematic('add-localization-key', {
+        path: emptyO3rComponentPath,
+        key: 'dummyLoc1',
+        description: 'Dummy 1 description',
+        value: 'Dummy 1'
+      }, initialTree)).rejects.toThrow();
+    });
+
+    it('should apply kebab-case with option selected', async () => {
+      const runner = new SchematicTestRunner('schematics', collectionPath);
+      const tree = await runner.runSchematic('add-localization-key', {
+        path: o3rComponentPath,
+        key: 'kebabKeyLoc',
+        description: 'Dummy 1 description',
+        value: 'Dummy 1',
+        keyToKebabCase: true
+      }, initialTree);
+
+      const localizationFileContent: any = tree.readJson(localizationPath);
+      expect(localizationFileContent['o3r-test-pres.kebab-key-loc']).toBeDefined();
+
+      const translationFileContent = tree.readText(translationPath);
+      expect(translationFileContent).toContain('kebabKeyLoc: \'o3r-test-pres.kebab-key-loc\'');
+    });
+
+    it('should sanitize key input to camelCase', async () => {
+      const runner = new SchematicTestRunner('schematics', collectionPath);
+      const tree = await runner.runSchematic('add-localization-key', {
+        path: o3rComponentPath,
+        key: 'messy Key_format',
+        description: 'Dummy 1 description',
+        value: 'Dummy 1'
+      }, initialTree);
+
+      const localizationFileContent: any = tree.readJson(localizationPath);
+      expect(localizationFileContent['o3r-test-pres.messyKeyFormat']).toBeDefined();
+
+      const translationFileContent = tree.readText(translationPath);
+      expect(translationFileContent).toContain('messyKeyFormat: \'o3r-test-pres.messyKeyFormat\'');
+    });
+  });
+
+  describe('Angular component', () => {
+    beforeEach(() => {
+      initialTree = Tree.empty();
+      initialTree.create(ngComponentPath, `
+        import {CommonModule} from '@angular/common';
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'ng-test',
+          imports: [CommonModule],
+          template: ''
+        })
+        export class NgComponent {}
+      `);
+      initialTree.create('.eslintrc.json', fs.readFileSync(path.resolve(__dirname, '..', '..', 'testing', 'mocks', '__dot__eslintrc.mocks.json')));
+    });
+
+    it('should throw if inexisting path', async () => {
+      const runner = new SchematicTestRunner('schematics', collectionPath);
+
+      await expect(runner.runSchematic('add-localization-key', {
+        path: 'inexisting-path.ts',
+        key: 'dummyLoc1',
+        description: 'Dummy 1 description',
+        value: 'Dummy 1'
+      }, initialTree)).rejects.toThrow();
+    });
+
+    describe('Angular component', () => {
+      it('should throw if no Otter component', async () => {
+        const runner = new SchematicTestRunner('schematics', collectionPath);
+
+        await expect(firstValueFrom(runner.callRule(ngAddLocalizationKeyFn({
+          path: ngComponentPath,
+          skipLinter: false,
+          key: 'dummyLoc1',
+          description: 'Dummy 1 description',
+          value: 'Dummy 1',
+          dictionary: false
+        }), initialTree, { interactive: false }))).rejects.toThrow();
+      });
+
+      it('should call convert-component if no Otter component', async () => {
+        const runner = new SchematicTestRunner('schematics', collectionPath);
+        const o3rCorePackageJson = require.resolve('@o3r/core/package.json');
+        runner.registerCollection('@o3r/core', path.resolve(path.dirname(o3rCorePackageJson), require(o3rCorePackageJson).schematics));
+        const spy = jest.spyOn(runner.engine, 'createSchematic');
+
+        const tree = await runner.runSchematic('add-localization-key', {
+          path: ngComponentPath,
+          skipLinter: false,
+          key: 'dummyLoc1',
+          description: 'Dummy 1 description',
+          value: 'Dummy 1',
+          dictionary: false
+        }, initialTree);
+
+        expect(spy).toHaveBeenCalledWith('convert-component', expect.anything(), expect.anything());
+        expect(tree.exists(ngComponentPath.replace(/\.ts$/, '-translation.ts'))).toBeTruthy();
+      });
+    });
+  });
+});

--- a/packages/@o3r/transloco/schematics/add-localization-key/index.ts
+++ b/packages/@o3r/transloco/schematics/add-localization-key/index.ts
@@ -1,0 +1,348 @@
+import {
+  dirname,
+  posix,
+} from 'node:path';
+import {
+  askConfirmation,
+} from '@angular/cli/src/utilities/prompt';
+import {
+  classify,
+  dasherize,
+} from '@angular-devkit/core/src/utils/strings';
+import {
+  chain,
+  externalSchematic,
+  noop,
+  Rule,
+  schematic,
+  SchematicContext,
+  Tree,
+} from '@angular-devkit/schematics';
+import {
+  applyEsLintFix,
+  askConfirmationToConvertComponent,
+  askUserInput,
+  createOtterSchematic,
+  getO3rComponentInfoOrThrowIfNotFound,
+  isO3rClassComponent,
+  NoOtterComponent,
+  O3rCliError,
+} from '@o3r/schematics';
+import * as ts from 'typescript';
+import type {
+  NgAddLocalizationKeySchematicsSchema,
+} from './schema';
+
+/**
+ * Error thrown when a component does not have localization architecture
+ */
+class NoLocalizationArchitectureError extends Error {
+  constructor(componentPath: string) {
+    super(
+      `This component is not localized. If you want to localize this component you can run the following command:\nng g @o3r/transloco:localization-to-component --path="${componentPath}"`
+    );
+  }
+}
+
+/**
+ * Error thrown when a localization key already exists
+ */
+class KeyAlreadyExistsError extends Error {
+  constructor(key: string, file: string) {
+    super(`There is already a key named ${key} in ${file}.`);
+  }
+}
+
+/**
+ * Retrieves localization information from a component
+ * @param componentPath Path to the component file
+ * @param tree Schematic tree
+ * @returns Localization information including paths and variable names
+ */
+const getLocalizationInformation = (componentPath: string, tree: Tree) => {
+  const componentSourceFile = ts.createSourceFile(
+    componentPath,
+    tree.readText(componentPath),
+    ts.ScriptTarget.ES2015,
+    true
+  );
+
+  const o3rClass = componentSourceFile.statements.find((statement): statement is ts.ClassDeclaration => ts.isClassDeclaration(statement) && isO3rClassComponent(statement))!;
+  let localizationJsonPath: string | undefined;
+  let defaultTranslationVariableName: string | undefined;
+  let translationsVariableName: string | undefined;
+  let translationsVariableType: string | undefined;
+  o3rClass.members.forEach((member) => {
+    if (ts.isPropertyDeclaration(member) && ts.isIdentifier(member.name) && member.type && ts.isTypeReferenceNode(member.type) && ts.isIdentifier(member.type.typeName)) {
+      const decorators = [...(ts.getDecorators(member) || [])];
+      const localizationDecorator = decorators.find((decorator): decorator is ts.Decorator & { expression: ts.CallExpression & { arguments: [ts.StringLiteral] } } =>
+        ts.isCallExpression(decorator.expression)
+        && ts.isIdentifier(decorator.expression.expression)
+        && decorator.expression.expression.escapedText.toString() === 'Localization'
+        && ts.isStringLiteral(decorator.expression.arguments[0])
+      );
+      if (localizationDecorator) {
+        localizationJsonPath = posix.join(dirname(componentPath), localizationDecorator.expression.arguments[0].text);
+        translationsVariableName = member.name.escapedText.toString();
+        translationsVariableType = member.type.typeName.escapedText.toString();
+        if (member.initializer && ts.isIdentifier(member.initializer)) {
+          defaultTranslationVariableName = member.initializer.escapedText.toString();
+        }
+      }
+    }
+  });
+
+  if (!localizationJsonPath || !tree.exists(localizationJsonPath)) {
+    throw new NoLocalizationArchitectureError(componentPath);
+  }
+
+  if (!defaultTranslationVariableName) {
+    const constructor = o3rClass.members.find((member) => ts.isConstructorDeclaration(member));
+    if (constructor?.body) {
+      constructor.body.statements.forEach((statement) => {
+        if (
+          ts.isExpressionStatement(statement)
+          && ts.isBinaryExpression(statement.expression)
+          && ts.isPropertyAccessExpression(statement.expression.left)
+          && statement.expression.left.name.escapedText.toString() === translationsVariableName
+          && ts.isIdentifier(statement.expression.right)
+        ) {
+          defaultTranslationVariableName = statement.expression.right.escapedText.toString();
+        }
+      });
+    }
+  }
+
+  if (!defaultTranslationVariableName) {
+    throw new O3rCliError(`Unable to find initialization of ${translationsVariableName!} in ${componentPath}.`);
+  }
+
+  const importDeclaration = componentSourceFile.statements.find((statement): statement is ts.ImportDeclaration & { moduleSpecifier: ts.StringLiteral } =>
+    ts.isImportDeclaration(statement)
+    && ts.isStringLiteral(statement.moduleSpecifier)
+    && !!statement.importClause
+    && !!statement.importClause.namedBindings
+    && ts.isNamedImports(statement.importClause.namedBindings)
+    && statement.importClause.namedBindings.elements.some((element) => ts.isIdentifier(element.name) && element.name.escapedText.toString() === defaultTranslationVariableName)
+  );
+  if (!importDeclaration) {
+    throw new O3rCliError(`Unable to find import declaration of ${defaultTranslationVariableName} in ${componentPath}`);
+  }
+  const translationsPath = posix.join(dirname(componentPath), `${importDeclaration.moduleSpecifier.text}.ts`);
+
+  return {
+    localizationJsonPath,
+    translationsPath,
+    translationsVariableType
+  };
+};
+
+/**
+ * Add localization key to an existing component
+ * @param options
+ */
+export function ngAddLocalizationKeyFn(options: NgAddLocalizationKeySchematicsSchema): Rule {
+  return async (tree: Tree, context: SchematicContext) => {
+    try {
+      const { selector, templateRelativePath } = getO3rComponentInfoOrThrowIfNotFound(tree, options.path);
+      const { localizationJsonPath, translationsPath, translationsVariableType } = getLocalizationInformation(options.path, tree);
+
+      const keyName = options.key.charAt(0).toLowerCase() + classify(options.key).slice(1);
+
+      const properties = {
+        ...options,
+        keyName,
+        keyValue: `${selector}.${options.keyToKebabCase ? dasherize(options.key) : keyName}`,
+        defaultValue: options.value
+      };
+
+      const localizationJson = tree.readJson(localizationJsonPath) || {};
+      if ((localizationJson as any)[properties.keyValue]) {
+        throw new KeyAlreadyExistsError(properties.keyValue, localizationJsonPath);
+      }
+      const translationFileContent = tree.readText(translationsPath);
+      if (new RegExp(`${properties.keyName}:`).test(translationFileContent)) {
+        throw new KeyAlreadyExistsError(properties.keyName, translationsPath);
+      }
+
+      const updateLocalizationFileRule: Rule = () => {
+        (localizationJson as any)[properties.keyValue] = {
+          ...(properties.dictionary
+            ? {
+              dictionary: true
+            }
+            : {
+              defaultValue: properties.defaultValue
+            }),
+          description: properties.description
+        };
+        tree.overwrite(localizationJsonPath, JSON.stringify(localizationJson, null, 2));
+        return tree;
+      };
+
+      const updateTranslationFileRule: Rule = () => {
+        const translationSourceFile = ts.createSourceFile(
+          translationsPath,
+          tree.readText(translationsPath),
+          ts.ScriptTarget.ES2020,
+          true
+        );
+
+        const result = ts.transform(translationSourceFile, [(ctx) => (rootNode: ts.Node) => {
+          const { factory } = ctx;
+          const visit = (node: ts.Node): ts.Node => {
+            if (
+              ts.isInterfaceDeclaration(node)
+              && node.name.escapedText.toString() === translationsVariableType
+            ) {
+              return factory.updateInterfaceDeclaration(
+                node,
+                ts.getModifiers(node),
+                node.name,
+                node.typeParameters,
+                node.heritageClauses,
+                node.members.concat(
+                  factory.createPropertySignature(
+                    undefined,
+                    factory.createIdentifier(properties.keyName),
+                    undefined,
+                    factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)
+                  )
+                )
+              );
+            }
+            if (
+              ts.isVariableDeclaration(node)
+              && node.type
+              && (
+                (
+                  ts.isTypeReferenceNode(node.type)
+                  && ts.isIdentifier(node.type.typeName)
+                  && node.type.typeName.escapedText.toString() === translationsVariableType
+                )
+                || (
+                  ts.isTypeReferenceNode(node.type)
+                  && ts.isIdentifier(node.type.typeName)
+                  && node.type.typeName.escapedText.toString() === 'Readonly'
+                  && node.type.typeArguments?.[0]
+                  && ts.isTypeReferenceNode(node.type.typeArguments[0])
+                  && ts.isIdentifier(node.type.typeArguments[0].typeName)
+                  && node.type.typeArguments[0].typeName.escapedText.toString() === translationsVariableType
+                )
+              )
+              && node.initializer
+            ) {
+              if (ts.isObjectLiteralExpression(node.initializer)) {
+                return factory.updateVariableDeclaration(
+                  node,
+                  node.name,
+                  node.exclamationToken,
+                  node.type,
+                  factory.updateObjectLiteralExpression(
+                    node.initializer,
+                    node.initializer.properties.concat(
+                      factory.createPropertyAssignment(
+                        factory.createIdentifier(properties.keyName),
+                        factory.createStringLiteral(properties.keyValue, true)
+                      )
+                    )
+                  )
+                );
+              } else if (
+                ts.isAsExpression(node.initializer)
+                && ts.isTypeReferenceNode(node.initializer.type)
+                && ts.isIdentifier(node.initializer.type.typeName)
+                && node.initializer.type.typeName.escapedText.toString() === 'const'
+                && ts.isObjectLiteralExpression(node.initializer.expression)
+              ) {
+                return factory.updateVariableDeclaration(
+                  node,
+                  node.name,
+                  node.exclamationToken,
+                  node.type,
+                  factory.updateAsExpression(
+                    node.initializer,
+                    factory.updateObjectLiteralExpression(
+                      node.initializer.expression,
+                      node.initializer.expression.properties.concat(
+                        factory.createPropertyAssignment(
+                          factory.createIdentifier(properties.keyName),
+                          factory.createStringLiteral(properties.keyValue, true)
+                        )
+                      )
+                    ),
+                    node.initializer.type
+                  )
+                );
+              }
+            }
+            return ts.visitEachChild(node, visit, ctx);
+          };
+          return ts.visitNode(rootNode, visit);
+        }]);
+
+        const printer = ts.createPrinter({
+          removeComments: false,
+          newLine: ts.NewLineKind.LineFeed
+        });
+
+        tree.overwrite(translationsPath, printer.printFile(result.transformed[0] as any as ts.SourceFile));
+        return tree;
+      };
+
+      const updateTemplateFile: Rule = () => {
+        const templatePath = templateRelativePath && posix.join(dirname(options.path), templateRelativePath);
+        if (templatePath) {
+          tree.overwrite(
+            templatePath,
+            tree.readText(templatePath).replaceAll(options.value, `{{ translations.${properties.keyName} | o3rTranslate }}`)
+          );
+        }
+      };
+
+      return chain([
+        updateLocalizationFileRule,
+        updateTranslationFileRule,
+        options.value && options.updateTemplate ? updateTemplateFile : noop(),
+        options.skipLinter ? noop() : applyEsLintFix()
+      ]);
+    } catch (e) {
+      if (e instanceof NoOtterComponent && context.interactive) {
+        const shouldConvertComponent = await askConfirmationToConvertComponent();
+        if (shouldConvertComponent) {
+          return chain([
+            externalSchematic('@o3r/core', 'convert-component', {
+              path: options.path
+            }),
+            ngAddLocalizationKeyFn(options)
+          ]);
+        }
+      } else if (e instanceof NoLocalizationArchitectureError && context.interactive) {
+        const shouldAddLocalization = await askConfirmation('This component is not localized. Would you like to add the localization architecture?', true);
+        if (shouldAddLocalization) {
+          return chain([
+            schematic('localization-to-component', {
+              path: options.path
+            }),
+            ngAddLocalizationKeyFn(options)
+          ]);
+        }
+      } else if (e instanceof KeyAlreadyExistsError && context.interactive) {
+        const newKey = await askUserInput(
+          `${e.message}\nPlease choose another key name:`
+        );
+        return ngAddLocalizationKeyFn({
+          ...options,
+          key: newKey
+        });
+      }
+      throw e;
+    }
+  };
+}
+
+/**
+ * Add localization key to an existing component
+ * @param options
+ */
+export const ngAddLocalizationKey = createOtterSchematic(ngAddLocalizationKeyFn);

--- a/packages/@o3r/transloco/schematics/add-localization-key/schema.json
+++ b/packages/@o3r/transloco/schematics/add-localization-key/schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "NgAddLocalizationKeySchematicsSchema",
+  "title": "Add Otter Localization key to an existing component",
+  "description": "Add Otter Localization key to an existing component",
+  "properties": {
+    "path": {
+      "type": "string",
+      "description": "Path to the component"
+    },
+    "skipLinter": {
+      "type": "boolean",
+      "description": "Skip the linter process which includes EsLint and EditorConfig rules applying",
+      "default": false
+    },
+    "key": {
+      "type": "string",
+      "description": "Localization key without the component prefix"
+    },
+    "description": {
+      "type": "string",
+      "description": "Description of the localization"
+    },
+    "value": {
+      "type": "string",
+      "description": "Default value of the localization",
+      "default": ""
+    },
+    "dictionary": {
+      "type": "boolean",
+      "description": "Is a dictionary key",
+      "default": false
+    },
+    "updateTemplate": {
+      "type": "boolean",
+      "description": "Update the template by replacing matching value by the localization key"
+    },
+    "keyToKebabCase": {
+      "type": "boolean",
+      "description": "Convert the key to kebab-case",
+      "default": false
+    }
+  },
+  "additionalProperties": true,
+  "required": [
+    "path",
+    "key"
+  ]
+}

--- a/packages/@o3r/transloco/schematics/add-localization-key/schema.ts
+++ b/packages/@o3r/transloco/schematics/add-localization-key/schema.ts
@@ -1,0 +1,29 @@
+import type {
+  SchematicOptionObject,
+} from '@o3r/schematics';
+
+export interface NgAddLocalizationKeySchematicsSchema extends SchematicOptionObject {
+  /** Path to the component */
+  path: string;
+
+  /** Skip the linter process which includes the run of EsLint and EditorConfig rules */
+  skipLinter: boolean;
+
+  /** Localization key without the component prefix */
+  key: string;
+
+  /** Description of the localization */
+  description?: string | undefined;
+
+  /** Default value of the localization */
+  value: string;
+
+  /** Is a dictionary key */
+  dictionary: boolean;
+
+  /** Update the template by replacing matching value by the localization key */
+  updateTemplate?: boolean | undefined;
+
+  /** Convert the key to kebab-case */
+  keyToKebabCase?: boolean | undefined;
+}

--- a/packages/@o3r/transloco/schematics/cms-adapter/index.ts
+++ b/packages/@o3r/transloco/schematics/cms-adapter/index.ts
@@ -1,0 +1,100 @@
+import * as path from 'node:path';
+import {
+  chain,
+  noop,
+  Rule,
+  SchematicContext,
+  Tree,
+} from '@angular-devkit/schematics';
+import {
+  createOtterSchematic,
+  getPackageManagerRunner,
+  getWorkspaceConfig,
+  readPackageJson,
+} from '@o3r/schematics';
+
+/**
+ * Update CMS adapter for localization
+ * @param options Options for the CMS adapter update
+ * @param options.projectName Name of the project to update
+ */
+function updateCmsAdapterFn(options: { projectName?: string | undefined }): Rule {
+  if (!options.projectName) {
+    return noop;
+  }
+
+  /**
+   * Add cms extractors builder into the angular.json
+   * @param tree
+   * @param context
+   */
+  const editAngularJson = (tree: Tree, context: SchematicContext) => {
+    const workspace = getWorkspaceConfig(tree);
+    const workspaceProject = options.projectName ? workspace?.projects[options.projectName] : undefined;
+
+    if (!workspace || !workspaceProject) {
+      context.logger.error('No project detected, the extractors will not be added');
+      return tree;
+    }
+
+    if (!workspaceProject.architect) {
+      workspaceProject.architect = {};
+    }
+
+    workspaceProject.architect['extract-translations'] ||= {
+      builder: '@o3r/transloco:extractor',
+      options: {
+        tsConfig: path.join(workspaceProject?.root || '', 'tsconfig.cms.json'),
+        libraries: []
+      }
+    };
+    workspaceProject.architect['check-localization-migration-metadata'] ||= {
+      builder: '@o3r/transloco:check-localization-migration-metadata',
+      options: {
+        migrationDataPath: 'migration-scripts/dist/MIGRATION-*.json'
+      }
+    };
+
+    workspace.projects[options.projectName!] = workspaceProject;
+    tree.overwrite('/angular.json', JSON.stringify(workspace, null, 2));
+    return tree;
+  };
+
+  /**
+   * Add cms extractors scripts into the package.json
+   * @param tree
+   * @param context
+   */
+  const addExtractorsScripts = (tree: Tree, context: SchematicContext) => {
+    const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
+
+    if (!workspaceProject) {
+      context.logger.error('No package detected, the extractor scripts will not be added');
+      return tree;
+    }
+
+    const packageJson = readPackageJson(tree, workspaceProject);
+    const packageManagerRunner = getPackageManagerRunner(getWorkspaceConfig(tree));
+    packageJson.scripts ||= {};
+    packageJson.scripts['cms-adapters:localizations'] ||= `ng run ${options.projectName!}:extract-translations`;
+    packageJson.scripts['cms-adapters:metadata'] = Object.keys(packageJson.scripts)
+      .filter((s) => /^cms-adapters:(?!metadata$)/.test(s))
+      .map((s) => `${packageManagerRunner} ${s}`)
+      .join(' && ');
+
+    tree.overwrite(`${workspaceProject.root}/package.json`, JSON.stringify(packageJson, null, 2));
+    return tree;
+  };
+
+  return chain([
+    addExtractorsScripts,
+    editAngularJson
+  ]);
+}
+
+/**
+ * Update CMS adapter tools
+ * @param options {@link RuleFactory.options}
+ * @param options.projectName
+ */
+export const updateCmsAdapter = createOtterSchematic(updateCmsAdapterFn);

--- a/packages/@o3r/transloco/schematics/index.it.spec.ts
+++ b/packages/@o3r/transloco/schematics/index.it.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * Test environment exported by O3rEnvironment, must be first line of the file
+ * @jest-environment @o3r/test-helpers/jest-environment
+ * @jest-environment-o3r-app-folder test-app-transloco
+ */
+const o3rEnvironment = globalThis.o3rEnvironment;
+
+import * as path from 'node:path';
+import {
+  addImportToAppModule,
+  getDefaultExecSyncOptions,
+  getGitDiff,
+  packageManagerExec,
+  packageManagerInstall,
+  packageManagerRunOnProject,
+} from '@o3r/test-helpers';
+
+describe('ng add otter transloco', () => {
+  test('should add transloco to an application', async () => {
+    const { applicationPath, workspacePath, appName, isInWorkspace, isYarnTest, o3rVersion, libraryPath, untouchedProjectsPaths } = o3rEnvironment.testEnvironment;
+    const execAppOptions = { ...getDefaultExecSyncOptions(), cwd: workspacePath };
+    const relativeApplicationPath = path.relative(workspacePath, applicationPath);
+    expect(() => packageManagerExec({ script: 'ng', args: ['add', `@o3r/transloco@${o3rVersion}`, '--skip-confirmation', '--project-name', appName] }, execAppOptions)).not.toThrow();
+
+    const componentPath = path.normalize(path.posix.join(relativeApplicationPath, 'src/components/test/test.ts'));
+    packageManagerExec({ script: 'ng', args: ['g', '@o3r/core:component', 'test', '--project-name', appName, '--use-localization', 'false'] }, execAppOptions);
+    packageManagerExec({ script: 'ng', args: ['g', '@o3r/transloco:add-localization', '--activate-dummy', '--path', componentPath] }, execAppOptions);
+    await addImportToAppModule(applicationPath, 'Test', 'src/components/test');
+
+    const diff = getGitDiff(workspacePath);
+
+    const modifiedFiles = [
+      isYarnTest ? 'yarn.lock' : 'package-lock.json',
+      'package.json',
+      'angular.json',
+      '.gitignore',
+      path.join(relativeApplicationPath, 'package.json').replace(/[/\\]+/g, '/'),
+      path.join(relativeApplicationPath, 'src/app/app.config.ts').replace(/[/\\]+/g, '/'),
+      path.join(relativeApplicationPath, 'src/app/app.spec.ts').replace(/[/\\]+/g, '/'),
+      path.join(relativeApplicationPath, 'src/app/app.ts').replace(/[/\\]+/g, '/'),
+      path.join(relativeApplicationPath, 'src/main.ts').replace(/[/\\]+/g, '/')
+    ].toSorted();
+    expect(diff.modified.toSorted()).toEqual(modifiedFiles);
+
+    const newFiles = [
+      path.join(relativeApplicationPath, 'src/components/test/test-translation.ts').replace(/[/\\]+/g, '/'),
+      path.join(relativeApplicationPath, 'src/components/test/test.scss').replace(/[/\\]+/g, '/'),
+      path.join(relativeApplicationPath, 'src/components/test/test-context.ts').replace(/[/\\]+/g, '/'),
+      path.join(relativeApplicationPath, 'src/components/test/test.html').replace(/[/\\]+/g, '/'),
+      path.join(relativeApplicationPath, 'src/components/test/test.spec.ts').replace(/[/\\]+/g, '/'),
+      path.join(relativeApplicationPath, 'src/components/test/test-localization.json').replace(/[/\\]+/g, '/'),
+      path.join(relativeApplicationPath, 'src/components/test/test.ts').replace(/[/\\]+/g, '/'),
+      path.join(relativeApplicationPath, 'src/components/test/index.ts').replace(/[/\\]+/g, '/'),
+      path.join(relativeApplicationPath, 'src/components/test/README.md').replace(/[/\\]+/g, '/'),
+      path.join(relativeApplicationPath, 'src/assets/locales/.gitkeep').replace(/[/\\]+/g, '/'),
+      path.join(relativeApplicationPath, 'migration-scripts/README.md').replace(/[/\\]+/g, '/'),
+      path.join(relativeApplicationPath, 'tsconfig.cms.json').replace(/[/\\]+/g, '/'),
+      path.join(relativeApplicationPath, '.gitignore').replace(/[/\\]+/g, '/')
+    ].toSorted();
+    expect(diff.added.toSorted()).toEqual(newFiles);
+
+    [libraryPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {
+      expect(diff.all.some((file) => file.startsWith(path.relative(workspacePath, untouchedProject).replace(/\\+/g, '/')))).toBe(false);
+    });
+
+    expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(appName, isInWorkspace, { script: 'build' }, execAppOptions)).not.toThrow();
+  });
+
+  test('should add transloco to a library', () => {
+    const { workspacePath, isInWorkspace, untouchedProjectsPaths, o3rVersion, libraryPath, libName, applicationPath, isYarnTest } = o3rEnvironment.testEnvironment;
+    const execAppOptions = { ...getDefaultExecSyncOptions(), cwd: workspacePath };
+    const relativeLibraryPath = path.relative(workspacePath, libraryPath);
+    expect(() => packageManagerExec({ script: 'ng', args: ['add', `@o3r/transloco@${o3rVersion}`, '--skip-confirmation', '--project-name', libName] }, execAppOptions)).not.toThrow();
+
+    const componentPath = path.normalize(path.posix.join(relativeLibraryPath, 'src/components/test/test.ts'));
+    packageManagerExec({ script: 'ng', args: ['g', '@o3r/core:component', 'test', '--project-name', libName, '--use-localization', 'false'] }, execAppOptions);
+    packageManagerExec({ script: 'ng', args: ['g', '@o3r/transloco:add-localization', '--activate-dummy', '--path', componentPath] }, execAppOptions);
+
+    const diff = getGitDiff(workspacePath);
+    const modifiedFiles = [
+      path.join(relativeLibraryPath, '.gitignore').replace(/[/\\]+/g, '/'),
+      path.join(relativeLibraryPath, 'package.json').replace(/[/\\]+/g, '/'),
+      '.gitignore',
+      'angular.json',
+      'package.json',
+      isYarnTest ? 'yarn.lock' : 'package-lock.json'
+    ].toSorted();
+    expect(diff.modified.toSorted()).toEqual(modifiedFiles);
+
+    const addedFiles = [
+      path.join(relativeLibraryPath, 'src/components/test/test-translation.ts').replace(/[/\\]+/g, '/'),
+      path.join(relativeLibraryPath, 'src/components/test/test.scss').replace(/[/\\]+/g, '/'),
+      path.join(relativeLibraryPath, 'src/components/test/test-context.ts').replace(/[/\\]+/g, '/'),
+      path.join(relativeLibraryPath, 'src/components/test/test.html').replace(/[/\\]+/g, '/'),
+      path.join(relativeLibraryPath, 'src/components/test/test.spec.ts').replace(/[/\\]+/g, '/'),
+      path.join(relativeLibraryPath, 'src/components/test/test-localization.json').replace(/[/\\]+/g, '/'),
+      path.join(relativeLibraryPath, 'src/components/test/test.ts').replace(/[/\\]+/g, '/'),
+      path.join(relativeLibraryPath, 'src/components/test/index.ts').replace(/[/\\]+/g, '/'),
+      path.join(relativeLibraryPath, 'src/components/test/README.md').replace(/[/\\]+/g, '/'),
+      path.join(relativeLibraryPath, 'migration-scripts/README.md').replace(/[/\\]+/g, '/'),
+      path.join(relativeLibraryPath, 'tsconfig.cms.json').replace(/[/\\]+/g, '/')
+    ].toSorted();
+    expect(diff.added.toSorted()).toEqual(addedFiles);
+
+    [applicationPath, ...untouchedProjectsPaths].forEach((untouchedProject) => {
+      expect(diff.all.some((file) => file.startsWith(path.relative(workspacePath, untouchedProject).replace(/\\+/g, '/')))).toBe(false);
+    });
+
+    expect(() => packageManagerInstall(execAppOptions)).not.toThrow();
+    expect(() => packageManagerRunOnProject(libName, isInWorkspace, { script: 'build' }, execAppOptions)).not.toThrow();
+  });
+});

--- a/packages/@o3r/transloco/schematics/localization-base/index.ts
+++ b/packages/@o3r/transloco/schematics/localization-base/index.ts
@@ -1,0 +1,481 @@
+import * as path from 'node:path';
+import {
+  apply,
+  applyToSubtree,
+  chain,
+  MergeStrategy,
+  mergeWith,
+  move,
+  noop,
+  Rule,
+  SchematicContext,
+  template,
+  Tree,
+  url,
+} from '@angular-devkit/schematics';
+import {
+  createOtterSchematic,
+  findFirstNodeOfKind,
+  getAppModuleFilePath,
+  getModuleIndex,
+  getPackageManagerRunner,
+  getTemplateFolder,
+  getWorkspaceConfig,
+  ignorePatterns,
+  insertBeforeModule as o3rInsertBeforeModule,
+  insertImportToModuleFile as o3rInsertImportToModuleFile,
+  readPackageJson,
+  writeAngularJson,
+} from '@o3r/schematics';
+import {
+  addRootImport,
+  addRootProvider,
+} from '@schematics/angular/utility';
+import {
+  insertImport,
+  isImported,
+} from '@schematics/angular/utility/ast-utils';
+import {
+  InsertChange,
+} from '@schematics/angular/utility/change';
+import * as ts from 'typescript';
+
+/**
+ * Add Otter localization support
+ * @param options {@link RuleFactory.options}
+ * @param options.projectName
+ * @param rootPath {@link RuleFactory.rootPath}
+ */
+export function updateLocalization(options: { projectName?: string | null | undefined }, rootPath: string): Rule {
+  const mainAssetsFolder = 'src/assets';
+  const devResourcesFolder = 'dev-resources';
+
+  /**
+   * Generate locales folder
+   * @param tree
+   */
+  const generateLocalesFolder: Rule = (tree: Tree) => {
+    const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
+    const projectType = workspaceProject?.projectType || 'application';
+    if (projectType === 'library') {
+      return tree;
+    }
+    const workingDirectory = (options.projectName && getWorkspaceConfig(tree)?.projects[options.projectName]?.root) || '.';
+    return mergeWith(apply(url(getTemplateFolder(rootPath, __dirname)), [
+      template({ empty: '' }),
+      move(workingDirectory)
+    ]), MergeStrategy.Overwrite);
+  };
+
+  /**
+   * Add translation generation builders into angular.json
+   * @param tree
+   * @param context
+   */
+  const updateAngularJson: Rule = (tree: Tree, context: SchematicContext) => {
+    const workspace = getWorkspaceConfig(tree);
+    const projectName = options.projectName;
+    const workspaceProject = options.projectName ? workspace?.projects[options.projectName] : undefined;
+    const projectRoot = path.posix.join(workspaceProject?.root || '');
+    const distFolder: string = (
+      workspaceProject
+      && workspaceProject.architect
+      && workspaceProject.architect.build
+      && workspaceProject.architect.build.options
+      && (
+        (
+          workspaceProject.architect.build.configurations
+          && workspaceProject.architect.build.configurations.production
+          && workspaceProject.architect.build.configurations.production.outputPath
+        ) || workspaceProject.architect.build.options.outputPath
+      )
+    ) || './dist';
+
+    // exit if not an application
+    if (!workspace || !projectName || !workspaceProject || workspaceProject.projectType === 'library') {
+      context.logger.debug('No application project found to add translation extraction');
+      return tree;
+    }
+
+    workspaceProject.architect ||= {};
+
+    const projectBasePath = workspaceProject.root.replace(/[/\\]$/, '');
+
+    workspaceProject.architect['generate-translations'] ||= {
+      builder: '@o3r/transloco:localization',
+      options: {
+        browserTarget: `${projectName}:build`,
+        localizationExtracterTarget: `${projectName}:extract-translations`,
+        locales: [
+          'en-GB'
+        ],
+        assets: [`${projectBasePath}/${mainAssetsFolder}/locales`],
+        outputPath: `${projectBasePath}/${devResourcesFolder}/localizations`
+      },
+      configurations: {
+        production: {
+          outputPath: `${projectBasePath}/${distFolder}/localizations`
+        }
+      }
+    };
+
+    const pathTsconfigCms = path.posix.join(projectRoot, 'tsconfig.cms.json');
+    workspaceProject.architect['extract-translations'] ||= {
+      builder: '@o3r/transloco:extractor',
+      options: {
+        tsConfig: pathTsconfigCms.replace(/^\//, ''),
+        libraries: []
+      }
+    };
+    const localizationAssetsConfig = {
+      glob: '**/*.json',
+      input: `${projectBasePath}/${devResourcesFolder}/localizations`,
+      output: '/localizations'
+    };
+    const projectType = workspaceProject?.projectType || 'application';
+    if (projectType === 'application' && workspaceProject.architect.build) {
+      const alreadyExistingBuildOption = workspaceProject.architect.build.options?.assets
+        ?.map((a: { glob: string; input: string; output: string }) => a.output)
+        .find((output: string) => output === '/localizations');
+
+      if (!alreadyExistingBuildOption) {
+        workspaceProject.architect.build.options ||= {};
+        workspaceProject.architect.build.options.assets ||= [];
+        workspaceProject.architect.build.options.assets.push(localizationAssetsConfig);
+      }
+    }
+
+    if (workspaceProject.architect.test) {
+      const alreadyExistingTestOption = workspaceProject.architect.test.options?.assets
+        ?.map((a: { glob: string; input: string; output: string }) => a.output)
+        .find((output: string) => output === '/localizations');
+      if (!alreadyExistingTestOption) {
+        workspaceProject.architect.test.options ||= {};
+        workspaceProject.architect.test.options.assets ||= [];
+        workspaceProject.architect.test.options.assets.push(localizationAssetsConfig);
+      }
+    }
+
+    const targets = [
+      `${projectName}:generate-translations`,
+      `${projectName}:serve`
+    ];
+    if (workspaceProject.architect.run?.options && Array.isArray(workspaceProject.architect.run.options.targets)) {
+      workspaceProject.architect.run.options.targets.push(...targets);
+      workspaceProject.architect.run.options.targets = (workspaceProject.architect.run.options.targets as string[])
+        .reduce<string[]>((acc, target) => acc.includes(target) ? acc : [...acc, target], []);
+    } else {
+      workspaceProject.architect.run = {
+        builder: '@o3r/core:multi-watcher',
+        options: {
+          targets
+        }
+      };
+    }
+
+    workspace.projects[projectName] = workspaceProject;
+    return writeAngularJson(tree, workspace);
+  };
+
+  /**
+   * Changed package.json start script to run localization generation
+   * @param tree
+   * @param context
+   */
+  const updatePackageJson: Rule = (tree: Tree, context: SchematicContext) => {
+    const workspace = getWorkspaceConfig(tree);
+    const projectName = options.projectName;
+    const workspaceProject = options.projectName ? workspace?.projects[options.projectName] : undefined;
+    const packageManagerRunner = getPackageManagerRunner(getWorkspaceConfig(tree));
+    if (!projectName || !workspace || !workspaceProject || workspaceProject.projectType === 'library') {
+      context.logger.debug('No application project found to add translation extraction');
+      return tree;
+    }
+
+    const packageJson = readPackageJson(tree, workspaceProject);
+
+    packageJson.scripts ||= {};
+    if (packageJson.scripts?.start && packageJson.scripts.start !== `ng run ${projectName}:run`) {
+      packageJson.scripts['start:no-translation'] ||= packageJson.scripts.start;
+    }
+    if (packageJson.scripts.watch) {
+      delete packageJson.scripts.watch;
+    }
+    packageJson.scripts.start ||= `ng run ${projectName}:run`;
+    if (packageJson.scripts.build?.indexOf('generate:translations') === -1) {
+      packageJson.scripts.build = `${packageManagerRunner} generate:translations && ${packageJson.scripts.build}`;
+    }
+    packageJson.scripts['generate:translations:dev'] ||= `ng run ${projectName}:generate-translations`;
+    packageJson.scripts['generate:translations'] ||= `ng run ${projectName}:generate-translations:production`;
+
+    tree.overwrite(`${workspaceProject.root}/package.json`, JSON.stringify(packageJson, null, 2));
+  };
+
+  /**
+   * Edit main module with the translation required configuration
+   * @param tree
+   * @param context
+   */
+  const registerModules: Rule = (tree: Tree, context: SchematicContext) => {
+    const additionalRules: Rule[] = [];
+    const moduleFilePath = getAppModuleFilePath(tree, context, options.projectName);
+    if (!moduleFilePath || !tree.exists(moduleFilePath)) {
+      context.logger.warn(moduleFilePath
+        ? `Module file not found under '${moduleFilePath}'. Localization modules not registered.`
+        : 'No module file found. Localization modules not registered.');
+      return tree;
+    }
+
+    const sourceFile = ts.createSourceFile(
+      moduleFilePath,
+      tree.read(moduleFilePath)!.toString(),
+      ts.ScriptTarget.ES2015,
+      true
+    );
+
+    // avoid overriding app module if Localization provider is already imported
+    if (isImported(sourceFile, 'provideLocalization', '@o3r/transloco')) {
+      return tree;
+    }
+
+    const recorder = tree.beginUpdate(moduleFilePath);
+    const appModuleFile = tree.read(moduleFilePath)!.toString();
+    const { moduleIndex } = getModuleIndex(sourceFile, appModuleFile);
+
+    const addImportToModuleFile = (name: string, file: string, moduleFunction?: string) => additionalRules.push(
+      addRootImport(options.projectName!, ({ code, external }) => code`${external(name, file)}${moduleFunction}`)
+    );
+
+    const insertImportToModuleFile = (name: string, file: string, isDefault?: boolean) =>
+      o3rInsertImportToModuleFile(name, file, sourceFile, recorder, moduleFilePath, isDefault);
+
+    const addProviderToModuleFile = (name: string, file: string, customProvider: string) => additionalRules.push(
+      addRootProvider(options.projectName!, ({ code, external }) =>
+        code`{provide: ${external(name, file)}, ${customProvider}}`)
+    );
+
+    const insertBeforeModule = (line: string) => o3rInsertBeforeModule(line, appModuleFile, recorder, moduleIndex);
+
+    addImportToModuleFile(
+      'TranslocoModule',
+      '@jsverse/transloco',
+      ''
+    );
+    additionalRules.push(
+      addRootProvider(options.projectName!, ({ code, external }) =>
+        code`${external('provideLocalization', '@o3r/transloco')}(localizationConfigurationFactory)`)
+    );
+
+    insertImportToModuleFile('translateLoaderProvider', '@o3r/transloco');
+    insertImportToModuleFile('LocalizationConfiguration', '@o3r/transloco');
+    insertImportToModuleFile('registerLocaleData', '@angular/common');
+    insertImportToModuleFile('localeEN', '@angular/common/locales/en', true);
+    insertImportToModuleFile('TRANSLOCO_LOADER', '@jsverse/transloco');
+
+    insertBeforeModule('registerLocaleData(localeEN, \'en-GB\');');
+
+    insertBeforeModule(`export function localizationConfigurationFactory(): Partial<LocalizationConfiguration> {
+  return {
+    supportedLocales: ['en-GB'],
+    fallbackLanguage: 'en-GB',
+    bundlesOutputPath: 'localizations/',
+    useDynamicContent: environment.production
+  };
+}`);
+
+    additionalRules.push(
+      addRootProvider(options.projectName!, ({ code, external }) =>
+        code`${external('provideTranslocoMessageformat', '@jsverse/transloco-messageformat')}()`)
+    );
+    addProviderToModuleFile('TRANSLOCO_LOADER', '@jsverse/transloco', 'useFactory: () => translateLoaderProvider');
+
+    if (!isImported(sourceFile, 'environment', '../environments/environment')) {
+      insertImportToModuleFile('environment', '../environments/environment');
+    }
+    tree.commitUpdate(recorder);
+
+    return chain(additionalRules)(tree, context);
+  };
+
+  /**
+   * Set language as default on application bootstrap
+   * @param tree
+   * @param context
+   */
+  const setDefaultLanguage: Rule = (tree: Tree, context: SchematicContext) => {
+    const moduleFilePath = getAppModuleFilePath(tree, context, options.projectName);
+    const componentFilePath = moduleFilePath?.replace(/[.-](?:module|config)\.ts$/i, '.ts');
+
+    if (!componentFilePath || !tree.exists(componentFilePath)) {
+      context.logger.warn(`File ${componentFilePath!} not found, the default language won't be set`);
+      return tree;
+    }
+
+    const sourceFile = ts.createSourceFile(
+      componentFilePath,
+      tree.read(componentFilePath)!.toString(),
+      ts.ScriptTarget.ES2015,
+      true
+    );
+
+    // avoid overriding app component file if Localization service is already imported
+    if (isImported(sourceFile, 'LocalizationService', '@o3r/transloco')) {
+      return tree;
+    }
+
+    const recorder = tree.beginUpdate(componentFilePath);
+
+    const insertImportToComponentFile = (name: string, file: string, isDefault?: boolean) => {
+      const importChange = insertImport(sourceFile, componentFilePath, name, file, isDefault);
+      if (importChange instanceof InsertChange) {
+        recorder.insertLeft(importChange.pos, importChange.toAdd);
+      }
+    };
+
+    insertImportToComponentFile('LocalizationService', '@o3r/transloco');
+
+    const constructorNode = findFirstNodeOfKind<ts.ConstructorDeclaration>(sourceFile, ts.SyntaxKind.Constructor);
+    if (constructorNode) {
+      const hasParam = !!constructorNode.parameters && constructorNode.parameters.length > 0;
+      const pos = hasParam ? constructorNode.parameters[0].pos : constructorNode.pos + constructorNode.getText().indexOf('(') + 1;
+      recorder.insertLeft(pos, `localizationService: LocalizationService${hasParam ? ', ' : ''}`);
+      if (constructorNode.body) {
+        recorder.insertLeft(constructorNode.body.end - 1, 'localizationService.useLanguage(\'en-GB\');');
+      }
+    } else {
+      const classNode = findFirstNodeOfKind<ts.ClassDeclaration>(sourceFile, ts.SyntaxKind.ClassDeclaration);
+      if (classNode) {
+        const firstToken = classNode.members[0];
+        if (firstToken) {
+          recorder.insertLeft(firstToken.pos, '\n  constructor(localizationService: LocalizationService) { localizationService.useLanguage(\'en-GB\'); }');
+        }
+      } else {
+        context.logger.warn(`No class found in ${componentFilePath}, the default language won't be set`);
+      }
+    }
+
+    tree.commitUpdate(recorder);
+    return tree;
+  };
+
+  /**
+   * Add mockTranslationModule to application tests.
+   * @param tree
+   * @param context
+   */
+  const addMockTranslationModule: Rule = (tree: Tree, context: SchematicContext) => {
+    const moduleFilePath = getAppModuleFilePath(tree, context, options.projectName);
+
+    const possibleComponentSpecPaths = [
+      moduleFilePath && moduleFilePath.replace(/\.(?:module|config)\.ts$/i, '.component.spec.ts'),
+      moduleFilePath && moduleFilePath.replace(/\.(?:module|config)\.ts$/i, '.spec.ts')
+    ];
+
+    const componentSpecFilePath = possibleComponentSpecPaths.find((compPath) => compPath && tree.exists(compPath));
+
+    if (!componentSpecFilePath || !tree.exists(componentSpecFilePath)) {
+      return tree;
+    }
+
+    const sourceFile = ts.createSourceFile(
+      componentSpecFilePath,
+      tree.read(componentSpecFilePath)!.toString(),
+      ts.ScriptTarget.ES2015,
+      true
+    );
+
+    // avoid overriding app component spec file if Localization mock is already imported
+    if (isImported(sourceFile, 'provideLocalizationMock', '@o3r/testing/transloco')) {
+      return tree;
+    }
+
+    const recorder = tree.beginUpdate(componentSpecFilePath);
+
+    const insertImportToComponentFile = (name: string, file: string, isDefault?: boolean) => {
+      const importChange = insertImport(sourceFile, componentSpecFilePath, name, file, isDefault);
+      if (importChange instanceof InsertChange) {
+        recorder.insertLeft(importChange.pos, importChange.toAdd);
+      }
+    };
+
+    insertImportToComponentFile('provideLocalizationMock', '@o3r/testing/transloco');
+
+    const providersRegExp = /TestBed\.configureTestingModule\({[^}]*providers\s*:\s*\[([^\]]*)/s;
+    const providersResult = sourceFile.text.match(providersRegExp);
+    if (providersResult && providersResult.length > 0 && typeof providersResult.index !== 'undefined') {
+      const providersArrayStart = providersResult.index + providersResult[0].length;
+      recorder.insertRight(providersArrayStart, '...provideLocalizationMock(), ');
+    }
+
+    tree.commitUpdate(recorder);
+    return tree;
+  };
+
+  // Ignore generated CMS metadata and dev resources
+  const ignoreDevResourcesFiles = (tree: Tree, _context: SchematicContext) => {
+    const workingDirectory = (options.projectName && getWorkspaceConfig(tree)?.projects[options.projectName]?.root) || '.';
+
+    return applyToSubtree(
+      workingDirectory, [
+        (subTree) => ignorePatterns(subTree, [
+          { description: 'Local Development resources files', patterns: [`/${devResourcesFolder}`] },
+          { description: 'CMS metadata files', patterns: ['/*.metadata.json'] }
+        ])
+      ]);
+  };
+
+  return chain([
+    registerModules,
+    generateLocalesFolder,
+    updateAngularJson,
+    updatePackageJson,
+    setDefaultLanguage,
+    addMockTranslationModule,
+    ignoreDevResourcesFiles
+  ]);
+}
+
+/**
+ * Updates i18n configuration for the project
+ * @param options Options for the i18n update
+ * @param options.projectName Name of the project to update
+ */
+function updateI18nFn(options: { projectName?: string | undefined }): Rule {
+  if (!options.projectName) {
+    return noop;
+  }
+  /**
+   * Add i18n generation builders into angular.json
+   * @param tree
+   */
+  const updateAngularJson: Rule = (tree: Tree) => {
+    const workspace = getWorkspaceConfig(tree);
+    const workspaceProject = options.projectName ? workspace?.projects[options.projectName] : undefined;
+
+    if (!workspace || !workspaceProject) {
+      return tree;
+    }
+
+    workspaceProject.architect ||= {};
+
+    workspaceProject.architect.i18n ||= {
+      builder: '@o3r/transloco:i18n',
+      options: {
+        localizationConfigs: [{
+          localizationFiles: workspace.schematics && workspace.schematics['@o3r/core:component']
+            ? [workspace.schematics['@o3r/core:component'].path]
+            : ['**/*-localization.json']
+        }]
+      }
+    };
+
+    workspace.projects[options.projectName!] = workspaceProject;
+    return writeAngularJson(tree, workspace);
+  };
+
+  return chain([
+    updateAngularJson
+  ]);
+}
+
+export const updateI18n = createOtterSchematic(updateI18nFn);

--- a/packages/@o3r/transloco/schematics/localization-base/index.ts
+++ b/packages/@o3r/transloco/schematics/localization-base/index.ts
@@ -1,0 +1,481 @@
+import * as path from 'node:path';
+import {
+  apply,
+  applyToSubtree,
+  chain,
+  MergeStrategy,
+  mergeWith,
+  move,
+  noop,
+  Rule,
+  SchematicContext,
+  template,
+  Tree,
+  url,
+} from '@angular-devkit/schematics';
+import {
+  createOtterSchematic,
+  findFirstNodeOfKind,
+  getAppModuleFilePath,
+  getModuleIndex,
+  getPackageManagerRunner,
+  getTemplateFolder,
+  getWorkspaceConfig,
+  ignorePatterns,
+  insertBeforeModule as o3rInsertBeforeModule,
+  insertImportToModuleFile as o3rInsertImportToModuleFile,
+  readPackageJson,
+  writeAngularJson,
+} from '@o3r/schematics';
+import {
+  addRootImport,
+  addRootProvider,
+} from '@schematics/angular/utility';
+import {
+  insertImport,
+  isImported,
+} from '@schematics/angular/utility/ast-utils';
+import {
+  InsertChange,
+} from '@schematics/angular/utility/change';
+import * as ts from 'typescript';
+
+/**
+ * Add Otter localization support
+ * @param options {@link RuleFactory.options}
+ * @param options.projectName
+ * @param rootPath {@link RuleFactory.rootPath}
+ */
+export function updateLocalization(options: { projectName?: string | null | undefined }, rootPath: string): Rule {
+  const mainAssetsFolder = 'src/assets';
+  const devResourcesFolder = 'dev-resources';
+
+  /**
+   * Generate locales folder
+   * @param tree
+   */
+  const generateLocalesFolder: Rule = (tree: Tree) => {
+    const workspaceProject = options.projectName ? getWorkspaceConfig(tree)?.projects[options.projectName] : undefined;
+    const projectType = workspaceProject?.projectType || 'application';
+    if (projectType === 'library') {
+      return tree;
+    }
+    const workingDirectory = (options.projectName && getWorkspaceConfig(tree)?.projects[options.projectName]?.root) || '.';
+    return mergeWith(apply(url(getTemplateFolder(rootPath, __dirname)), [
+      template({ empty: '' }),
+      move(workingDirectory)
+    ]), MergeStrategy.Overwrite);
+  };
+
+  /**
+   * Add translation generation builders into angular.json
+   * @param tree
+   * @param context
+   */
+  const updateAngularJson: Rule = (tree: Tree, context: SchematicContext) => {
+    const workspace = getWorkspaceConfig(tree);
+    const projectName = options.projectName;
+    const workspaceProject = options.projectName ? workspace?.projects[options.projectName] : undefined;
+    const projectRoot = path.posix.join(workspaceProject?.root || '');
+    const distFolder: string = (
+      workspaceProject
+      && workspaceProject.architect
+      && workspaceProject.architect.build
+      && workspaceProject.architect.build.options
+      && (
+        (
+          workspaceProject.architect.build.configurations
+          && workspaceProject.architect.build.configurations.production
+          && workspaceProject.architect.build.configurations.production.outputPath
+        ) || workspaceProject.architect.build.options.outputPath
+      )
+    ) || './dist';
+
+    // exit if not an application
+    if (!workspace || !projectName || !workspaceProject || workspaceProject.projectType === 'library') {
+      context.logger.debug('No application project found to add translation extraction');
+      return tree;
+    }
+
+    workspaceProject.architect ||= {};
+
+    const projectBasePath = workspaceProject.root.replace(/[/\\]$/, '');
+
+    workspaceProject.architect['generate-translations'] ||= {
+      builder: '@o3r/transloco:localization',
+      options: {
+        browserTarget: `${projectName}:build`,
+        localizationExtracterTarget: `${projectName}:extract-translations`,
+        locales: [
+          'en-GB'
+        ],
+        assets: [`${projectBasePath}/${mainAssetsFolder}/locales`],
+        outputPath: `${projectBasePath}/${devResourcesFolder}/localizations`
+      },
+      configurations: {
+        production: {
+          outputPath: `${projectBasePath}/${distFolder}/localizations`
+        }
+      }
+    };
+
+    const pathTsconfigCms = path.posix.join(projectRoot, 'tsconfig.cms.json');
+    workspaceProject.architect['extract-translations'] ||= {
+      builder: '@o3r/transloco:extractor',
+      options: {
+        tsConfig: pathTsconfigCms.replace(/^\//, ''),
+        libraries: []
+      }
+    };
+    const localizationAssetsConfig = {
+      glob: '**/*.json',
+      input: `${projectBasePath}/${devResourcesFolder}/localizations`,
+      output: '/localizations'
+    };
+    const projectType = workspaceProject?.projectType || 'application';
+    if (projectType === 'application' && workspaceProject.architect.build) {
+      const alreadyExistingBuildOption = workspaceProject.architect.build.options?.assets
+        ?.map((a: { glob: string; input: string; output: string }) => a.output)
+        .find((output: string) => output === '/localizations');
+
+      if (!alreadyExistingBuildOption) {
+        workspaceProject.architect.build.options ||= {};
+        workspaceProject.architect.build.options.assets ||= [];
+        workspaceProject.architect.build.options.assets.push(localizationAssetsConfig);
+      }
+    }
+
+    if (workspaceProject.architect.test) {
+      const alreadyExistingTestOption = workspaceProject.architect.test.options?.assets
+        ?.map((a: { glob: string; input: string; output: string }) => a.output)
+        .find((output: string) => output === '/localizations');
+      if (!alreadyExistingTestOption) {
+        workspaceProject.architect.test.options ||= {};
+        workspaceProject.architect.test.options.assets ||= [];
+        workspaceProject.architect.test.options.assets.push(localizationAssetsConfig);
+      }
+    }
+
+    const targets = [
+      `${projectName}:generate-translations`,
+      `${projectName}:serve`
+    ];
+    if (workspaceProject.architect.run?.options && Array.isArray(workspaceProject.architect.run.options.targets)) {
+      workspaceProject.architect.run.options.targets = Array.from(
+        new Set(workspaceProject.architect.run.options.targets as string[]).union(new Set(targets))
+      );
+    } else {
+      workspaceProject.architect.run = {
+        builder: '@o3r/core:multi-watcher',
+        options: {
+          targets
+        }
+      };
+    }
+
+    workspace.projects[projectName] = workspaceProject;
+    return writeAngularJson(tree, workspace);
+  };
+
+  /**
+   * Changed package.json start script to run localization generation
+   * @param tree
+   * @param context
+   */
+  const updatePackageJson: Rule = (tree: Tree, context: SchematicContext) => {
+    const workspace = getWorkspaceConfig(tree);
+    const projectName = options.projectName;
+    const workspaceProject = options.projectName ? workspace?.projects[options.projectName] : undefined;
+    const packageManagerRunner = getPackageManagerRunner(getWorkspaceConfig(tree));
+    if (!projectName || !workspace || !workspaceProject || workspaceProject.projectType === 'library') {
+      context.logger.debug('No application project found to add translation extraction');
+      return tree;
+    }
+
+    const packageJson = readPackageJson(tree, workspaceProject);
+
+    packageJson.scripts ||= {};
+    if (packageJson.scripts?.start && packageJson.scripts.start !== `ng run ${projectName}:run`) {
+      packageJson.scripts['start:no-translation'] ||= packageJson.scripts.start;
+    }
+    if (packageJson.scripts.watch) {
+      delete packageJson.scripts.watch;
+    }
+    packageJson.scripts.start ||= `ng run ${projectName}:run`;
+    if (packageJson.scripts.build?.indexOf('generate:translations') === -1) {
+      packageJson.scripts.build = `${packageManagerRunner} generate:translations && ${packageJson.scripts.build}`;
+    }
+    packageJson.scripts['generate:translations:dev'] ||= `ng run ${projectName}:generate-translations`;
+    packageJson.scripts['generate:translations'] ||= `ng run ${projectName}:generate-translations:production`;
+
+    tree.overwrite(`${workspaceProject.root}/package.json`, JSON.stringify(packageJson, null, 2));
+  };
+
+  /**
+   * Edit main module with the translation required configuration
+   * @param tree
+   * @param context
+   */
+  const registerModules: Rule = (tree: Tree, context: SchematicContext) => {
+    const additionalRules: Rule[] = [];
+    const moduleFilePath = getAppModuleFilePath(tree, context, options.projectName);
+    if (!moduleFilePath || !tree.exists(moduleFilePath)) {
+      context.logger.warn(moduleFilePath
+        ? `Module file not found under '${moduleFilePath}'. Localization modules not registered.`
+        : 'No module file found. Localization modules not registered.');
+      return tree;
+    }
+
+    const sourceFile = ts.createSourceFile(
+      moduleFilePath,
+      tree.read(moduleFilePath)!.toString(),
+      ts.ScriptTarget.ES2015,
+      true
+    );
+
+    // avoid overriding app module if Localization provider is already imported
+    if (isImported(sourceFile, 'provideLocalization', '@o3r/transloco')) {
+      return tree;
+    }
+
+    const recorder = tree.beginUpdate(moduleFilePath);
+    const appModuleFile = tree.read(moduleFilePath)!.toString();
+    const { moduleIndex } = getModuleIndex(sourceFile, appModuleFile);
+
+    const addImportToModuleFile = (name: string, file: string, moduleFunction?: string) => additionalRules.push(
+      addRootImport(options.projectName!, ({ code, external }) => code`${external(name, file)}${moduleFunction}`)
+    );
+
+    const insertImportToModuleFile = (name: string, file: string, isDefault?: boolean) =>
+      o3rInsertImportToModuleFile(name, file, sourceFile, recorder, moduleFilePath, isDefault);
+
+    const addProviderToModuleFile = (name: string, file: string, customProvider: string) => additionalRules.push(
+      addRootProvider(options.projectName!, ({ code, external }) =>
+        code`{provide: ${external(name, file)}, ${customProvider}}`)
+    );
+
+    const insertBeforeModule = (line: string) => o3rInsertBeforeModule(line, appModuleFile, recorder, moduleIndex);
+
+    addImportToModuleFile(
+      'TranslocoModule',
+      '@jsverse/transloco',
+      ''
+    );
+    additionalRules.push(
+      addRootProvider(options.projectName!, ({ code, external }) =>
+        code`${external('provideLocalization', '@o3r/transloco')}(localizationConfigurationFactory)`)
+    );
+
+    insertImportToModuleFile('translateLoaderProvider', '@o3r/transloco');
+    insertImportToModuleFile('LocalizationConfiguration', '@o3r/transloco');
+    insertImportToModuleFile('registerLocaleData', '@angular/common');
+    insertImportToModuleFile('localeEN', '@angular/common/locales/en', true);
+    insertImportToModuleFile('TRANSLOCO_LOADER', '@jsverse/transloco');
+
+    insertBeforeModule('registerLocaleData(localeEN, \'en-GB\');');
+
+    insertBeforeModule(`export function localizationConfigurationFactory(): Partial<LocalizationConfiguration> {
+  return {
+    supportedLocales: ['en-GB'],
+    fallbackLanguage: 'en-GB',
+    bundlesOutputPath: 'localizations/',
+    useDynamicContent: environment.production
+  };
+}`);
+
+    additionalRules.push(
+      addRootProvider(options.projectName!, ({ code, external }) =>
+        code`${external('provideTranslocoMessageformat', '@jsverse/transloco-messageformat')}()`)
+    );
+    addProviderToModuleFile('TRANSLOCO_LOADER', '@jsverse/transloco', 'useFactory: () => translateLoaderProvider');
+
+    tree.commitUpdate(recorder);
+    if (!isImported(sourceFile, 'environment', '../environments/environment')) {
+      insertImportToModuleFile('environment', '../environments/environment');
+    }
+
+    return chain(additionalRules)(tree, context);
+  };
+
+  /**
+   * Set language as default on application bootstrap
+   * @param tree
+   * @param context
+   */
+  const setDefaultLanguage: Rule = (tree: Tree, context: SchematicContext) => {
+    const moduleFilePath = getAppModuleFilePath(tree, context, options.projectName);
+    const componentFilePath = moduleFilePath?.replace(/[.-](?:module|config)\.ts$/i, '.ts');
+
+    if (!componentFilePath || !tree.exists(componentFilePath)) {
+      context.logger.warn(`File ${componentFilePath!} not found, the default language won't be set`);
+      return tree;
+    }
+
+    const sourceFile = ts.createSourceFile(
+      componentFilePath,
+      tree.read(componentFilePath)!.toString(),
+      ts.ScriptTarget.ES2015,
+      true
+    );
+
+    // avoid overriding app component file if Localization service is already imported
+    if (isImported(sourceFile, 'LocalizationService', '@o3r/transloco')) {
+      return tree;
+    }
+
+    const recorder = tree.beginUpdate(componentFilePath);
+
+    const insertImportToComponentFile = (name: string, file: string, isDefault?: boolean) => {
+      const importChange = insertImport(sourceFile, componentFilePath, name, file, isDefault);
+      if (importChange instanceof InsertChange) {
+        recorder.insertLeft(importChange.pos, importChange.toAdd);
+      }
+    };
+
+    insertImportToComponentFile('LocalizationService', '@o3r/transloco');
+
+    const constructorNode = findFirstNodeOfKind<ts.ConstructorDeclaration>(sourceFile, ts.SyntaxKind.Constructor);
+    if (constructorNode) {
+      const hasParam = !!constructorNode.parameters && constructorNode.parameters.length > 0;
+      const pos = hasParam ? constructorNode.parameters[0].pos : constructorNode.pos + constructorNode.getText().indexOf('(') + 1;
+      recorder.insertLeft(pos, `localizationService: LocalizationService${hasParam ? ', ' : ''}`);
+      if (constructorNode.body) {
+        recorder.insertLeft(constructorNode.body.end - 1, 'localizationService.useLanguage(\'en-GB\');');
+      }
+    } else {
+      const classNode = findFirstNodeOfKind<ts.ClassDeclaration>(sourceFile, ts.SyntaxKind.ClassDeclaration);
+      if (classNode) {
+        const firstToken = classNode.members[0];
+        if (firstToken) {
+          recorder.insertLeft(firstToken.pos, '\n  constructor(localizationService: LocalizationService) { localizationService.useLanguage(\'en-GB\'); }');
+        }
+      } else {
+        context.logger.warn(`No class found in ${componentFilePath}, the default language won't be set`);
+      }
+    }
+
+    tree.commitUpdate(recorder);
+    return tree;
+  };
+
+  /**
+   * Add mockTranslationModule to application tests.
+   * @param tree
+   * @param context
+   */
+  const addMockTranslationModule: Rule = (tree: Tree, context: SchematicContext) => {
+    const moduleFilePath = getAppModuleFilePath(tree, context, options.projectName);
+
+    const possibleComponentSpecPaths = [
+      moduleFilePath && moduleFilePath.replace(/\.(?:module|config)\.ts$/i, '.component.spec.ts'),
+      moduleFilePath && moduleFilePath.replace(/\.(?:module|config)\.ts$/i, '.spec.ts')
+    ];
+
+    const componentSpecFilePath = possibleComponentSpecPaths.find((compPath) => compPath && tree.exists(compPath));
+
+    if (!componentSpecFilePath || !tree.exists(componentSpecFilePath)) {
+      return tree;
+    }
+
+    const sourceFile = ts.createSourceFile(
+      componentSpecFilePath,
+      tree.read(componentSpecFilePath)!.toString(),
+      ts.ScriptTarget.ES2015,
+      true
+    );
+
+    // avoid overriding app component spec file if Localization mock is already imported
+    if (isImported(sourceFile, 'provideLocalizationMock', '@o3r/testing/transloco')) {
+      return tree;
+    }
+
+    const recorder = tree.beginUpdate(componentSpecFilePath);
+
+    const insertImportToComponentFile = (name: string, file: string, isDefault?: boolean) => {
+      const importChange = insertImport(sourceFile, componentSpecFilePath, name, file, isDefault);
+      if (importChange instanceof InsertChange) {
+        recorder.insertLeft(importChange.pos, importChange.toAdd);
+      }
+    };
+
+    insertImportToComponentFile('provideLocalizationMock', '@o3r/testing/transloco');
+
+    const providersRegExp = /TestBed\.configureTestingModule\({[^}]*providers\s*:\s*\[([^\]]*)/s;
+    const providersResult = sourceFile.text.match(providersRegExp);
+    if (providersResult && providersResult.length > 0 && typeof providersResult.index !== 'undefined') {
+      const providersArrayStart = providersResult.index + providersResult[0].length;
+      recorder.insertRight(providersArrayStart, '...provideLocalizationMock(), ');
+    }
+
+    tree.commitUpdate(recorder);
+    return tree;
+  };
+
+  // Ignore generated CMS metadata
+  const ignoreDevResourcesFiles = (tree: Tree, _context: SchematicContext) => {
+    const workingDirectory = (options.projectName && getWorkspaceConfig(tree)?.projects[options.projectName]?.root) || '.';
+
+    return applyToSubtree(
+      workingDirectory, [
+        (subTree) => ignorePatterns(subTree, [
+          { description: 'Local Development resources files', patterns: [`/${devResourcesFolder}`] },
+          { description: 'CMS metadata files', patterns: ['/*.metadata.json'] }
+        ])
+      ]);
+  };
+
+  return chain([
+    registerModules,
+    generateLocalesFolder,
+    updateAngularJson,
+    updatePackageJson,
+    setDefaultLanguage,
+    addMockTranslationModule,
+    ignoreDevResourcesFiles
+  ]);
+}
+
+/**
+ * Updates i18n configuration for the project
+ * @param options Options for the i18n update
+ * @param options.projectName Name of the project to update
+ */
+function updateI18nFn(options: { projectName?: string | undefined }): Rule {
+  if (!options.projectName) {
+    return noop;
+  }
+  /**
+   * Add i18n generation builders into angular.json
+   * @param tree
+   */
+  const updateAngularJson: Rule = (tree: Tree) => {
+    const workspace = getWorkspaceConfig(tree);
+    const workspaceProject = options.projectName ? workspace?.projects[options.projectName] : undefined;
+
+    if (!workspace || !workspaceProject) {
+      return tree;
+    }
+
+    workspaceProject.architect ||= {};
+
+    workspaceProject.architect.i18n ||= {
+      builder: '@o3r/transloco:i18n',
+      options: {
+        localizationConfigs: [{
+          localizationFiles: workspace.schematics && workspace.schematics['@o3r/core:component']
+            ? [workspace.schematics['@o3r/core:component'].path]
+            : ['**/*-localization.json']
+        }]
+      }
+    };
+
+    workspace.projects[options.projectName!] = workspaceProject;
+    return writeAngularJson(tree, workspace);
+  };
+
+  return chain([
+    updateAngularJson
+  ]);
+}
+
+export const updateI18n = createOtterSchematic(updateI18nFn);

--- a/packages/@o3r/transloco/schematics/localization-to-component/index.spec.ts
+++ b/packages/@o3r/transloco/schematics/localization-to-component/index.spec.ts
@@ -1,0 +1,324 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  Tree,
+} from '@angular-devkit/schematics';
+import {
+  SchematicTestRunner,
+} from '@angular-devkit/schematics/testing';
+import {
+  firstValueFrom,
+} from 'rxjs';
+import {
+  ngAddLocalizationFn,
+} from './index';
+
+const collectionPath = path.join(__dirname, '..', '..', 'collection.json');
+const o3rComponentPath = '/src/components/test/test.ts';
+const specPath = '/src/components/test/test.spec.ts';
+const templatePath = '/src/components/test/test.html';
+const modulePath = '/src/components/test/test-module.ts';
+const ngComponentPath = '/src/components/ng/ng.ts';
+
+describe('Add Localization', () => {
+  let initialTree: Tree;
+
+  describe('Otter standalone component', () => {
+    beforeEach(() => {
+      initialTree = Tree.empty();
+      initialTree.create(o3rComponentPath, `
+        import {CommonModule} from '@angular/common';
+        import {ChangeDetectionStrategy, Component, OnDestroy, OnInit, ViewEncapsulation} from '@angular/core';
+        import {O3rComponent} from '@o3r/core';
+        import {Subscription} from 'rxjs';
+
+        @O3rComponent({
+          componentType: 'Component'
+        })
+        @Component({
+          selector: 'o3r-test-pres',
+          imports: [CommonModule],
+          styleUrls: ['./test.scss'],
+          templateUrl: './test.html',
+          changeDetection: ChangeDetectionStrategy.OnPush,
+          encapsulation: ViewEncapsulation.None
+        })
+        export class Test implements OnInit, OnDestroy {
+          /**
+           * List of subscriptions to unsubscribe on destroy
+           */
+          private subscriptions: Subscription[] = [];
+
+          public ngOnInit() {
+            // Run on component initialization
+          }
+
+          public ngOnDestroy() {
+            // Run on component destruction
+            this.subscriptions.forEach((subscription) => subscription.unsubscribe());
+          }
+        }
+      `);
+      initialTree.create(templatePath, '<div>My HTML content</div>');
+      initialTree.create(specPath, `
+        import { ComponentFixture, TestBed } from '@angular/core/testing';
+        import { Test } from './test';
+
+        describe('Test', () => {
+          let component: Test;
+          let fixture: ComponentFixture<Test>;
+
+          beforeEach(() => {
+            TestBed.configureTestingModule({
+              imports: [Test]
+            });
+            fixture = TestBed.createComponent(Test);
+            component = fixture.componentInstance;
+            fixture.detectChanges();
+          });
+
+          it('should create', () => {
+            expect(component).toBeTruthy();
+          });
+        });
+      `);
+      initialTree.create('.eslintrc.json', fs.readFileSync(path.resolve(__dirname, '..', '..', 'testing', 'mocks', '__dot__eslintrc.mocks.json')));
+    });
+
+    it('should create the localization files and update the component', async () => {
+      const runner = new SchematicTestRunner('schematics', collectionPath);
+      const tree = await runner.runSchematic('localization-to-component', {
+        projectName: 'test-project',
+        path: o3rComponentPath,
+        activateDummy: true,
+        skipLinter: true
+      }, initialTree);
+
+      const translationFile = o3rComponentPath.replace(/\.ts$/, '-translation.ts');
+      const localizationFile = o3rComponentPath.replace(/\.ts$/, '-localization.json');
+
+      expect(tree.exists(translationFile)).toBeTruthy();
+      expect(tree.readText(translationFile)).toContain('dummyLoc1');
+
+      expect(tree.exists(localizationFile)).toBeTruthy();
+      expect((tree.readJson(localizationFile) as any)['o3r-test-pres.dummyLoc1']).toBeDefined();
+
+      const componentFileContent = tree.readText(o3rComponentPath);
+      expect(componentFileContent).toContain('Translatable<TestTranslation>');
+      expect(componentFileContent).toContain('public translations: TestTranslation;');
+      expect(componentFileContent).toContain('this.translations = translations');
+      expect(componentFileContent).toContain('@Localization(\'./test-localization.json\')');
+
+      const templateFileContent = tree.readText(templatePath);
+      expect(templateFileContent).toContain('<div>Localization: {{ translations.dummyLoc1 | o3rTranslate }}</div>');
+
+      const specFileContent = tree.readText(specPath);
+      expect(specFileContent).toContain('const localizationService = TestBed.inject(LocalizationService);');
+      expect(specFileContent).toContain('localizationService.configure()');
+      expect(specFileContent).toContain('...provideLocalizationMock(localizationConfiguration, mockTranslations)');
+      expect(specFileContent).toContain('const localizationConfiguration = ');
+      expect(specFileContent).toContain('const mockTranslations = ');
+    });
+
+    it('should create the localization files and update the typed component', async () => {
+      const componentWithTypePath = '/src/components/other-test/other-test.test-type.ts';
+      initialTree.create(componentWithTypePath, `
+        import {CommonModule} from '@angular/common';
+        import {ChangeDetectionStrategy, Component, OnDestroy, OnInit, ViewEncapsulation} from '@angular/core';
+        import {O3rComponent} from '@o3r/core';
+        import {Subscription} from 'rxjs';
+
+        @O3rComponent({
+          componentType: 'Component'
+        })
+        @Component({
+          selector: 'o3r-other-test-pres',
+          imports: [CommonModule],
+          styleUrls: ['./other-test.test-type.scss'],
+          templateUrl: './other-test.test-type.html',
+          changeDetection: ChangeDetectionStrategy.OnPush,
+          encapsulation: ViewEncapsulation.None
+        })
+        export class OtherTestTestType implements OnInit, OnDestroy {
+          /**
+           * List of subscriptions to unsubscribe on destroy
+           */
+          private subscriptions: Subscription[] = [];
+
+          public ngOnInit() {
+            // Run on component initialization
+          }
+
+          public ngOnDestroy() {
+            // Run on component destruction
+            this.subscriptions.forEach((subscription) => subscription.unsubscribe());
+          }
+        }
+      `);
+      const runner = new SchematicTestRunner('schematics', collectionPath);
+      const tree = await runner.runSchematic('localization-to-component', {
+        projectName: 'test-project',
+        path: componentWithTypePath,
+        activateDummy: true,
+        skipLinter: true
+      }, initialTree);
+
+      const translationFile = componentWithTypePath.replace(/\.test-type\.ts$/, '-translation.ts');
+      const localizationFile = componentWithTypePath.replace(/\.test-type\.ts$/, '-localization.json');
+
+      expect(tree.exists(translationFile)).toBeTruthy();
+      expect(tree.exists(localizationFile)).toBeTruthy();
+    });
+
+    it('should throw if we add localization to a component that already has it', async () => {
+      const runner = new SchematicTestRunner('schematics', collectionPath);
+      const tree = await runner.runSchematic('localization-to-component', {
+        projectName: 'test-project',
+        path: o3rComponentPath
+      }, initialTree);
+      await expect(runner.runSchematic('localization-to-component', {
+        projectName: 'test-project',
+        path: o3rComponentPath
+      }, tree)).rejects.toThrow();
+    });
+  });
+
+  describe('Otter non standalone component', () => {
+    beforeEach(() => {
+      initialTree = Tree.empty();
+      initialTree.create(o3rComponentPath, `
+        import {ChangeDetectionStrategy, Component, OnDestroy, OnInit, ViewEncapsulation} from '@angular/core';
+        import {O3rComponent} from '@o3r/core';
+        import {Subscription} from 'rxjs';
+
+        @O3rComponent({
+          componentType: 'Component'
+        })
+        @Component({
+          selector: 'o3r-test-pres',
+          styleUrls: ['./test.scss'],
+          templateUrl: './test.html',
+          changeDetection: ChangeDetectionStrategy.OnPush,
+          encapsulation: ViewEncapsulation.None,
+          standalone: false
+        })
+        export class Test implements OnInit, OnDestroy {
+          /**
+           * List of subscriptions to unsubscribe on destroy
+           */
+          private subscriptions: Subscription[] = [];
+
+          public ngOnInit() {
+            // Run on component initialization
+          }
+
+          public ngOnDestroy() {
+            // Run on component destruction
+            this.subscriptions.forEach((subscription) => subscription.unsubscribe());
+          }
+        }
+      `);
+      initialTree.create(templatePath, '<div>My HTML content</div>');
+      initialTree.create(specPath, `
+        import { ComponentFixture, TestBed } from '@angular/core/testing';
+        import { Test } from './test';
+
+        describe('Test', () => {
+          let component: Test;
+          let fixture: ComponentFixture<Test>;
+
+          beforeEach(() => {
+            TestBed.configureTestingModule({
+              declarations: [Test]
+            });
+            fixture = TestBed.createComponent(Test);
+            component = fixture.componentInstance;
+            fixture.detectChanges();
+          });
+
+          it('should create', () => {
+            expect(component).toBeTruthy();
+          });
+        });
+      `);
+      initialTree.create(modulePath, `
+        import {CommonModule} from '@angular/common';
+        import {NgModule} from '@angular/core';
+        import {Test} from './test';
+
+        @NgModule({
+          imports: [CommonModule],
+          declarations: [Test],
+          exports: [Test]
+        })
+        export class TestModule {}
+      `);
+      initialTree.create('.eslintrc.json', fs.readFileSync(path.resolve(__dirname, '..', '..', 'testing', 'mocks', '__dot__eslintrc.mocks.json')));
+    });
+
+    it('should update the module', async () => {
+      const runner = new SchematicTestRunner('schematics', collectionPath);
+      const tree = await runner.runSchematic('localization-to-component', {
+        projectName: 'test-project',
+        path: o3rComponentPath
+      }, initialTree);
+
+      const moduleFileContent = tree.readText(modulePath);
+      expect(moduleFileContent).toContain('provideLocalization');
+    });
+  });
+
+  describe('Angular component', () => {
+    beforeEach(() => {
+      initialTree = Tree.empty();
+      initialTree.create(ngComponentPath, `
+        import {CommonModule} from '@angular/common';
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'ng-test',
+          imports: [CommonModule],
+          template: ''
+        })
+        export class NgComponent {}
+      `);
+      initialTree.create('.eslintrc.json', fs.readFileSync(path.resolve(__dirname, '..', '..', 'testing', 'mocks', '__dot__eslintrc.mocks.json')));
+    });
+
+    it('should throw if inexisting path', async () => {
+      const runner = new SchematicTestRunner('schematics', collectionPath);
+
+      await expect(runner.runSchematic('localization-to-component', {
+        projectName: 'test-project',
+        path: 'inexisting-path.ts'
+      }, initialTree)).rejects.toThrow();
+    });
+
+    describe('Angular component', () => {
+      it('should throw if no Otter component', async () => {
+        const runner = new SchematicTestRunner('schematics', collectionPath);
+
+        await expect(firstValueFrom(runner.callRule(ngAddLocalizationFn({
+          path: ngComponentPath,
+          skipLinter: false,
+          activateDummy: false,
+          specFilePath: undefined
+        }), initialTree, { interactive: false }))).rejects.toThrow();
+      });
+
+      it('should call convert-component if no Otter component', async () => {
+        const runner = new SchematicTestRunner('schematics', collectionPath);
+        const o3rCorePackageJson = require.resolve('@o3r/core/package.json');
+        runner.registerCollection('@o3r/core', path.resolve(path.dirname(o3rCorePackageJson), require(o3rCorePackageJson).schematics));
+        const spy = jest.spyOn(runner.engine, 'createSchematic');
+
+        const tree = await runner.runSchematic('localization-to-component', {
+          path: ngComponentPath
+        }, initialTree);
+
+        expect(spy).toHaveBeenCalledWith('convert-component', expect.anything(), expect.anything());
+        expect(tree.exists(ngComponentPath.replace(/\.ts$/, '-translation.ts'))).toBeTruthy();
+      });
+    });
+  });
+});

--- a/packages/@o3r/transloco/schematics/localization-to-component/index.ts
+++ b/packages/@o3r/transloco/schematics/localization-to-component/index.ts
@@ -1,0 +1,417 @@
+import {
+  dirname,
+  posix,
+} from 'node:path';
+import {
+  apply,
+  chain,
+  externalSchematic,
+  MergeStrategy,
+  mergeWith,
+  move,
+  noop,
+  renameTemplateFiles,
+  Rule,
+  schematic,
+  SchematicContext,
+  template,
+  Tree,
+  url,
+} from '@angular-devkit/schematics';
+import {
+  addCommentsOnClassProperties,
+  addImportsAndCodeBlockStatementAtSpecInitializationTransformerFactory,
+  addImportsIntoComponentDecoratorTransformerFactory,
+  addImportsRule,
+  addInterfaceToClassTransformerFactory,
+  applyEsLintFix,
+  askConfirmationToConvertComponent,
+  createOtterSchematic,
+  generateBlockStatementsFromString,
+  generateClassElementsFromString,
+  getComponentBaseFileName,
+  getComponentTranslationName,
+  getO3rComponentInfoOrThrowIfNotFound,
+  isO3rClassComponent,
+  NoOtterComponent,
+  O3rCliError,
+  sortClassElement,
+} from '@o3r/schematics';
+import {
+  addProviderToModule,
+  insertImport,
+} from '@schematics/angular/utility/ast-utils';
+import {
+  applyToUpdateRecorder,
+  InsertChange,
+} from '@schematics/angular/utility/change';
+import * as ts from 'typescript';
+import type {
+  NgAddLocalizationSchematicsSchema,
+} from './schema';
+
+/**
+ * List of properties that will be added to the component for localization
+ */
+const localizationProperties = [
+  'translations'
+];
+
+/**
+ * Checks if localization files already exist for a component
+ * @param componentPath Path to the component file
+ * @param tree Schematic tree
+ * @param baseFileName Base file name of the component
+ */
+const checkLocalization = (componentPath: string, tree: Tree, baseFileName: string) => {
+  const files = [
+    posix.join(dirname(componentPath), `${baseFileName}-localization.json`),
+    posix.join(dirname(componentPath), `${baseFileName}-translation.ts`)
+  ];
+  if (files.some((file) => tree.exists(file))) {
+    throw new O3rCliError(`Unable to add localization to this component because it already has at least one of these files: ${files.join(', ')}.`);
+  }
+
+  const componentSourceFile = ts.createSourceFile(
+    componentPath,
+    tree.readText(componentPath),
+    ts.ScriptTarget.ES2020,
+    true
+  );
+  const o3rClassDeclaration = componentSourceFile.statements.find((statement): statement is ts.ClassDeclaration =>
+    ts.isClassDeclaration(statement)
+    && isO3rClassComponent(statement)
+  )!;
+  if (o3rClassDeclaration.members.some((classElement) =>
+    ts.isPropertyDeclaration(classElement)
+    && ts.isIdentifier(classElement.name)
+    && localizationProperties.includes(classElement.name.escapedText.toString())
+  )) {
+    throw new O3rCliError(`Unable to add localization to this component because it already has at least one of these properties: ${localizationProperties.join(', ')}.`);
+  }
+};
+
+/**
+ * Add localization architecture to an existing component
+ * @param options
+ */
+export function ngAddLocalizationFn(options: NgAddLocalizationSchematicsSchema): Rule {
+  return async (tree: Tree, context: SchematicContext) => {
+    try {
+      const baseFileName = getComponentBaseFileName(options.path);
+      const { selector, standalone, templateRelativePath } = getO3rComponentInfoOrThrowIfNotFound(tree, options.path);
+
+      checkLocalization(options.path, tree, baseFileName);
+
+      const properties = {
+        ...options,
+        componentTranslation: getComponentTranslationName(baseFileName),
+        componentSelector: selector,
+        name: baseFileName
+      };
+
+      const createLocalizationFilesRule: Rule = mergeWith(apply(url('./templates'), [
+        template(properties),
+        renameTemplateFiles(),
+        move(dirname(options.path))
+      ]), MergeStrategy.Overwrite);
+
+      const updateComponentRule: Rule = chain([
+        addImportsRule(options.path, [
+          {
+            from: '@angular/core',
+            importNames: [
+              'Input'
+            ]
+          },
+          {
+            from: '@o3r/transloco',
+            importNames: [
+              'Localization',
+              'Translatable',
+              ...(standalone ? ['O3rLocalizationTranslatePipe'] : [])
+            ]
+          },
+          {
+            from: `./${properties.name}-translation`,
+            importNames: [
+              'translations',
+              properties.componentTranslation
+            ]
+          }
+        ]),
+        () => {
+          const componentSourceFile = ts.createSourceFile(
+            options.path,
+            tree.readText(options.path),
+            ts.ScriptTarget.ES2020,
+            true
+          );
+          const result = ts.transform(componentSourceFile, [
+            addInterfaceToClassTransformerFactory(`Translatable<${properties.componentTranslation}>`, isO3rClassComponent),
+            ...(
+              standalone
+                ? [addImportsIntoComponentDecoratorTransformerFactory(['O3rLocalizationTranslatePipe'])]
+                : []
+            ),
+            (ctx) => (rootNode: ts.Node) => {
+              const { factory } = ctx;
+              const visit = (node: ts.Node): ts.Node => {
+                if (ts.isClassDeclaration(node) && isO3rClassComponent(node)) {
+                  const propertiesToAdd = generateClassElementsFromString(`
+              @Input()
+              public translations: ${properties.componentTranslation};
+            `);
+                  const constructorDeclaration = node.members.find((classElement): classElement is ts.ConstructorDeclaration => ts.isConstructorDeclaration(classElement));
+
+                  const localizationConstructorBlockStatements = generateBlockStatementsFromString('this.translations = translations;');
+
+                  const newContructorDeclaration = constructorDeclaration
+                    ? factory.updateConstructorDeclaration(
+                      constructorDeclaration,
+                      ts.getModifiers(constructorDeclaration) || [],
+                      constructorDeclaration.parameters,
+                      constructorDeclaration.body
+                        ? factory.updateBlock(
+                          constructorDeclaration.body, constructorDeclaration.body.statements.concat(localizationConstructorBlockStatements)
+                        )
+                        : factory.createBlock(localizationConstructorBlockStatements, true)
+                    )
+                    : factory.createConstructorDeclaration(
+                      [],
+                      [],
+                      factory.createBlock(localizationConstructorBlockStatements, true)
+                    );
+
+                  const newModifiers = ([] as ts.ModifierLike[])
+                    .concat(ts.getDecorators(node) || [])
+                    .concat(ts.getModifiers(node) || []);
+
+                  const newMembers = node.members
+                    .filter((classElement) => !ts.isConstructorDeclaration(classElement))
+                    .concat(propertiesToAdd, newContructorDeclaration)
+                    .toSorted(sortClassElement);
+
+                  addCommentsOnClassProperties(
+                    newMembers,
+                    {
+                      translations: 'Localization of the component'
+                    }
+                  );
+
+                  return factory.updateClassDeclaration(
+                    node,
+                    newModifiers,
+                    node.name,
+                    node.typeParameters,
+                    node.heritageClauses,
+                    newMembers
+                  );
+                }
+                return ts.visitEachChild(node, visit, ctx);
+              };
+              return ts.visitNode(rootNode, visit);
+            }
+          ]);
+
+          const printer = ts.createPrinter({
+            removeComments: false,
+            newLine: ts.NewLineKind.LineFeed
+          });
+
+          tree.overwrite(options.path, printer.printFile(result.transformed[0] as any as ts.SourceFile));
+
+          const sf = ts.createSourceFile(
+            options.path,
+            tree.readText(options.path),
+            ts.ScriptTarget.ES2020,
+            true
+          );
+
+          // Has to be done at the end because ts.Printer as some issues with Decorators with arguments
+          const translationsPropDeclaration = sf.statements
+            .find((statement): statement is ts.ClassDeclaration => ts.isClassDeclaration(statement) && isO3rClassComponent(statement))!
+            .members.find((member): member is ts.PropertyDeclaration => ts.isPropertyDeclaration(member) && member.name.getText() === 'translations')!;
+          const translationsPropLastDecorator = ts.getDecorators(translationsPropDeclaration)?.at(-1);
+          if (translationsPropLastDecorator) {
+            tree.commitUpdate(
+              tree
+                .beginUpdate(options.path)
+                .insertRight(
+                  translationsPropLastDecorator.getEnd(),
+                  `\n  @Localization('./${baseFileName}-localization.json')`
+                )
+            );
+          }
+
+          return tree;
+        }
+      ]);
+
+      const updateTemplateRule: Rule = () => {
+        const templatePath = templateRelativePath && posix.join(dirname(options.path), templateRelativePath);
+        if (templatePath && tree.exists(templatePath)) {
+          tree.commitUpdate(
+            tree
+              .beginUpdate(templatePath)
+              .insertLeft(0, '<div>Localization: {{ translations.dummyLoc1 | o3rTranslate }}</div>\n')
+          );
+        }
+
+        return tree;
+      };
+
+      const specFilePath = options.specFilePath || posix.join(dirname(options.path), `${baseFileName}.spec.ts`);
+      const updateSpecRule: Rule = chain([
+        addImportsRule(specFilePath, [
+          {
+            from: '@angular/core',
+            importNames: ['Provider']
+          },
+          {
+            from: '@o3r/transloco',
+            importNames: ['LocalizationService']
+          },
+          {
+            from: '@o3r/testing/transloco',
+            importNames: ['provideLocalizationMock']
+          }
+        ]),
+        () => {
+          if (!tree.exists(specFilePath)) {
+            context.logger.warn(`No update applied on spec file because ${specFilePath} does not exist.`);
+            return;
+          }
+
+          let specSourceFile = ts.createSourceFile(
+            specFilePath,
+            tree.readText(specFilePath),
+            ts.ScriptTarget.ES2020,
+            true
+          );
+
+          const recorder = tree.beginUpdate(specFilePath);
+
+          const lastImport = [...specSourceFile.statements].reverse().find((statement) =>
+            ts.isImportDeclaration(statement)
+          );
+
+          const changes = [new InsertChange(specFilePath, lastImport?.getEnd() || 0, `
+const localizationConfiguration = {language: 'en'};
+const mockTranslations = {
+  en: {${options.activateDummy
+    ? `
+    '${properties.componentSelector}.dummyLoc1': 'Dummy 1'
+  `
+    : ''}}
+};
+      `)];
+
+          applyToUpdateRecorder(recorder, changes);
+          tree.commitUpdate(recorder);
+
+          specSourceFile = ts.createSourceFile(
+            specFilePath,
+            tree.readText(specFilePath),
+            ts.ScriptTarget.ES2020,
+            true
+          );
+
+          const result = ts.transform(specSourceFile, [
+            (ctx) => addImportsAndCodeBlockStatementAtSpecInitializationTransformerFactory(
+              [
+                ctx.factory.createSpreadElement(ctx.factory.createCallExpression(
+                  ctx.factory.createIdentifier('provideLocalizationMock'),
+                  undefined,
+                  [
+                    ctx.factory.createIdentifier('localizationConfiguration'),
+                    ctx.factory.createIdentifier('mockTranslations')
+                  ]
+                ))
+              ],
+              `const localizationService = TestBed.inject(LocalizationService);\nlocalizationService.configure();\n`
+            )(ctx)
+          ]);
+
+          const printer = ts.createPrinter({
+            removeComments: false,
+            newLine: ts.NewLineKind.LineFeed
+          });
+
+          const newContent = printer.printFile(result.transformed[0] as any as ts.SourceFile);
+
+          tree.overwrite(specFilePath, newContent);
+
+          return tree;
+        }
+      ]);
+
+      const updateModuleRule: Rule = () => {
+        const moduleFilePath = options.path.replace(/\.ts$/, '-module.ts');
+
+        // Check if module file exists
+        if (!tree.exists(moduleFilePath)) {
+          return tree;
+        }
+
+        const moduleSourceFile = ts.createSourceFile(
+          moduleFilePath,
+          tree.readText(moduleFilePath),
+          ts.ScriptTarget.ES2020,
+          true
+        );
+
+        // Check if provideLocalization is already in the module
+        const moduleContent = tree.readText(moduleFilePath);
+        if (moduleContent.includes('provideLocalization')) {
+          return tree;
+        }
+
+        const recorder = tree.beginUpdate(moduleFilePath);
+        const importChanges = insertImport(moduleSourceFile, moduleFilePath, 'provideLocalization', '@o3r/transloco');
+        if (importChanges instanceof InsertChange) {
+          recorder.insertLeft(importChanges.pos, importChanges.toAdd);
+        }
+        const providerChanges = addProviderToModule(moduleSourceFile, moduleFilePath, 'provideLocalization()', '@o3r/transloco');
+        applyToUpdateRecorder(recorder, providerChanges);
+        tree.commitUpdate(recorder);
+      };
+
+      const addDummyKeyRule: Rule = schematic('add-localization-key', {
+        path: options.path,
+        skipLinter: options.skipLinter,
+        key: 'dummyLoc1',
+        description: 'Dummy 1 description',
+        value: 'Dummy 1'
+      });
+
+      return chain([
+        createLocalizationFilesRule,
+        updateComponentRule,
+        updateSpecRule,
+        standalone ? noop() : updateModuleRule,
+        ...(options.activateDummy ? [addDummyKeyRule, updateTemplateRule] : []),
+        options.skipLinter ? noop() : applyEsLintFix()
+      ]);
+    } catch (e) {
+      if (e instanceof NoOtterComponent && context.interactive) {
+        const shouldConvertComponent = await askConfirmationToConvertComponent();
+        if (shouldConvertComponent) {
+          return chain([
+            externalSchematic('@o3r/core', 'convert-component', {
+              path: options.path
+            }),
+            ngAddLocalizationFn(options)
+          ]);
+        }
+      }
+      throw e;
+    }
+  };
+}
+
+/**
+ * Add localization architecture to an existing component
+ * @param options
+ */
+export const ngAddLocalization = createOtterSchematic(ngAddLocalizationFn);

--- a/packages/@o3r/transloco/schematics/localization-to-component/schema.json
+++ b/packages/@o3r/transloco/schematics/localization-to-component/schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "NgAddLocalizationSchematicsSchema",
+  "title": "Add Otter Localization to an existing component",
+  "description": "Add Otter Localization to an existing component",
+  "properties": {
+    "path": {
+      "type": "string",
+      "description": "Path to the component",
+      "default": ""
+    },
+    "specFilePath": {
+      "type": "string",
+      "description": "Path to spec file of the component"
+    },
+    "skipLinter": {
+      "type": "boolean",
+      "description": "Skip the linter process which includes EsLint and EditorConfig rules applying",
+      "default": false
+    },
+    "activateDummy": {
+      "type": "boolean",
+      "description": "Generate dummy values",
+      "default": false
+    }
+  },
+  "additionalProperties": true,
+  "required": [
+    "path"
+  ]
+}

--- a/packages/@o3r/transloco/schematics/localization-to-component/schema.ts
+++ b/packages/@o3r/transloco/schematics/localization-to-component/schema.ts
@@ -1,0 +1,17 @@
+import type {
+  SchematicOptionObject,
+} from '@o3r/schematics';
+
+export interface NgAddLocalizationSchematicsSchema extends SchematicOptionObject {
+  /** Path to the component */
+  path: string;
+
+  /** Path to spec file of the component */
+  specFilePath?: string | undefined;
+
+  /** Skip the linter process which includes the run of EsLint and EditorConfig rules */
+  skipLinter: boolean;
+
+  /** Determine if the dummy localization should be generated */
+  activateDummy: boolean;
+}

--- a/packages/@o3r/transloco/schematics/localization-to-component/templates/__name__-localization.json
+++ b/packages/@o3r/transloco/schematics/localization-to-component/templates/__name__-localization.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://raw.githubusercontent.com/AmadeusITGroup/otter/main/packages/%40o3r/transloco/schemas/localization.schema.json"
+}

--- a/packages/@o3r/transloco/schematics/localization-to-component/templates/__name__-translation.ts.template
+++ b/packages/@o3r/transloco/schematics/localization-to-component/templates/__name__-translation.ts.template
@@ -1,0 +1,5 @@
+import type {Translation} from '@o3r/core';
+
+export interface <%= componentTranslation %> extends Translation {}
+
+export const translations: Readonly<<%= componentTranslation %>> = {} as const;

--- a/packages/@o3r/transloco/schematics/ng-add/helpers/devtools-registration.ts
+++ b/packages/@o3r/transloco/schematics/ng-add/helpers/devtools-registration.ts
@@ -1,0 +1,44 @@
+import {
+  readFileSync,
+} from 'node:fs';
+import * as path from 'node:path';
+import {
+  chain,
+  Rule,
+} from '@angular-devkit/schematics';
+import {
+  registerDevtoolsToApplication,
+} from '@o3r/schematics';
+import type {
+  NgAddSchematicsSchema,
+} from '../schema';
+
+/** Name of the devtools module */
+const DEVTOOL_MODULE_NAME = 'LocalizationDevtoolsModule';
+/** Name of the message devtools service */
+const MESSAGE_DEVTOOL_SERVICE_NAME = 'LocalizationDevtoolsMessageService';
+/** Name of the console devtools service */
+const CONSOLE_DEVTOOL_SERVICE_NAME = 'LocalizationDevtoolsConsoleService';
+/** Package name from package.json */
+const PACKAGE_NAME: string = JSON.parse(readFileSync(path.resolve(__dirname, '..', '..', '..', 'package.json'), { encoding: 'utf8' })).name;
+
+/**
+ * Register Devtools to the application
+ * @param options
+ */
+export const registerDevtools = (options: NgAddSchematicsSchema): Rule => {
+  return chain([
+    registerDevtoolsToApplication({
+      moduleName: DEVTOOL_MODULE_NAME,
+      packageName: PACKAGE_NAME,
+      serviceName: MESSAGE_DEVTOOL_SERVICE_NAME,
+      projectName: options.projectName
+    }),
+    registerDevtoolsToApplication({
+      moduleName: DEVTOOL_MODULE_NAME,
+      packageName: PACKAGE_NAME,
+      serviceName: CONSOLE_DEVTOOL_SERVICE_NAME,
+      projectName: options.projectName
+    })
+  ]);
+};

--- a/packages/@o3r/transloco/schematics/ng-add/index.ts
+++ b/packages/@o3r/transloco/schematics/ng-add/index.ts
@@ -1,0 +1,85 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  chain,
+  noop,
+  Rule,
+} from '@angular-devkit/schematics';
+import {
+  applyEsLintFix,
+  createOtterSchematic,
+  ngAddDependenciesRule,
+  registerPackageCollectionSchematics,
+  setupSchematicsParamsForProject,
+} from '@o3r/schematics';
+import type {
+  PackageJson,
+} from 'type-fest';
+import {
+  updateCmsAdapter,
+} from '../cms-adapter';
+import {
+  updateI18n,
+  updateLocalization,
+} from '../localization-base';
+import {
+  registerDevtools,
+} from './helpers/devtools-registration';
+import type {
+  NgAddSchematicsSchema,
+} from './schema';
+
+/**
+ * List of external dependencies to be added to the project as peer dependencies
+ */
+const dependenciesToInstall = [
+  '@angular/cdk',
+  '@angular/common',
+  '@angular/core',
+  '@jsverse/transloco',
+  '@jsverse/transloco-messageformat',
+  '@jsverse/utils',
+  '@ngrx/store',
+  'rxjs'
+];
+
+/**
+ * List of external dependencies to be added to the project as dev dependencies
+ */
+const devDependenciesToInstall = [
+  '@angular-devkit/core',
+  'chokidar',
+  'globby'
+];
+
+/** Path to the package.json file */
+const packageJsonPath = path.resolve(__dirname, '..', '..', 'package.json');
+/** Package.json content */
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' })) as PackageJson;
+
+/**
+ * Add Otter localization (Transloco) to an Angular Project
+ * @param options for the dependencies installations
+ */
+function ngAddFn(options: NgAddSchematicsSchema): Rule {
+  return chain([
+    (_, context) => {
+      context.logger.info(`The package @o3r/transloco comes with a debug mechanism`);
+      context.logger.info('Get information on https://github.com/AmadeusITGroup/otter/tree/main/docs/localization/LOCALIZATION.md#Debugging');
+    },
+    updateLocalization(options, __dirname),
+    updateI18n(options),
+    options.skipLinter ? noop() : applyEsLintFix(),
+    ngAddDependenciesRule(options, packageJsonPath, { dependenciesToInstall, devDependenciesToInstall }),
+    updateCmsAdapter(options),
+    registerPackageCollectionSchematics(packageJson),
+    setupSchematicsParamsForProject({ '@o3r/core:component*': { useLocalization: true } }, options.projectName),
+    registerDevtools(options)
+  ]);
+}
+
+/**
+ * Add Otter localization (Transloco) to an Angular Project
+ * @param options for the dependencies installations
+ */
+export const ngAdd = (options: NgAddSchematicsSchema) => createOtterSchematic(ngAddFn)(options);

--- a/packages/@o3r/transloco/schematics/ng-add/schema.json
+++ b/packages/@o3r/transloco/schematics/ng-add/schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "ngAddSchematicsSchema",
+  "title": "Add Otter Localization (Transloco)",
+  "description": "ngAdd Otter Localization (Transloco)",
+  "properties": {
+    "projectName": {
+      "type": "string",
+      "description": "Project name",
+      "$default": {
+        "$source": "projectName"
+      },
+      "alias": "project"
+    },
+    "skipLinter": {
+      "type": "boolean",
+      "description": "Skip the linter process which includes EsLint and EditorConfig rules applying",
+      "default": false
+    },
+    "skipInstall": {
+      "type": "boolean",
+      "description": "Skip the install process",
+      "default": true
+    },
+    "exactO3rVersion": {
+      "type": "boolean",
+      "description": "Use a pinned version for otter packages"
+    }
+  },
+  "additionalProperties": true,
+  "required": [
+  ]
+}

--- a/packages/@o3r/transloco/schematics/ng-add/schema.ts
+++ b/packages/@o3r/transloco/schematics/ng-add/schema.ts
@@ -1,0 +1,12 @@
+import type {
+  NgAddOptions,
+  SchematicOptionObject,
+} from '@o3r/schematics';
+
+/**
+ * Schema for ng-add schematic
+ */
+export interface NgAddSchematicsSchema extends NgAddOptions, SchematicOptionObject {
+  /** Skip the linter process which includes the run of EsLint and EditorConfig rules */
+  skipLinter: boolean;
+}

--- a/packages/@o3r/transloco/src/devkit/localization-devtools-module.ts
+++ b/packages/@o3r/transloco/src/devkit/localization-devtools-module.ts
@@ -2,9 +2,6 @@ import {
   ModuleWithProviders,
   NgModule,
 } from '@angular/core';
-import {
-  LocalizationModule,
-} from '../tools/index';
 import type {
   LocalizationDevtoolsServiceOptions,
 } from './localization-devkit-interface';
@@ -26,9 +23,7 @@ import {
  * Module that provides localization devtools functionality
  */
 @NgModule({
-  imports: [
-    LocalizationModule
-  ],
+  imports: [],
   providers: [
     { provide: OTTER_LOCALIZATION_DEVTOOLS_OPTIONS, useValue: OTTER_LOCALIZATION_DEVTOOLS_DEFAULT_OPTIONS },
     LocalizationDevtoolsMessageService,

--- a/packages/@o3r/transloco/src/public_api.ts
+++ b/packages/@o3r/transloco/src/public_api.ts
@@ -1,5 +1,6 @@
 export type { Translation } from '@o3r/core';
 export * from './annotations/index';
 export * from './core/index';
+export * from './devkit/index';
 export * from './stores/index';
 export * from './tools/index';

--- a/packages/@o3r/transloco/testing/jest.config.it.js
+++ b/packages/@o3r/transloco/testing/jest.config.it.js
@@ -1,0 +1,13 @@
+const path = require('node:path');
+const { getTsJestBaseConfig, getOtterJestBaseConfig, getJestIntegrationTestConfig } = require('@o3r/test-helpers');
+const { createDefaultPreset } = require('ts-jest');
+
+const rootDir = path.join(__dirname, '..');
+
+/** @type {import('ts-jest/dist/types').JestConfigWithTsJest} */
+module.exports = {
+  ...createDefaultPreset(getTsJestBaseConfig()),
+  ...getOtterJestBaseConfig(rootDir),
+  ...getJestIntegrationTestConfig(),
+  setupFilesAfterEnv: ['<rootDir>/testing/setup-jest.builders.ts']
+};

--- a/packages/@o3r/transloco/testing/mocks/__dot__eslintrc.mocks.json
+++ b/packages/@o3r/transloco/testing/mocks/__dot__eslintrc.mocks.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "ban": [true, "fit", "fdescribe"]
+  }
+}

--- a/packages/@o3r/transloco/tsconfig.build.json
+++ b/packages/@o3r/transloco/tsconfig.build.json
@@ -8,6 +8,7 @@
     "src/**/*.ts"
   ],
   "exclude": [
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "src/builders/**/*.ts"
   ]
 }

--- a/packages/@o3r/transloco/tsconfig.builders.json
+++ b/packages/@o3r/transloco/tsconfig.builders.json
@@ -12,9 +12,12 @@
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },
   "include": [
-    "builders/**/*.ts"
+    "builders/**/*.ts",
+    "schematics/**/*.ts"
   ],
   "exclude": [
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "builders/**/templates/**",
+    "schematics/**/templates/**"
   ]
 }

--- a/packages/@o3r/transloco/tsconfig.builders.json
+++ b/packages/@o3r/transloco/tsconfig.builders.json
@@ -7,14 +7,18 @@
     "module": "CommonJS",
     "moduleResolution": "node10",
     "rootDir": ".",
+    "lib": ["ESNext"],
     "types": ["node"],
     "skipLibCheck": true,
     "tsBuildInfoFile": "build/.tsbuildinfo.builders"
   },
   "include": [
-    "builders/**/*.ts"
+    "builders/**/*.ts",
+    "schematics/**/*.ts"
   ],
   "exclude": [
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "builders/**/templates/**",
+    "schematics/**/templates/**"
   ]
 }

--- a/packages/@o3r/transloco/tsconfig.doc.json
+++ b/packages/@o3r/transloco/tsconfig.doc.json
@@ -1,5 +1,9 @@
 {
   "extends": "../../../tsconfig.doc",
+  "exclude": [
+    "**/*reducer.ts",
+    "**/*.fixture.ts"
+  ],
   "include": [
     "src/**/*.ts"
   ]

--- a/packages/@o3r/transloco/tsconfig.eslint.json
+++ b/packages/@o3r/transloco/tsconfig.eslint.json
@@ -3,6 +3,8 @@
   "include": [
     "eslint*.config.mjs",
     "jest.config.js",
-    "testing/*"
+    "testing/*",
+    "tooling/**/*.js",
+    "builders/**/index.js"
   ]
 }

--- a/packages/@o3r/transloco/tsconfig.spec.json
+++ b/packages/@o3r/transloco/tsconfig.spec.json
@@ -7,7 +7,8 @@
   },
   "include": [
     "./src/**/*.spec.ts",
-    "./builders/**/*.spec.ts"
+    "./builders/**/*.spec.ts",
+    "./schematics/**/*.spec.ts"
   ],
   "exclude": [],
   "references": [

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -256,6 +256,9 @@
       "@o3r/transloco": [
         "packages/@o3r/transloco/src/public_api"
       ],
+      "@o3r/transloco/schemas/*": [
+        "packages/@o3r/transloco/schemas/*"
+      ],
       "@o3r/transloco/*": [
         "packages/@o3r/transloco/src/*/public_api"
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2085,18 +2085,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular-devkit/architect@npm:0.2102.2":
-  version: 0.2102.2
-  resolution: "@angular-devkit/architect@npm:0.2102.2"
-  dependencies:
-    "@angular-devkit/core": "npm:21.2.2"
-    rxjs: "npm:7.8.2"
-  bin:
-    architect: bin/cli.js
-  checksum: 10/200e1f425980536e835ac909c9c877d5eda45698e3facfb552b3752d8e847771829673d37ced539f9bb0127450bf3c68190dd0bbbef6ac87790ce8095898a603
-  languageName: node
-  linkType: hard
-
 "@angular-devkit/architect@npm:0.2102.7, @angular-devkit/architect@npm:>= 0.2100.0 < 0.2200.0":
   version: 0.2102.7
   resolution: "@angular-devkit/architect@npm:0.2102.7"
@@ -2231,25 +2219,6 @@ __metadata:
     webpack: ^5.30.0
     webpack-dev-server: ^5.0.2
   checksum: 10/03971a3ca70cb799999c0f36cdf7c40d119aae0f2944032ce1107f63af44c561bcc092cab8dfaa3bccc1a5af211e8edce9b38906ccabf484fc0c8243b719da7b
-  languageName: node
-  linkType: hard
-
-"@angular-devkit/core@npm:21.2.2":
-  version: 21.2.2
-  resolution: "@angular-devkit/core@npm:21.2.2"
-  dependencies:
-    ajv: "npm:8.18.0"
-    ajv-formats: "npm:3.0.1"
-    jsonc-parser: "npm:3.3.1"
-    picomatch: "npm:4.0.3"
-    rxjs: "npm:7.8.2"
-    source-map: "npm:0.7.6"
-  peerDependencies:
-    chokidar: ^5.0.0
-  peerDependenciesMeta:
-    chokidar:
-      optional: true
-  checksum: 10/8077116039f94e4a9795046119a2c92327c80c1cdd604c101cf0bb2685056579154de6884be301de5ce0955c471c9b9576e777ee73bd6b57a1c2488d41cc49de
   languageName: node
   linkType: hard
 
@@ -6929,19 +6898,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsonjoy.com/fs-core@npm:4.56.11":
-  version: 4.56.11
-  resolution: "@jsonjoy.com/fs-core@npm:4.56.11"
-  dependencies:
-    "@jsonjoy.com/fs-node-builtins": "npm:4.56.11"
-    "@jsonjoy.com/fs-node-utils": "npm:4.56.11"
-    thingies: "npm:^2.5.0"
-  peerDependencies:
-    tslib: 2
-  checksum: 10/46adecf53d79246eed43503e999f3068b38d6c5b209e305c5b6ca55cfbb68fd2780a2fe3ddc2de3535c51a6db76e4acaca67dc127d1ce54399cf786a5ccbd4ca
-  languageName: node
-  linkType: hard
-
 "@jsonjoy.com/fs-core@npm:4.57.2":
   version: 4.57.2
   resolution: "@jsonjoy.com/fs-core@npm:4.57.2"
@@ -6952,20 +6908,6 @@ __metadata:
   peerDependencies:
     tslib: 2
   checksum: 10/6db8b3a7fb874229c7991bbdc094d752adbde7d774e5ef70df5a787130c7c8ed4ac2d34eaac079383c527269feaa91d1cb4f5c1504af995cca95070af769a0bd
-  languageName: node
-  linkType: hard
-
-"@jsonjoy.com/fs-fsa@npm:4.56.11":
-  version: 4.56.11
-  resolution: "@jsonjoy.com/fs-fsa@npm:4.56.11"
-  dependencies:
-    "@jsonjoy.com/fs-core": "npm:4.56.11"
-    "@jsonjoy.com/fs-node-builtins": "npm:4.56.11"
-    "@jsonjoy.com/fs-node-utils": "npm:4.56.11"
-    thingies: "npm:^2.5.0"
-  peerDependencies:
-    tslib: 2
-  checksum: 10/ed322ec4596f0b385d17dfeca6f2e1c2de51aa7c356f092700ad7b8930816f27f7f49234ba5eb544f03d173ea3cf5f9509597a5c64f0c03d2c4c456b751e2a16
   languageName: node
   linkType: hard
 
@@ -6983,34 +6925,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsonjoy.com/fs-node-builtins@npm:4.56.11":
-  version: 4.56.11
-  resolution: "@jsonjoy.com/fs-node-builtins@npm:4.56.11"
-  peerDependencies:
-    tslib: 2
-  checksum: 10/04ca8c56cd3b883149b42cce5d9376d18445a071b6d88c5366f930c2ba93505a7d708ad8f5af1a15e691dd87ffb971048b906450287d5faf363472ced43ea884
-  languageName: node
-  linkType: hard
-
 "@jsonjoy.com/fs-node-builtins@npm:4.57.2":
   version: 4.57.2
   resolution: "@jsonjoy.com/fs-node-builtins@npm:4.57.2"
   peerDependencies:
     tslib: 2
   checksum: 10/3284f0f0a989ad2bc0abc485748b2f3581648401c7d86be9b4541374f65050d384b61b5e44eff9b463d43fd1764bead1251783681105962ba5954b5e64b42480
-  languageName: node
-  linkType: hard
-
-"@jsonjoy.com/fs-node-to-fsa@npm:4.56.11":
-  version: 4.56.11
-  resolution: "@jsonjoy.com/fs-node-to-fsa@npm:4.56.11"
-  dependencies:
-    "@jsonjoy.com/fs-fsa": "npm:4.56.11"
-    "@jsonjoy.com/fs-node-builtins": "npm:4.56.11"
-    "@jsonjoy.com/fs-node-utils": "npm:4.56.11"
-  peerDependencies:
-    tslib: 2
-  checksum: 10/e4e8b6ea18969665925b97055cb06636fbd74e5025cd126280ede2245ba2efe328146e0b7a5e45c45a64175dc74231caa982de4dda51bffb061c028c931f2fad
   languageName: node
   linkType: hard
 
@@ -7027,17 +6947,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsonjoy.com/fs-node-utils@npm:4.56.11":
-  version: 4.56.11
-  resolution: "@jsonjoy.com/fs-node-utils@npm:4.56.11"
-  dependencies:
-    "@jsonjoy.com/fs-node-builtins": "npm:4.56.11"
-  peerDependencies:
-    tslib: 2
-  checksum: 10/72ca92de077c34d26c935b1ec6011de587bc2f382e822d9e57c76318d506f3c40f5075d04ede666b59d45e275e577ea77032a10b48161483040f3e3f7c381232
-  languageName: node
-  linkType: hard
-
 "@jsonjoy.com/fs-node-utils@npm:4.57.2":
   version: 4.57.2
   resolution: "@jsonjoy.com/fs-node-utils@npm:4.57.2"
@@ -7046,23 +6955,6 @@ __metadata:
   peerDependencies:
     tslib: 2
   checksum: 10/f63c7c8fd5a63a163a01bc70dac262419bcc1ae182186f249e038703b04a401e49eab9043514384555177e9385929b58a76cab945e8c7cdc6809efc2ea50bf31
-  languageName: node
-  linkType: hard
-
-"@jsonjoy.com/fs-node@npm:4.56.11":
-  version: 4.56.11
-  resolution: "@jsonjoy.com/fs-node@npm:4.56.11"
-  dependencies:
-    "@jsonjoy.com/fs-core": "npm:4.56.11"
-    "@jsonjoy.com/fs-node-builtins": "npm:4.56.11"
-    "@jsonjoy.com/fs-node-utils": "npm:4.56.11"
-    "@jsonjoy.com/fs-print": "npm:4.56.11"
-    "@jsonjoy.com/fs-snapshot": "npm:4.56.11"
-    glob-to-regex.js: "npm:^1.0.0"
-    thingies: "npm:^2.5.0"
-  peerDependencies:
-    tslib: 2
-  checksum: 10/a6a7e84de467d644bd2b23f34afaf61e93eb05245f40325a067403d2af5b4b22adce806639b80ff0f8431049dda706a803e6f73f2bf944d73a1ad78ac04bbd15
   languageName: node
   linkType: hard
 
@@ -7083,18 +6975,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsonjoy.com/fs-print@npm:4.56.11":
-  version: 4.56.11
-  resolution: "@jsonjoy.com/fs-print@npm:4.56.11"
-  dependencies:
-    "@jsonjoy.com/fs-node-utils": "npm:4.56.11"
-    tree-dump: "npm:^1.1.0"
-  peerDependencies:
-    tslib: 2
-  checksum: 10/352fb4932c0ed44b5fb148b253754748b6d3e9859452ef1b03cebb6b9601e9f84336ef0932ca4de9687b2f3ec703083d4572c7bf2036537f787673229c3ed68b
-  languageName: node
-  linkType: hard
-
 "@jsonjoy.com/fs-print@npm:4.57.2":
   version: 4.57.2
   resolution: "@jsonjoy.com/fs-print@npm:4.57.2"
@@ -7104,20 +6984,6 @@ __metadata:
   peerDependencies:
     tslib: 2
   checksum: 10/4931c8de684a655ab11ba2285016c35f3558f1f8f3444ac42fe7f5ea417556661b6f88d238c107f30c30b2d131eb2e0ecb1bb8626a7f6e0440996f42ea31dd7b
-  languageName: node
-  linkType: hard
-
-"@jsonjoy.com/fs-snapshot@npm:4.56.11":
-  version: 4.56.11
-  resolution: "@jsonjoy.com/fs-snapshot@npm:4.56.11"
-  dependencies:
-    "@jsonjoy.com/buffers": "npm:^17.65.0"
-    "@jsonjoy.com/fs-node-utils": "npm:4.56.11"
-    "@jsonjoy.com/json-pack": "npm:^17.65.0"
-    "@jsonjoy.com/util": "npm:^17.65.0"
-  peerDependencies:
-    tslib: 2
-  checksum: 10/97665962c5bf609720ac2913111da540235fa8aed52241e017da16ae2ac0228ae9e1938906d51e61f85fdaa0511c46db22b3c8212c9ba77a0ae4082cd20e4d57
   languageName: node
   linkType: hard
 
@@ -7215,6 +7081,21 @@ __metadata:
   peerDependencies:
     tslib: 2
   checksum: 10/1a6e5301d725a7161b93ff707eb1a954bf4552a2fa96eee9a960d3ae3ed5f993d18b56dcff29e98036341a5968c5d1b2dfe21f76695390e7f0d89b81f24c85e0
+  languageName: node
+  linkType: hard
+
+"@jsverse/transloco-messageformat@npm:~8.2.1":
+  version: 8.2.1
+  resolution: "@jsverse/transloco-messageformat@npm:8.2.1"
+  dependencies:
+    "@messageformat/core": "npm:^3.0.0"
+    tslib: "npm:^2.2.0"
+  peerDependencies:
+    "@angular/core": ">=16.0.0"
+    "@jsverse/transloco": ">=8.0.0"
+    "@jsverse/utils": 1.0.0-beta.5
+    rxjs: ">=6.0.0"
+  checksum: 10/96902837d2963c8a3193aecb669683b2f6cf5fa2a6d622fa65459bd1dd5c1817160d429987225392f0ba44205ba979bf96122775a6af5c1adf07651cf9bb354b
   languageName: node
   linkType: hard
 
@@ -7464,6 +7345,52 @@ __metadata:
   dependencies:
     langium: "npm:^4.0.0"
   checksum: 10/648c96da8464113c3694587f3f950421b1914d34fddc194b6dff7a8c28da5e37273ddc4d56a4efaeda82e93c7a168389f035dbac6c8d5b65930ee60b5063ece4
+  languageName: node
+  linkType: hard
+
+"@messageformat/core@npm:^3.0.0":
+  version: 3.4.0
+  resolution: "@messageformat/core@npm:3.4.0"
+  dependencies:
+    "@messageformat/date-skeleton": "npm:^1.0.0"
+    "@messageformat/number-skeleton": "npm:^1.0.0"
+    "@messageformat/parser": "npm:^5.1.0"
+    "@messageformat/runtime": "npm:^3.0.1"
+    make-plural: "npm:^7.0.0"
+    safe-identifier: "npm:^0.4.1"
+  checksum: 10/a75745bb36715a6460623610646de56e52e0642b4b87dcfe074c3d47561042ea7e1bea13fac137808bc1e2807f456691b0ad315d4dbc93d05d943b306738c384
+  languageName: node
+  linkType: hard
+
+"@messageformat/date-skeleton@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "@messageformat/date-skeleton@npm:1.1.0"
+  checksum: 10/b90a8bf4bdff26e1762865456ef8cd16cb0208385509fa1db1ed4a113607a2449fc3775d51f2ba764349489d616f66b33f15bc7a867a95fe8667c1280924197e
+  languageName: node
+  linkType: hard
+
+"@messageformat/number-skeleton@npm:^1.0.0":
+  version: 1.2.0
+  resolution: "@messageformat/number-skeleton@npm:1.2.0"
+  checksum: 10/6591ceee52cc008c4bdaf3026e5272ce0f88c6658ec3dae1fa253a608931e06b85826a89aae69143d9d29f66c7444c63c643c4fb3181fdbb862fd46b7e0472a8
+  languageName: node
+  linkType: hard
+
+"@messageformat/parser@npm:^5.1.0":
+  version: 5.1.1
+  resolution: "@messageformat/parser@npm:5.1.1"
+  dependencies:
+    moo: "npm:^0.5.1"
+  checksum: 10/32b1e503532f62df976dd62fbe27fcec9d8ff44770d9fa9722cbbc86545fdacb11038594f739d0c29e984535df8535a1da69375109f684bd4efd3c60156b3b49
+  languageName: node
+  linkType: hard
+
+"@messageformat/runtime@npm:^3.0.1":
+  version: 3.0.2
+  resolution: "@messageformat/runtime@npm:3.0.2"
+  dependencies:
+    make-plural: "npm:^7.0.0"
+  checksum: 10/9baf876a98d017ed79fa7ca6da6f43f44e48570b2723d6745df5a1eb31e86bea116b63e23ec1663be493f6188a36b1c81ecfbdac662ab531b2e2d6ee46a6a220
   languageName: node
   linkType: hard
 
@@ -8276,18 +8203,6 @@ __metadata:
     "@ngrx/store": 21.1.0
     rxjs: ^6.5.3 || ^7.5.0
   checksum: 10/8983300a6d893f9c5a56c3086ad7cf14ab62b3769770035830a7cbaf470b62e6e599928158328300c7581a5ee9f429f68fd853b755be0426dac4203f340e1c47
-  languageName: node
-  linkType: hard
-
-"@ngrx/store@npm:~21.0.0":
-  version: 21.0.1
-  resolution: "@ngrx/store@npm:21.0.1"
-  dependencies:
-    tslib: "npm:^2.0.0"
-  peerDependencies:
-    "@angular/core": ^21.0.0
-    rxjs: ^6.5.3 || ^7.5.0
-  checksum: 10/72604bc19da753ef959f8940fd066b5cef39d93d147dd59d6baa021e5f709ede2ac4a4e670f5b64e4f8ccbbfeb1da5f67022d39044784c697c63b922c353f793
   languageName: node
   linkType: hard
 
@@ -12339,6 +12254,7 @@ __metadata:
     "@babel/preset-typescript": "npm:~7.28.0"
     "@compodoc/compodoc": "npm:^1.1.32"
     "@eslint-community/eslint-plugin-eslint-comments": "npm:^4.4.0"
+    "@jsverse/transloco": "npm:~8.2.1"
     "@material/slider": "npm:^14.0.0"
     "@ngrx/store": "npm:~21.1.0"
     "@ngx-translate/core": "npm:~16.0.4"
@@ -12350,6 +12266,7 @@ __metadata:
     "@o3r/localization": "workspace:~"
     "@o3r/schematics": "workspace:~"
     "@o3r/test-helpers": "workspace:~"
+    "@o3r/transloco": "workspace:~"
     "@playwright/test": "npm:~1.59.0"
     "@schematics/angular": "npm:~21.2.0"
     "@standard-schema/spec": "npm:~1.1.0"
@@ -12404,6 +12321,7 @@ __metadata:
     "@angular/core": ^21.0.0
     "@angular/forms": ^21.0.0
     "@angular/platform-browser": ^21.0.0
+    "@jsverse/transloco": ^8.0.0
     "@material/slider": ^14.0.0
     "@ngrx/store": ^21.0.0
     "@ngx-translate/core": ^15.0.0 || ~16.0.4
@@ -12411,6 +12329,7 @@ __metadata:
     "@o3r/eslint-config": "workspace:~"
     "@o3r/localization": "workspace:~"
     "@o3r/schematics": "workspace:~"
+    "@o3r/transloco": "workspace:~"
     "@playwright/test": ^1.49.0
     "@schematics/angular": ^21.0.0
     eslint: ~9.39.0
@@ -12431,6 +12350,8 @@ __metadata:
       optional: true
     "@angular/forms":
       optional: true
+    "@jsverse/transloco":
+      optional: true
     "@material/slider":
       optional: true
     "@ngrx/store":
@@ -12444,6 +12365,8 @@ __metadata:
     "@o3r/localization":
       optional: true
     "@o3r/schematics":
+      optional: true
+    "@o3r/transloco":
       optional: true
     "@playwright/test":
       optional: true
@@ -12546,11 +12469,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@o3r/transloco@workspace:packages/@o3r/transloco":
+"@o3r/transloco@workspace:packages/@o3r/transloco, @o3r/transloco@workspace:~":
   version: 0.0.0-use.local
   resolution: "@o3r/transloco@workspace:packages/@o3r/transloco"
   dependencies:
-    "@angular-devkit/architect": "npm:0.2102.2"
+    "@angular-devkit/architect": "npm:0.2102.7"
     "@angular-devkit/build-angular": "npm:~21.2.0"
     "@angular-devkit/core": "npm:~21.2.0"
     "@angular-devkit/schematics": "npm:~21.2.0"
@@ -12568,7 +12491,9 @@ __metadata:
     "@compodoc/compodoc": "npm:^1.1.32"
     "@eslint-community/eslint-plugin-eslint-comments": "npm:^4.4.0"
     "@jsverse/transloco": "npm:~8.2.1"
-    "@ngrx/store": "npm:~21.0.0"
+    "@jsverse/transloco-messageformat": "npm:~8.2.1"
+    "@jsverse/utils": "npm:1.0.0-beta.5"
+    "@ngrx/store": "npm:~21.1.0"
     "@nx/eslint": "npm:~22.6.0"
     "@nx/eslint-plugin": "npm:~22.6.0"
     "@nx/jest": "npm:~22.6.0"
@@ -12587,6 +12512,11 @@ __metadata:
     "@types/jest": "npm:~30.0.0"
     "@types/node": "npm:~24.12.0"
     "@typescript-eslint/parser": "npm:~8.58.0"
+    "@yarnpkg/cli": "npm:^4.5.0"
+    "@yarnpkg/core": "npm:^4.1.3"
+    "@yarnpkg/fslib": "npm:^3.1.0"
+    "@yarnpkg/plugin-npm": "npm:^3.0.1"
+    "@yarnpkg/plugin-pack": "npm:^4.0.0"
     angular-eslint: "npm:~21.3.0"
     chokidar: "npm:~5.0.0"
     cpy-cli: "npm:^6.0.0"
@@ -12610,12 +12540,13 @@ __metadata:
     jest-util: "npm:~30.3.0"
     jsdom: "npm:~27.4.0"
     jsonc-eslint-parser: "npm:~2.4.0"
-    memfs: "npm:~4.56.0"
+    memfs: "npm:~4.57.0"
     nx: "npm:~22.6.0"
     rxjs: "npm:^7.8.1"
     semver: "npm:^7.5.2"
     ts-jest: "npm:~29.4.0"
     tslib: "npm:^2.6.2"
+    type-fest: "npm:^5.3.1"
     typescript: "npm:~5.9.2"
     typescript-eslint: "npm:~8.58.0"
     unionfs: "npm:~4.6.0"
@@ -12624,9 +12555,13 @@ __metadata:
     "@angular-devkit/core": ^21.0.0
     "@angular-devkit/schematics": ^21.0.0
     "@angular/cdk": ^21.0.0
+    "@angular/cli": ^21.0.0
     "@angular/common": ^21.0.0
     "@angular/core": ^21.0.0
+    "@angular/platform-browser-dynamic": ^21.0.0
     "@jsverse/transloco": ^8.0.0
+    "@jsverse/transloco-messageformat": ^8.0.0
+    "@jsverse/utils": 1.0.0-beta.5
     "@ngrx/store": ^21.0.0
     "@o3r/core": "workspace:~"
     "@o3r/dynamic-content": "workspace:~"
@@ -12634,9 +12569,16 @@ __metadata:
     "@o3r/logger": "workspace:~"
     "@o3r/schematics": "workspace:~"
     "@schematics/angular": ^21.0.0
+    "@yarnpkg/cli": ^4.3.1
+    "@yarnpkg/core": ^4.1.1
+    "@yarnpkg/fslib": ^3.1.0
+    "@yarnpkg/plugin-npm": ^3.0.1
+    "@yarnpkg/plugin-pack": ^4.0.0
     chokidar: ^4.0.0 || ^5.0.0
     globby: ^11.1.0
     rxjs: ^7.8.1
+    semver: ^7.5.2
+    type-fest: ^5.3.1
     typescript: ^5.9.0
   peerDependenciesMeta:
     "@angular-devkit/architect":
@@ -12645,19 +12587,29 @@ __metadata:
       optional: true
     "@angular-devkit/schematics":
       optional: true
-    "@o3r/dynamic-content":
-      optional: true
-    "@o3r/extractors":
-      optional: true
-    "@o3r/logger":
+    "@angular/cli":
       optional: true
     "@o3r/schematics":
       optional: true
     "@schematics/angular":
       optional: true
+    "@yarnpkg/cli":
+      optional: true
+    "@yarnpkg/core":
+      optional: true
+    "@yarnpkg/fslib":
+      optional: true
+    "@yarnpkg/plugin-npm":
+      optional: true
+    "@yarnpkg/plugin-pack":
+      optional: true
     chokidar:
       optional: true
     globby:
+      optional: true
+    semver:
+      optional: true
+    type-fest:
       optional: true
     typescript:
       optional: true
@@ -30483,6 +30435,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"make-plural@npm:^7.0.0":
+  version: 7.5.0
+  resolution: "make-plural@npm:7.5.0"
+  checksum: 10/096241357d7f6b274967998ca03006723ab40a9b49282ed37a0f863aeb1ac9fb12704a07fafbd2dfa3b75ee2e39edbb6c665a3884865ed1c805e8b4d419714d1
+  languageName: node
+  linkType: hard
+
 "makeerror@npm:1.0.12":
   version: 1.0.12
   resolution: "makeerror@npm:1.0.12"
@@ -30688,30 +30647,6 @@ __metadata:
   peerDependencies:
     tslib: 2
   checksum: 10/872b08504889b616a2ec28655509632112d80f8f0fd6d8c23219f4f62b4ff7d6a890205e3127379d985f3bdcaf82909a9f2c3a17867495f98b4678bc2af8a458
-  languageName: node
-  linkType: hard
-
-"memfs@npm:~4.56.0":
-  version: 4.56.11
-  resolution: "memfs@npm:4.56.11"
-  dependencies:
-    "@jsonjoy.com/fs-core": "npm:4.56.11"
-    "@jsonjoy.com/fs-fsa": "npm:4.56.11"
-    "@jsonjoy.com/fs-node": "npm:4.56.11"
-    "@jsonjoy.com/fs-node-builtins": "npm:4.56.11"
-    "@jsonjoy.com/fs-node-to-fsa": "npm:4.56.11"
-    "@jsonjoy.com/fs-node-utils": "npm:4.56.11"
-    "@jsonjoy.com/fs-print": "npm:4.56.11"
-    "@jsonjoy.com/fs-snapshot": "npm:4.56.11"
-    "@jsonjoy.com/json-pack": "npm:^1.11.0"
-    "@jsonjoy.com/util": "npm:^1.9.0"
-    glob-to-regex.js: "npm:^1.0.1"
-    thingies: "npm:^2.5.0"
-    tree-dump: "npm:^1.0.3"
-    tslib: "npm:^2.0.0"
-  peerDependencies:
-    tslib: 2
-  checksum: 10/2d99bce59dee0f5c96a039851892e39c09c1eee11d8978cf37dbb93462d706d842d6a5b0b3d5081d47f19883ed4b6d973c8086301a9155b098b80d66c3e79cb7
   languageName: node
   linkType: hard
 
@@ -31179,6 +31114,13 @@ __metadata:
     dompurify: "npm:3.2.7"
     marked: "npm:14.0.0"
   checksum: 10/73836b612a923342001b8cbb459aad0de486c94672fb7cf9d28bdafed9f3b7523d5aba510d9f8e7d24476a5aacf0d3a5c0cdc520ed4764f6f89f8cf5ba8d9329
+  languageName: node
+  linkType: hard
+
+"moo@npm:^0.5.1":
+  version: 0.5.3
+  resolution: "moo@npm:0.5.3"
+  checksum: 10/ce4a2e5ccab15bbe1b1ade5b8f821eea7d03cecda2898c2b343bd2c84f357c04ada2bdbc9bef9201cd1e4ddd7f2be7d365c2e058bb4862734790e0fa77740d81
   languageName: node
   linkType: hard
 
@@ -33320,13 +33262,6 @@ __metadata:
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: 10/e1cf46bf84886c79055fdfa9dcb3e4711ad259949e3565154b004b260cd356c5d54b31a1437ce9782624bf766272fe6b0154f5f0c744fb7af5d454d2b60db045
-  languageName: node
-  linkType: hard
-
-"picomatch@npm:4.0.3":
-  version: 4.0.3
-  resolution: "picomatch@npm:4.0.3"
-  checksum: 10/57b99055f40b16798f2802916d9c17e9744e620a0db136554af01d19598b96e45e2f00014c91d1b8b13874b80caa8c295b3d589a3f72373ec4aaf54baa5962d5
   languageName: node
   linkType: hard
 
@@ -35780,6 +35715,13 @@ __metadata:
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: 10/32872cd0ff68a3ddade7a7617b8f4c2ae8764d8b7d884c651b74457967a9e0e886267d3ecc781220629c44a865167b61c375d2da6c720c840ecd73f45d5d9451
+  languageName: node
+  linkType: hard
+
+"safe-identifier@npm:^0.4.1":
+  version: 0.4.2
+  resolution: "safe-identifier@npm:0.4.2"
+  checksum: 10/c2697c0d2fe128aa5f5faa7bd3ccf02d06ba937cdff9b2f65afb247e222a1505fc414a3b6a04d2a6a71bb5a84b8bc345edc408fabc8afc498f04e367ddc02366
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2085,18 +2085,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular-devkit/architect@npm:0.2102.2":
-  version: 0.2102.2
-  resolution: "@angular-devkit/architect@npm:0.2102.2"
-  dependencies:
-    "@angular-devkit/core": "npm:21.2.2"
-    rxjs: "npm:7.8.2"
-  bin:
-    architect: bin/cli.js
-  checksum: 10/200e1f425980536e835ac909c9c877d5eda45698e3facfb552b3752d8e847771829673d37ced539f9bb0127450bf3c68190dd0bbbef6ac87790ce8095898a603
-  languageName: node
-  linkType: hard
-
 "@angular-devkit/architect@npm:0.2102.7, @angular-devkit/architect@npm:>= 0.2100.0 < 0.2200.0":
   version: 0.2102.7
   resolution: "@angular-devkit/architect@npm:0.2102.7"
@@ -2231,25 +2219,6 @@ __metadata:
     webpack: ^5.30.0
     webpack-dev-server: ^5.0.2
   checksum: 10/03971a3ca70cb799999c0f36cdf7c40d119aae0f2944032ce1107f63af44c561bcc092cab8dfaa3bccc1a5af211e8edce9b38906ccabf484fc0c8243b719da7b
-  languageName: node
-  linkType: hard
-
-"@angular-devkit/core@npm:21.2.2":
-  version: 21.2.2
-  resolution: "@angular-devkit/core@npm:21.2.2"
-  dependencies:
-    ajv: "npm:8.18.0"
-    ajv-formats: "npm:3.0.1"
-    jsonc-parser: "npm:3.3.1"
-    picomatch: "npm:4.0.3"
-    rxjs: "npm:7.8.2"
-    source-map: "npm:0.7.6"
-  peerDependencies:
-    chokidar: ^5.0.0
-  peerDependenciesMeta:
-    chokidar:
-      optional: true
-  checksum: 10/8077116039f94e4a9795046119a2c92327c80c1cdd604c101cf0bb2685056579154de6884be301de5ce0955c471c9b9576e777ee73bd6b57a1c2488d41cc49de
   languageName: node
   linkType: hard
 
@@ -6929,19 +6898,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsonjoy.com/fs-core@npm:4.56.11":
-  version: 4.56.11
-  resolution: "@jsonjoy.com/fs-core@npm:4.56.11"
-  dependencies:
-    "@jsonjoy.com/fs-node-builtins": "npm:4.56.11"
-    "@jsonjoy.com/fs-node-utils": "npm:4.56.11"
-    thingies: "npm:^2.5.0"
-  peerDependencies:
-    tslib: 2
-  checksum: 10/46adecf53d79246eed43503e999f3068b38d6c5b209e305c5b6ca55cfbb68fd2780a2fe3ddc2de3535c51a6db76e4acaca67dc127d1ce54399cf786a5ccbd4ca
-  languageName: node
-  linkType: hard
-
 "@jsonjoy.com/fs-core@npm:4.57.2":
   version: 4.57.2
   resolution: "@jsonjoy.com/fs-core@npm:4.57.2"
@@ -6952,20 +6908,6 @@ __metadata:
   peerDependencies:
     tslib: 2
   checksum: 10/6db8b3a7fb874229c7991bbdc094d752adbde7d774e5ef70df5a787130c7c8ed4ac2d34eaac079383c527269feaa91d1cb4f5c1504af995cca95070af769a0bd
-  languageName: node
-  linkType: hard
-
-"@jsonjoy.com/fs-fsa@npm:4.56.11":
-  version: 4.56.11
-  resolution: "@jsonjoy.com/fs-fsa@npm:4.56.11"
-  dependencies:
-    "@jsonjoy.com/fs-core": "npm:4.56.11"
-    "@jsonjoy.com/fs-node-builtins": "npm:4.56.11"
-    "@jsonjoy.com/fs-node-utils": "npm:4.56.11"
-    thingies: "npm:^2.5.0"
-  peerDependencies:
-    tslib: 2
-  checksum: 10/ed322ec4596f0b385d17dfeca6f2e1c2de51aa7c356f092700ad7b8930816f27f7f49234ba5eb544f03d173ea3cf5f9509597a5c64f0c03d2c4c456b751e2a16
   languageName: node
   linkType: hard
 
@@ -6983,34 +6925,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsonjoy.com/fs-node-builtins@npm:4.56.11":
-  version: 4.56.11
-  resolution: "@jsonjoy.com/fs-node-builtins@npm:4.56.11"
-  peerDependencies:
-    tslib: 2
-  checksum: 10/04ca8c56cd3b883149b42cce5d9376d18445a071b6d88c5366f930c2ba93505a7d708ad8f5af1a15e691dd87ffb971048b906450287d5faf363472ced43ea884
-  languageName: node
-  linkType: hard
-
 "@jsonjoy.com/fs-node-builtins@npm:4.57.2":
   version: 4.57.2
   resolution: "@jsonjoy.com/fs-node-builtins@npm:4.57.2"
   peerDependencies:
     tslib: 2
   checksum: 10/3284f0f0a989ad2bc0abc485748b2f3581648401c7d86be9b4541374f65050d384b61b5e44eff9b463d43fd1764bead1251783681105962ba5954b5e64b42480
-  languageName: node
-  linkType: hard
-
-"@jsonjoy.com/fs-node-to-fsa@npm:4.56.11":
-  version: 4.56.11
-  resolution: "@jsonjoy.com/fs-node-to-fsa@npm:4.56.11"
-  dependencies:
-    "@jsonjoy.com/fs-fsa": "npm:4.56.11"
-    "@jsonjoy.com/fs-node-builtins": "npm:4.56.11"
-    "@jsonjoy.com/fs-node-utils": "npm:4.56.11"
-  peerDependencies:
-    tslib: 2
-  checksum: 10/e4e8b6ea18969665925b97055cb06636fbd74e5025cd126280ede2245ba2efe328146e0b7a5e45c45a64175dc74231caa982de4dda51bffb061c028c931f2fad
   languageName: node
   linkType: hard
 
@@ -7027,17 +6947,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsonjoy.com/fs-node-utils@npm:4.56.11":
-  version: 4.56.11
-  resolution: "@jsonjoy.com/fs-node-utils@npm:4.56.11"
-  dependencies:
-    "@jsonjoy.com/fs-node-builtins": "npm:4.56.11"
-  peerDependencies:
-    tslib: 2
-  checksum: 10/72ca92de077c34d26c935b1ec6011de587bc2f382e822d9e57c76318d506f3c40f5075d04ede666b59d45e275e577ea77032a10b48161483040f3e3f7c381232
-  languageName: node
-  linkType: hard
-
 "@jsonjoy.com/fs-node-utils@npm:4.57.2":
   version: 4.57.2
   resolution: "@jsonjoy.com/fs-node-utils@npm:4.57.2"
@@ -7046,23 +6955,6 @@ __metadata:
   peerDependencies:
     tslib: 2
   checksum: 10/f63c7c8fd5a63a163a01bc70dac262419bcc1ae182186f249e038703b04a401e49eab9043514384555177e9385929b58a76cab945e8c7cdc6809efc2ea50bf31
-  languageName: node
-  linkType: hard
-
-"@jsonjoy.com/fs-node@npm:4.56.11":
-  version: 4.56.11
-  resolution: "@jsonjoy.com/fs-node@npm:4.56.11"
-  dependencies:
-    "@jsonjoy.com/fs-core": "npm:4.56.11"
-    "@jsonjoy.com/fs-node-builtins": "npm:4.56.11"
-    "@jsonjoy.com/fs-node-utils": "npm:4.56.11"
-    "@jsonjoy.com/fs-print": "npm:4.56.11"
-    "@jsonjoy.com/fs-snapshot": "npm:4.56.11"
-    glob-to-regex.js: "npm:^1.0.0"
-    thingies: "npm:^2.5.0"
-  peerDependencies:
-    tslib: 2
-  checksum: 10/a6a7e84de467d644bd2b23f34afaf61e93eb05245f40325a067403d2af5b4b22adce806639b80ff0f8431049dda706a803e6f73f2bf944d73a1ad78ac04bbd15
   languageName: node
   linkType: hard
 
@@ -7083,18 +6975,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsonjoy.com/fs-print@npm:4.56.11":
-  version: 4.56.11
-  resolution: "@jsonjoy.com/fs-print@npm:4.56.11"
-  dependencies:
-    "@jsonjoy.com/fs-node-utils": "npm:4.56.11"
-    tree-dump: "npm:^1.1.0"
-  peerDependencies:
-    tslib: 2
-  checksum: 10/352fb4932c0ed44b5fb148b253754748b6d3e9859452ef1b03cebb6b9601e9f84336ef0932ca4de9687b2f3ec703083d4572c7bf2036537f787673229c3ed68b
-  languageName: node
-  linkType: hard
-
 "@jsonjoy.com/fs-print@npm:4.57.2":
   version: 4.57.2
   resolution: "@jsonjoy.com/fs-print@npm:4.57.2"
@@ -7104,20 +6984,6 @@ __metadata:
   peerDependencies:
     tslib: 2
   checksum: 10/4931c8de684a655ab11ba2285016c35f3558f1f8f3444ac42fe7f5ea417556661b6f88d238c107f30c30b2d131eb2e0ecb1bb8626a7f6e0440996f42ea31dd7b
-  languageName: node
-  linkType: hard
-
-"@jsonjoy.com/fs-snapshot@npm:4.56.11":
-  version: 4.56.11
-  resolution: "@jsonjoy.com/fs-snapshot@npm:4.56.11"
-  dependencies:
-    "@jsonjoy.com/buffers": "npm:^17.65.0"
-    "@jsonjoy.com/fs-node-utils": "npm:4.56.11"
-    "@jsonjoy.com/json-pack": "npm:^17.65.0"
-    "@jsonjoy.com/util": "npm:^17.65.0"
-  peerDependencies:
-    tslib: 2
-  checksum: 10/97665962c5bf609720ac2913111da540235fa8aed52241e017da16ae2ac0228ae9e1938906d51e61f85fdaa0511c46db22b3c8212c9ba77a0ae4082cd20e4d57
   languageName: node
   linkType: hard
 
@@ -7215,6 +7081,21 @@ __metadata:
   peerDependencies:
     tslib: 2
   checksum: 10/1a6e5301d725a7161b93ff707eb1a954bf4552a2fa96eee9a960d3ae3ed5f993d18b56dcff29e98036341a5968c5d1b2dfe21f76695390e7f0d89b81f24c85e0
+  languageName: node
+  linkType: hard
+
+"@jsverse/transloco-messageformat@npm:~8.2.1":
+  version: 8.2.1
+  resolution: "@jsverse/transloco-messageformat@npm:8.2.1"
+  dependencies:
+    "@messageformat/core": "npm:^3.0.0"
+    tslib: "npm:^2.2.0"
+  peerDependencies:
+    "@angular/core": ">=16.0.0"
+    "@jsverse/transloco": ">=8.0.0"
+    "@jsverse/utils": 1.0.0-beta.5
+    rxjs: ">=6.0.0"
+  checksum: 10/96902837d2963c8a3193aecb669683b2f6cf5fa2a6d622fa65459bd1dd5c1817160d429987225392f0ba44205ba979bf96122775a6af5c1adf07651cf9bb354b
   languageName: node
   linkType: hard
 
@@ -7464,6 +7345,52 @@ __metadata:
   dependencies:
     langium: "npm:^4.0.0"
   checksum: 10/648c96da8464113c3694587f3f950421b1914d34fddc194b6dff7a8c28da5e37273ddc4d56a4efaeda82e93c7a168389f035dbac6c8d5b65930ee60b5063ece4
+  languageName: node
+  linkType: hard
+
+"@messageformat/core@npm:^3.0.0":
+  version: 3.4.0
+  resolution: "@messageformat/core@npm:3.4.0"
+  dependencies:
+    "@messageformat/date-skeleton": "npm:^1.0.0"
+    "@messageformat/number-skeleton": "npm:^1.0.0"
+    "@messageformat/parser": "npm:^5.1.0"
+    "@messageformat/runtime": "npm:^3.0.1"
+    make-plural: "npm:^7.0.0"
+    safe-identifier: "npm:^0.4.1"
+  checksum: 10/a75745bb36715a6460623610646de56e52e0642b4b87dcfe074c3d47561042ea7e1bea13fac137808bc1e2807f456691b0ad315d4dbc93d05d943b306738c384
+  languageName: node
+  linkType: hard
+
+"@messageformat/date-skeleton@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "@messageformat/date-skeleton@npm:1.1.0"
+  checksum: 10/b90a8bf4bdff26e1762865456ef8cd16cb0208385509fa1db1ed4a113607a2449fc3775d51f2ba764349489d616f66b33f15bc7a867a95fe8667c1280924197e
+  languageName: node
+  linkType: hard
+
+"@messageformat/number-skeleton@npm:^1.0.0":
+  version: 1.2.0
+  resolution: "@messageformat/number-skeleton@npm:1.2.0"
+  checksum: 10/6591ceee52cc008c4bdaf3026e5272ce0f88c6658ec3dae1fa253a608931e06b85826a89aae69143d9d29f66c7444c63c643c4fb3181fdbb862fd46b7e0472a8
+  languageName: node
+  linkType: hard
+
+"@messageformat/parser@npm:^5.1.0":
+  version: 5.1.1
+  resolution: "@messageformat/parser@npm:5.1.1"
+  dependencies:
+    moo: "npm:^0.5.1"
+  checksum: 10/32b1e503532f62df976dd62fbe27fcec9d8ff44770d9fa9722cbbc86545fdacb11038594f739d0c29e984535df8535a1da69375109f684bd4efd3c60156b3b49
+  languageName: node
+  linkType: hard
+
+"@messageformat/runtime@npm:^3.0.1":
+  version: 3.0.2
+  resolution: "@messageformat/runtime@npm:3.0.2"
+  dependencies:
+    make-plural: "npm:^7.0.0"
+  checksum: 10/9baf876a98d017ed79fa7ca6da6f43f44e48570b2723d6745df5a1eb31e86bea116b63e23ec1663be493f6188a36b1c81ecfbdac662ab531b2e2d6ee46a6a220
   languageName: node
   linkType: hard
 
@@ -8276,18 +8203,6 @@ __metadata:
     "@ngrx/store": 21.1.0
     rxjs: ^6.5.3 || ^7.5.0
   checksum: 10/8983300a6d893f9c5a56c3086ad7cf14ab62b3769770035830a7cbaf470b62e6e599928158328300c7581a5ee9f429f68fd853b755be0426dac4203f340e1c47
-  languageName: node
-  linkType: hard
-
-"@ngrx/store@npm:~21.0.0":
-  version: 21.0.1
-  resolution: "@ngrx/store@npm:21.0.1"
-  dependencies:
-    tslib: "npm:^2.0.0"
-  peerDependencies:
-    "@angular/core": ^21.0.0
-    rxjs: ^6.5.3 || ^7.5.0
-  checksum: 10/72604bc19da753ef959f8940fd066b5cef39d93d147dd59d6baa021e5f709ede2ac4a4e670f5b64e4f8ccbbfeb1da5f67022d39044784c697c63b922c353f793
   languageName: node
   linkType: hard
 
@@ -12339,6 +12254,7 @@ __metadata:
     "@babel/preset-typescript": "npm:~7.28.0"
     "@compodoc/compodoc": "npm:^1.1.32"
     "@eslint-community/eslint-plugin-eslint-comments": "npm:^4.4.0"
+    "@jsverse/transloco": "npm:~8.2.1"
     "@material/slider": "npm:^14.0.0"
     "@ngrx/store": "npm:~21.1.0"
     "@ngx-translate/core": "npm:~16.0.4"
@@ -12350,6 +12266,7 @@ __metadata:
     "@o3r/localization": "workspace:~"
     "@o3r/schematics": "workspace:~"
     "@o3r/test-helpers": "workspace:~"
+    "@o3r/transloco": "workspace:~"
     "@playwright/test": "npm:~1.59.0"
     "@schematics/angular": "npm:~21.2.0"
     "@standard-schema/spec": "npm:~1.1.0"
@@ -12404,6 +12321,7 @@ __metadata:
     "@angular/core": ^21.0.0
     "@angular/forms": ^21.0.0
     "@angular/platform-browser": ^21.0.0
+    "@jsverse/transloco": ^8.0.0
     "@material/slider": ^14.0.0
     "@ngrx/store": ^21.0.0
     "@ngx-translate/core": ^15.0.0 || ~16.0.4
@@ -12411,6 +12329,7 @@ __metadata:
     "@o3r/eslint-config": "workspace:~"
     "@o3r/localization": "workspace:~"
     "@o3r/schematics": "workspace:~"
+    "@o3r/transloco": "workspace:~"
     "@playwright/test": ^1.49.0
     "@schematics/angular": ^21.0.0
     eslint: ~9.39.0
@@ -12431,6 +12350,8 @@ __metadata:
       optional: true
     "@angular/forms":
       optional: true
+    "@jsverse/transloco":
+      optional: true
     "@material/slider":
       optional: true
     "@ngrx/store":
@@ -12444,6 +12365,8 @@ __metadata:
     "@o3r/localization":
       optional: true
     "@o3r/schematics":
+      optional: true
+    "@o3r/transloco":
       optional: true
     "@playwright/test":
       optional: true
@@ -12546,11 +12469,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@o3r/transloco@workspace:packages/@o3r/transloco":
+"@o3r/transloco@workspace:packages/@o3r/transloco, @o3r/transloco@workspace:~":
   version: 0.0.0-use.local
   resolution: "@o3r/transloco@workspace:packages/@o3r/transloco"
   dependencies:
-    "@angular-devkit/architect": "npm:0.2102.2"
+    "@angular-devkit/architect": "npm:0.2102.7"
     "@angular-devkit/build-angular": "npm:~21.2.0"
     "@angular-devkit/core": "npm:~21.2.0"
     "@angular-devkit/schematics": "npm:~21.2.0"
@@ -12568,7 +12491,9 @@ __metadata:
     "@compodoc/compodoc": "npm:^1.1.32"
     "@eslint-community/eslint-plugin-eslint-comments": "npm:^4.4.0"
     "@jsverse/transloco": "npm:~8.2.1"
-    "@ngrx/store": "npm:~21.0.0"
+    "@jsverse/transloco-messageformat": "npm:~8.2.1"
+    "@jsverse/utils": "npm:1.0.0-beta.5"
+    "@ngrx/store": "npm:~21.1.0"
     "@nx/eslint": "npm:~22.6.0"
     "@nx/eslint-plugin": "npm:~22.6.0"
     "@nx/jest": "npm:~22.6.0"
@@ -12587,6 +12512,11 @@ __metadata:
     "@types/jest": "npm:~30.0.0"
     "@types/node": "npm:~24.12.0"
     "@typescript-eslint/parser": "npm:~8.58.0"
+    "@yarnpkg/cli": "npm:^4.5.0"
+    "@yarnpkg/core": "npm:^4.1.3"
+    "@yarnpkg/fslib": "npm:^3.1.0"
+    "@yarnpkg/plugin-npm": "npm:^3.0.1"
+    "@yarnpkg/plugin-pack": "npm:^4.0.0"
     angular-eslint: "npm:~21.3.0"
     chokidar: "npm:~5.0.0"
     cpy-cli: "npm:^6.0.0"
@@ -12610,12 +12540,13 @@ __metadata:
     jest-util: "npm:~30.3.0"
     jsdom: "npm:~27.4.0"
     jsonc-eslint-parser: "npm:~2.4.0"
-    memfs: "npm:~4.56.0"
+    memfs: "npm:~4.57.0"
     nx: "npm:~22.6.0"
     rxjs: "npm:^7.8.1"
     semver: "npm:^7.5.2"
     ts-jest: "npm:~29.4.0"
     tslib: "npm:^2.6.2"
+    type-fest: "npm:^5.3.1"
     typescript: "npm:~5.9.2"
     typescript-eslint: "npm:~8.58.0"
     unionfs: "npm:~4.6.0"
@@ -12624,9 +12555,13 @@ __metadata:
     "@angular-devkit/core": ^21.0.0
     "@angular-devkit/schematics": ^21.0.0
     "@angular/cdk": ^21.0.0
+    "@angular/cli": ^21.0.0
     "@angular/common": ^21.0.0
     "@angular/core": ^21.0.0
+    "@angular/platform-browser-dynamic": ^21.0.0
     "@jsverse/transloco": ^8.0.0
+    "@jsverse/transloco-messageformat": ^8.0.0
+    "@jsverse/utils": 1.0.0-beta.5
     "@ngrx/store": ^21.0.0
     "@o3r/core": "workspace:~"
     "@o3r/dynamic-content": "workspace:~"
@@ -12634,30 +12569,45 @@ __metadata:
     "@o3r/logger": "workspace:~"
     "@o3r/schematics": "workspace:~"
     "@schematics/angular": ^21.0.0
+    "@yarnpkg/cli": ^4.3.1
+    "@yarnpkg/core": ^4.1.1
+    "@yarnpkg/fslib": ^3.1.0
+    "@yarnpkg/plugin-npm": ^3.0.1
+    "@yarnpkg/plugin-pack": ^4.0.0
     chokidar: ^4.0.0 || ^5.0.0
     globby: ^11.1.0
     rxjs: ^7.8.1
+    semver: ^7.5.2
+    type-fest: ^5.3.1
     typescript: ^5.9.0
   peerDependenciesMeta:
-    "@angular-devkit/architect":
-      optional: true
     "@angular-devkit/core":
       optional: true
     "@angular-devkit/schematics":
       optional: true
-    "@o3r/dynamic-content":
-      optional: true
-    "@o3r/extractors":
-      optional: true
-    "@o3r/logger":
+    "@angular/cli":
       optional: true
     "@o3r/schematics":
       optional: true
     "@schematics/angular":
       optional: true
+    "@yarnpkg/cli":
+      optional: true
+    "@yarnpkg/core":
+      optional: true
+    "@yarnpkg/fslib":
+      optional: true
+    "@yarnpkg/plugin-npm":
+      optional: true
+    "@yarnpkg/plugin-pack":
+      optional: true
     chokidar:
       optional: true
     globby:
+      optional: true
+    semver:
+      optional: true
+    type-fest:
       optional: true
     typescript:
       optional: true
@@ -30483,6 +30433,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"make-plural@npm:^7.0.0":
+  version: 7.5.0
+  resolution: "make-plural@npm:7.5.0"
+  checksum: 10/096241357d7f6b274967998ca03006723ab40a9b49282ed37a0f863aeb1ac9fb12704a07fafbd2dfa3b75ee2e39edbb6c665a3884865ed1c805e8b4d419714d1
+  languageName: node
+  linkType: hard
+
 "makeerror@npm:1.0.12":
   version: 1.0.12
   resolution: "makeerror@npm:1.0.12"
@@ -30688,30 +30645,6 @@ __metadata:
   peerDependencies:
     tslib: 2
   checksum: 10/872b08504889b616a2ec28655509632112d80f8f0fd6d8c23219f4f62b4ff7d6a890205e3127379d985f3bdcaf82909a9f2c3a17867495f98b4678bc2af8a458
-  languageName: node
-  linkType: hard
-
-"memfs@npm:~4.56.0":
-  version: 4.56.11
-  resolution: "memfs@npm:4.56.11"
-  dependencies:
-    "@jsonjoy.com/fs-core": "npm:4.56.11"
-    "@jsonjoy.com/fs-fsa": "npm:4.56.11"
-    "@jsonjoy.com/fs-node": "npm:4.56.11"
-    "@jsonjoy.com/fs-node-builtins": "npm:4.56.11"
-    "@jsonjoy.com/fs-node-to-fsa": "npm:4.56.11"
-    "@jsonjoy.com/fs-node-utils": "npm:4.56.11"
-    "@jsonjoy.com/fs-print": "npm:4.56.11"
-    "@jsonjoy.com/fs-snapshot": "npm:4.56.11"
-    "@jsonjoy.com/json-pack": "npm:^1.11.0"
-    "@jsonjoy.com/util": "npm:^1.9.0"
-    glob-to-regex.js: "npm:^1.0.1"
-    thingies: "npm:^2.5.0"
-    tree-dump: "npm:^1.0.3"
-    tslib: "npm:^2.0.0"
-  peerDependencies:
-    tslib: 2
-  checksum: 10/2d99bce59dee0f5c96a039851892e39c09c1eee11d8978cf37dbb93462d706d842d6a5b0b3d5081d47f19883ed4b6d973c8086301a9155b098b80d66c3e79cb7
   languageName: node
   linkType: hard
 
@@ -31179,6 +31112,13 @@ __metadata:
     dompurify: "npm:3.2.7"
     marked: "npm:14.0.0"
   checksum: 10/73836b612a923342001b8cbb459aad0de486c94672fb7cf9d28bdafed9f3b7523d5aba510d9f8e7d24476a5aacf0d3a5c0cdc520ed4764f6f89f8cf5ba8d9329
+  languageName: node
+  linkType: hard
+
+"moo@npm:^0.5.1":
+  version: 0.5.3
+  resolution: "moo@npm:0.5.3"
+  checksum: 10/ce4a2e5ccab15bbe1b1ade5b8f821eea7d03cecda2898c2b343bd2c84f357c04ada2bdbc9bef9201cd1e4ddd7f2be7d365c2e058bb4862734790e0fa77740d81
   languageName: node
   linkType: hard
 
@@ -33320,13 +33260,6 @@ __metadata:
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: 10/e1cf46bf84886c79055fdfa9dcb3e4711ad259949e3565154b004b260cd356c5d54b31a1437ce9782624bf766272fe6b0154f5f0c744fb7af5d454d2b60db045
-  languageName: node
-  linkType: hard
-
-"picomatch@npm:4.0.3":
-  version: 4.0.3
-  resolution: "picomatch@npm:4.0.3"
-  checksum: 10/57b99055f40b16798f2802916d9c17e9744e620a0db136554af01d19598b96e45e2f00014c91d1b8b13874b80caa8c295b3d589a3f72373ec4aaf54baa5962d5
   languageName: node
   linkType: hard
 
@@ -35780,6 +35713,13 @@ __metadata:
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: 10/32872cd0ff68a3ddade7a7617b8f4c2ae8764d8b7d884c651b74457967a9e0e886267d3ecc781220629c44a865167b61c375d2da6c720c840ecd73f45d5d9451
+  languageName: node
+  linkType: hard
+
+"safe-identifier@npm:^0.4.1":
+  version: 0.4.2
+  resolution: "safe-identifier@npm:0.4.2"
+  checksum: 10/c2697c0d2fe128aa5f5faa7bd3ccf02d06ba937cdff9b2f65afb247e222a1505fc414a3b6a04d2a6a71bb5a84b8bc345edc408fabc8afc498f04e367ddc02366
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed change

- Create `collection.json`.
- Port `schematics/ng-add/` to install `@jsverse/transloco` instead of `@ngx-translate/core`.
- Port `schematics/localization-to-component/` — update templates to use Transloco pipe/directive.
- Port `schematics/add-localization-key/` — update templates similarly.
- Copy `schematics/localization-base/` and `schematics/cms-adapter/`.
- Port corresponding `*.spec.ts` files for schematics.

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
