### PR TITLE
fix: transloco - typo in rules engine action schema

### DIFF
--- a/packages/@o3r/transloco/schemas/rules-engine.localization-action.schema.json
+++ b/packages/@o3r/transloco/schemas/rules-engine.localization-action.schema.json
@@ -7,7 +7,7 @@
     "actionType": {
       "type": "string",
       "description": "Action Type",
-      "const": "UPDATE_LOCALIZATION"
+      "const": "UPDATE_LOCALISATION"
     },
     "key": {
       "type": "string",


### PR DESCRIPTION
## Proposed change

Related to: https://github.com/AmadeusITGroup/otter/commit/78d1ee40a0e19628f9be44d7af278aff6b0187ff

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
