### PR TITLE
fix: schematic - o3r transloco as external dep for apps

### DIFF
--- a/migration-guides/14.4.md
+++ b/migration-guides/14.4.md
@@ -1,0 +1,59 @@
+# Minor 14.4 Migration guide
+
+> [!IMPORTANT]
+> Please make sure to first follow the ["Upgrade new version guide"](https://github.com/AmadeusITGroup/otter/blob/main/docs/core/UPGRADE_NEW_VERSION.md) before going through these steps.
+
+## @o3r/components — `@o3r/transloco` build error
+
+Starting from v14.4, `@o3r/components` dynamically imports `@o3r/transloco` at runtime (with `@o3r/localization` as a fallback).
+Both packages are optional peer dependencies, but webpack and the Angular esbuild builder statically resolve all `import()` expressions at build time.
+If `@o3r/transloco` is not installed in your project you may encounter the following build error:
+
+```
+Module not found: Error: Can't resolve '@o3r/transloco' in '.../node_modules/@o3r/components/fesm2022'
+```
+
+### Automatic migration
+
+The `ng update @o3r/components` migration will automatically add `@o3r/transloco` to `externalDependencies` in your `angular.json` for all application projects that do not have the package installed, so that the bundler skips it at build time and the runtime `.catch()` handles its absence gracefully.
+
+### Manual fix
+
+If you need to apply the fix manually, add `@o3r/transloco` to the `externalDependencies` option of your build target in `angular.json`:
+
+```json
+{
+  "projects": {
+    "my-app": {
+      "architect": {
+        "build": {
+          "options": {
+            "externalDependencies": ["@o3r/transloco"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+> [!NOTE]
+> If you **do** use `@o3r/transloco` in your application (i.e. it is listed in your `package.json` dependencies), no action is required — the package will be bundled as usual.
+
+### Manual fix for custom-webpack builders
+
+If your build target uses an `@angular-builders/custom-webpack:*` builder, the `externalDependencies` option is not available — the migration cannot update it automatically and will instead log a warning pointing to your webpack config file.
+Add the following to the webpack config referenced by `customWebpackConfig.path` so the bundler skips the optional `@o3r/transloco` import:
+
+```js
+const { IgnorePlugin } = require('webpack');
+
+config.plugins.push(new IgnorePlugin({
+  resourceRegExp: /^@o3r\/transloco$/
+}));
+```
+
+## @o3r/components — remove `@o3r/localization` when using `@o3r/transloco`
+
+`@o3r/components` now resolves the translation service by trying `@o3r/transloco` first and falling back to `@o3r/localization`.
+If your application uses `@o3r/transloco`, you no longer need `@o3r/localization` as a dependency for placeholder translation to work and can remove it from your `package.json`.

--- a/packages/@o3r/components/migration.json
+++ b/packages/@o3r/components/migration.json
@@ -5,6 +5,11 @@
       "version": "10.0.0-alpha.0",
       "description": "Updates of @o3r/components to v10.0.*",
       "factory": "./schematics/ng-update/v10-0/index#updateV10_0"
+    },
+    "migration-v14_4": {
+      "version": "14.4.0-alpha.0",
+      "description": "Updates of @o3r/components to v14.4.*",
+      "factory": "./schematics/ng-update/v14-4/index#updateV14_4"
     }
   }
 }

--- a/packages/@o3r/components/schematics/ng-update/v14-4/index.spec.ts
+++ b/packages/@o3r/components/schematics/ng-update/v14-4/index.spec.ts
@@ -1,0 +1,158 @@
+import * as path from 'node:path';
+import {
+  Tree,
+} from '@angular-devkit/schematics';
+import {
+  SchematicTestRunner,
+  type UnitTestTree,
+} from '@angular-devkit/schematics/testing';
+
+const migrationPath = path.join(__dirname, '..', '..', '..', 'migration.json');
+
+/** Minimal angular.json with a real bundling builder and a lint target that should NOT be touched */
+const angularJsonMock = JSON.stringify({
+  version: 1,
+  projects: {
+    'test-app': {
+      projectType: 'application',
+      root: '.',
+      architect: {
+        build: {
+          builder: '@angular/build:application',
+          options: { tsConfig: 'tsconfig.json' }
+        },
+        server: {
+          builder: '@angular-devkit/build-angular:server',
+          options: { tsConfig: 'tsconfig.server.json' }
+        },
+        lint: {
+          builder: '@angular-eslint/builder:lint',
+          options: {}
+        },
+        test: {
+          builder: '@angular-devkit/build-angular:jest',
+          options: {}
+        }
+      }
+    }
+  }
+}, null, 2);
+
+describe('Update V14.4', () => {
+  let initialTree: Tree;
+  let runner: SchematicTestRunner;
+
+  beforeEach(() => {
+    initialTree = Tree.empty();
+    initialTree.create('angular.json', angularJsonMock);
+    runner = new SchematicTestRunner('schematics', migrationPath);
+  });
+
+  describe('addTranslocoExternalDependency', () => {
+    it('should add @o3r/transloco to externalDependencies of bundling targets when it is not installed', async () => {
+      initialTree.create('package.json', JSON.stringify({ name: 'test-project', version: '0.0.0' }));
+      const tree: UnitTestTree = await runner.runSchematic('migration-v14_4', {}, initialTree);
+      const angularJson = JSON.parse(tree.readText('angular.json'));
+      const app = angularJson.projects['test-app'].architect;
+      expect(app.build.options.externalDependencies).toContain('@o3r/transloco');
+      expect(app.server.options.externalDependencies).toContain('@o3r/transloco');
+    });
+
+    it('should not add @o3r/transloco to non-bundling targets (lint, jest)', async () => {
+      initialTree.create('package.json', JSON.stringify({ name: 'test-project', version: '0.0.0' }));
+      const tree: UnitTestTree = await runner.runSchematic('migration-v14_4', {}, initialTree);
+      const angularJson = JSON.parse(tree.readText('angular.json'));
+      const app = angularJson.projects['test-app'].architect;
+      expect(app.lint.options.externalDependencies).toBeUndefined();
+      expect(app.test.options.externalDependencies).toBeUndefined();
+    });
+
+    it('should add @o3r/transloco to karma test targets (webpack-based)', async () => {
+      initialTree.create('package.json', JSON.stringify({ name: 'test-project', version: '0.0.0' }));
+      const parsed = JSON.parse(angularJsonMock);
+      parsed.projects['test-app'].architect.karmaTest = {
+        builder: '@angular-devkit/build-angular:karma',
+        options: {}
+      };
+      initialTree.overwrite('angular.json', JSON.stringify(parsed, null, 2));
+
+      const tree: UnitTestTree = await runner.runSchematic('migration-v14_4', {}, initialTree);
+      const result = JSON.parse(tree.readText('angular.json'));
+      expect(result.projects['test-app'].architect.karmaTest.options.externalDependencies).toContain('@o3r/transloco');
+    });
+
+    it('should not add @o3r/transloco to externalDependencies when it is already installed as a dependency', async () => {
+      initialTree.create('package.json', JSON.stringify({
+        name: 'test-project',
+        version: '0.0.0',
+        dependencies: { '@o3r/transloco': '14.4.0' }
+      }));
+      const tree: UnitTestTree = await runner.runSchematic('migration-v14_4', {}, initialTree);
+      expect(tree.readText('angular.json')).toEqual(angularJsonMock);
+    });
+
+    it('should not add @o3r/transloco to externalDependencies when it is already installed as a devDependency', async () => {
+      initialTree.create('package.json', JSON.stringify({
+        name: 'test-project',
+        version: '0.0.0',
+        devDependencies: { '@o3r/transloco': '14.4.0' }
+      }));
+      const tree: UnitTestTree = await runner.runSchematic('migration-v14_4', {}, initialTree);
+      expect(tree.readText('angular.json')).toEqual(angularJsonMock);
+    });
+
+    it('should not duplicate @o3r/transloco if already in externalDependencies', async () => {
+      initialTree.create('package.json', JSON.stringify({ name: 'test-project', version: '0.0.0' }));
+      const parsed = JSON.parse(angularJsonMock);
+      parsed.projects['test-app'].architect.build.options.externalDependencies = ['@o3r/transloco'];
+      initialTree.overwrite('angular.json', JSON.stringify(parsed, null, 2));
+
+      const tree: UnitTestTree = await runner.runSchematic('migration-v14_4', {}, initialTree);
+      const result = JSON.parse(tree.readText('angular.json'));
+      const externals: string[] = result.projects['test-app'].architect.build.options.externalDependencies;
+      expect(externals.filter((e) => e === '@o3r/transloco')).toHaveLength(1);
+    });
+
+    it('should warn (and not touch angular.json) for custom-webpack builders', async () => {
+      initialTree.create('package.json', JSON.stringify({ name: 'test-project', version: '0.0.0' }));
+      const parsed = JSON.parse(angularJsonMock);
+      parsed.projects['test-app'].architect.build = {
+        builder: '@angular-builders/custom-webpack:browser',
+        options: { customWebpackConfig: { path: './webpack.config.js' } }
+      };
+      const customWebpackAngularJson = JSON.stringify(parsed, null, 2);
+      initialTree.overwrite('angular.json', customWebpackAngularJson);
+
+      const warnings: string[] = [];
+      runner.logger.subscribe((entry) => {
+        if (entry.level === 'warn') {
+          warnings.push(entry.message);
+        }
+      });
+
+      const tree: UnitTestTree = await runner.runSchematic('migration-v14_4', {}, initialTree);
+
+      // angular.json build target left untouched (no externalDependencies added for custom-webpack)
+      const result = JSON.parse(tree.readText('angular.json'));
+      expect(result.projects['test-app'].architect.build.options.externalDependencies).toBeUndefined();
+      expect(warnings.some((w) => w.includes('./webpack.config.js') && w.includes('IgnorePlugin') && w.includes('@o3r/transloco'))).toBe(true);
+    });
+
+    it('should not modify library projects', async () => {
+      initialTree.create('package.json', JSON.stringify({ name: 'test-project', version: '0.0.0' }));
+      const parsed = JSON.parse(angularJsonMock);
+      parsed.projects['test-lib'] = {
+        projectType: 'library',
+        root: './projects/test-lib',
+        architect: {
+          build: { builder: '@angular-devkit/build-angular:ng-packagr', options: {} }
+        }
+      };
+      initialTree.overwrite('angular.json', JSON.stringify(parsed, null, 2));
+
+      const tree: UnitTestTree = await runner.runSchematic('migration-v14_4', {}, initialTree);
+      const result = JSON.parse(tree.readText('angular.json'));
+      expect(result.projects['test-lib'].architect.build.options.externalDependencies).toBeUndefined();
+    });
+  });
+});

--- a/packages/@o3r/components/schematics/ng-update/v14-4/index.ts
+++ b/packages/@o3r/components/schematics/ng-update/v14-4/index.ts
@@ -1,0 +1,116 @@
+import {
+  chain,
+  type Rule,
+} from '@angular-devkit/schematics';
+import {
+  createOtterSchematic,
+  getWorkspaceConfig,
+  writeAngularJson,
+} from '@o3r/schematics';
+import type {
+  PackageJson,
+} from 'type-fest';
+
+const TRANSLOCO_PACKAGE = '@o3r/transloco';
+
+/** Angular builders that perform JavaScript bundling and support the externalDependencies option */
+const BUNDLING_BUILDERS = new Set([
+  '@angular-devkit/build-angular:browser',
+  '@angular-devkit/build-angular:browser-esbuild',
+  '@angular/build:application',
+  '@angular-devkit/build-angular:server',
+  '@angular-devkit/build-angular:app-shell',
+  '@angular-devkit/build-angular:prerender',
+  '@angular-devkit/build-angular:karma'
+]);
+
+/**
+ * Builders from `@angular-builders/custom-webpack` that bundle JavaScript through a user-provided webpack config file.
+ * These do not support the `externalDependencies` option, so the equivalent fix must be applied in the webpack config
+ * referenced by their `customWebpackConfig.path` option.
+ */
+const CUSTOM_WEBPACK_BUILDERS = new Set([
+  '@angular-builders/custom-webpack:browser',
+  '@angular-builders/custom-webpack:server',
+  '@angular-builders/custom-webpack:karma'
+]);
+
+/**
+ * Add `@o3r/transloco` to externalDependencies in bundling targets of angular.json
+ * when it is not a direct dependency of the project.
+ * This is required because `@o3r/components` performs a dynamic `import('@o3r/transloco')` at runtime,
+ * and webpack/esbuild will fail at build time if the module is not installed and not marked as external.
+ * @param tree
+ * @param context
+ */
+const addTranslocoExternalDependency: Rule = (tree, context) => {
+  const workspace = getWorkspaceConfig(tree);
+  if (!workspace) {
+    context.logger.warn('No angular.json found, skipping migration.');
+    return;
+  }
+
+  const packageJson = tree.exists('/package.json')
+    ? tree.readJson('/package.json') as PackageJson
+    : null;
+
+  const isTranslocoInstalled = !!packageJson?.dependencies?.[TRANSLOCO_PACKAGE]
+    || !!packageJson?.devDependencies?.[TRANSLOCO_PACKAGE];
+
+  if (isTranslocoInstalled) {
+    context.logger.info(`${TRANSLOCO_PACKAGE} is already installed, no externalDependencies update needed.`);
+    return;
+  }
+
+  let modified = false;
+  for (const [projectName, project] of Object.entries(workspace.projects || {})) {
+    if (project.projectType !== 'application') {
+      continue;
+    }
+    const architect = project.architect || {};
+    for (const [targetName, target] of Object.entries(architect)) {
+      if (CUSTOM_WEBPACK_BUILDERS.has(target.builder)) {
+        const webpackConfigPath = (target.options as { customWebpackConfig?: { path?: string } } | undefined)?.customWebpackConfig?.path;
+        const webpackConfigLabel = webpackConfigPath ? `the webpack config "${webpackConfigPath}"` : 'your webpack config';
+        context.logger.warn(
+          `${projectName}/${targetName} uses the custom-webpack builder "${target.builder}", which does not support the externalDependencies option.\n`
+          + `Please add the following to ${webpackConfigLabel} manually so the bundler skips the optional ${TRANSLOCO_PACKAGE} import:\n`
+          + '  const { IgnorePlugin } = require(\'webpack\');\n'
+          + '  config.plugins.push(new IgnorePlugin({\n'
+          + `    resourceRegExp: /^${TRANSLOCO_PACKAGE.replace('/', '\\/')}$/\n`
+          + '  }));'
+        );
+        continue;
+      }
+      if (!BUNDLING_BUILDERS.has(target.builder)) {
+        continue;
+      }
+      if (!target.options) {
+        target.options = {};
+      }
+      const existingExternals: string[] = (target.options).externalDependencies ?? [];
+      if (!existingExternals.includes(TRANSLOCO_PACKAGE)) {
+        (target.options).externalDependencies = [...existingExternals, TRANSLOCO_PACKAGE];
+        context.logger.info(`Added ${TRANSLOCO_PACKAGE} to externalDependencies in ${projectName}/${targetName}.`);
+        modified = true;
+      }
+    }
+  }
+
+  if (modified) {
+    writeAngularJson(tree, workspace);
+  }
+};
+
+// eslint-disable-next-line @typescript-eslint/naming-convention -- version in the function name
+function updateV14_4Fn(): Rule {
+  return (tree, context) => chain([
+    addTranslocoExternalDependency
+  ])(tree, context);
+}
+
+/**
+ * Update of `@o3r/components` v14.4
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention -- version in the function name
+export const updateV14_4 = createOtterSchematic(updateV14_4Fn);

--- a/packages/@o3r/transloco/schematics/ng-add/helpers/remove-transloco-external-dependency.spec.ts
+++ b/packages/@o3r/transloco/schematics/ng-add/helpers/remove-transloco-external-dependency.spec.ts
@@ -1,0 +1,87 @@
+import {
+  callRule,
+  SchematicContext,
+  Tree,
+} from '@angular-devkit/schematics';
+import {
+  firstValueFrom,
+} from 'rxjs';
+import {
+  removeTranslocoExternalDependency,
+} from './remove-transloco-external-dependency';
+
+const context = { logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() } } as unknown as SchematicContext;
+
+// angular.json with `@o3r/transloco` previously added to externalDependencies by the `@o3r/components` migration
+const angularJsonMock = (build: Record<string, unknown>) => JSON.stringify({
+  version: 1,
+  projects: {
+    'test-app': {
+      projectType: 'application',
+      root: '.',
+      architect: { build }
+    }
+  }
+}, null, 2);
+
+describe('removeTranslocoExternalDependency', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = Tree.empty();
+    jest.clearAllMocks();
+  });
+
+  it('should remove @o3r/transloco from externalDependencies while keeping other entries', async () => {
+    tree.create('angular.json', angularJsonMock({
+      builder: '@angular/build:application',
+      options: { externalDependencies: ['some-other-pkg', '@o3r/transloco'] }
+    }));
+
+    await firstValueFrom(callRule(removeTranslocoExternalDependency, tree, context));
+
+    const externals = JSON.parse(tree.readText('angular.json')).projects['test-app'].architect.build.options.externalDependencies;
+    expect(externals).toEqual(['some-other-pkg']);
+  });
+
+  it('should drop the externalDependencies option entirely when @o3r/transloco was the only entry', async () => {
+    tree.create('angular.json', angularJsonMock({
+      builder: '@angular/build:application',
+      options: { externalDependencies: ['@o3r/transloco'], tsConfig: 'tsconfig.json' }
+    }));
+
+    await firstValueFrom(callRule(removeTranslocoExternalDependency, tree, context));
+
+    const options = JSON.parse(tree.readText('angular.json')).projects['test-app'].architect.build.options;
+    expect(options.externalDependencies).toBeUndefined();
+    expect(options.tsConfig).toBe('tsconfig.json');
+  });
+
+  it('should warn to remove the IgnorePlugin for custom-webpack builders without touching angular.json', async () => {
+    const original = angularJsonMock({
+      builder: '@angular-builders/custom-webpack:browser',
+      options: { customWebpackConfig: { path: './webpack.config.js' } }
+    });
+    tree.create('angular.json', original);
+
+    await firstValueFrom(callRule(removeTranslocoExternalDependency, tree, context));
+
+    expect(tree.readText('angular.json')).toEqual(original);
+    const warnMock = context.logger.warn as jest.Mock;
+    expect(warnMock).toHaveBeenCalledWith(expect.stringContaining('./webpack.config.js'));
+    expect(warnMock).toHaveBeenCalledWith(expect.stringContaining('IgnorePlugin'));
+    expect(warnMock).toHaveBeenCalledWith(expect.stringContaining('@o3r/transloco'));
+  });
+
+  it('should leave angular.json untouched when @o3r/transloco is not in externalDependencies', async () => {
+    const original = angularJsonMock({
+      builder: '@angular/build:application',
+      options: { externalDependencies: ['some-other-pkg'] }
+    });
+    tree.create('angular.json', original);
+
+    await firstValueFrom(callRule(removeTranslocoExternalDependency, tree, context));
+
+    expect(tree.readText('angular.json')).toEqual(original);
+  });
+});

--- a/packages/@o3r/transloco/schematics/ng-add/helpers/remove-transloco-external-dependency.ts
+++ b/packages/@o3r/transloco/schematics/ng-add/helpers/remove-transloco-external-dependency.ts
@@ -1,0 +1,69 @@
+import {
+  type Rule,
+} from '@angular-devkit/schematics';
+import {
+  getWorkspaceConfig,
+} from '@o3r/schematics';
+
+const TRANSLOCO_PACKAGE = '@o3r/transloco';
+
+/** Builders from `@angular-builders/custom-webpack` whose bundling is driven by a user-provided webpack config file. */
+const CUSTOM_WEBPACK_BUILDERS = new Set([
+  '@angular-builders/custom-webpack:browser',
+  '@angular-builders/custom-webpack:server',
+  '@angular-builders/custom-webpack:karma'
+]);
+
+/**
+ * Remove `@o3r/transloco` from the `externalDependencies` of all application bundling targets in angular.json.
+ *
+ * The `@o3r/components` `ng update` migration adds `@o3r/transloco` to `externalDependencies` when the package is not
+ * installed, so that the bundler skips its dynamic `import()`. Once `@o3r/transloco` is added to the project (via this
+ * `ng add`), it must be bundled again, so the previously added entry has to be cleaned up.
+ * Custom-webpack builders cannot be updated automatically, so a warning is logged to revert the manual `IgnorePlugin`.
+ * @param tree
+ * @param context
+ */
+export const removeTranslocoExternalDependency: Rule = (tree, context) => {
+  const workspace = getWorkspaceConfig(tree);
+  if (!workspace) {
+    return tree;
+  }
+
+  let modified = false;
+  for (const [projectName, project] of Object.entries(workspace.projects || {})) {
+    if (project.projectType !== 'application') {
+      continue;
+    }
+    for (const [targetName, target] of Object.entries(project.architect || {})) {
+      if (CUSTOM_WEBPACK_BUILDERS.has(target.builder)) {
+        const webpackConfigPath = (target.options as { customWebpackConfig?: { path?: string } } | undefined)?.customWebpackConfig?.path;
+        const webpackConfigLabel = webpackConfigPath ? `the webpack config "${webpackConfigPath}"` : 'your webpack config';
+        context.logger.warn(
+          `${projectName}/${targetName} uses the custom-webpack builder "${target.builder}".\n`
+          + `If you previously added an IgnorePlugin for ${TRANSLOCO_PACKAGE} in ${webpackConfigLabel} (following the @o3r/components migration), `
+          + 'please remove it now so the package is bundled again:\n'
+          + `  config.plugins.push(new IgnorePlugin({ resourceRegExp: /^${TRANSLOCO_PACKAGE.replace('/', '\\/')}$/ }));`
+        );
+        continue;
+      }
+      const existingExternals: string[] | undefined = (target.options as { externalDependencies?: string[] } | undefined)?.externalDependencies;
+      if (!existingExternals?.includes(TRANSLOCO_PACKAGE)) {
+        continue;
+      }
+      const updatedExternals = existingExternals.filter((dependency) => dependency !== TRANSLOCO_PACKAGE);
+      if (updatedExternals.length > 0) {
+        (target.options as { externalDependencies?: string[] }).externalDependencies = updatedExternals;
+      } else {
+        delete (target.options as { externalDependencies?: string[] }).externalDependencies;
+      }
+      context.logger.info(`Removed ${TRANSLOCO_PACKAGE} from externalDependencies in ${projectName}/${targetName} as it is now a project dependency.`);
+      modified = true;
+    }
+  }
+
+  if (modified) {
+    tree.overwrite('/angular.json', JSON.stringify(workspace, null, 2));
+  }
+  return tree;
+};

--- a/packages/@o3r/transloco/schematics/ng-add/index.ts
+++ b/packages/@o3r/transloco/schematics/ng-add/index.ts
@@ -25,6 +25,9 @@ import {
 import {
   registerDevtools,
 } from './helpers/devtools-registration';
+import {
+  removeTranslocoExternalDependency,
+} from './helpers/remove-transloco-external-dependency';
 import type {
   NgAddSchematicsSchema,
 } from './schema';
@@ -71,6 +74,7 @@ function ngAddFn(options: NgAddSchematicsSchema): Rule {
     updateI18n(options),
     options.skipLinter ? noop() : applyEsLintFix(),
     ngAddDependenciesRule(options, packageJsonPath, { dependenciesToInstall, devDependenciesToInstall }),
+    removeTranslocoExternalDependency,
     updateCmsAdapter(options),
     registerPackageCollectionSchematics(packageJson),
     setupSchematicsParamsForProject({ '@o3r/core:component*': { useLocalization: true } }, options.projectName),


### PR DESCRIPTION
## Proposed change

schematic to add o3r/transloco as external dependency for apps build

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
