### PR TITLE
fix: type common js for js subentries + o3r/application migration.json copy

### DIFF
--- a/packages/@o3r/analytics/package.json
+++ b/packages/@o3r/analytics/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "nx": "nx",
     "ng": "yarn nx",
-    "build:plugins": "tsc -b tsconfig.plugins.json",
+    "build:plugins": "tsc -b tsconfig.plugins.json && yarn generate-cjs-manifest plugins",
     "postbuild": "patch-package-json-exports",
     "build": "yarn nx build analytics",
     "prepare:compile": "cp-package-json",

--- a/packages/@o3r/application/package.json
+++ b/packages/@o3r/application/package.json
@@ -19,7 +19,7 @@
     "nx": "nx",
     "ng": "yarn nx",
     "build": "yarn nx build application",
-    "prepare:build:builders": "yarn cpy 'schematics/**/*.json' dist/schematics && yarn cpy 'collection.json' dist",
+    "prepare:build:builders": "yarn cpy 'schematics/**/*.json' dist/schematics && yarn cpy '{collection,migration}.json' dist",
     "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest"
   },
   "peerDependencies": {

--- a/packages/@o3r/configuration/package.json
+++ b/packages/@o3r/configuration/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "nx": "nx",
     "ng": "yarn nx",
-    "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest",
+    "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest middlewares schematics builders cli",
     "postbuild": "patch-package-json-exports",
     "prepare:compile": "cp-package-json",
     "build": "yarn nx build configuration",

--- a/packages/@o3r/dynamic-content/package.json
+++ b/packages/@o3r/dynamic-content/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "nx": "nx",
     "ng": "yarn nx",
-    "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest",
+    "build:builders": "tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest middlewares schematics builders cli",
     "postbuild": "patch-package-json-exports",
     "prepare:compile": "cp-package-json",
     "build": "yarn nx build dynamic-content",

--- a/packages/@o3r/mobile/package.json
+++ b/packages/@o3r/mobile/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "nx": "nx",
     "ng": "yarn nx",
-    "build:builders": "tsc -p ./tsconfig.pcloudy.json && tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest",
+    "build:builders": "tsc -p ./tsconfig.pcloudy.json && tsc -b tsconfig.builders.json --pretty && yarn generate-cjs-manifest pcloudy schematics builders cli",
     "build": "yarn nx build mobile",
     "prepare:build:builders": "yarn cpy 'schematics/**/*.json' dist/schematics && yarn cpy 'collection.json' dist"
   },


### PR DESCRIPTION
## Proposed change

The new version of ng packager adds a `type: module` on the root package.json, but there are some subentries which still needs to have the `type: commonjs`, so a package.json with this type is created for those subentries. 

This PR just extends the list of subentries folder.

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
