### PR TITLE
fix(ama-openapi): schema $id to make it readable by claude

### DIFF
--- a/packages/@ama-openapi/core/src/schema/generate-schema.mts
+++ b/packages/@ama-openapi/core/src/schema/generate-schema.mts
@@ -1,3 +1,6 @@
+import {
+  MANIFEST_SCHEMA_FILE,
+} from '../constants.mjs';
 import type {
   Context,
 } from '../context.mjs';
@@ -43,7 +46,7 @@ export const generateOpenApiManifestSchema = async (options: GenerateOpenApiMani
     manifest: {
       $schema: 'http://json-schema.org/draft-07/schema#',
       title: 'OpenApi specification package manifest',
-      $id: '@ama-openapi/core/schemas/manifest.schema.json',
+      $id: MANIFEST_SCHEMA_FILE,
       type: 'object',
       properties: {
         models: {

--- a/packages/@ama-openapi/core/src/schema/mask/dependencies-masks.mts
+++ b/packages/@ama-openapi/core/src/schema/mask/dependencies-masks.mts
@@ -43,7 +43,7 @@ export const getDependencyModelMasks = async (artifacts: SpecificationArtifact[]
             mask: {
               $schema: 'http://json-schema.org/draft-07/schema#',
               title: `OpenApi specification mask ${modelRef}`,
-              $id: `@ama-openapi/core/schemas/${fileName}`,
+              $id: fileName,
               ...await generateMaskSchemaModelAt(modelPath, ctx),
               definitions: {
                 ...FIELD_SCHEMA_DEFINITION

--- a/packages/@ama-openapi/create/templates/.vscode/settings.json.template
+++ b/packages/@ama-openapi/create/templates/.vscode/settings.json.template
@@ -1,8 +1,5 @@
 {
   "chat.plugins.enabled": true,
-  "chat.plugins.marketplaces": [
-    "AmadeusITGroup/otter"
-  ],
   "editor.defaultFormatter": "Redocly.openapi-vs-code",
   "files.readonlyFromPermissions": true,
   "files.readonlyInclude": {

--- a/packages/@ama-openapi/create/templates/README.md.template
+++ b/packages/@ama-openapi/create/templates/README.md.template
@@ -2,6 +2,40 @@
 
 This package exposes [OpenApi specification](https://swagger.io/specification/) which can be used to use to generate an SDK or be referred in another specification.
 
+## LLM Integration
+
+This project uses the **`ama-openapi`** plugin from the Otter marketplace to enhance LLM-powered coding assistants with
+OpenAPI specification operations.
+
+**What the plugin provides:**
+
+- OpenAPI spec editing, validation, and linting assistance
+- Model generation and SDK scaffolding support
+- Intelligent suggestions for API design and spec operations
+- Integration with the Redocly workflow used in this project
+
+**Setup for VS Code with GitHub Copilot:**
+
+The plugin is already configured in this project's `.claude/` instructions. To use it with GitHub Copilot in VS Code:
+
+1. **Install GitHub Copilot Extension:**
+- Install from [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot)
+- Or search for "GitHub Copilot" in VS Code Extensions
+
+2. **Verify Plugin Configuration:**
+- The plugin instructions are configured in the `.claude/` directory
+- The Otter marketplace is configured to use the GitHub repo `AmadeusITGroup/otter`
+
+3. **Usage:**
+- When working in the `spec/` directory, Copilot will automatically use the plugin for OpenAPI-related tasks
+- Ask Copilot to help with spec editing, validation, or model generation
+- The plugin understands the Redocly workflow and project structure
+
+**Documentation:**
+
+- [Otter Plugin Documentation](https://github.com/AmadeusITGroup/otter/tree/main/tools/llm/plugins/ama-openapi)
+- [GitHub Copilot Documentation](https://docs.github.com/en/copilot)
+
 ## How to work on it
 
 **Requirements:**


### PR DESCRIPTION
## Proposed change

fix(ama-openapi): schema $id to make it readable by claude
fix(ama-openapi): removed vscode config allowed only at user level
docs(ama-openapi): to give instruction to user to setup copilot/claude
fix(ama-openapi): duplicate claude instruction to be used by github agents

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
