### PR TITLE
feat(ama-sdk): add `@default` to requesst parameters

### DIFF
--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/java/com/amadeus/codegen/ts/LambdaHelper.java
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/java/com/amadeus/codegen/ts/LambdaHelper.java
@@ -32,7 +32,7 @@ public class LambdaHelper {
 
   private static final String VALID_PROPERTY_REGEXP = "^(?!\\d)[\\w$]+$";
 
-    /**
+  /**
    * Mustache lambda helper for camelizing strings.
    * <p>
    * Converts strings to camelCase or PascalCase depending on the configuration.

--- a/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/api.mustache
+++ b/packages/@ama-sdk/schematics/schematics/typescript/core/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/api.mustache
@@ -21,7 +21,10 @@ export type {{classname}}{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}{{#up
 /** Parameters object to {{classname}}'s {{nickname}} function */
 export interface {{classname}}{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}RequestData {
     {{#allParams}}
-  /** {{#description}}{{{description}}}{{/description}}{{^description}}{{#isArray}}List of {{#plurialize}}{{#noArrayInType}}{{{dataType}}}{{/noArrayInType}}{{/plurialize}}{{/isArray}}{{/description}} */
+  /**
+   * {{#description}}{{{description}}}{{/description}}{{^description}}{{#isArray}}List of {{#plurialize}}{{#noArrayInType}}{{{dataType}}}{{/noArrayInType}}{{/plurialize}}{{/isArray}}{{/description}} {{#defaultValue}}
+   * @default {{{defaultValue}}}{{/defaultValue}}
+   */
   '{{^isBodyParam}}{{baseName}}{{/isBodyParam}}{{#isBodyParam}}{{#vendorExtensions}}{{#x-body-param-name}}{{x-body-param-name}}{{/x-body-param-name}}{{^x-body-param-name}}{{#transformBodyRequest}}{{baseName}}{{/transformBodyRequest}}{{/x-body-param-name}}{{/vendorExtensions}}{{/isBodyParam}}'{{^required}}?{{/required}}{{#required}}{{#defaultValue}}?{{/defaultValue}}{{/required}}: {{#isEnum}}{{classname}}{{#uppercaseFirst}}{{nickname}}{{/uppercaseFirst}}{{#uppercaseFirst}}{{paramName}}{{/uppercaseFirst}}Enum{{#isArray}}[]{{/isArray}}{{/isEnum}}{{^isEnum}}{{#isBodyParam}}{{{baseType}}}{{#isArray}}[]{{/isArray}}{{/isBodyParam}}{{^isBodyParam}}{{{dataType}}}{{/isBodyParam}}{{/isEnum}};
     {{/allParams}}
 }


### PR DESCRIPTION
## Release Notes

feat(ama-sdk): add `@default` to requesst parameters

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
* :octocat: Pull Request #4159
