### PR TITLE
refactor(showcase): migrate to standalone bootstrapApplication and si…

### DIFF
--- a/apps/showcase/project.json
+++ b/apps/showcase/project.json
@@ -12,7 +12,7 @@
     },
     "@o3r/core:page": {
       "path": "apps/showcase/src/app",
-      "appRoutingModulePath": "apps/showcase/src/app/app-routing-module.ts",
+      "appRoutesDefinitionPath": "apps/showcase/src/app/app.routes.ts",
       "scope": "",
       "standalone": true
     },

--- a/apps/showcase/src/app/app.config.ts
+++ b/apps/showcase/src/app/app.config.ts
@@ -3,7 +3,7 @@ import {
 } from '@ama-sdk/client-fetch';
 import {
   OTTER_STYLING_DEVTOOLS_OPTIONS,
-  StylingDevtoolsModule,
+  provideStylingDevtools,
 } from '@ama-styling/devkit';
 import {
   registerLocaleData,
@@ -11,47 +11,44 @@ import {
 import localeEN from '@angular/common/locales/en';
 import localeFR from '@angular/common/locales/fr';
 import {
+  ApplicationConfig,
   isDevMode,
-  NgModule,
   provideZonelessChangeDetection,
   SecurityContext,
 } from '@angular/core';
 import {
-  BrowserModule,
-} from '@angular/platform-browser';
-import {
-  BrowserAnimationsModule,
+  provideAnimations,
+  provideNoopAnimations,
 } from '@angular/platform-browser/animations';
+import {
+  provideRouter,
+  withHashLocation,
+  withInMemoryScrolling,
+} from '@angular/router';
 import {
   provideTranslocoMessageformat,
 } from '@jsverse/transloco-messageformat';
 import {
-  NgbOffcanvasModule,
-} from '@ng-bootstrap/ng-bootstrap';
-import {
-  EffectsModule,
-} from '@ngrx/effects';
-import {
+  provideStore,
   RuntimeChecks,
-  StoreModule,
 } from '@ngrx/store';
 import {
-  StoreDevtoolsModule,
+  provideStoreDevtools,
 } from '@ngrx/store-devtools';
 import {
-  ApplicationDevtoolsModule,
   OTTER_APPLICATION_DEVTOOLS_OPTIONS,
   prefersReducedMotion,
+  provideApplicationDevtools,
 } from '@o3r/application';
 import {
-  ComponentsDevtoolsModule,
   OTTER_COMPONENTS_DEVTOOLS_OPTIONS,
+  provideComponentsDevtools,
   provideCustomComponents,
   withComponent,
 } from '@o3r/components';
 import {
-  ConfigurationDevtoolsModule,
   OTTER_CONFIGURATION_DEVTOOLS_OPTIONS,
+  provideConfigurationDevtools,
 } from '@o3r/configuration';
 import {
   provideDynamicContent,
@@ -64,17 +61,16 @@ import {
 } from '@o3r/logger';
 import {
   OTTER_RULES_ENGINE_DEVTOOLS_OPTIONS,
-  RulesEngineRunnerModule,
+  provideRulesEngineRunner,
 } from '@o3r/rules-engine';
 import {
   LocalizationConfiguration,
-  LocalizationOverrideStoreModule,
   OTTER_LOCALIZATION_DEVTOOLS_OPTIONS,
   provideLocalization,
   provideLocalizationDevtools,
 } from '@o3r/transloco';
 import {
-  LocalizationRulesEngineActionModule,
+  provideLocalizationRulesEngineAction,
 } from '@o3r/transloco/rules-engine';
 import {
   PetApi,
@@ -86,24 +82,19 @@ import {
   SANITIZE,
 } from 'ngx-markdown';
 import {
-  MonacoEditorModule,
   NGX_MONACO_EDITOR_CONFIG,
+  provideMonacoEditor,
 } from 'ngx-monaco-editor-v2';
 import {
   ClipboardButtonPres,
   DatePickerHebrewInputPres,
-  ScrollBackTopPres,
-  SidenavPres,
 } from '../components/utilities';
 import {
   markedAlert,
 } from '../helpers/marked-alert-extension';
 import {
-  App,
-} from './app';
-import {
-  AppRoutingModule,
-} from './app-routing-module';
+  appRoutes,
+} from './app.routes';
 
 const runtimeChecks = {
   strictActionImmutability: false,
@@ -146,31 +137,24 @@ export function localizationConfigurationFactory(): Partial<LocalizationConfigur
   };
 }
 
-@NgModule({
-  declarations: [
-    App
-  ],
-  imports: [
-    BrowserModule,
-    BrowserAnimationsModule.withConfig({ disableAnimations: prefersReducedMotion() }),
-    EffectsModule.forRoot([]),
-    StoreModule.forRoot({}, { runtimeChecks }),
-    StoreDevtoolsModule.instrument({ maxAge: 25, logOnly: !isDevMode() }),
-    LocalizationOverrideStoreModule,
-    LocalizationRulesEngineActionModule,
-    RulesEngineRunnerModule.forRoot({ debug: true }),
-    AppRoutingModule,
-    SidenavPres,
-    NgbOffcanvasModule,
-    ScrollBackTopPres,
-    ApplicationDevtoolsModule,
-    ComponentsDevtoolsModule,
-    StylingDevtoolsModule,
-    ConfigurationDevtoolsModule,
-    MonacoEditorModule.forRoot()
-  ],
+export const appConfig: ApplicationConfig = {
   providers: [
     provideZonelessChangeDetection(),
+    ...(prefersReducedMotion() ? [provideNoopAnimations()] : [provideAnimations()]),
+    provideRouter(
+      appRoutes,
+      withHashLocation(),
+      withInMemoryScrolling({ scrollPositionRestoration: 'enabled' })
+    ),
+    provideStore({}, { runtimeChecks }),
+    provideStoreDevtools({ maxAge: 25, logOnly: !isDevMode() }),
+    provideRulesEngineRunner({ debug: true }),
+    provideLocalizationRulesEngineAction(),
+    provideApplicationDevtools(),
+    provideComponentsDevtools(),
+    provideConfigurationDevtools(),
+    provideStylingDevtools(),
+    provideMonacoEditor(),
     provideCustomComponents(new Map(), withComponent('exampleDatePickerFlavorHebrew', DatePickerHebrewInputPres)),
     provideDynamicContent(),
     { provide: LOGGER_CLIENT_TOKEN, useValue: new ConsoleLogger() },
@@ -202,7 +186,5 @@ export function localizationConfigurationFactory(): Partial<LocalizationConfigur
     provideLocalization(localizationConfigurationFactory),
     provideLocalizationDevtools(),
     provideTranslocoMessageformat()
-  ],
-  bootstrap: [App]
-})
-export class AppModule {}
+  ]
+};

--- a/apps/showcase/src/app/app.routes.ts
+++ b/apps/showcase/src/app/app.routes.ts
@@ -1,12 +1,8 @@
 import {
-  NgModule,
-} from '@angular/core';
-import {
-  RouterModule,
   Routes,
 } from '@angular/router';
 
-const appRoutes: Routes = [
+export const appRoutes: Routes = [
   { path: '', redirectTo: '/home', pathMatch: 'full' },
   { path: 'configuration', loadComponent: () => import('./configuration/index').then((m) => m.Configuration), title: 'Otter Showcase - Configuration' },
   { path: 'component-replacement', loadComponent: () => import('./component-replacement/index').then((m) => m.ComponentReplacement), title: 'Otter Showcase - Component replacement' },
@@ -23,11 +19,3 @@ const appRoutes: Routes = [
   { path: 'forms', loadComponent: () => import('./forms/index').then((m) => m.Forms), title: 'Otter Showcase - Forms' },
   { path: '**', redirectTo: '/home', pathMatch: 'full' }
 ];
-
-@NgModule({
-  imports: [
-    RouterModule.forRoot(appRoutes, { scrollPositionRestoration: 'enabled', useHash: true })
-  ],
-  exports: [RouterModule]
-})
-export class AppRoutingModule {}

--- a/apps/showcase/src/app/app.spec.ts
+++ b/apps/showcase/src/app/app.spec.ts
@@ -41,14 +41,14 @@ describe('App', () => {
       ComponentsDevtoolsModule,
       StoreModule.forRoot(),
       ConfigurationDevtoolsModule,
-      EffectsModule.forRoot()
+      EffectsModule.forRoot(),
+      App
     ],
     providers: [
       provideMockStore(),
       provideLocalizationDevtools(),
       provideLocalizationMock(localizationConfiguration, mockTranslations)
-    ],
-    declarations: [App]
+    ]
   }));
 
   it('should create the app', () => {

--- a/apps/showcase/src/app/app.ts
+++ b/apps/showcase/src/app/app.ts
@@ -1,4 +1,7 @@
 import {
+  AsyncPipe,
+} from '@angular/common';
+import {
   Component,
   DestroyRef,
   inject,
@@ -10,6 +13,7 @@ import {
 import {
   NavigationEnd,
   Router,
+  RouterOutlet,
 } from '@angular/router';
 import {
   NgbOffcanvas,
@@ -26,6 +30,10 @@ import {
   shareReplay,
 } from 'rxjs';
 import {
+  ScrollBackTopPres,
+  SidenavPres,
+} from '../components/utilities';
+import {
   SideNavLinksGroup,
 } from '../components/utilities/sidenav';
 
@@ -34,7 +42,7 @@ import {
   selector: 'app-root',
   templateUrl: './app.html',
   styleUrls: ['./app.scss'],
-  standalone: false
+  imports: [AsyncPipe, RouterOutlet, SidenavPres, ScrollBackTopPres]
 })
 export class App {
   public title = 'showcase';

--- a/apps/showcase/src/app/configuration/configuration.ts
+++ b/apps/showcase/src/app/configuration/configuration.ts
@@ -76,7 +76,7 @@ export class Configuration implements DynamicConfigurableWithSignal<Configuratio
   public links$ = this.inPageNavPresService.links$;
 
   /** Input configuration to override the default configuration of the component */
-  public config = input<Partial<ConfigurationConfig>>();
+  public readonly config = input<Partial<ConfigurationConfig>>();
   /** Configuration signal based on the input and the stored configuration */
   @O3rConfig()
   public configSignal = configSignal(

--- a/apps/showcase/src/components/showcase/component-replacement/component-replacement-pres.ts
+++ b/apps/showcase/src/components/showcase/component-replacement/component-replacement-pres.ts
@@ -53,7 +53,7 @@ export class ComponentReplacementPres implements DynamicConfigurableWithSignal<C
   private readonly c11nService = inject(C11nService);
 
   /** Input configuration to override the default configuration of the component*/
-  public config = input<Partial<ComponentReplacementPresConfig>>();
+  public readonly config = input<Partial<ComponentReplacementPresConfig>>();
 
   /** Id of the child component */
   protected childId = 'date-outbound';

--- a/apps/showcase/src/components/showcase/configuration/configuration-pres.ts
+++ b/apps/showcase/src/components/showcase/configuration/configuration-pres.ts
@@ -47,7 +47,7 @@ export class ConfigurationPres implements DynamicConfigurableWithSignal<Configur
   private readonly fb = inject(FormBuilder);
 
   /** Input configuration to override the default configuration of the component */
-  public config = input<Partial<ConfigurationPresConfig>>();
+  public readonly config = input<Partial<ConfigurationPresConfig>>();
   /** Configuration signal based on the input and the stored configuration */
   @O3rConfig()
   public configSignal = configSignal(

--- a/apps/showcase/src/components/showcase/rules-engine/rules-engine-pres.ts
+++ b/apps/showcase/src/components/showcase/rules-engine/rules-engine-pres.ts
@@ -99,7 +99,7 @@ export class RulesEnginePres implements OnDestroy, DynamicConfigurableWithSignal
   });
 
   /** Input configuration to override the default configuration of the component */
-  public config = input<Partial<RulesEnginePresConfig>>();
+  public readonly config = input<Partial<RulesEnginePresConfig>>();
 
   @O3rConfig()
   public readonly configSignal = configSignal(

--- a/apps/showcase/src/components/showcase/sdk/sdk-pres.html
+++ b/apps/showcase/src/components/showcase/sdk/sdk-pres.html
@@ -69,7 +69,7 @@
         @for (pet of displayedPets(); track pet.id) {
           <tr>
             <td>
-              @if (pet.photoUrls?.[0]; as icon) {
+              @if (pet.photoUrls[0]; as icon) {
                 <img width="34" height="34" [src]="icon | otterIconPath" alt="{{icon}}" />
               }
             </td>

--- a/apps/showcase/src/components/training/code-editor-control/code-editor-control.ts
+++ b/apps/showcase/src/components/training/code-editor-control/code-editor-control.ts
@@ -5,7 +5,7 @@ import {
   computed,
   ElementRef,
   inject,
-  Input,
+  input,
   OnDestroy,
   viewChild,
   ViewEncapsulation,
@@ -51,7 +51,7 @@ export class CodeEditorControl implements OnDestroy, AfterViewInit {
   /**
    * Show the terminal used as output for the command process
    */
-  @Input() public showOutput = true;
+  public readonly showOutput = input(true);
 
   /**
    * Reference to the iframe used to display the content of the application served in the web container

--- a/apps/showcase/src/components/training/code-editor-terminal/code-editor-terminal.ts
+++ b/apps/showcase/src/components/training/code-editor-terminal/code-editor-terminal.ts
@@ -5,9 +5,8 @@ import {
   Component,
   DestroyRef,
   ElementRef,
-  EventEmitter,
   inject,
-  Output,
+  output,
   viewChild,
 } from '@angular/core';
 import {
@@ -42,20 +41,17 @@ export class CodeEditorTerminal implements AfterViewChecked, AfterViewInit {
    * Inform the parent that the terminal of the component has been created and is ready to use as input/output
    * of a process
    */
-  @Output()
-  public readonly terminalUpdated = new EventEmitter<Terminal>();
+  public readonly terminalUpdated = output<Terminal>();
 
   /**
    * Inform the parent that something got written in the terminal
    */
-  @Output()
-  public readonly terminalActivity = new EventEmitter<void>();
+  public readonly terminalActivity = output<void>();
 
   /**
    * Inform the parent that the terminal of the component has been disposed of
    */
-  @Output()
-  public readonly disposed = new EventEmitter<void>();
+  public readonly disposed = output<void>();
 
   constructor() {
     this.terminal.loadAddon(this.fitAddon);

--- a/apps/showcase/src/components/training/code-editor-view/code-editor-view.ts
+++ b/apps/showcase/src/components/training/code-editor-view/code-editor-view.ts
@@ -151,19 +151,19 @@ export class CodeEditorView implements OnDestroy {
   /**
    * Allow to edit the code in the monaco editor
    */
-  public editorMode = input<EditorMode>('readonly');
+  public readonly editorMode = input<EditorMode>('readonly');
 
   /**
    * Display terminal
    */
-  public displayTerminal = input<boolean>(true);
+  public readonly displayTerminal = input<boolean>(true);
 
   /**
    * Project to load in the code editor.
    * It should describe the files to load, the starting file, the folder dedicated to the project as well as the
    * commands to initialize the project
    */
-  public project = input.required<TrainingProject>();
+  public readonly project = input.required<TrainingProject>();
 
   /**
    * Service to load files and run commands in the application instance of the webcontainer.

--- a/apps/showcase/src/components/training/training-step/training-step-pres.ts
+++ b/apps/showcase/src/components/training/training-step/training-step-pres.ts
@@ -26,21 +26,21 @@ export class TrainingStepPres {
   /**
    * Description of the coding project to load in the code view editor
    */
-  public project = input<TrainingProject | undefined | null>();
+  public readonly project = input<TrainingProject | undefined | null>();
   /**
    * Whether to allow the user to modify the project files in the editor
    */
-  public editorMode = input<EditorMode>();
+  public readonly editorMode = input<EditorMode>();
   /**
    * Training step title
    */
-  public title = input<string>();
+  public readonly title = input<string>();
   /**
    * Training instructions to do the exercise
    */
-  public instructions = input<string>();
+  public readonly instructions = input<string>();
   /**
    * Display terminal
    */
-  public displayTerminal = input<boolean>(true);
+  public readonly displayTerminal = input<boolean>(true);
 }

--- a/apps/showcase/src/components/training/training.ts
+++ b/apps/showcase/src/components/training/training.ts
@@ -133,11 +133,11 @@ export class Training implements OnInit {
   );
 
   /** Path to the training assets */
-  public trainingPath = input('');
+  public readonly trainingPath = input('');
   /** Title of the training */
-  public title = input('');
+  public readonly title = input('');
   /** Feedback form link for this specific training */
-  public feedbackFormLink = input('');
+  public readonly feedbackFormLink = input('');
 
   private readonly dynamicContentService = inject(DynamicContentService);
   private readonly loggerService = inject(LoggerService);

--- a/apps/showcase/src/components/utilities/date-picker-input-hebrew/date-picker-input-hebrew-pres.ts
+++ b/apps/showcase/src/components/utilities/date-picker-input-hebrew/date-picker-input-hebrew-pres.ts
@@ -81,7 +81,7 @@ export class DatePickerHebrewInputPres implements ControlValueAccessor, DatePick
   public selectedDate = signal<NgbDate | null>(null);
 
   /** @inheritDoc */
-  public id = input.required<string>();
+  public readonly id = input.required<string>();
 
   private readonly calendar = inject(NgbCalendar);
 

--- a/apps/showcase/src/components/utilities/date-picker-input/date-picker-input-pres.ts
+++ b/apps/showcase/src/components/utilities/date-picker-input/date-picker-input-pres.ts
@@ -50,10 +50,10 @@ export class DatePickerInputPres implements ControlValueAccessor, DatePickerInpu
   /** Internal selected date by NgBootstrap */
   public dateControl = new FormControl<NgbDateStruct | undefined>(undefined, { nonNullable: true });
   /** @inheritDoc */
-  public id = input.required<string>();
+  public readonly id = input.required<string>();
 
   /** @inheritDoc */
-  public label = input<string | undefined>();
+  public readonly label = input<string | undefined>();
 
   constructor() {
     this.dateControl.valueChanges.pipe(

--- a/apps/showcase/src/components/utilities/forms-emergency-contact/forms-emergency-contact-pres.spec.ts
+++ b/apps/showcase/src/components/utilities/forms-emergency-contact/forms-emergency-contact-pres.spec.ts
@@ -24,6 +24,7 @@ describe('FormsEmergencyContactPres', () => {
 
     fixture = TestBed.createComponent(FormsEmergencyContactPres);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput('id', 'test-emergency-contact');
     fixture.detectChanges();
   });
 

--- a/apps/showcase/src/components/utilities/forms-emergency-contact/forms-emergency-contact-pres.ts
+++ b/apps/showcase/src/components/utilities/forms-emergency-contact/forms-emergency-contact-pres.ts
@@ -6,13 +6,13 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
-  EventEmitter,
   forwardRef,
   inject,
   Input,
+  input,
   type OnDestroy,
   type OnInit,
-  Output,
+  output,
   ViewEncapsulation,
 } from '@angular/core';
 import {
@@ -90,16 +90,16 @@ export class FormsEmergencyContactPres implements OnInit, OnDestroy, ControlValu
   public translations: FormsEmergencyContactPresTranslation = translations;
 
   /** ID of the parent component used to compute the ids of the form controls */
-  @Input() public id!: string;
+  public readonly id = input.required<string>();
 
   /** Custom validators applied on the form */
-  @Input() public customValidators?: CustomFormValidation<EmergencyContact>;
+  public readonly customValidators = input<CustomFormValidation<EmergencyContact>>();
 
   /** Register a function to be called when the submit is done outside of the presenter (from page) */
-  @Output() public registerInteraction: EventEmitter<() => void> = new EventEmitter<() => void>();
+  public registerInteraction = output<() => void>();
 
   /** Emit when the submit has been fired on the form */
-  @Output() public submitEmergencyContactForm: EventEmitter<void> = new EventEmitter<void>();
+  public submitEmergencyContactForm = output<void>();
 
   protected changeDetector = inject(ChangeDetectorRef);
 
@@ -155,9 +155,10 @@ export class FormsEmergencyContactPres implements OnInit, OnDestroy, ControlValu
    * Get custom validators and primitive validators and apply them on the form
    */
   public applyValidation() {
+    const customValidators = this.customValidators();
     const globalValidators = [];
-    if (this.customValidators && this.customValidators.global) {
-      globalValidators.push(this.customValidators.global);
+    if (customValidators && customValidators.global) {
+      globalValidators.push(customValidators.global);
     }
     this.form.setValidators(globalValidators);
 
@@ -166,15 +167,15 @@ export class FormsEmergencyContactPres implements OnInit, OnDestroy, ControlValu
     const phoneValidators = [Validators.required, Validators.pattern('^[0-9]{10}$')];
     const emailValidators = [Validators.email];
     /* eslint-enable @typescript-eslint/unbound-method */
-    if (this.customValidators && this.customValidators.fields) {
-      if (this.customValidators.fields.name) {
-        nameValidators.push(this.customValidators.fields.name);
+    if (customValidators && customValidators.fields) {
+      if (customValidators.fields.name) {
+        nameValidators.push(customValidators.fields.name);
       }
-      if (this.customValidators.fields.phone) {
-        phoneValidators.push(this.customValidators.fields.phone);
+      if (customValidators.fields.phone) {
+        phoneValidators.push(customValidators.fields.phone);
       }
-      if (this.customValidators.fields.email) {
-        emailValidators.push(this.customValidators.fields.email);
+      if (customValidators.fields.email) {
+        emailValidators.push(customValidators.fields.email);
       }
     }
     this.form.controls.name.setValidators(nameValidators);
@@ -197,7 +198,7 @@ export class FormsEmergencyContactPres implements OnInit, OnDestroy, ControlValu
       return {
         ...errorsMap,
         [controlFlatErrors.controlName || 'global']: {
-          htmlElementId: `${this.id}${controlFlatErrors.controlName || ''}`,
+          htmlElementId: `${this.id()}${controlFlatErrors.controlName || ''}`,
           errorMessages: (controlFlatErrors.customErrors || []).concat(
             controlFlatErrors.errors.map((error) => {
               const translationKey = `${this.componentSelector}.${controlFlatErrors.controlName || ''}.${error.errorKey}`;

--- a/apps/showcase/src/components/utilities/forms-personal-info/forms-personal-info-pres.spec.ts
+++ b/apps/showcase/src/components/utilities/forms-personal-info/forms-personal-info-pres.spec.ts
@@ -24,6 +24,8 @@ describe('FormsPersonalInfoPres', () => {
 
     fixture = TestBed.createComponent(FormsPersonalInfoPres);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput('id', 'test-personal-info');
+    fixture.componentRef.setInput('config', { nameMaxLength: 50 });
     fixture.detectChanges();
   });
 

--- a/apps/showcase/src/components/utilities/forms-personal-info/forms-personal-info-pres.ts
+++ b/apps/showcase/src/components/utilities/forms-personal-info/forms-personal-info-pres.ts
@@ -7,13 +7,13 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
-  EventEmitter,
   forwardRef,
   inject,
   Input,
+  input,
   type OnDestroy,
   type OnInit,
-  Output,
+  output,
   ViewEncapsulation,
 } from '@angular/core';
 import {
@@ -99,19 +99,19 @@ export class FormsPersonalInfoPres implements OnInit, OnDestroy, ControlValueAcc
   public translations: FormsPersonalInfoPresTranslation = translations;
 
   /** ID of the parent component used to compute the ids of the form controls */
-  @Input() public id!: string;
+  public readonly id = input.required<string>();
 
   /** Input configuration to override the default configuration of the component */
-  @Input() public config!: FormsPersonalInfoPresConfig;
+  public readonly config = input.required<FormsPersonalInfoPresConfig>();
 
   /** Custom validators applied on the form */
-  @Input() public customValidators?: CustomFormValidation<PersonalInfo>;
+  public readonly customValidators = input<CustomFormValidation<PersonalInfo>>();
 
   /** Register a function to be called when the submit is done outside of the presenter (from page) */
-  @Output() public registerInteraction: EventEmitter<() => void> = new EventEmitter<() => void>();
+  public registerInteraction = output<() => void>();
 
   /** Emit when the submit has been fired on the form */
-  @Output() public submitPersonalInfoForm: EventEmitter<void> = new EventEmitter<void>();
+  public submitPersonalInfoForm = output<void>();
 
   protected changeDetector = inject(ChangeDetectorRef);
 
@@ -169,24 +169,26 @@ export class FormsPersonalInfoPres implements OnInit, OnDestroy, ControlValueAcc
    * Get custom validators and primitive validators and apply them on the form
    */
   public applyValidation() {
+    const customValidators = this.customValidators();
+    const config = this.config();
     const globalValidators = [];
-    if (this.customValidators && this.customValidators.global) {
-      globalValidators.push(this.customValidators.global);
+    if (customValidators && customValidators.global) {
+      globalValidators.push(customValidators.global);
     }
     this.form.setValidators(globalValidators);
 
     // eslint-disable-next-line @typescript-eslint/unbound-method -- Validators are bound methods
     const nameValidators = [Validators.required];
     const dateOfBirthValidators = [];
-    if (this.config?.nameMaxLength) {
-      nameValidators.push(Validators.maxLength(this.config.nameMaxLength));
+    if (config?.nameMaxLength) {
+      nameValidators.push(Validators.maxLength(config.nameMaxLength));
     }
-    if (this.customValidators && this.customValidators.fields) {
-      if (this.customValidators.fields.name) {
-        nameValidators.push(this.customValidators.fields.name);
+    if (customValidators && customValidators.fields) {
+      if (customValidators.fields.name) {
+        nameValidators.push(customValidators.fields.name);
       }
-      if (this.customValidators.fields.dateOfBirth) {
-        dateOfBirthValidators.push(this.customValidators.fields.dateOfBirth);
+      if (customValidators.fields.dateOfBirth) {
+        dateOfBirthValidators.push(customValidators.fields.dateOfBirth);
       }
     }
     this.form.controls.name.setValidators(nameValidators);
@@ -208,7 +210,7 @@ export class FormsPersonalInfoPres implements OnInit, OnDestroy, ControlValueAcc
       return {
         ...errorsMap,
         [controlFlatErrors.controlName || 'global']: {
-          htmlElementId: `${this.id}${controlFlatErrors.controlName || ''}`,
+          htmlElementId: `${this.id()}${controlFlatErrors.controlName || ''}`,
           errorMessages: (controlFlatErrors.customErrors || []).concat(
             controlFlatErrors.errors.map((error) => {
               const translationKey = `${this.componentSelector}.${controlFlatErrors.controlName || ''}.${error.errorKey}`;

--- a/apps/showcase/src/components/utilities/otter-picker/otter-picker-pres.html
+++ b/apps/showcase/src/components/utilities/otter-picker/otter-picker-pres.html
@@ -1,12 +1,12 @@
 <div ngbDropdown class="d-inline-block w-100">
-  <button type="button" class="btn btn-outline-primary otter-dropdown w-100" [class.selected]="!!selectedOtter()" [id]="id" ngbDropdownToggle>
+  <button type="button" class="btn btn-outline-primary otter-dropdown w-100" [class.selected]="!!selectedOtter()" [id]="id()" ngbDropdownToggle>
     @if (selectedOtter()) {
       <div class="w-100"><img alt="Otter image" [src]="baseUrl+selectedOtter()" width="34" height="34" /></div>
     } @else {
       <span>Pick an icon</span>
     }
   </button>
-  <div ngbDropdownMenu [attr.aria-labelledby]="id">
+  <div ngbDropdownMenu [attr.aria-labelledby]="id()">
     <button ngbDropdownItem (click)="selectOtter('')">None</button>
     @for (otter of otters; track $index) {
       <button ngbDropdownItem (click)="selectOtter(otter)">

--- a/apps/showcase/src/components/utilities/otter-picker/otter-picker-pres.spec.ts
+++ b/apps/showcase/src/components/utilities/otter-picker/otter-picker-pres.spec.ts
@@ -16,6 +16,7 @@ describe('OtterPickerPres', () => {
     });
     fixture = TestBed.createComponent(OtterPickerPres);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput('id', 'test-otter-picker');
     fixture.detectChanges();
   });
 

--- a/apps/showcase/src/components/utilities/otter-picker/otter-picker-pres.ts
+++ b/apps/showcase/src/components/utilities/otter-picker/otter-picker-pres.ts
@@ -2,7 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   forwardRef,
-  Input,
+  input,
   signal,
   ViewEncapsulation,
 } from '@angular/core';
@@ -38,8 +38,7 @@ import {
 })
 export class OtterPickerPres implements ControlValueAccessor {
   /** ID of the html element used for selection */
-  @Input()
-  public id!: string;
+  public readonly id = input.required<string>();
 
   /** Currently selected otter */
   public selectedOtter = signal('');

--- a/apps/showcase/src/components/utilities/sidenav/sidenav-pres.html
+++ b/apps/showcase/src/components/utilities/sidenav/sidenav-pres.html
@@ -1,13 +1,13 @@
 <nav>
-    @for (group of linksGroups; track $index) {
+    @for (group of linksGroups(); track $index) {
       <nav class="nav nav-pills flex-column" [attr.aria-label]="group.label || null" [class.sub-group]="group.label">
         @if (group.label) {
           <div class="nav-group">{{group.label}}</div>
         }
         @for (link of group.links; track $index) {
           <a class="nav-link"
-              [class.active]="activeUrl === link.url"
-              [routerLinkActive]="activeUrl === link.url ? 'active' : ''"
+              [class.active]="activeUrl() === link.url"
+              [routerLinkActive]="activeUrl() === link.url ? 'active' : ''"
               ariaCurrentWhenActive="page"
               [routerLink]="link.url"
             >

--- a/apps/showcase/src/components/utilities/sidenav/sidenav-pres.ts
+++ b/apps/showcase/src/components/utilities/sidenav/sidenav-pres.ts
@@ -1,7 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  Input,
+  input,
   ViewEncapsulation,
 } from '@angular/core';
 import {
@@ -40,10 +40,8 @@ export class SidenavPres {
   /**
    * List of links' groups
    */
-  @Input()
-  public linksGroups: SideNavLinksGroup[] = [];
+  public readonly linksGroups = input<SideNavLinksGroup[]>([]);
 
   /** Active url */
-  @Input()
-  public activeUrl?: string | null = null;
+  public readonly activeUrl = input<string | null | undefined>(null);
 }

--- a/apps/showcase/src/main.ts
+++ b/apps/showcase/src/main.ts
@@ -3,11 +3,10 @@ import {
 } from '@ama-styling/devkit';
 import {
   inject,
-  provideZonelessChangeDetection,
   runInInjectionContext,
 } from '@angular/core';
 import {
-  platformBrowser,
+  bootstrapApplication,
 } from '@angular/platform-browser';
 import {
   ApplicationDevtoolsConsoleService,
@@ -29,13 +28,16 @@ import {
   LocalizationDevtoolsMessageService,
 } from '@o3r/transloco';
 import {
-  AppModule,
-} from './app/app-module';
+  App,
+} from './app/app';
+import {
+  appConfig,
+} from './app/app.config';
 
 document.body.dataset.dynamiccontentpath = localStorage.getItem('dynamicPath') || '';
-platformBrowser().bootstrapModule(AppModule, { applicationProviders: [provideZonelessChangeDetection()] })
-  .then((m) => {
-    runInInjectionContext(m.injector, () => {
+bootstrapApplication(App, appConfig)
+  .then((appRef) => {
+    runInInjectionContext(appRef.injector, () => {
       inject(ApplicationDevtoolsConsoleService);
       inject(ApplicationDevtoolsMessageService);
       inject(RulesEngineDevtoolsConsoleService);

--- a/packages/@ama-mfe/ng-utils/src/connect/connect-directive.ts
+++ b/packages/@ama-mfe/ng-utils/src/connect/connect-directive.ts
@@ -27,12 +27,12 @@ export class ConnectDirective {
   /**
    * The connection ID required for the message peer service.
    */
-  public connect = input.required<string>();
+  public readonly connect = input.required<string>();
 
   /**
    * The sanitized source URL for the iframe.
    */
-  public src = input<SafeResourceUrl>();
+  public readonly src = input<SafeResourceUrl>();
 
   /**
    * Binds the `src` attribute of the iframe to the sanitized source URL.

--- a/packages/@ama-mfe/ng-utils/src/navigation/route-memorize/route-memorize-directive.ts
+++ b/packages/@ama-mfe/ng-utils/src/navigation/route-memorize/route-memorize-directive.ts
@@ -25,29 +25,29 @@ export class RouteMemorizeDirective {
    * Whether to memorize the route.
    * Default is true.
    */
-  public memorizeRoute = input<boolean | undefined | ''>(true);
+  public readonly memorizeRoute = input<boolean | undefined | ''>(true);
 
   /**
    * The ID used to memorize the route.
    */
-  public memorizeRouteId = input<string>();
+  public readonly memorizeRouteId = input<string>();
 
   /**
    * The maximum age for memorizing the route.
    * Default is 0.
    */
-  public memorizeMaxAge = input<number>(0);
+  public readonly memorizeMaxAge = input<number>(0);
 
   /**
    * The maximum age for memorizing the route, used as a fallback.
    * Default is 0.
    */
-  public memorizeRouteMaxAge = input<number>(0);
+  public readonly memorizeRouteMaxAge = input<number>(0);
 
   /**
    * The connection ID for the iframe where the actual directive is applied.
    */
-  public connect = input<string>();
+  public readonly connect = input<string>();
 
   private readonly maxAge = computed(() => {
     return this.memorizeMaxAge() || this.memorizeRouteMaxAge();

--- a/packages/@ama-mfe/ng-utils/src/resize/scalable-directive.ts
+++ b/packages/@ama-mfe/ng-utils/src/resize/scalable-directive.ts
@@ -46,12 +46,12 @@ export class ScalableDirective {
   /**
    * The connection ID for the element, used as channel id backup
    */
-  public connect = input<string>();
+  public readonly connect = input<string>();
 
   /**
    * The channel id
    */
-  public scalable = input<string>();
+  public readonly scalable = input<string>();
 
   private readonly resizeHandler = inject(ResizeConsumerService);
   private readonly destroyRef = inject(DestroyRef);

--- a/packages/@ama-styling/devkit/src/core/styling-devtools-module.ts
+++ b/packages/@ama-styling/devkit/src/core/styling-devtools-module.ts
@@ -1,4 +1,6 @@
 import {
+  EnvironmentProviders,
+  makeEnvironmentProviders,
   ModuleWithProviders,
   NgModule,
 } from '@angular/core';
@@ -16,6 +18,9 @@ import {
   OTTER_STYLING_DEVTOOLS_OPTIONS,
 } from './styling-devtools-token';
 
+/**
+ * @deprecated Will be removed in v16. Use {@link provideStylingDevtools} instead.
+ */
 @NgModule({
   providers: [
     { provide: OTTER_STYLING_DEVTOOLS_OPTIONS, useValue: OTTER_STYLING_DEVTOOLS_DEFAULT_OPTIONS },
@@ -38,4 +43,16 @@ export class StylingDevtoolsModule {
       ]
     };
   }
+}
+
+/**
+ * Provide styling devtools functionality.
+ * @param options Optional partial styling devtools configuration to override defaults.
+ */
+export function provideStylingDevtools(options?: Partial<StylingDevtoolsServiceOptions>): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    { provide: OTTER_STYLING_DEVTOOLS_OPTIONS, useValue: { ...OTTER_STYLING_DEVTOOLS_DEFAULT_OPTIONS, ...options } },
+    StylingDevtoolsMessageService,
+    OtterStylingDevtools
+  ]);
 }

--- a/packages/@o3r/application/src/devkit/application-devtools-module.ts
+++ b/packages/@o3r/application/src/devkit/application-devtools-module.ts
@@ -1,4 +1,6 @@
 import {
+  EnvironmentProviders,
+  makeEnvironmentProviders,
   ModuleWithProviders,
   NgModule,
 } from '@angular/core';
@@ -19,6 +21,9 @@ import {
   OTTER_APPLICATION_DEVTOOLS_OPTIONS,
 } from './application-devtools-token';
 
+/**
+ * @deprecated Will be removed in v16. Use {@link provideApplicationDevtools} instead.
+ */
 @NgModule({
   providers: [
     { provide: OTTER_APPLICATION_DEVTOOLS_OPTIONS, useValue: OTTER_APPLICATION_DEVTOOLS_DEFAULT_OPTIONS },
@@ -43,4 +48,17 @@ export class ApplicationDevtoolsModule {
       ]
     };
   }
+}
+
+/**
+ * Provide application devtools functionality.
+ * @param options Application devtools options
+ */
+export function provideApplicationDevtools(options?: Partial<ApplicationDevtoolsServiceOptions>): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    { provide: OTTER_APPLICATION_DEVTOOLS_OPTIONS, useValue: { ...OTTER_APPLICATION_DEVTOOLS_DEFAULT_OPTIONS, ...options } },
+    ApplicationDevtoolsMessageService,
+    ApplicationDevtoolsConsoleService,
+    OtterApplicationDevtools
+  ]);
 }

--- a/packages/@o3r/components/src/devkit/components-devtools-module.ts
+++ b/packages/@o3r/components/src/devkit/components-devtools-module.ts
@@ -1,4 +1,6 @@
 import {
+  EnvironmentProviders,
+  makeEnvironmentProviders,
   ModuleWithProviders,
   NgModule,
 } from '@angular/core';
@@ -7,6 +9,7 @@ import {
 } from '@ngrx/store';
 import {
   PlaceholderTemplateStoreModule,
+  providePlaceholderTemplateStore,
 } from '../stores/placeholder-template/placeholder-template-module';
 import type {
   ComponentsDevtoolsServiceOptions,
@@ -19,6 +22,9 @@ import {
   OTTER_COMPONENTS_DEVTOOLS_OPTIONS,
 } from './components-devtools-token';
 
+/**
+ * @deprecated Will be removed in v16. Use {@link provideComponentsDevtools} instead.
+ */
 @NgModule({
   imports: [
     StoreModule,
@@ -43,4 +49,16 @@ export class ComponentsDevtoolsModule {
       ]
     };
   }
+}
+
+/**
+ * Provide components devtools functionality.
+ * @param options Components devtools options
+ */
+export function provideComponentsDevtools(options?: Partial<ComponentsDevtoolsServiceOptions>): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    providePlaceholderTemplateStore(),
+    { provide: OTTER_COMPONENTS_DEVTOOLS_OPTIONS, useValue: { ...OTTER_COMPONENTS_DEVTOOLS_DEFAULT_OPTIONS, ...options } },
+    ComponentsDevtoolsMessageService
+  ]);
 }

--- a/packages/@o3r/components/src/stores/placeholder-template/placeholder-template-module.ts
+++ b/packages/@o3r/components/src/stores/placeholder-template/placeholder-template-module.ts
@@ -1,11 +1,14 @@
 import {
+  EnvironmentProviders,
   InjectionToken,
+  makeEnvironmentProviders,
   ModuleWithProviders,
   NgModule,
 } from '@angular/core';
 import {
   Action,
   ActionReducer,
+  provideState,
   StoreModule,
 } from '@ngrx/store';
 import {
@@ -24,6 +27,9 @@ export function getDefaultPlaceholderTemplateReducer() {
   return placeholderTemplateReducer;
 }
 
+/**
+ * @deprecated Will be removed in v16. Use {@link providePlaceholderTemplateStore} instead.
+ */
 @NgModule({
   imports: [
     StoreModule.forFeature(PLACEHOLDER_TEMPLATE_STORE_NAME, PLACEHOLDER_TEMPLATE_REDUCER_TOKEN)
@@ -41,4 +47,14 @@ export class PlaceholderTemplateStoreModule {
       ]
     };
   }
+}
+
+/**
+ * Provide PlaceholderTemplate feature store.
+ * @param reducerFactory Optional factory to override the default reducer.
+ */
+export function providePlaceholderTemplateStore(reducerFactory?: () => ActionReducer<PlaceholderTemplateState, Action>): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    provideState(PLACEHOLDER_TEMPLATE_STORE_NAME, reducerFactory ? reducerFactory() : placeholderTemplateReducer)
+  ]);
 }

--- a/packages/@o3r/configuration/schematics/configuration-to-component/index.spec.ts
+++ b/packages/@o3r/configuration/schematics/configuration-to-component/index.spec.ts
@@ -126,7 +126,7 @@ export class NgComponent {}
     expect(tree.exists(o3rComponentPath.replace(/\.ts$/, '-config.ts'))).toBeTruthy();
     const componentFileContent = tree.readText(o3rComponentPath);
     expect(componentFileContent).toContain('DynamicConfigurableWithSignal<TestConfig>');
-    expect(componentFileContent).toContain('public config = input<Partial<TestConfig>>()');
+    expect(componentFileContent).toContain('public readonly config = input<Partial<TestConfig>>()');
     expect(componentFileContent).toContain('public readonly configSignal = configSignal(this.config, TEST_CONFIG_ID, TEST_DEFAULT_CONFIG)');
   });
 

--- a/packages/@o3r/configuration/schematics/configuration-to-component/index.ts
+++ b/packages/@o3r/configuration/schematics/configuration-to-component/index.ts
@@ -362,7 +362,7 @@ export function ngAddConfigFn(options: NgAddConfigSchematicsSchema): Rule {
               const visit = (node: ts.Node): ts.Node => {
                 if (ts.isClassDeclaration(node) && isO3rClassComponent(node)) {
                   const propertiesToAdd = generateClassElementsFromString(`
-  public config = input<Partial<${properties.componentConfig}>>();
+  public readonly config = input<Partial<${properties.componentConfig}>>();
 
   @O3rConfig()
   public readonly configSignal = configSignal(this.config, ${properties.configKey}_CONFIG_ID, ${properties.configKey}_DEFAULT_CONFIG);`);

--- a/packages/@o3r/configuration/schematics/use-config-signal/index.spec.ts
+++ b/packages/@o3r/configuration/schematics/use-config-signal/index.spec.ts
@@ -60,7 +60,7 @@ describe('Migrate to config signal-based', () => {
     const componentFileContent = tree.readText('my-component.ts');
 
     expect(componentFileContent).toContain('DynamicConfigurableWithSignal<MyConfig>');
-    expect(componentFileContent).toContain('public config = input<Partial<MyConfig>>()');
+    expect(componentFileContent).toContain('public readonly config = input<Partial<MyConfig>>()');
     expect(componentFileContent).toContain('public readonly configSignal = configSignal(this.config, MY_CONFIG_CONFIG_ID, MY_CONFIG_DEFAULT_CONFIG)');
     expect(componentFileContent).toContain('public readonly config$ = toObservable(this.configSignal)');
 

--- a/packages/@o3r/configuration/schematics/use-config-signal/index.ts
+++ b/packages/@o3r/configuration/schematics/use-config-signal/index.ts
@@ -77,7 +77,7 @@ function ngUseConfigSignalFn(options: NgUseConfigSignalSchematicsSchema): Rule {
           const visit = (node: ts.Node): ts.Node => {
             if (ts.isClassDeclaration(node) && isO3rClassComponent(node)) {
               const propertiesToAdd = generateClassElementsFromString(`
-  public config = input<Partial<${configName}>>();
+  public readonly config = input<Partial<${configName}>>();
 
   @O3rConfig()
   public readonly configSignal = configSignal(this.config, ${configId}, ${defaultConfig});

--- a/packages/@o3r/configuration/src/devkit/configuration-devtools-module.ts
+++ b/packages/@o3r/configuration/src/devkit/configuration-devtools-module.ts
@@ -1,4 +1,6 @@
 import {
+  EnvironmentProviders,
+  makeEnvironmentProviders,
   ModuleWithProviders,
   NgModule,
 } from '@angular/core';
@@ -7,6 +9,7 @@ import {
 } from '@ngrx/store';
 import {
   ConfigurationStoreModule,
+  provideConfigurationStore,
 } from '../stores/index';
 import {
   OtterConfigurationDevtools,
@@ -25,6 +28,9 @@ import {
   OTTER_CONFIGURATION_DEVTOOLS_OPTIONS,
 } from './configuration-devtools-token';
 
+/**
+ * @deprecated Will be removed in v16. Use {@link provideConfigurationDevtools} instead.
+ */
 @NgModule({
   imports: [
     StoreModule,
@@ -53,4 +59,18 @@ export class ConfigurationDevtoolsModule {
       ]
     };
   }
+}
+
+/**
+ * Provide configuration devtools functionality.
+ * @param options Configuration devtools options
+ */
+export function provideConfigurationDevtools(options?: Partial<ConfigurationDevtoolsServiceOptions>): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    provideConfigurationStore(),
+    { provide: OTTER_CONFIGURATION_DEVTOOLS_OPTIONS, useValue: { ...OTTER_CONFIGURATION_DEVTOOLS_DEFAULT_OPTIONS, ...options } },
+    ConfigurationDevtoolsMessageService,
+    ConfigurationDevtoolsConsoleService,
+    OtterConfigurationDevtools
+  ]);
 }

--- a/packages/@o3r/configuration/src/stores/configuration/configuration-module.ts
+++ b/packages/@o3r/configuration/src/stores/configuration/configuration-module.ts
@@ -1,11 +1,14 @@
 import {
+  EnvironmentProviders,
   InjectionToken,
+  makeEnvironmentProviders,
   ModuleWithProviders,
   NgModule,
 } from '@angular/core';
 import {
   Action,
   ActionReducer,
+  provideState,
   StoreModule,
 } from '@ngrx/store';
 import {
@@ -24,6 +27,9 @@ export function getDefaultConfigurationReducer() {
   return configurationReducer;
 }
 
+/**
+ * @deprecated Will be removed in v16. Use {@link provideConfigurationStore} instead.
+ */
 @NgModule({
   imports: [
     StoreModule.forFeature(CONFIGURATION_STORE_NAME, CONFIGURATION_REDUCER_TOKEN)
@@ -41,4 +47,14 @@ export class ConfigurationStoreModule {
       ]
     };
   }
+}
+
+/**
+ * Provide Configuration feature store.
+ * @param reducerFactory Optional factory to override the default reducer.
+ */
+export function provideConfigurationStore(reducerFactory?: () => ActionReducer<ConfigurationState, Action>): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    provideState(CONFIGURATION_STORE_NAME, reducerFactory ? reducerFactory() : configurationReducer)
+  ]);
 }

--- a/packages/@o3r/rules-engine/src/devkit/rules-engine-devtools-module.ts
+++ b/packages/@o3r/rules-engine/src/devkit/rules-engine-devtools-module.ts
@@ -1,4 +1,6 @@
 import {
+  EnvironmentProviders,
+  makeEnvironmentProviders,
   ModuleWithProviders,
   NgModule,
 } from '@angular/core';
@@ -6,11 +8,15 @@ import {
   StoreModule,
 } from '@ngrx/store';
 import {
+  provideRulesetsStore,
   RulesetsStoreModule,
 } from '../stores/index';
 import type {
   RulesEngineDevtoolsServiceOptions,
 } from './rules-engine-devkit-interface';
+import {
+  OtterRulesEngineDevtools,
+} from './rules-engine-devtools';
 import {
   RulesEngineDevtoolsConsoleService,
 } from './rules-engine-devtools-console-service';
@@ -22,6 +28,9 @@ import {
   OTTER_RULES_ENGINE_DEVTOOLS_OPTIONS,
 } from './rules-engine-devtools-token';
 
+/**
+ * @deprecated Will be removed in v16. Use {@link provideRulesEngineDevtools} instead.
+ */
 @NgModule({
   imports: [
     StoreModule,
@@ -48,4 +57,18 @@ export class RulesEngineDevtoolsModule {
       ]
     };
   }
+}
+
+/**
+ * Provide rules engine devtools functionality.
+ * @param options Rules engine devtools options
+ */
+export function provideRulesEngineDevtools(options?: Partial<RulesEngineDevtoolsServiceOptions>): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    provideRulesetsStore(),
+    { provide: OTTER_RULES_ENGINE_DEVTOOLS_OPTIONS, useValue: { ...OTTER_RULES_ENGINE_DEVTOOLS_DEFAULT_OPTIONS, ...options } },
+    RulesEngineDevtoolsMessageService,
+    RulesEngineDevtoolsConsoleService,
+    OtterRulesEngineDevtools
+  ]);
 }

--- a/packages/@o3r/rules-engine/src/services/runner/rules-engine-runner-module.ts
+++ b/packages/@o3r/rules-engine/src/services/runner/rules-engine-runner-module.ts
@@ -1,4 +1,6 @@
 import {
+  EnvironmentProviders,
+  makeEnvironmentProviders,
   ModuleWithProviders,
   NgModule,
 } from '@angular/core';
@@ -9,6 +11,7 @@ import {
   provideLogger,
 } from '@o3r/logger';
 import {
+  provideRulesetsStore,
   RulesetsStoreModule,
 } from '../../stores/index';
 import {
@@ -20,6 +23,9 @@ import {
   RulesEngineRunnerService,
 } from './rules-engine-runner-service';
 
+/**
+ * @deprecated Will be removed in v16. Use {@link provideRulesEngineRunner} instead.
+ */
 @NgModule({
   imports: [
     StoreModule,
@@ -38,4 +44,18 @@ export class RulesEngineRunnerModule {
       ]
     };
   }
+}
+
+/**
+ * Provide rules engine runner service.
+ * @param options Rules engine service options
+ */
+export function provideRulesEngineRunner(options?: Partial<RulesEngineServiceOptions>): EnvironmentProviders {
+  const opts = options ? { ...DEFAULT_RULES_ENGINE_OPTIONS, ...options } : DEFAULT_RULES_ENGINE_OPTIONS;
+  return makeEnvironmentProviders([
+    provideRulesetsStore(),
+    provideLogger(),
+    { provide: RULES_ENGINE_OPTIONS, useValue: opts },
+    RulesEngineRunnerService
+  ]);
 }

--- a/packages/@o3r/rules-engine/src/stores/rulesets/rulesets-module.ts
+++ b/packages/@o3r/rules-engine/src/stores/rulesets/rulesets-module.ts
@@ -1,14 +1,18 @@
 import {
+  EnvironmentProviders,
   InjectionToken,
+  makeEnvironmentProviders,
   ModuleWithProviders,
   NgModule,
 } from '@angular/core';
 import {
   EffectsModule,
+  provideEffects,
 } from '@ngrx/effects';
 import {
   Action,
   ActionReducer,
+  provideState,
   StoreModule,
 } from '@ngrx/store';
 import {
@@ -30,6 +34,9 @@ export function getDefaultRulesetsReducer() {
   return rulesetsReducer;
 }
 
+/**
+ * @deprecated Will be removed in v16. Use {@link provideRulesetsStore} instead.
+ */
 @NgModule({
   imports: [
     StoreModule.forFeature(RULESETS_STORE_NAME, RULESETS_REDUCER_TOKEN), EffectsModule.forFeature([RulesetsEffect])
@@ -47,4 +54,15 @@ export class RulesetsStoreModule {
       ]
     };
   }
+}
+
+/**
+ * Provide Rulesets feature store.
+ * @param reducerFactory Optional factory to override the default reducer.
+ */
+export function provideRulesetsStore(reducerFactory?: () => ActionReducer<RulesetsState, Action>): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    provideState(RULESETS_STORE_NAME, reducerFactory ? reducerFactory() : rulesetsReducer),
+    provideEffects(RulesetsEffect)
+  ]);
 }

--- a/packages/@o3r/transloco/src/rules-engine/localization-rules-engine-module.ts
+++ b/packages/@o3r/transloco/src/rules-engine/localization-rules-engine-module.ts
@@ -1,4 +1,6 @@
 import {
+  EnvironmentProviders,
+  makeEnvironmentProviders,
   NgModule,
 } from '@angular/core';
 import {
@@ -6,8 +8,12 @@ import {
 } from './localization-rules-engine-action-handler';
 import {
   LocalizationOverrideStoreModule,
+  provideLocalizationOverrideStore,
 } from '@o3r/transloco';
 
+/**
+ * @deprecated Will be removed in v16. Use {@link provideLocalizationRulesEngineAction} instead.
+ */
 @NgModule({
   imports: [
     LocalizationOverrideStoreModule
@@ -17,3 +23,11 @@ import {
   ]
 })
 export class LocalizationRulesEngineActionModule {}
+
+/** Provide localization rules engine action handler. */
+export function provideLocalizationRulesEngineAction(): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    provideLocalizationOverrideStore(),
+    LocalizationRulesEngineActionHandler
+  ]);
+}

--- a/packages/@o3r/transloco/src/stores/localization-override/localization-override-module.ts
+++ b/packages/@o3r/transloco/src/stores/localization-override/localization-override-module.ts
@@ -1,11 +1,14 @@
 import {
+  EnvironmentProviders,
   InjectionToken,
+  makeEnvironmentProviders,
   ModuleWithProviders,
   NgModule,
 } from '@angular/core';
 import {
   Action,
   ActionReducer,
+  provideState,
   StoreModule,
 } from '@ngrx/store';
 import {
@@ -26,6 +29,7 @@ export function getDefaultLocalizationOverrideReducer() {
 
 /**
  * NgModule for localization override store.
+ * @deprecated Will be removed in v16. Use {@link provideLocalizationOverrideStore} instead.
  */
 @NgModule({
   imports: [
@@ -44,4 +48,14 @@ export class LocalizationOverrideStoreModule {
       ]
     };
   }
+}
+
+/**
+ * Provide LocalizationOverride feature store.
+ * @param reducerFactory Optional factory to override the default reducer.
+ */
+export function provideLocalizationOverrideStore(reducerFactory?: () => ActionReducer<LocalizationOverrideState, Action>): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    provideState(LOCALIZATION_OVERRIDE_STORE_NAME, reducerFactory ? reducerFactory() : localizationOverrideReducer)
+  ]);
 }


### PR DESCRIPTION
…gnal APIs

Convert the showcase app from NgModule-based bootstrap to standalone bootstrapApplication with fully standalone providers (no importProvidersFrom).

- Migrate @Input/@Output decorators to signal-based input()/output() APIs
- Replace StoreModule/EffectsModule with provideStore/provideState/provideEffects
- Add provide* functions to library packages as standalone alternatives to their NgModules (deprecated, to be removed in v16): provideLocalizationOverrideStore, provideLocalizationRulesEngineAction, provideRulesetsStore, provideRulesEngineRunner, provideRulesEngineDevtools, providePlaceholderTemplateStore, provideComponentsDevtools, provideConfigurationStore, provideConfigurationDevtools, provideApplicationDevtools, provideStylingDevtools

## Proposed change

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
