### PR TITLE
feat(plugins): add Playwright E2E testing skill for Otter plugin

### DIFF
--- a/tools/llm/plugins/otter/skills/playwright-e2e-testing/SKILL.md
+++ b/tools/llm/plugins/otter/skills/playwright-e2e-testing/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: playwright-e2e-testing
+description: This skill should be used when the user asks to "create an E2E test", "write a Playwright scenario", "add a Playwright test", "generate e2e tests", "create actions and checks", "write playwright checks", "add scenario for feature", or when modifying, reviewing, or debugging Playwright E2E test files in the workspace.
+---
+
+# Playwright E2E Testing
+
+Standardized architecture and creation process for Playwright end-to-end tests. Enforces a three-layer separation (Actions / Checks / Scenarios), a mandatory 3-gate creation workflow, and consistent coding standards across all UI teams.
+
+## Tooling: Playwright CLI vs Playwright MCP
+
+Use the right tool for each phase of the workflow:
+
+| Phase | Tool | Why |
+|-------|------|-----|
+| **Exploring the app** (understanding UI, discovering selectors, navigating flows) | **Playwright MCP** | Designed for exploratory automation — headed mode, structured accessibility snapshots in context |
+| **Writing & running tests** (authoring test code, debugging failures, CI) | **Playwright CLI** (`@playwright/cli`) | Designed for coding agents in large codebases — lower token cost, headless, concise output |
+
+### Playwright MCP — for exploration
+
+Use Playwright MCP tools when you need to:
+- Navigate the application to understand its structure before writing tests
+- Discover available roles, labels, and test IDs on a page
+- Verify a user journey works interactively before codifying it
+
+### Playwright CLI — for test authoring
+
+Use the CLI when you need to:
+- Verify test behavior during development (`playwright-cli open <url> --headed`)
+- Debug failing selectors by inspecting snapshots (`playwright-cli snapshot`)
+- Prototype interactions before writing test code (`playwright-cli click <ref>`, `playwright-cli fill <ref> <text>`)
+- Run tests in headless mode for validation
+
+## Architecture: Actions / Checks / Scenarios
+
+All E2E test code follows a strict separation of concerns:
+
+| Layer | Directory | Contains | Rules |
+|-------|-----------|----------|-------|
+| **Actions** | `actions/<journey>-actions.ts` | User interactions (clicks, types, navigations) | No assertions. No side effects beyond UI interaction. Reusable across scenarios. |
+| **Checks** | `checks/<journey>-checks.ts` | Assertions (visibility, text, state) | No interactions. Pure verification. Composable. |
+| **Scenarios** | `scenarios/<feature>/` | Composers wiring actions + checks | Readable as Given-When-Then. One journey per scenario. |
+
+**Why this separation matters:**
+- Actions are reusable across scenarios (same interaction, different assertions)
+- Checks are composable (combine for smoke vs. full regression)
+- Scenarios read as requirements documentation
+- Flaky tests are isolated to one layer (broken selector? fix in one action)
+
+### File structure
+
+```
+e2e-playwright/
+├── actions/<journey>-actions.ts
+├── checks/<journey>-checks.ts
+├── scenarios/<feature>/
+│   └── <name>.e2e.spec.ts
+```
+
+## 3-Gate Creation Process (Mandatory)
+
+Before generating any scenario file, pass all 3 gates in order. Skipping any gate is a violation.
+
+### Gate 1: Confirm Inputs
+
+Present the following to the user for explicit approval:
+- Feature name
+- Scenario name
+
+Do NOT proceed without explicit user confirmation.
+
+### Gate 2: Deduplication Check
+
+Search existing scenarios for overlap:
+
+1. Search all files under `scenarios/`, `actions/`, and `checks/` for the primary action/feature keywords
+2. For each match, compute: `shared_steps / max(existing_steps, new_steps) * 100`
+3. Present results with recommendation:
+   - **>=70%** overlap: complement existing scenario with missing steps, do not create new
+   - **40-70%** overlap: extract shared steps into helper, create new scenario
+   - **<40%** overlap: create new scenario (with user approval)
+
+### Gate 3: Flow Approval
+
+Present the planned sequence of actions and checks to the user as a step-by-step flow (Given/When/Then). The user confirms it matches the expected behavior. Only after all 3 gates pass, generate files.
+
+## Coding Standards Summary
+
+Action helpers: `Page` as first argument, wait for resulting UI state, return `void`, name describes user intent.
+
+Check helpers: `Page` as first argument, `expect()` assertions only, name describes expected state.
+
+Scenario composition: No raw Playwright calls — only action/check helpers. Comments mark Given/When/Then boundaries. One journey per file.
+
+### Selector Priority
+
+1. Role-based: `getByRole('button', { name: /submit/i })` (preferred)
+2. Label-based: `getByLabel('Email address')` (form fields)
+3. Test ID: `getByTestId('item-0')` (when no accessible role)
+4. Text: `getByText('Continue')` (visible content)
+5. CSS (last resort): `page.locator('.item')` (avoid)
+
+Never use XPath, auto-generated class names, or DOM position without semantic meaning.
+
+### Wait Strategy
+
+- After navigation: `waitForLoadState('networkidle')` or `waitForURL()`
+- After interaction: `expect(element).toBeVisible()` or `toBeEnabled()`
+- After form submit: wait for response or next page indicator
+- Never use `waitForTimeout()` with hardcoded values
+
+### Tagging
+
+Use tags to categorize tests by kind for filtering:
+
+```typescript
+test.describe('Feature Name @happy-path', () => {
+  test('should complete the main flow', async ({ page }) => { ... });
+  test('should display correctly @visual', async ({ page }) => { ... });
+});
+```
+
+Common tags: `@happy-path`, `@visual`, `@edge-case`, `@regression`.
+
+## Anti-Patterns (Hard Rules)
+
+- Assertions inside action helpers (mixing concerns)
+- Raw `page.click()` / `page.fill()` in scenario files (bypasses action layer)
+- Hardcoded `waitForTimeout()` (slow, flaky)
+- CSS/XPath selectors when role-based available
+- Skipping dedup check (creates maintenance burden)
+- Missing tags in test titles (breaks filtering)
+- Mock wiring logic in scenario (breaks reusability)
+- Testing implementation details (CSS classes, internal state)
+- Extracting actions/checks into shared `actions/` or `checks/` directories before a second scenario needs them (premature abstraction — keep scenario-specific helpers as local functions in the spec file until reuse is needed)
+
+## Stop Rules
+
+Halt and request user input if:
+- Any of the 3 gates has not passed
+- Deduplication check was skipped
+- Architecture violation detected (assertions in actions, raw selectors in scenarios)
+
+## Additional Resources
+
+### Reference Files
+
+For detailed patterns, code examples, and advanced techniques:
+- **`references/coding-standards.md`** — Complete action, check, and scenario code examples with patterns
+- **`references/creation-process.md`** — Detailed 3-gate process with deduplication scoring examples
+- **`references/accessibility.md`** — Accessibility testing coverage requirements and patterns

