### PR TITLE
fix(apis-manager): fix the ApiFactory to be provided in root.

### DIFF
--- a/packages/@o3r/apis-manager/src/apis-manager/api-factory-service.ts
+++ b/packages/@o3r/apis-manager/src/apis-manager/api-factory-service.ts
@@ -23,7 +23,9 @@ export type ApiClassType<T extends Api = Api> = (new (client: ApiClient) => T) &
  */
 export const INITIAL_APIS_TOKEN = new InjectionToken<(Api | ApiClassType)[]>('Initial APIs token');
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class ApiFactoryService {
   private readonly apiManager = inject<ApiManager>(API_TOKEN);
 


### PR DESCRIPTION
## Proposed change

fix(apis-manager): fix the `ApiFactory` to be provided in root which avoid having multiple instance of the service in a lazy loaded app.

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
