### PR TITLE
chore: fix error at vitest vscode extension launch

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -115,7 +115,5 @@
   "js/ts.tsdk.path": ".yarn/sdks/typescript/lib",
   "js/ts.tsserver.watchOptions": "vscode",
   "js/ts.preferences.preferTypeOnlyAutoImports": true,
-  "vitest.maximumConfigs": 100,
-  "typescript.tsdk": ".yarn/sdks/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true
+  "vitest.configSearchPatternExclude": "apps/chrome-devtools/vite.config.ts"
 }


### PR DESCRIPTION
## Proposed change

chore: fix error at vitest vscode extension launch

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