--- a/tools/llm/plugins/otter/skills/playwright-e2e-testing/references/accessibility.md
+++ b/tools/llm/plugins/otter/skills/playwright-e2e-testing/references/accessibility.md
@@ -1,0 +1,257 @@
+# Accessibility Testing Reference
+
+Accessibility coverage requirements and patterns for Playwright E2E tests.
+
+## Coverage Requirements
+
+For each scenario, add parallel accessibility coverage:
+
+1. **Keyboard-only variant** — same journey navigated via Tab/Enter/Space
+2. **Axe scan** — automated accessibility audit at key page states
+3. **Focus management** — verify focus moves to expected elements after interactions
+
+## Keyboard-Only Variants
+
+Replicate the scenario journey using only keyboard navigation. Tag with `@a11y`.
+
+### Example
+
+```typescript
+// scenarios/add-to-cart/add-to-cart-keyboard.e2e.spec.ts
+test.describe('Add to Cart - Keyboard @happy-path @a11y', () => {
+  test('complete flow via keyboard only', async ({ page }) => {
+    // Given
+    await actions.navigateToCatalog(page);
+    await keyboardActions.focusSearchAndType(page, 'laptop');
+    await keyboardActions.submitWithEnter(page);
+
+    // When
+    await keyboardActions.tabToAndActivate(page); // first result
+    await keyboardActions.tabToAndActivate(page); // add-to-cart button
+
+    // Then
+    await checks.verifyItemInCart(page, 'Laptop');
+  });
+});
+```
+
+### Keyboard Navigation Patterns
+
+| Action | Keys | Notes |
+|--------|------|-------|
+| Move to next interactive element | `Tab` | Forward navigation |
+| Move to previous element | `Shift+Tab` | Backward navigation |
+| Activate button/link | `Enter` | Triggers click |
+| Toggle checkbox/radio | `Space` | Toggles state |
+| Open dropdown | `Enter` or `Space` | Context-dependent |
+| Navigate dropdown options | `Arrow Down` / `Arrow Up` | Within open dropdown |
+| Select dropdown option | `Enter` | Confirms selection |
+| Close modal/dialog | `Escape` | Should return focus |
+| Navigate tabs | `Arrow Left` / `Arrow Right` | Within tablist |
+
+## Axe Accessibility Scans
+
+Run automated accessibility audits at key states in the journey.
+
+### Setup with @axe-core/playwright
+
+```typescript
+test.describe('Catalog Page Accessibility @a11y', () => {
+  test('catalog page meets WCAG 2.1 AA', async ({ page }) => {
+    // Given
+    await actions.navigateToCatalog(page);
+
+    // Then
+    await a11yChecks.verifyNoAxeViolations(page);
+  });
+
+  test('search results meet WCAG 2.1 AA', async ({ page }) => {
+    // Given
+    await actions.navigateToCatalog(page);
+
+    // When
+    await actions.searchProducts(page, { query: 'laptop' });
+
+    // Then
+    await a11yChecks.verifyNoAxeViolations(page);
+  });
+});
+```
+
+### When to Run Axe Scans
+
+Run an axe scan at each significant page state transition:
+- Initial page load
+- After form submission
+- After navigation to a new page/view
+- After modal/dialog opens
+- After dynamic content loads (search results, filtered lists)
+
+### Handling Violations
+
+When violations are found:
+- Group by impact level (critical > serious > moderate > minor)
+- Critical and serious violations must be fixed before merge
+- Moderate violations should be tracked as tech debt
+- Minor violations are informational
+
+## Focus Management Checks
+
+Verify that focus moves predictably after interactions.
+
+### Common Focus Expectations
+
+| Interaction | Expected Focus Target |
+|-------------|----------------------|
+| Modal opens | First focusable element in modal |
+| Modal closes | Element that triggered the modal |
+| Form submit (success) | Success message or next page first heading |
+| Form submit (error) | First invalid field or error summary |
+| Tab/accordion toggle | Content area of opened panel |
+| Delete action | Next item in list, or empty state message |
+| Page navigation | Main content heading (`h1`) |
+
+### Example: Focus Check Helpers (Pure Assertions)
+
+```typescript
+// checks/a11y-checks.ts
+export async function verifyFocusOnElement(
+  page: Page,
+  role: AriaRole,
+  options?: { name?: string | RegExp }
+): Promise<void> {
+  const element = page.getByRole(role, options);
+  await expect(element).toBeFocused();
+}
+
+export async function verifyFocusInsideContainer(
+  page: Page,
+  container: Locator
+): Promise<void> {
+  await expect(container.locator(':focus')).toHaveCount(1);
+}
+
+export async function verifyFocusReturnedTo(
+  page: Page,
+  element: Locator
+): Promise<void> {
+  await expect(element).toBeFocused();
+}
+```
+
+### Example: Focus Management Actions (Interactions)
+
+```typescript
+// actions/keyboard-actions.ts
+export async function tabThroughElements(page: Page, count: number): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    await page.keyboard.press('Tab');
+  }
+}
+
+export async function shiftTabThroughElements(page: Page, count: number): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    await page.keyboard.press('Shift+Tab');
+  }
+}
+
+export async function closeModalViaEscape(page: Page): Promise<void> {
+  await page.keyboard.press('Escape');
+}
+```
+
+### Example: Focus Trap Scenario (Composing Actions + Checks)
+
+```typescript
+// scenarios/focus-trap/focus-trap.e2e.spec.ts
+export async function focusTrapScenario(
+  page: Page,
+  container: Locator,
+  focusableCount: number
+): Promise<void> {
+  // When: tab forward through all focusable elements
+  for (let i = 0; i < focusableCount; i++) {
+    await keyboardActions.tabThroughElements(page, 1);
+    // Then: focus remains inside container
+    await a11yChecks.verifyFocusInsideContainer(page, container);
+  }
+
+  // When: tab one more time (should cycle forward)
+  await keyboardActions.tabThroughElements(page, 1);
+  // Then: focus wraps back inside container
+  await a11yChecks.verifyFocusInsideContainer(page, container);
+
+  // When: shift+tab backward through all focusable elements
+  for (let i = 0; i < focusableCount; i++) {
+    await keyboardActions.shiftTabThroughElements(page, 1);
+    // Then: focus remains inside container
+    await a11yChecks.verifyFocusInsideContainer(page, container);
+  }
+
+  // When: shift+tab one more time (should cycle backward)
+  await keyboardActions.shiftTabThroughElements(page, 1);
+  // Then: focus wraps back inside container
+  await a11yChecks.verifyFocusInsideContainer(page, container);
+}
+
+export async function modalFocusBehaviorScenario(
+  page: Page,
+  triggerName: string | RegExp,
+  modalRole: AriaRole
+): Promise<void> {
+  const trigger = page.getByRole('button', { name: triggerName });
+  const modal = page.getByRole(modalRole);
+
+  // When: activate trigger via keyboard
+  await trigger.focus();
+  await page.keyboard.press('Enter');
+  // Then: focus moves inside modal
+  await a11yChecks.verifyFocusInsideContainer(page, modal);
+
+  // When: close modal
+  await keyboardActions.closeModalViaEscape(page);
+  // Then: focus returns to trigger
+  await a11yChecks.verifyFocusReturnedTo(page, trigger);
+}
+```
+
+## Integrating Accessibility into Existing Scenarios
+
+For each existing scenario, create a parallel accessibility file in the same directory:
+
+```
+scenarios/add-to-cart/
+├── add-to-cart.e2e.spec.ts          ← functional test
+├── add-to-cart-keyboard.e2e.spec.ts ← keyboard variant
+└── add-to-cart-a11y.e2e.spec.ts     ← axe + focus checks
+```
+
+The accessibility scenario reuses the same flow but adds axe scans at key states and verifies focus management:
+
+```typescript
+// scenarios/add-to-cart/add-to-cart-a11y.e2e.spec.ts
+test.describe('Add to Cart - Accessibility @happy-path @a11y', () => {
+  test('meets WCAG 2.1 AA throughout flow', async ({ page }) => {
+    // Given
+    await actions.navigateToCatalog(page);
+    await a11yChecks.verifyNoAxeViolations(page);
+
+    // When
+    await actions.searchProducts(page, { query: 'laptop' });
+    await a11yChecks.verifyNoAxeViolations(page);
+
+    // Then
+    await actions.selectProduct(page, 0);
+    await a11yChecks.verifyFocusOnElement(page, 'heading', { name: /laptop/i });
+  });
+});
+```
+
+## Tag Convention for Accessibility Tests
+
+All accessibility tests must include `@a11y` in the title.
+
+This enables filtering:
+```bash
+npx playwright test --grep "@a11y" # all accessibility tests
+```

