### PR TITLE
fix: bump websocket-driver to ^0.7.5 to fix critical audit vulnerability

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -40635,13 +40635,13 @@ __metadata:
   linkType: hard
 
 "websocket-driver@npm:>=0.5.1, websocket-driver@npm:^0.7.4":
-  version: 0.7.4
-  resolution: "websocket-driver@npm:0.7.4"
+  version: 0.7.5
+  resolution: "websocket-driver@npm:0.7.5"
   dependencies:
     http-parser-js: "npm:>=0.5.1"
     safe-buffer: "npm:>=5.1.0"
     websocket-extensions: "npm:>=0.1.1"
-  checksum: 10/17197d265d5812b96c728e70fd6fe7d067471e121669768fe0c7100c939d997ddfc807d371a728556e24fc7238aa9d58e630ea4ff5fd4cfbb40f3d0a240ef32d
+  checksum: 10/0671fef8c79ba1b1b2fa6b7d95cb034d059410e7c4cfd7ef42063a254e12ca2917806c3a5026206b33abf25a5d44a651c547b8f74d9ec94c9fe4df6fa1bc63f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed change

`sockjs@0.3.24` depends on `websocket-driver@^0.7.4`, which resolved to `0.7.4`. That version has a critical vulnerability ([GHSA-xv26-6w52-cph6](https://github.com/advisories/GHSA-xv26-6w52-cph6)): message corruption via abuse of protocol length headers. Version `0.7.5` fixes it.

## Related issues

* :bug: Fix audit failure in https://github.com/AmadeusITGroup/otter/actions/runs/29500435974/job/87627721918?pr=4361