### PR TITLE
fix(ama-styling): fix metadata formatter edge case when token name ha…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 24
+          node-version: 24.14
       - name: New Version
         if: github.event_name != 'merge_group'
         id: newVersion

--- a/packages/@ama-styling/style-dictionary/src/formats/metadata-format.mts
+++ b/packages/@ama-styling/style-dictionary/src/formats/metadata-format.mts
@@ -21,6 +21,17 @@ import type {
   FormatterOptions,
 } from './css-formatters/interface-formatter.mjs';
 
+const unwrapReferenceToken = (ref: TransformedToken | { value: TransformedToken }): TransformedToken => {
+  // Unwrap when getReferences returns a parent structural node instead of the leaf token.
+  // This occurs when token path resolution yields a parent object with child tokens,
+  // e.g., { label: token, value: token } instead of the token itself.
+  // Safe to unwrap only when outer has no name (not a token) but inner.value has name (is a token).
+  if (ref && typeof ref === 'object' && 'value' in ref && !('name' in ref) && ref.value?.name) {
+    return ref.value;
+  }
+  return ref as TransformedToken;
+};
+
 export const metadataFormat: Format = {
   name: `${OTTER_NAME_PREFIX}/json/metadata`,
   format: ({ dictionary, options }) => {
@@ -67,11 +78,14 @@ export const metadataFormat: Format = {
       const originalValue = usesDtcg ? token.original.$value : token.original.value;
       const refs = getReferences(originalValue, tokens);
       return refs
-        .map((ref) => ({
-          defaultValue: getValueFromCssVariable(propertyFormatter(ref)),
-          name: ref.name,
-          references: getMetadataReferences(ref)
-        }));
+        .map((ref) => {
+          const resolvedRef = unwrapReferenceToken(ref);
+          return {
+            defaultValue: getValueFromCssVariable(propertyFormatter(resolvedRef)),
+            name: resolvedRef.name,
+            references: getMetadataReferences(resolvedRef)
+          };
+        });
     };
 
     const metadata = allTokens

--- a/packages/@ama-styling/style-dictionary/src/formats/metadata-format.spec.ts
+++ b/packages/@ama-styling/style-dictionary/src/formats/metadata-format.spec.ts
@@ -5,6 +5,9 @@ import {
   resolve,
 } from 'node:path';
 import {
+  getReferences,
+} from 'style-dictionary/utils';
+import {
   OTTER_NAME_PREFIX,
 } from '../constants.mjs';
 import {
@@ -38,6 +41,8 @@ jest.mock('style-dictionary/utils', () => ({
   }),
   sortByReference: jest.fn()
 }));
+
+const getMockReferences = jest.mocked(getReferences);
 
 describe('metadataFormat', () => {
   beforeEach(() => jest.clearAllMocks());
@@ -161,5 +166,94 @@ describe('metadataFormat', () => {
         }
       }
     });
+  });
+
+  test('should unwrap parent structural nodes returned by getReferences for token paths ending in .value', async () => {
+    // In DTCG mode, token paths like `{input.color.foreground.value}` have `.value` treated as
+    // a literal path segment, not a token-value accessor (which would be `.$value`).
+    // When the token hierarchy has a structural parent like:
+    //   foreground: { value: { token }, label: { token } }
+    // getReferences returns the parent object instead of the leaf token.
+    // This test verifies the formatter unwraps such parent objects when:
+    // - outer object lacks a `name` property (not a token)
+    // - inner `value` object has a `name` property (is a token)
+    const referencedToken = {
+      $type: 'color',
+      $value: '#545352',
+      attributes: {
+        category: 'input'
+      },
+      isSource: true,
+      name: 'input-color-foreground-value',
+      original: {
+        $value: '#545352'
+      },
+      path: ['input', 'color', 'foreground', 'value']
+    };
+
+    const labelToken = {
+      $type: 'color',
+      $value: '#545352',
+      attributes: {
+        category: 'input'
+      },
+      isSource: true,
+      name: 'input-color-foreground-label',
+      original: {
+        $value: '{input.color.foreground.value}'
+      },
+      path: ['input', 'color', 'foreground', 'label']
+    };
+
+    const wrappedReferenceDictionary = {
+      allTokens: [referencedToken, labelToken],
+      tokens: {
+        input: {
+          color: {
+            foreground: {
+              value: referencedToken,
+              label: labelToken
+            }
+          }
+        }
+      },
+      unfilteredTokens: {}
+    };
+    const wrappedRef = wrappedReferenceDictionary.tokens.input.color.foreground.value;
+    const defaultGetReferences = getMockReferences.getMockImplementation();
+
+    getMockReferences.mockImplementation((value, tokens) => {
+      if (value === '{input.color.foreground.value}') {
+        return [{ value: wrappedRef } as any];
+      }
+
+      return defaultGetReferences ? defaultGetReferences(value, tokens) : [];
+    });
+
+    const css = await metadataFormat.format({
+      dictionary: wrappedReferenceDictionary as any,
+      file: {},
+      options: { outputReferences: true, usesDtcg: true },
+      platform: {}
+    }) as string;
+    const obj = JSON.parse(css);
+
+    expect(obj).toMatchObject({
+      variables: {
+        'input-color-foreground-label': {
+          name: 'input-color-foreground-label',
+          defaultValue: 'var(--input-color-foreground-value)',
+          references: [
+            {
+              name: 'input-color-foreground-value',
+              defaultValue: '#545352',
+              references: []
+            }
+          ]
+        }
+      }
+    });
+
+    expect(getMockReferences).toHaveBeenCalledWith('{input.color.foreground.value}', wrappedReferenceDictionary.tokens);
   });
 });

--- a/tools/github-actions/setup/action.yml
+++ b/tools/github-actions/setup/action.yml
@@ -11,7 +11,7 @@ runs:
   steps:
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
-        node-version: 24
+        node-version: 24.14
     - name: Enable Corepack
       shell: bash
       run: corepack enable


### PR DESCRIPTION
## Fix metadata formatter to unwrap parent nodes returned by getReferences for DTCG token paths

### Summary
This fixes metadata generation when token paths like `{input.color.foreground.value}` reference tokens nested within a structural parent object. In DTCG mode, `.value` is treated as a literal path segment rather than a token-value accessor, causing path resolution to return the parent object instead of the leaf token.

### Root Cause
When building metadata for a token like `input-color-foreground-label` that references `{input.color.foreground.value}`:

1. In DTCG mode, the `.value` suffix is NOT stripped (only `.$value` is stripped by Style Dictionary's getReferences)
2. `getReferences` tries to resolve the full path `input.color.foreground.value`
3. The token hierarchy has `foreground` as a parent containing both `value` and `label` as sibling tokens:
   ```json
   "foreground": {
     "value": { "$type": "color", "$value": "#545352" },
     "label": { "$type": "color", "$value": "{input.color.foreground.value}" }
   }
4.Style Dictionary's getValueByPath traverses to foreground and returns that parent object instead of drilling into value
5.The metadata formatter receives { value: <actual token>, label: <another token> } (no name property on the wrapper)
6.It tries to read properties like ref.name and ref.original from this parent wrapper and fails with unnamed-ref  error