--- a/tools/llm/plugins/otter/skills/playwright-e2e-testing/references/coding-standards.md
+++ b/tools/llm/plugins/otter/skills/playwright-e2e-testing/references/coding-standards.md
@@ -1,0 +1,200 @@
+# Coding Standards Reference
+
+Complete code examples and patterns for the Actions / Checks / Scenarios architecture.
+
+## Action Helpers
+
+Action helpers encapsulate user interactions. They live in `actions/<journey>-actions.ts`.
+
+### Rules
+
+- `Page` as first argument (consistent signature across all helpers)
+- Wait for resulting UI state after each interaction (not hardcoded timeouts)
+- Return `void`
+- Name describes user intent (`addItemToCart` not `clickButton`)
+- No assertions — never use `expect()` in actions (that belongs in checks)
+- No side effects beyond UI interaction
+
+### Example: Product Catalog Actions
+
+```typescript
+// actions/catalog-actions.ts
+export async function navigateToCatalog(page: Page): Promise<void> {
+  await page.goto('/products');
+  await page.waitForLoadState('networkidle');
+}
+
+export async function searchProducts(
+  page: Page,
+  params: { query: string; category?: string }
+): Promise<void> {
+  await page.getByLabel('Search').fill(params.query);
+  if (params.category) {
+    await page.getByRole('combobox', { name: /category/i }).selectOption(params.category);
+  }
+  await page.getByRole('button', { name: /search/i }).click();
+  await page.waitForLoadState('networkidle');
+}
+
+export async function selectProduct(page: Page, index: number): Promise<void> {
+  await page.getByRole('listitem').nth(index).getByRole('link').click();
+  await page.waitForLoadState('networkidle');
+}
+
+export async function addToCart(page: Page): Promise<void> {
+  await page.getByRole('button', { name: /add to cart/i }).click();
+  await page.waitForLoadState('networkidle');
+}
+
+export async function fillShippingDetails(
+  page: Page,
+  details: { firstName: string; lastName: string; email: string }
+): Promise<void> {
+  await page.getByLabel('First name').fill(details.firstName);
+  await page.getByLabel('Last name').fill(details.lastName);
+  await page.getByLabel('Email').fill(details.email);
+}
+```
+
+## Check Helpers
+
+Check helpers encapsulate assertions. They live in `checks/<journey>-checks.ts`.
+
+### Rules
+
+- `Page` as first argument
+- `expect()` assertions only — no interactions
+- Name describes expected state (`verifyItemInCart` not `checkListItem`)
+- Composable — multiple checks can be combined in different scenarios
+- No waiting for state transitions (that belongs in actions)
+
+### Example: Product Catalog Checks
+
+```typescript
+// checks/catalog-checks.ts
+export async function verifySearchResultsDisplayed(
+  page: Page,
+  expectedCount?: number
+): Promise<void> {
+  const results = page.getByRole('listitem');
+  await expect(results.first()).toBeVisible();
+  if (expectedCount !== undefined) {
+    await expect(results).toHaveCount(expectedCount);
+  }
+}
+
+export async function verifyProductDetailPage(
+  page: Page,
+  productName: string
+): Promise<void> {
+  await expect(page.getByRole('heading', { name: productName })).toBeVisible();
+  await expect(page.getByRole('button', { name: /add to cart/i })).toBeVisible();
+}
+
+export async function verifyItemInCart(
+  page: Page,
+  itemName: string
+): Promise<void> {
+  await expect(page.getByRole('region', { name: /cart/i })).toContainText(itemName);
+}
+
+export async function verifyOrderConfirmation(page: Page): Promise<void> {
+  await expect(page.getByRole('heading', { name: /order confirmed/i })).toBeVisible();
+  await expect(page.getByText(/order number/i)).toBeVisible();
+}
+
+export async function verifyErrorMessage(
+  page: Page,
+  message: string | RegExp
+): Promise<void> {
+  await expect(page.getByRole('alert')).toContainText(message);
+}
+```
+
+## Scenario Composition (Given-When-Then)
+
+Scenarios wire actions and checks into readable journeys. They live in `scenarios/<feature>/`.
+
+### Rules
+
+- No raw Playwright calls — only action/check helpers
+- Comments mark Given/When/Then boundaries
+- One journey per scenario file
+
+### Example: Generic Scenario
+
+```typescript
+// scenarios/add-to-cart/add-to-cart.e2e.spec.ts
+export async function addToCartScenario(page: Page): Promise<void> {
+  // Given
+  await actions.navigateToCatalog(page);
+  await actions.searchProducts(page, { query: 'laptop' });
+  await actions.selectProduct(page, 0);
+
+  // When
+  await actions.addToCart(page);
+
+  // Then
+  await checks.verifyItemInCart(page, 'Laptop');
+}
+```
+
+## Selector Strategy — Extended Examples
+
+### Role-based (preferred)
+
+```typescript
+page.getByRole('button', { name: /submit/i });
+page.getByRole('link', { name: 'Home' });
+page.getByRole('heading', { level: 1 });
+page.getByRole('combobox', { name: /country/i });
+page.getByRole('tab', { name: /details/i });
+page.getByRole('dialog');
+```
+
+### Label-based (form fields)
+
+```typescript
+page.getByLabel('Email address');
+page.getByLabel('Password');
+page.getByPlaceholder('Search...');
+```
+
+### Test ID (when no accessible role)
+
+```typescript
+page.getByTestId('product-card-0');
+page.getByTestId('price-breakdown');
+```
+
+### Text (visible content)
+
+```typescript
+page.getByText('No results found');
+page.getByText(/total: \$\d+/i);
+```
+
+## Wait Strategy Patterns
+
+```typescript
+// After navigation
+await page.goto('/products');
+await page.waitForLoadState('networkidle');
+
+// After click that triggers navigation
+await page.getByRole('link', { name: 'Details' }).click();
+await page.waitForURL('**/details/**');
+
+// After interaction that reveals content
+await page.getByRole('button', { name: /expand/i }).click();
+await expect(page.getByRole('region', { name: /details/i })).toBeVisible();
+
+// After form submit
+await page.getByRole('button', { name: /submit/i }).click();
+await expect(page.getByText(/success/i)).toBeVisible();
+
+// Waiting for API response
+const responsePromise = page.waitForResponse('**/api/orders');
+await page.getByRole('button', { name: /place order/i }).click();
+await responsePromise;
+```

