### PR TITLE
feat(plugin): add sdk-mcp-setup skill to ama-sdk plugin

### DIFF
--- a/collections/ama-sdk.collection.yml
+++ b/collections/ama-sdk.collection.yml
@@ -25,6 +25,14 @@ items:
     tags:
       - plugins
       - extensibility
+  - path: tools/llm/plugins/ama-sdk/skills/sdk-mcp-setup.md
+    kind: skill
+    title: SDK MCP Setup
+    description: Configure the @ama-sdk/mcp server to expose SDK_CONTEXT.md to Claude Code and GitHub Copilot
+    tags:
+      - mcp
+      - context
+      - setup
   - path: tools/llm/plugins/ama-sdk/agents/sdk-setup.agent.md
     kind: agent
     title: SDK Setup

--- a/tools/llm/plugins/ama-sdk/README.md
+++ b/tools/llm/plugins/ama-sdk/README.md
@@ -9,6 +9,7 @@ AI-powered skills for creating, using, and extending TypeScript SDKs generated f
 | **create-sdk** | Create a TypeScript SDK from an OpenAPI spec (standalone or monorepo) |
 | **use-sdk** | Install, configure clients (Fetch/Angular/Beacon), and call APIs |
 | **sdk-plugins** | Use built-in plugins and create custom ones for auth, retry, etc. |
+| **sdk-mcp-setup** | Configure the `@ama-sdk/mcp` server so AI assistants read `SDK_CONTEXT.md` |
 
 ## Agents
 
@@ -52,6 +53,8 @@ The same [`.claude-plugin/`](../../../../.claude-plugin/marketplace.json) manife
 **"How do I call the search endpoint from my SDK?"** → triggers `use-sdk` skill
 
 **"I have a monorepo, add an SDK library"** → triggers `create-sdk` skill
+
+**"Set up the ama-sdk MCP so Copilot/Claude knows my SDK"** → triggers `sdk-mcp-setup` skill
 
 ## Related Packages
 

--- a/tools/llm/plugins/ama-sdk/agents/sdk-setup.agent.md
+++ b/tools/llm/plugins/ama-sdk/agents/sdk-setup.agent.md
@@ -61,6 +61,11 @@ Ask if they need:
 - Resilience (retry, timeout) → configure fetch plugins
 - Custom behavior → guide through custom plugin creation
 
+### Phase 6: AI Context / MCP (Optional)
+
+Ask if they want AI assistants (Claude Code, GitHub Copilot) to understand the SDK:
+- Generate `SDK_CONTEXT.md` with `amasdk-update-sdk-context` and configure the `@ama-sdk/mcp` server → delegate to `sdk-mcp-setup` skill
+
 ## Constraints
 
 - **Never modify an OpenAPI specification.** If the spec has issues, suggest the user fix it upstream.

--- a/tools/llm/plugins/ama-sdk/skills/create-sdk.md
+++ b/tools/llm/plugins/ama-sdk/skills/create-sdk.md
@@ -153,3 +153,4 @@ For schematic options, see: https://github.com/AmadeusITGroup/otter/blob/main/pa
 - Install and configure a client (`@ama-sdk/client-fetch`, `@ama-sdk/client-angular`, or `@ama-sdk/client-beacon`) — see **use-sdk** skill
 - Add plugins for auth, retry, or caching — see **sdk-plugins** skill
 - Generate mocks for testing with `typescript-mock` schematic
+- Expose the SDK to AI assistants (generate `SDK_CONTEXT.md` and configure the MCP server) — see **sdk-mcp-setup** skill

--- a/tools/llm/plugins/ama-sdk/skills/sdk-mcp-setup.md
+++ b/tools/llm/plugins/ama-sdk/skills/sdk-mcp-setup.md
@@ -1,0 +1,86 @@
+---
+name: sdk-mcp-setup
+description: Install and configure the @ama-sdk/mcp server so AI assistants can read SDK_CONTEXT.md from installed SDK packages. Use when the get_sdk_context tool is unavailable, or the user asks to "set up the ama-sdk mcp" or "configure sdk context server".
+---
+
+# ama-sdk MCP Server Setup
+
+Configure the [`@ama-sdk/mcp`](https://github.com/AmadeusITGroup/otter/tree/main/mcps/@ama-sdk/mcp) server so AI assistants can read the `SDK_CONTEXT.md` of installed SDK packages and use real operation IDs, models, and domains instead of hallucinating.
+
+## Prerequisites
+
+- One or more SDKs generated with `@ama-sdk/schematics`, each exposing an `SDK_CONTEXT.md`.
+- The server needs the **package names** of the SDKs to expose (e.g. `@my-scope/my-sdk`).
+
+How you get the `SDK_CONTEXT.md` depends on where the SDK lives:
+
+- **SDK source available (monorepo or local project)** — generate the context from the SDK project:
+
+  ```bash
+  npx amasdk-update-sdk-context --interactive
+  ```
+
+- **SDK consumed from `node_modules`** — you can't regenerate it; the context must already ship inside the published package. Point `@ama-sdk/mcp` at the package name and it reads the bundled `SDK_CONTEXT.md`. If the package doesn't ship one, ask the SDK maintainer to generate and publish it.
+
+## Configuration
+
+The server runs via `npx` with no permanent install.
+
+### Step 1: Declare the SDK packages in package.json
+
+List the SDKs to expose under `sdkContext.packages` in the project's `package.json`. Prefer this over passing `--packages` on the command line — the list lives in one place, so the Claude Code and Copilot configs below stay identical with nothing to duplicate:
+
+```json
+{
+  "sdkContext": {
+    "packages": ["@my-scope/my-sdk", "@other-scope/other-sdk"]
+  }
+}
+```
+
+### Step 2: Register the server
+
+The server reads `sdkContext.packages` automatically, so both clients use the same args.
+
+**Claude Code** — add to `.mcp.json` at the project root:
+
+```json
+{
+  "mcpServers": {
+    "sdk-context": {
+      "command": "npx",
+      "args": ["-y", "-p", "@ama-sdk/mcp", "ama-sdk-mcp"]
+    }
+  }
+}
+```
+
+**GitHub Copilot (VS Code)** — add to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "sdk-context": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "-p", "@ama-sdk/mcp", "ama-sdk-mcp"]
+    }
+  }
+}
+```
+
+### Alternative: pass packages on the command line
+
+If you can't edit `package.json`, list the SDKs after `--packages` instead (append to the `args` array): `["-y", "-p", "@ama-sdk/mcp", "ama-sdk-mcp", "--packages", "@my-scope/my-sdk", "@other-scope/other-sdk"]`. This has to be repeated in each client's config.
+
+## Metrics (optional)
+
+Ask the user whether to enable anonymous usage metrics. If they agree, add an `env` block to the server config:
+
+```json
+"env": {
+  "O3R_METRICS": true
+}
+```
+
+Privacy policy: https://github.com/AmadeusITGroup/otter/blob/main/PRIVACY.md


### PR DESCRIPTION
## Summary
- Add a new `sdk-mcp-setup` skill that guides installing and configuring the `@ama-sdk/mcp` server so AI assistants (Claude Code, GitHub Copilot) can read `SDK_CONTEXT.md` from installed SDK packages
- Wire the skill into the ama-sdk collection, plugin README, `sdk-setup` agent (new optional Phase 6), and the `create-sdk` next steps

## Test plan
- [ ] Verify the collection YAML validates against the schema
- [ ] Confirm the skill's `npx` invocations and `--packages` / `sdkContext.packages` config match the `@ama-sdk/mcp` CLI
- [ ] Confirm `amasdk-update-sdk-context --interactive` is referenced correctly