### PR TITLE
[draft] feat(nx-cache): scope external deps via custom hasher

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -22,7 +22,6 @@
   },
   "namedInputs": {
     "sharedGlobals": [
-      "{workspaceRoot}/yarn.lock",
       "{workspaceRoot}/tsconfig.base.json",
       "{workspaceRoot}/nx.json",
       "{workspaceRoot}/.nxignore",
@@ -259,7 +258,7 @@
       "cache": true
     },
     "test-int": {
-      "executor": "@nx/jest:jest",
+      "executor": "@o3r-internal/external-deps-hasher:jest",
       "dependsOn": [
         {
           "projects": [
@@ -281,7 +280,10 @@
         "source",
         "schematics",
         "integration-test",
-        "^schematics"
+        "^schematics",
+        {
+          "externalDependencies": []
+        }
       ],
       "outputs": [
         "{projectRoot}/dist-test/it-report.xml",

--- a/package.json
+++ b/package.json
@@ -210,6 +210,7 @@
     "@nx/js": "~22.7.0",
     "@nx/vitest": "~22.7.0",
     "@nx/workspace": "~22.7.0",
+    "@o3r-internal/external-deps-hasher": "workspace:*",
     "@o3r/components": "workspace:~",
     "@o3r/eslint-config": "workspace:~",
     "@o3r/eslint-plugin": "workspace:~",

--- a/tools/@o3r-internal/external-deps-hasher/executors.json
+++ b/tools/@o3r-internal/external-deps-hasher/executors.json
@@ -1,0 +1,10 @@
+{
+  "executors": {
+    "jest": {
+      "implementation": "./jest-with-hasher.impl.mjs",
+      "schema": "./schema.json",
+      "hasher": "./external-deps.hasher.mjs",
+      "description": "PROTOTYPE — wraps @nx/jest:jest and attaches a custom hasher that scopes the cache to the project's actually-used external dependencies."
+    }
+  }
+}

--- a/tools/@o3r-internal/external-deps-hasher/external-deps.hasher.mjs
+++ b/tools/@o3r-internal/external-deps-hasher/external-deps.hasher.mjs
@@ -1,0 +1,116 @@
+/*
+ * PROTOTYPE — Option B: a custom Nx hasher (the "compute the hash ourselves"
+ * approach), verified against Nx 22.7.6.
+ *
+ * Nx calls this with (task, context) and expects a `Hash` back
+ * ({ value, details, inputs }). See nx/dist/src/hasher/hash-task.js:74.
+ *
+ * Unlike Option A (which writes `externalDependencies` named inputs into every
+ * project.json) and unlike the failed createNodesV2 attempt (whose injected
+ * inputs were dropped during config merge), this bypasses named inputs
+ * entirely: it is attached to the executor via `hasherFactory` and computes the
+ * final hash value directly. Nothing is written to disk.
+ *
+ * Strategy:
+ *   1. Ask Nx's DEFAULT hasher for the task's hash — but with external
+ *      dependencies neutralised (nx.json declares `externalDependencies: []`
+ *      in `base`, so the default no longer folds in ALL deps). This preserves
+ *      every other input (source files, configs, env, runtime, ^deps).
+ *   2. Walk the transitive closure of the project's own external dependencies
+ *      from `context.projectGraph`, combine each reached package's yarn.lock
+ *      content hash, and fold that digest into the final value.
+ *
+ * Result: the task re-runs only when a dependency the project ACTUALLY uses
+ * changes in yarn.lock — not on unrelated bumps.
+ *
+ * Blind spot (shared with Option A): tools invoked purely via CLI / dynamic
+ * import that are not edges in the project graph are not captured. For a
+ * jest-executed task the runner deps ARE import edges, so this is low-risk here.
+ */
+
+import {
+  createHash,
+} from 'node:crypto';
+
+/**
+ * Collect the transitive closure of external (npm) nodes reachable from a project.
+ * @param {import('nx/src/config/project-graph').ProjectGraph} projectGraph
+ * @param {string} projectName
+ * @returns {string[]} sorted external node ids (e.g. `npm:typescript@5.9.2`)
+ */
+const collectTransitiveExternalNodes = (projectGraph, projectName) => {
+  const visited = new Set();
+  const externals = new Set();
+  const stack = [projectName];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+
+    for (const edge of projectGraph.dependencies[current] || []) {
+      const { target } = edge;
+      if (target.startsWith('npm:')) {
+        if (!externals.has(target)) {
+          externals.add(target);
+          stack.push(target);
+        }
+      } else if (!visited.has(target)) {
+        stack.push(target);
+      }
+    }
+  }
+
+  return [...externals].toSorted();
+};
+
+/**
+ * Build a stable digest from the yarn.lock content hashes of the given externals.
+ * @param {import('nx/src/config/project-graph').ProjectGraph} projectGraph
+ * @param {string[]} externalIds
+ * @returns {string} hex digest
+ */
+const digestExternals = (projectGraph, externalIds) => {
+  const hasher = createHash('sha256');
+  for (const id of externalIds) {
+    const data = projectGraph.externalNodes?.[id]?.data;
+    hasher.update(`${id}@${data?.hash ?? data?.version ?? '?'}\n`);
+  }
+  return hasher.digest('hex');
+};
+
+/**
+ * Custom hasher: default task hash folded with a digest of the project's
+ * transitively-used external dependencies.
+ * @type {import('nx/src/config/misc-interfaces').CustomHasher}
+ */
+const externalDepsHasher = async (task, context) => {
+  // 1. Default hash for everything except external deps (neutralised in nx.json).
+  const base = await context.hasher.hashTask(task, context.taskGraph, context.env);
+
+  // 2. Digest of the transitive external deps this project actually uses.
+  const externals = collectTransitiveExternalNodes(context.projectGraph, task.target.project);
+  const externalDigest = digestExternals(context.projectGraph, externals);
+
+  // 3. Fold the digest into the final value.
+  const value = createHash('sha256')
+    .update(base.value)
+    .update(externalDigest)
+    .digest('hex');
+
+  return {
+    value,
+    details: {
+      ...base.details,
+      nodes: {
+        ...base.details?.nodes,
+        'external-deps-digest': externalDigest
+      }
+    },
+    inputs: base.inputs
+  };
+};
+
+export default externalDepsHasher;

--- a/tools/@o3r-internal/external-deps-hasher/jest-with-hasher.impl.mjs
+++ b/tools/@o3r-internal/external-deps-hasher/jest-with-hasher.impl.mjs
@@ -1,0 +1,19 @@
+/*
+ * PROTOTYPE — Option B: execution is unchanged; we only wrap the @nx/jest jest
+ * executor so that our executor entry can declare a custom `hasher`. All test
+ * behaviour is delegated verbatim to the real jest executor.
+ */
+
+import {
+  jestExecutor,
+// eslint-disable-next-line import/no-unresolved -- deep import into @nx/jest; PnP resolves it at runtime, the linter cannot
+} from '@nx/jest/src/executors/jest/jest.impl.js';
+
+/**
+ * Delegating executor: forwards to the real jest implementation. Exists only so
+ * our executors.json entry can declare a custom hasher alongside it.
+ * @type {import('nx/src/config/misc-interfaces').PromiseExecutor}
+ */
+const runExecutor = async (options, context) => jestExecutor(options, context);
+
+export default runExecutor;

--- a/tools/@o3r-internal/external-deps-hasher/package.json
+++ b/tools/@o3r-internal/external-deps-hasher/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@o3r-internal/external-deps-hasher",
+  "version": "0.0.0",
+  "private": true,
+  "description": "PROTOTYPE (Option B): local Nx executor that wraps @nx/jest:jest with a custom hasher scoping the cache to a project's actually-used external dependencies.",
+  "executors": "./executors.json",
+  "peerDependencies": {
+    "@nx/jest": "~22.7.0",
+    "nx": "~22.7.0"
+  }
+}

--- a/tools/@o3r-internal/external-deps-hasher/schema.json
+++ b/tools/@o3r-internal/external-deps-hasher/schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "version": 2,
+  "title": "Jest (with external-deps custom hasher)",
+  "description": "PROTOTYPE — passthrough schema; options are forwarded to @nx/jest:jest.",
+  "type": "object",
+  "properties": {
+    "jestConfig": {
+      "type": "string",
+      "description": "The path of the Jest configuration."
+    }
+  },
+  "additionalProperties": true,
+  "required": ["jestConfig"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8962,6 +8962,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@o3r-internal/external-deps-hasher@workspace:*, @o3r-internal/external-deps-hasher@workspace:tools/@o3r-internal/external-deps-hasher":
+  version: 0.0.0-use.local
+  resolution: "@o3r-internal/external-deps-hasher@workspace:tools/@o3r-internal/external-deps-hasher"
+  peerDependencies:
+    "@nx/jest": ~22.7.0
+    nx: ~22.7.0
+  languageName: unknown
+  linkType: soft
+
 "@o3r-training/showcase-sdk@workspace:packages/@o3r-training/showcase-sdk, @o3r-training/showcase-sdk@workspace:~":
   version: 0.0.0-use.local
   resolution: "@o3r-training/showcase-sdk@workspace:packages/@o3r-training/showcase-sdk"
@@ -10743,6 +10752,7 @@ __metadata:
     "@nx/js": "npm:~22.7.0"
     "@nx/vitest": "npm:~22.7.0"
     "@nx/workspace": "npm:~22.7.0"
+    "@o3r-internal/external-deps-hasher": "workspace:*"
     "@o3r/components": "workspace:~"
     "@o3r/eslint-config": "workspace:~"
     "@o3r/eslint-plugin": "workspace:~"


### PR DESCRIPTION
## Proposed change

PROTOTYPE for team review. Compute-the-hash-ourselves approach: a local executor (@o3r-internal/external-deps-hasher:jest) wraps @nx/jest:jest and attaches a CustomHasher (hasherFactory) that folds the default task hash with a digest of the project's transitively-used external deps (from the Nx graph + yarn.lock hashes). Nothing written to disk.

- nx.json: test-int uses the local executor; externalDependencies:[] neutralises the AllExternalDependencies default so our digest is the sole dep signal.
- yarn.lock removed from sharedGlobals.

Verified on Nx 22.7.6: getCustomHasher resolves our hasher for test-int, it produces a stable hash, and digests differ per project (core/analytics/ rules-engine) — proving per-project scoping.

Note: a createNodesV2 variant was attempted first but Nx dropped the injected inputs during config merge; the custom-hasher route bypasses that entirely.

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