--- a/tools/llm/plugins/otter/skills/playwright-e2e-testing/references/creation-process.md
+++ b/tools/llm/plugins/otter/skills/playwright-e2e-testing/references/creation-process.md
@@ -1,0 +1,203 @@
+# Scenario Creation Process — Detailed Reference
+
+Complete reference for the 3-gate creation workflow, including deduplication scoring examples and decision trees.
+
+## Gate 1: Confirm Inputs — Detailed
+
+Present the following to the user for explicit approval:
+
+| Field | Value | Notes |
+|-------|-------|-------|
+| Feature | `<feature-name>` | Specific feature being tested |
+| Scenario name | `<descriptive-name>` | Used for file/directory naming |
+
+### Naming Conventions
+
+- Feature: kebab-case, describes what is being tested (`add-to-cart`, `login-form`, `payment-validation`)
+- Scenario: kebab-case, describes the specific test case (`add-to-cart`, `error-invalid-email`)
+
+Do NOT proceed without explicit user confirmation.
+
+## Gate 2: Deduplication Check — Detailed
+
+### Step-by-step Process
+
+1. **Search for existing scenarios** that cover the same feature — search all files under `scenarios/` and `actions/` for the primary action/feature keywords.
+
+2. **For each matching scenario**, list the steps it performs:
+   - Read the scenario file
+   - Extract the sequence of action + check calls
+   - Compare with the planned new scenario steps
+
+3. **Compute overlap score**:
+
+```
+overlap = shared_steps / max(existing_steps, new_steps) * 100
+```
+
+Where:
+- `shared_steps` = number of action/check calls that appear in both scenarios
+- `existing_steps` = total action/check calls in the existing scenario
+- `new_steps` = total action/check calls in the planned new scenario
+
+### Scoring Examples
+
+**Example 1: High overlap (>=70%) — Extend existing**
+
+Existing scenario `add-to-cart.e2e.spec.ts`:
+```
+1. actions.navigateToCatalog
+2. actions.searchProducts
+3. actions.selectProduct
+4. actions.addToCart
+5. checks.verifyItemInCart
+```
+
+Proposed new scenario `add-to-cart-with-quantity.e2e.spec.ts`:
+```
+1. actions.navigateToCatalog
+2. actions.searchProducts
+3. actions.selectProduct
+4. actions.setQuantity
+5. actions.addToCart
+6. checks.verifyItemInCart
+```
+
+Score: 5 shared / max(5, 6) = 5/6 = **83%** → Extend existing scenario with quantity step.
+
+**Example 2: Medium overlap (40-70%) — Extract shared steps**
+
+Existing scenario `checkout-happy-path.e2e.spec.ts`:
+```
+1. actions.navigateToCatalog
+2. actions.searchProducts
+3. actions.selectProduct
+4. actions.addToCart
+5. actions.proceedToCheckout
+6. checks.verifyOrderConfirmation
+```
+
+Proposed new scenario `checkout-cancel-flow.e2e.spec.ts`:
+```
+1. actions.navigateToCatalog
+2. actions.searchProducts
+3. actions.selectProduct
+4. actions.addToCart
+5. actions.cancelOrder
+6. checks.verifyCancellationConfirmed
+```
+
+Score: 4 shared / max(6, 6) = 4/6 = **67%** → Extract shared browse+add steps into a helper, create new scenario.
+
+**Example 3: Low overlap (<40%) — Create new**
+
+Existing scenario `login-happy-path.e2e.spec.ts`:
+```
+1. actions.navigateToLogin
+2. actions.fillCredentials
+3. actions.submitLogin
+4. checks.verifyDashboard
+```
+
+Proposed new scenario `product-filter.e2e.spec.ts`:
+```
+1. actions.navigateToCatalog
+2. actions.applyFilter('in-stock')
+3. actions.applyFilter('price-low-high')
+4. actions.searchProducts
+5. checks.verifyFilteredResults
+6. checks.verifyResultOrder
+```
+
+Score: 0 shared / max(4, 6) = 0/6 = **0%** → Create new scenario.
+
+### Decision Presentation
+
+Present findings to the user in this format:
+
+```
+Deduplication Check Results:
+
+Found 2 existing scenarios with potential overlap:
+
+1. add-to-cart.e2e.spec.ts — 83% overlap
+   Shared steps: navigateToCatalog, searchProducts, selectProduct, addToCart,
+                 verifyItemInCart
+   Recommendation: EXTEND existing scenario with new steps
+
+2. checkout-complete.e2e.spec.ts — 33% overlap
+   Shared steps: navigateToCatalog, searchProducts
+   Recommendation: No conflict, safe to create new
+
+Overall recommendation: Extend add-to-cart.e2e.spec.ts rather than creating a new file.
+Proceed? [user must confirm]
+```
+
+## Gate 3: Flow Approval — Detailed
+
+Present the planned sequence of actions and checks to the user as a step-by-step flow (Given/When/Then):
+
+```
+Resolved Action Mapping for: <scenario-name>
+
+Feature: <feature>
+
+Steps:
+  Given:
+    1. actions.navigateToCatalog(page)
+    2. actions.searchProducts(page, { query: 'laptop' })
+    3. actions.selectProduct(page, 0)
+
+  When:
+    4. actions.addToCart(page)
+
+  Then:
+    5. checks.verifyItemInCart(page, 'Laptop')
+
+New helpers needed:
+  - None (all actions/checks already exist)
+
+  OR
+
+  - NEW ACTION: actions.applyFilter(page, filterName) — in actions/catalog-actions.ts
+  - NEW CHECK: checks.verifyFilteredResults(page, expectedCount) — in checks/catalog-checks.ts
+
+Files to create:
+  - scenarios/add-to-cart/add-to-cart.e2e.spec.ts
+
+Confirm this mapping matches expectations? [user must confirm]
+```
+
+The user confirms it matches the expected behavior. Only after all 3 gates pass, generate files.
+
+## Post-Gate File Generation
+
+After all 3 gates pass, generate files in this order:
+
+1. **New action helpers** (if any) — add to existing action file or create new
+2. **New check helpers** (if any) — add to existing check file or create new
+3. **Scenario file** — wiring actions + checks into Given/When/Then
+
+### File generation checklist
+
+- [ ] Action helpers have no assertions
+- [ ] Check helpers have no interactions
+- [ ] Scenario uses only action/check helpers (no raw Playwright calls)
+- [ ] Given/When/Then comments present
+- [ ] Tags in test title (e.g., `@happy-path`, `@visual`, `@edge-case`, `@regression`)
+- [ ] File names follow kebab-case convention
+- [ ] Proper import paths (relative, no aliases unless configured)
+
+## Extending Existing Scenarios (>=70% overlap)
+
+When extending rather than creating new:
+
+1. **Add new checks** to the existing scenario's "Then" block
+2. **Add new test cases** within the same `test.describe` block if testing variants
+3. **Create new action/check helpers** if the extension requires new interactions or assertions
+4. **Update tags** if the extension broadens scope (e.g., adding `@a11y` coverage)
+
+Do NOT:
+- Duplicate the existing scenario's setup in a new file
+- Create a "v2" of an existing scenario
+- Modify the existing scenario's happy path without user approval


### PR DESCRIPTION
Adds a new skill with references covering accessibility testing, coding standards, and test creation process for Playwright E2E tests.

## Proposed change

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
