### PR TITLE
chore(deps): fix audit critical

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,11 +131,13 @@
   "resolutions": {
     "@sinonjs/fake-timers": "^14.0.0",
     "@types/node": "~24.10.0",
+    "@xhmikosr/decompress": "^10.2.1",
     "form-data": "^4.0.4",
     "koa": "~3.1.0",
     "handlebars": "~4.7.9",
     "qs": "~6.15.0",
     "rxjs": "^7.8.1",
+    "shell-quote": "^1.8.4",
     "typescript-json-schema/typescript": "~5.9.2"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18152,9 +18152,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xhmikosr/decompress@npm:^10.2.0":
-  version: 10.2.0
-  resolution: "@xhmikosr/decompress@npm:10.2.0"
+"@xhmikosr/decompress@npm:^10.2.1":
+  version: 10.2.1
+  resolution: "@xhmikosr/decompress@npm:10.2.1"
   dependencies:
     "@xhmikosr/decompress-tar": "npm:^8.1.0"
     "@xhmikosr/decompress-tarbz2": "npm:^8.1.0"
@@ -18162,7 +18162,7 @@ __metadata:
     "@xhmikosr/decompress-unzip": "npm:^7.1.0"
     graceful-fs: "npm:^4.2.11"
     strip-dirs: "npm:^3.0.0"
-  checksum: 10/083f59bda6440b698322802e61c2b68e47d9a7f3c90d432d91a260b1630bda3c19088fb0cc8a42c67754a9de86e546f68c8d314408ff72180f0bba2b6ef65f81
+  checksum: 10/b2d3f2a9b06669628aa60e9d215d2f2730ff5370cb7e54b07b08ea0a355941a0c0eec6c25f856499d21ad14f2976309c811bb41a365d6adf64efcff206a7d7f5
   languageName: node
   linkType: hard
 
@@ -36783,10 +36783,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:1.8.3, shell-quote@npm:^1.6.1, shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.1, shell-quote@npm:^1.8.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 10/5473e354637c2bd698911224129c9a8961697486cff1fb221f234d71c153fc377674029b0223d1d3c953a68d451d79366abfe53d1a0b46ee1f28eb9ade928f4c
+"shell-quote@npm:^1.8.4":
+  version: 1.9.0
+  resolution: "shell-quote@npm:1.9.0"
+  checksum: 10/c3bc91e74a469c4f96b6fd13b0c777fff16bcbda202692a4e5402d3d6b78fc6e02fe92fdf8dc0bddf992a9c6758e43207bfc5bdbefbf8a58190b1c885cbcc171
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Add root `resolutions` for `@xhmikosr/decompress` (`^10.2.1`) and `shell-quote` (`^1.8.4`) to clear the two critical advisories failing the `audit` CI job.
- `@xhmikosr/decompress@10.2.0` (transitive via `@swc/cli` → `@xhmikosr/bin-wrapper` → `@xhmikosr/downloader`): [GHSA-mp2f-45pm-3cg9](https://github.com/advisories/GHSA-mp2f-45pm-3cg9) — archive extraction can create files/links outside the target directory.
- `shell-quote@1.8.3` (direct dep of `@o3r/create`, plus several transitive users): [GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p) — `quote()` does not escape newlines. This advisory was published after the referenced CI run, so it would fail the next audit.

Split out as a dedicated PR so the audit passes independently.

## Test plan
- [x] `yarn npm audit --environment all --all --recursive --json` reports **0 critical** vulnerabilities
- [ ] CI `audit` job passes