### PR TITLE
fix(core): update package entrypoint metadata

### DIFF
--- a/packages/@o3r/core/package.json
+++ b/packages/@o3r/core/package.json
@@ -30,8 +30,8 @@
     "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest",
     "postbuild": "patch-package-json-main"
   },
-  "main": "./src/public_api.js",
-  "types": "./src/public_api.d.ts",
+  "main": "./dist/fesm2022/o3r-core.mjs",
+  "types": "./dist/types/o3r-core.d.ts",
   "peerDependencies": {
     "@angular-devkit/architect": ">=0.2100.0 <0.2200.0-0",
     "@angular-devkit/core": "^21.0.0",


### PR DESCRIPTION
## Problem

`@o3r/core@14.3.2` publishes top-level `main` and `types` entries that point to `./src/public_api.js` and `./src/public_api.d.ts`, but those files are not included in the npm tarball.

The package already exposes the generated files through `exports`:

- `./fesm2022/o3r-core.mjs`
- `./types/o3r-core.d.ts`

## Fix

Point the source package metadata to the generated files under `dist/`. The existing `patch-package-json-main` postbuild step strips the leading `dist/` before publish, producing valid package metadata in the npm tarball.

## Validation

- Verified `@o3r/core@14.3.2` tarball lacks `src/public_api.*`
- Verified tarball contains `fesm2022/o3r-core.mjs` and `types/o3r-core.d.ts`
- Verified local postbuild path transform would produce `./fesm2022/o3r-core.mjs` and `./types/o3r-core.d.ts`
- `git diff --check`