### PR TITLE
feat(ama-openapi): prepend filePath for modelPath starting with `#/`

### DIFF
--- a/packages/@ama-openapi/core/src/schema/mask/generate-mask-from-model.mts
+++ b/packages/@ama-openapi/core/src/schema/mask/generate-mask-from-model.mts
@@ -39,7 +39,9 @@ export const generateMaskSchemaModelAt = async (modelPath: string, ctx: MaskCont
 
   modelPath = modelPath.replaceAll(sep, '/');
   if (ctx.filePath) {
-    modelPath = posix.resolve(dirname(ctx.filePath).replaceAll(sep, '/'), modelPath);
+    modelPath = modelPath.startsWith('#/')
+      ? `${ctx.filePath}${modelPath}`.replaceAll(sep, '/')
+      : posix.resolve(dirname(ctx.filePath).replaceAll(sep, '/'), modelPath);
   }
 
   if (ctx.parsedFiles?.includes(modelPath)) {

--- a/packages/@ama-openapi/core/src/schema/mask/generate-mask-from-model.spec.ts
+++ b/packages/@ama-openapi/core/src/schema/mask/generate-mask-from-model.spec.ts
@@ -156,6 +156,67 @@ describe('generateMaskSchemaModelAt', () => {
     });
   });
 
+  it('should prepend filePath when modelPath starts with #/', async () => {
+    const ctxFilePath = '/root/schemas/root.json';
+    const modelPath = '#/definitions/User';
+    const description = 'User definition';
+
+    parseFileMock.mockResolvedValueOnce({
+      definitions: {
+        User: {
+          type: 'string',
+          description
+        }
+      }
+    });
+
+    const ctx = createBaseCtx({
+      filePath: ctxFilePath,
+      modelPaths: {}
+    });
+
+    const result = await generateMaskSchemaModelAt(modelPath, ctx);
+
+    expect(parseFileMock).toHaveBeenCalledWith('/root/schemas/root.json');
+    expect(result).toEqual({
+      description,
+      oneOf: [
+        { $ref: FIELD_SCHEMA_REF },
+        { type: 'string' }
+      ]
+    });
+  });
+
+  it('should prepend filePath and build mask $ref when modelPath starts with #/ and modelPaths has entry', async () => {
+    const ctxFilePath = '/root/schemas/root.json';
+    const modelPath = '#/definitions/User';
+    const description = 'Root schema';
+
+    parseFileMock.mockResolvedValueOnce({ description });
+
+    const ctx = createBaseCtx({
+      filePath: ctxFilePath,
+      packageName: 'my-pkg',
+      modelPaths: {
+        [ctxFilePath]: 'models/root.ts'
+      }
+    });
+
+    generateModelNameRefMock.mockReturnValue('MyPkgRoot');
+    getMaskFileNameMock.mockReturnValue('my-pkg-root.mask.json');
+
+    const result = await generateMaskSchemaModelAt(modelPath, ctx);
+
+    expect(parseFileMock).toHaveBeenCalledWith('/root/schemas/root.json');
+    expect(result).toEqual({
+      description,
+      oneOf: [
+        { $ref: FIELD_SCHEMA_REF },
+        { $ref: './my-pkg-root.mask.json#/definitions/properties/User' }
+      ]
+    });
+  });
+
   it('should drill down into model using innerPath when no modelPaths entry is present', async () => {
     const filePath = '/root/schemas/user.json';
     const modelPath = `${filePath}#/components/schemas/User`;


### PR DESCRIPTION
## Proposed change

feat(ama-openapi): prepend filePath for modelPath starting with `#/` in `generateMaskSchemaModelAt`

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
