### PR TITLE
feat(apis-manager): allow API instantiation without cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "qs": "~6.15.0",
     "rxjs": "^7.8.1",
     "shell-quote": "^1.8.4",
+    "tar": "^7.5.22",
     "typescript-json-schema/typescript": "~5.9.2"
   },
   "dependencies": {

--- a/packages/@o3r/apis-manager/src/apis-manager/api-factory-service.spec.ts
+++ b/packages/@o3r/apis-manager/src/apis-manager/api-factory-service.spec.ts
@@ -1,0 +1,61 @@
+import type {
+  ApiClient,
+} from '@ama-sdk/core';
+import {
+  TestBed,
+} from '@angular/core/testing';
+import {
+  ApiFactoryService,
+} from './api-factory-service';
+import {
+  ApiManager,
+} from './api-manager';
+import {
+  API_TOKEN,
+} from './api-manager-token';
+
+class TestApi {
+  public static apiName = 'test-api';
+
+  constructor(public readonly client: ApiClient) {}
+}
+
+describe('ApiFactoryService', () => {
+  let service: ApiFactoryService;
+  let getConfiguration: jest.Mock;
+
+  beforeEach(() => {
+    getConfiguration = jest.fn();
+    const apiManager = {
+      getConfiguration
+    } as unknown as ApiManager;
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: API_TOKEN, useValue: apiManager }]
+    });
+
+    service = TestBed.inject(ApiFactoryService);
+  });
+
+  it('should instantiate an API with the configuration returned by the API manager', () => {
+    const clientConfig = { basePath: 'https://example.com' } as unknown as ApiClient;
+    getConfiguration.mockReturnValue(clientConfig);
+
+    const api = service.createApi(TestApi as never);
+
+    expect(api).toBeInstanceOf(TestApi);
+    expect(api.client).toBe(clientConfig);
+    expect(getConfiguration).toHaveBeenCalledWith(TestApi);
+  });
+
+  it('should use the custom API name when creating an API', () => {
+    const clientConfig = { basePath: 'https://custom.example.com' } as unknown as ApiClient;
+    getConfiguration.mockReturnValue(clientConfig);
+
+    const api = service.createApi(TestApi as never, 'custom-api-name');
+
+    expect(api).toBeInstanceOf(TestApi);
+    expect(api.client).toBe(clientConfig);
+    expect(getConfiguration).toHaveBeenCalledWith('custom-api-name');
+  });
+});

