### PR TITLE
docs(agents): document PnP pre-commit hook troubleshooting

### DIFF
--- a/.agents/git-workflow.md
+++ b/.agents/git-workflow.md
@@ -62,3 +62,21 @@ yarn build      # Full build (mandatory)
 yarn lint       # Linting (mandatory)
 yarn test       # Unit tests (mandatory)
 ```
+
+## Troubleshooting
+
+### Pre-commit hook fails with a PnP resolution error
+
+If a commit fails on the pre-commit hook with an error like:
+
+```
+Couldn't find <package>@npm:<version> in the currently installed PnP map - running an install might help
+```
+
+the Yarn PnP map is out of date. Run `yarn install`, then retry the commit:
+
+```bash
+yarn install
+```
+
+This only repairs the local PnP state; it does not change the lockfile when dependencies are unchanged.


### PR DESCRIPTION
## Summary
- Add a Troubleshooting section to `.agents/git-workflow.md` documenting the Yarn PnP pre-commit hook failure (`Couldn't find <pkg>@npm:<version> in the currently installed PnP map`) and its fix: run `yarn install`, then retry the commit
- Helps all contributors resolve this recurring setup issue quickly

## Test plan
- [ ] Docs-only change — verify the new section renders correctly and matches the existing file's formatting