--- a/packages/@o3r/apis-manager/src/apis-manager/api-factory-service.ts
+++ b/packages/@o3r/apis-manager/src/apis-manager/api-factory-service.ts
@@ -23,7 +23,9 @@ export type ApiClassType<T extends Api = Api> = (new (client: ApiClient) => T) &
  */
 export const INITIAL_APIS_TOKEN = new InjectionToken<(Api | ApiClassType)[]>('Initial APIs token');
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class ApiFactoryService {
   private readonly apiManager = inject<ApiManager>(API_TOKEN);
 
@@ -61,9 +63,21 @@ export class ApiFactoryService {
       return cache as T;
     }
 
-    const instance = new apiClass(this.getConfigFor(customApiName ?? apiClass));
+    const instance = this.createApi(apiClass, customApiName);
     this.loadedApis[apiName] = instance;
     return instance;
+  }
+
+  /**
+   * Instantiate a new instance of a specific API with loaded configuration, without using cache mechanism.
+   * Warning: This function should be used only in specific cases when the cache should not be used. Otherwise, {@see getApi} is highly recommended.
+   * @param apiClass class of the API to retrieve
+   * @param customApiName override the `apiName` set in the `apiClass`
+   * @note When passing `customApiName` the configuration is expecting to exist else an error is thrown
+   * @note When passing an Api instance that does not match a registered configuration without `customApiName`, the default one will be returned
+   */
+  public createApi<T extends Api>(apiClass: (new (client: ApiClient) => T) & ApiName, customApiName?: string): T {
+    return new apiClass(this.getConfigFor(customApiName ?? apiClass));
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -20924,13 +20924,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chownr@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "chownr@npm:2.0.0"
-  checksum: 10/c57cf9dd0791e2f18a5ee9c1a299ae6e801ff58fee96dc8bfd0dcb4738a6ce58dd252a3605b1c93c6418fe4f9d5093b28ffbf4d66648cb2a9c67eaef9679be2f
-  languageName: node
-  linkType: hard
-
 "chownr@npm:^3.0.0":
   version: 3.0.0
   resolution: "chownr@npm:3.0.0"
@@ -26026,15 +26019,6 @@ __metadata:
     jsonfile: "npm:^4.0.0"
     universalify: "npm:^0.1.0"
   checksum: 10/6fb12449f5349be724a138b4a7b45fe6a317d2972054517f5971959c26fbd17c0e145731a11c7324460262baa33e0a799b183ceace98f7a372c95fbb6f20f5de
-  languageName: node
-  linkType: hard
-
-"fs-minipass@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "fs-minipass@npm:2.1.0"
-  dependencies:
-    minipass: "npm:^3.0.0"
-  checksum: 10/03191781e94bc9a54bd376d3146f90fe8e082627c502185dbf7b9b3032f66b0b142c1115f3b2cc5936575fc1b44845ce903dd4c21bec2a8d69f3bd56f9cee9ec
   languageName: node
   linkType: hard
 
@@ -31314,13 +31298,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "minipass@npm:5.0.0"
-  checksum: 10/61682162d29f45d3152b78b08bab7fb32ca10899bc5991ffe98afc18c9e9543bd1e3be94f8b8373ba6262497db63607079dc242ea62e43e7b2270837b7347c93
-  languageName: node
-  linkType: hard
-
 "minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.0.4, minipass@npm:^7.1.2":
   version: 7.1.2
   resolution: "minipass@npm:7.1.2"
@@ -31332,16 +31309,6 @@ __metadata:
   version: 7.1.3
   resolution: "minipass@npm:7.1.3"
   checksum: 10/175e4d5e20980c3cd316ae82d2c031c42f6c746467d8b1905b51060a0ba4461441a0c25bb67c025fd9617f9a3873e152c7b543c6b5ac83a1846be8ade80dffd6
-  languageName: node
-  linkType: hard
-
-"minizlib@npm:^2.1.1":
-  version: 2.1.2
-  resolution: "minizlib@npm:2.1.2"
-  dependencies:
-    minipass: "npm:^3.0.0"
-    yallist: "npm:^4.0.0"
-  checksum: 10/ae0f45436fb51344dcb87938446a32fbebb540d0e191d63b35e1c773d47512e17307bf54aa88326cc6d176594d00e4423563a091f7266c2f9a6872cdc1e234d1
   languageName: node
   linkType: hard
 
@@ -31368,7 +31335,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:1.0.4, mkdirp@npm:^1.0.3, mkdirp@npm:^1.0.4":
+"mkdirp@npm:1.0.4, mkdirp@npm:^1.0.4":
   version: 1.0.4
   resolution: "mkdirp@npm:1.0.4"
   bin:
@@ -38283,30 +38250,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^6.0.5, tar@npm:^6.1.11":
-  version: 6.2.1
-  resolution: "tar@npm:6.2.1"
-  dependencies:
-    chownr: "npm:^2.0.0"
-    fs-minipass: "npm:^2.0.0"
-    minipass: "npm:^5.0.0"
-    minizlib: "npm:^2.1.1"
-    mkdirp: "npm:^1.0.3"
-    yallist: "npm:^4.0.0"
-  checksum: 10/bfbfbb2861888077fc1130b84029cdc2721efb93d1d1fb80f22a7ac3a98ec6f8972f29e564103bbebf5e97be67ebc356d37fa48dbc4960600a1eb7230fbd1ea0
-  languageName: node
-  linkType: hard
-
-"tar@npm:^7.0.0, tar@npm:^7.4.3, tar@npm:^7.5.2":
-  version: 7.5.2
-  resolution: "tar@npm:7.5.2"
+"tar@npm:^7.5.22":
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10/dbad9c9a07863cd1bdf8801d563b3280aa7dd0f4a6cead779ff7516d148dc80b4c04639ba732d47f91f04002f57e8c3c6573a717d649daecaac74ce71daa7ad3
+  checksum: 10/129606384b3c895f422aaca48bf316357be6dc7aa35c1066c3f06c28acfff0be5b356e1b0a0be7c53a7a8945534ac06cec6d8e296d170d8a09c8bff67b29300e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
feat(apis-manager): allow API instantiation without cache

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
