### PR TITLE
feat: clean up deprecated v15 - prepareUrl

### DIFF
--- a/packages/@ama-sdk/client-angular/src/api-angular-client.ts
+++ b/packages/@ama-sdk/client-angular/src/api-angular-client.ts
@@ -17,7 +17,6 @@ import {
   filterUndefinedValues,
   getPropertiesFromData,
   getResponseReviver,
-  prepareUrl,
   prepareUrlWithQueryParams,
   processFormData,
   RequestFailedError,
@@ -123,13 +122,8 @@ export class ApiAngularClient implements ApiClient {
   }
 
   /** @inheritdoc */
-  public prepareUrl(url: string, queryParameters: { [key: string]: string | undefined } = {}) {
-    return prepareUrl(url, queryParameters);
-  }
-
-  /** @inheritdoc */
-  public prepareUrlWithQueryParams(url: string, serializedQueryParams?: { [key: string]: string }): string {
-    return prepareUrlWithQueryParams(url, serializedQueryParams);
+  public prepareUrlWithQueryParams(url: string, serializedQueryParams?: { [key: string]: string }, enableParameterSerialization?: boolean): string {
+    return prepareUrlWithQueryParams(url, serializedQueryParams, enableParameterSerialization);
   }
 
   /** @inheritdoc */

--- a/packages/@ama-sdk/client-beacon/src/api-beacon-client.ts
+++ b/packages/@ama-sdk/client-beacon/src/api-beacon-client.ts
@@ -12,7 +12,6 @@ import type {
 import {
   filterUndefinedValues,
   getPropertiesFromData,
-  prepareUrl,
   prepareUrlWithQueryParams,
   processFormData,
   serializePathParams,
@@ -126,13 +125,8 @@ export class ApiBeaconClient implements ApiClient {
   }
 
   /** @inheritdoc */
-  public prepareUrl(url: string, queryParameters?: { [key: string]: string }): string {
-    return prepareUrl(url, queryParameters);
-  }
-
-  /** @inheritdoc */
-  public prepareUrlWithQueryParams(url: string, serializedQueryParams?: { [key: string]: string }): string {
-    return prepareUrlWithQueryParams(url, serializedQueryParams);
+  public prepareUrlWithQueryParams(url: string, serializedQueryParams?: { [key: string]: string }, enableParameterSerialization?: boolean): string {
+    return prepareUrlWithQueryParams(url, serializedQueryParams, enableParameterSerialization);
   }
 
   /** @inheritdoc */

--- a/packages/@ama-sdk/client-fetch/src/api-fetch-client.ts
+++ b/packages/@ama-sdk/client-fetch/src/api-fetch-client.ts
@@ -18,7 +18,6 @@ import {
   filterUndefinedValues,
   getPropertiesFromData,
   getResponseReviver,
-  prepareUrl,
   prepareUrlWithQueryParams,
   processFormData,
   RequestFailedError,
@@ -124,13 +123,8 @@ export class ApiFetchClient implements ApiClient {
   }
 
   /** @inheritdoc */
-  public prepareUrl(url: string, queryParameters: { [key: string]: string | undefined } = {}) {
-    return prepareUrl(url, queryParameters);
-  }
-
-  /** @inheritdoc */
-  public prepareUrlWithQueryParams(url: string, serializedQueryParams?: { [key: string]: string }): string {
-    return prepareUrlWithQueryParams(url, serializedQueryParams);
+  public prepareUrlWithQueryParams(url: string, serializedQueryParams?: { [key: string]: string }, enableParameterSerialization?: boolean): string {
+    return prepareUrlWithQueryParams(url, serializedQueryParams, enableParameterSerialization);
   }
 
   /** @inheritdoc */

--- a/packages/@ama-sdk/core/src/fwk/api-helpers.spec.ts
+++ b/packages/@ama-sdk/core/src/fwk/api-helpers.spec.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-console -- only using the reference */
 import {
   getResponseReviver,
-  prepareUrl,
   prepareUrlWithQueryParams,
   ReviverType,
+  stringifyQueryParams,
 } from '@ama-sdk/core';
 
 describe('getResponseReviver - revivers by status code', () => {
@@ -69,13 +69,6 @@ describe('getResponseReviver - reviver as function', () => {
 });
 
 describe('Prepare URL', () => {
-  it('should correctly prepare url with query parameters of deprecated type', () => {
-    // primitive value
-    expect(prepareUrl('https://sampleUrl/samplePath/sampleOperation', { id: '5' })).toEqual('https://sampleUrl/samplePath/sampleOperation?id=5');
-    // array value
-    expect(prepareUrl('https://sampleUrl/samplePath/sampleOperation', { id: '3,4,5' })).toEqual('https://sampleUrl/samplePath/sampleOperation?id=3,4,5');
-  });
-
   it('should correctly prepare url with serialized query parameters', () => {
     // one parameter
     expect(prepareUrlWithQueryParams('https://sampleUrl/samplePath/sampleOperation', { id: 'id=5' }))
@@ -87,5 +80,68 @@ describe('Prepare URL', () => {
     // multiple parameters
     expect(prepareUrlWithQueryParams('https://sampleUrl/samplePath/sampleOperation', { id1: 'id1=3,4,5', id2: 'id2=5' }))
       .toEqual('https://sampleUrl/samplePath/sampleOperation?id1=3,4,5&id2=5');
+  });
+
+  it('should correctly prepare url with serialized query parameters when enableParameterSerialization is true', () => {
+    // Serialized values already contain "key=value" — Object.values is used
+    expect(prepareUrlWithQueryParams('https://sampleUrl/samplePath/sampleOperation', { id: 'id=5' }, true))
+      .toEqual('https://sampleUrl/samplePath/sampleOperation?id=5');
+
+    expect(prepareUrlWithQueryParams('https://sampleUrl/samplePath/sampleOperation', { id1: 'id1=3,4,5', id2: 'id2=5' }, true))
+      .toEqual('https://sampleUrl/samplePath/sampleOperation?id1=3,4,5&id2=5');
+  });
+
+  it('should correctly prepare url with stringified query parameters when enableParameterSerialization is false', () => {
+    // Stringified values are bare — Object.entries is used to produce "key=value"
+    expect(prepareUrlWithQueryParams('https://sampleUrl/samplePath/sampleOperation', { id: '5' }, false))
+      .toEqual('https://sampleUrl/samplePath/sampleOperation?id=5');
+
+    // no parameters
+    expect(prepareUrlWithQueryParams('https://sampleUrl/samplePath/sampleOperation', {}, false))
+      .toEqual('https://sampleUrl/samplePath/sampleOperation');
+
+    // multiple parameters
+    expect(prepareUrlWithQueryParams('https://sampleUrl/samplePath/sampleOperation', { id1: '3,4,5', id2: '5' }, false))
+      .toEqual('https://sampleUrl/samplePath/sampleOperation?id1=3,4,5&id2=5');
+
+    // array-like values
+    expect(prepareUrlWithQueryParams('https://sampleUrl/samplePath/sampleOperation', { tags: 'a,b,c' }, false))
+      .toEqual('https://sampleUrl/samplePath/sampleOperation?tags=a,b,c');
+
+    // undefined values should be filtered
+    expect(prepareUrlWithQueryParams('https://sampleUrl/samplePath/sampleOperation', { id: '5', filter: undefined }, false))
+      .toEqual('https://sampleUrl/samplePath/sampleOperation?id=5');
+  });
+
+  it('should use & as separator when url already contains ?', () => {
+    expect(prepareUrlWithQueryParams('https://sampleUrl/samplePath?existing=1', { id: 'id=5' }, true))
+      .toEqual('https://sampleUrl/samplePath?existing=1&id=5');
+
+    expect(prepareUrlWithQueryParams('https://sampleUrl/samplePath?existing=1', { id: '5' }, false))
+      .toEqual('https://sampleUrl/samplePath?existing=1&id=5');
+  });
+});
+
+describe('stringifyQueryParams', () => {
+  it('should exclude undefined values from the result', () => {
+    const queryParams = { id: '5', filter: undefined, name: 'test' };
+    const result = stringifyQueryParams(queryParams);
+    expect(result).toEqual({ id: '5', name: 'test' });
+    expect('filter' in result).toBe(false);
+  });
+
+  it('should exclude null values from the result', () => {
+    const queryParams = { id: '5', filter: null, name: 'test' };
+    const result = stringifyQueryParams(queryParams);
+    expect(result).toEqual({ id: '5', name: 'test' });
+    expect('filter' in result).toBe(false);
+  });
+
+  it('should produce correct URL when combined with prepareUrlWithQueryParams and enableParameterSerialization is false', () => {
+    // Simulates the template flow: stringifyQueryParams -> prepareUrlWithQueryParams(url, params, false)
+    const queryParams = { id: '5', filter: undefined, page: '2' };
+    const stringified = stringifyQueryParams(queryParams);
+    const url = prepareUrlWithQueryParams('https://api.example.com/resource', stringified, false);
+    expect(url).toEqual('https://api.example.com/resource?id=5&page=2');
   });
 });

--- a/packages/@ama-sdk/core/src/fwk/api-helpers.ts
+++ b/packages/@ama-sdk/core/src/fwk/api-helpers.ts
@@ -10,30 +10,19 @@ import type {
 } from './reviver';
 
 /**
- * Prepares the url to be called
- * @param url Base url to be used
- * @param queryParameters Key value pair with the parameters. If the value is undefined, the key is dropped
- * @deprecated use {@link prepareUrlWithQueryParams} with query parameter serialization, will be removed in v15.
- */
-export function prepareUrl(url: string, queryParameters: { [key: string]: string | undefined } = {}) {
-  const queryPart = Object.keys(queryParameters)
-    .filter((name) => typeof queryParameters[name] !== 'undefined')
-    .map((name) => `${name}=${queryParameters[name]!}`)
-    .join('&');
-
-  const paramsPrefix = url.includes('?') ? '&' : '?';
-
-  return url + (queryPart ? paramsPrefix + queryPart : '');
-}
-
-/**
  * Prepares the url to be called with the query parameters
  * @param url Base url to be used
  * @param serializedQueryParams Key value pairs of query parameter names and their serialized values
+ * @param enableParameterSerialization Enable parameter serialization
  */
-export function prepareUrlWithQueryParams(url: string, serializedQueryParams: { [key: string]: string } = {}): string {
+export function prepareUrlWithQueryParams(url: string, serializedQueryParams: { [key: string]: string } = {}, enableParameterSerialization = true): string {
   const paramsPrefix = url.includes('?') ? '&' : '?';
-  const queryPart = Object.values(serializedQueryParams).join('&');
+  const queryPart = enableParameterSerialization
+    ? Object.values(serializedQueryParams).join('&')
+    : Object.entries(serializedQueryParams)
+      .filter(([, value]) => typeof value !== 'undefined')
+      .map(([key, value]) => `${key}=${value}`)
+      .join('&');
   return url + (queryPart ? paramsPrefix + queryPart : '');
 }
 

--- a/packages/@ama-sdk/core/src/fwk/core/api-client.ts
+++ b/packages/@ama-sdk/core/src/fwk/core/api-client.ts
@@ -74,19 +74,12 @@ export interface ApiClient {
   getRequestOptions(requestOptionsParameters: RequestOptionsParameters): Promise<RequestOptions>;
 
   /**
-   * Prepares the url to be called
-   * @param url Base url to be used
-   * @param queryParameters Key value pair with the parameters. If the value is undefined, the key is dropped
-   * @deprecated use {@link prepareUrlWithQueryParams} with query parameter serialization, will be removed in v15.
-   */
-  prepareUrl(url: string, queryParameters?: { [key: string]: string | undefined }): string;
-
-  /**
    * Prepares the url to be called with the query parameters
    * @param url Base url to be used
    * @param serializedQueryParams Key value pairs of query parameter names and their serialized values
+   * @param enableParameterSerialization Whether parameter serialization is enabled (determines how query params are joined)
    */
-  prepareUrlWithQueryParams(url: string, serializedQueryParams?: { [key: string]: string }): string;
+  prepareUrlWithQueryParams(url: string, serializedQueryParams?: { [key: string]: string }, enableParameterSerialization?: boolean): string;
 
   /**
    * Serialize query parameters based on the values of exploded and style
@@ -135,7 +128,7 @@ export function isApiClient(client: any): client is ApiClient {
     && !!apiClient.options
     && typeof apiClient.stringifyQueryParams === 'function'
     && typeof apiClient.getRequestOptions === 'function'
-    && (typeof apiClient.prepareUrl === 'function' || typeof apiClient.prepareUrlWithQueryParams === 'function')
+    && typeof apiClient.prepareUrlWithQueryParams === 'function'
     && typeof apiClient.processFormData === 'function'
     && typeof apiClient.processCall === 'function';
 }

--- a/packages/@ama-sdk/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/api.mustache
+++ b/packages/@ama-sdk/openapi-codegen-typescript/src/main/resources/typescriptFetch/api/api.mustache
@@ -163,7 +163,7 @@ export class {{classname}} implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<{{#vendorExtensions}}{{#responses2xxReturnTypes}}{{{.}}}{{^-last}} | {{/-last}}{{/responses2xxReturnTypes}}{{^responses2xxReturnTypes}}never{{/responses2xxReturnTypes}}{{/vendorExtensions}}>(url, options, {{#tags.0.extensions.x-api-type}}ApiTypes.{{tags.0.extensions.x-api-type}}{{/tags.0.extensions.x-api-type}}{{^tags.0.extensions.x-api-type}}ApiTypes.DEFAULT{{/tags.0.extensions.x-api-type}}, {{classname}}.apiName,{{#keepRevivers}}{{#vendorExtensions}}{{#responses2xx}}{{#-first}} { {{/-first}}{{code}}: {{^primitiveType}}revive{{baseType}}{{/primitiveType}}{{#primitiveType}}undefined{{/primitiveType}}{{^-last}}, {{/-last}}{{#-last}} } {{/-last}}{{/responses2xx}}{{^responses2xx}} undefined{{/responses2xx}}{{/vendorExtensions}}{{/keepRevivers}}{{^keepRevivers}} undefined{{/keepRevivers}}, '{{nickname}}');
     return ret;

--- a/packages/@ama-styling/figma-sdk/src/api/activity-logs/activity-logs-api.ts
+++ b/packages/@ama-styling/figma-sdk/src/api/activity-logs/activity-logs-api.ts
@@ -85,7 +85,7 @@ export class ActivityLogsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetActivityLogs200Response>(url, options, ApiTypes.DEFAULT, ActivityLogsApi.apiName, undefined, 'getActivityLogs');
     return ret;

--- a/packages/@ama-styling/figma-sdk/src/api/comment-reactions/comment-reactions-api.ts
+++ b/packages/@ama-styling/figma-sdk/src/api/comment-reactions/comment-reactions-api.ts
@@ -104,7 +104,7 @@ export class CommentReactionsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<DeleteComment200Response>(url, options, ApiTypes.DEFAULT, CommentReactionsApi.apiName, undefined, 'deleteCommentReaction');
     return ret;
@@ -161,7 +161,7 @@ export class CommentReactionsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetCommentReactions200Response>(url, options, ApiTypes.DEFAULT, CommentReactionsApi.apiName, undefined, 'getCommentReactions');
     return ret;
@@ -218,7 +218,7 @@ export class CommentReactionsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<DeleteComment200Response>(url, options, ApiTypes.DEFAULT, CommentReactionsApi.apiName, undefined, 'postCommentReaction');
     return ret;

--- a/packages/@ama-styling/figma-sdk/src/api/comments/comments-api.ts
+++ b/packages/@ama-styling/figma-sdk/src/api/comments/comments-api.ts
@@ -94,7 +94,7 @@ export class CommentsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<DeleteComment200Response>(url, options, ApiTypes.DEFAULT, CommentsApi.apiName, undefined, 'deleteComment');
     return ret;
@@ -151,7 +151,7 @@ export class CommentsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetComments200Response>(url, options, ApiTypes.DEFAULT, CommentsApi.apiName, undefined, 'getComments');
     return ret;
@@ -208,7 +208,7 @@ export class CommentsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<Comment>(url, options, ApiTypes.DEFAULT, CommentsApi.apiName, undefined, 'postComment');
     return ret;

--- a/packages/@ama-styling/figma-sdk/src/api/component-sets/component-sets-api.ts
+++ b/packages/@ama-styling/figma-sdk/src/api/component-sets/component-sets-api.ts
@@ -93,7 +93,7 @@ export class ComponentSetsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetComponentSet200Response>(url, options, ApiTypes.DEFAULT, ComponentSetsApi.apiName, undefined, 'getComponentSet');
     return ret;
@@ -145,7 +145,7 @@ export class ComponentSetsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetFileComponentSets200Response>(url, options, ApiTypes.DEFAULT, ComponentSetsApi.apiName, undefined, 'getFileComponentSets');
     return ret;
@@ -203,7 +203,7 @@ export class ComponentSetsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetTeamComponentSets200Response>(url, options, ApiTypes.DEFAULT, ComponentSetsApi.apiName, undefined, 'getTeamComponentSets');
     return ret;

--- a/packages/@ama-styling/figma-sdk/src/api/components/components-api.ts
+++ b/packages/@ama-styling/figma-sdk/src/api/components/components-api.ts
@@ -93,7 +93,7 @@ export class ComponentsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetComponent200Response>(url, options, ApiTypes.DEFAULT, ComponentsApi.apiName, undefined, 'getComponent');
     return ret;
@@ -145,7 +145,7 @@ export class ComponentsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetFileComponents200Response>(url, options, ApiTypes.DEFAULT, ComponentsApi.apiName, undefined, 'getFileComponents');
     return ret;
@@ -203,7 +203,7 @@ export class ComponentsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetTeamComponents200Response>(url, options, ApiTypes.DEFAULT, ComponentsApi.apiName, undefined, 'getTeamComponents');
     return ret;

--- a/packages/@ama-styling/figma-sdk/src/api/dev-resources/dev-resources-api.ts
+++ b/packages/@ama-styling/figma-sdk/src/api/dev-resources/dev-resources-api.ts
@@ -98,7 +98,7 @@ export class DevResourcesApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<void>(url, options, ApiTypes.DEFAULT, DevResourcesApi.apiName, undefined, 'deleteDevResource');
     return ret;
@@ -155,7 +155,7 @@ export class DevResourcesApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetDevResources200Response>(url, options, ApiTypes.DEFAULT, DevResourcesApi.apiName, undefined, 'getDevResources');
     return ret;
@@ -202,7 +202,7 @@ export class DevResourcesApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<PostDevResources200Response>(url, options, ApiTypes.DEFAULT, DevResourcesApi.apiName, undefined, 'postDevResources');
     return ret;
@@ -249,7 +249,7 @@ export class DevResourcesApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<PutDevResources200Response>(url, options, ApiTypes.DEFAULT, DevResourcesApi.apiName, undefined, 'putDevResources');
     return ret;

--- a/packages/@ama-styling/figma-sdk/src/api/files/files-api.ts
+++ b/packages/@ama-styling/figma-sdk/src/api/files/files-api.ts
@@ -162,7 +162,7 @@ export class FilesApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetFile200Response>(url, options, ApiTypes.DEFAULT, FilesApi.apiName, undefined, 'getFile');
     return ret;
@@ -214,7 +214,7 @@ export class FilesApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetFileMeta200Response>(url, options, ApiTypes.DEFAULT, FilesApi.apiName, undefined, 'getFileMeta');
     return ret;
@@ -271,7 +271,7 @@ export class FilesApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetFileNodes200Response>(url, options, ApiTypes.DEFAULT, FilesApi.apiName, undefined, 'getFileNodes');
     return ret;
@@ -328,7 +328,7 @@ export class FilesApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetFileVersions200Response>(url, options, ApiTypes.DEFAULT, FilesApi.apiName, undefined, 'getFileVersions');
     return ret;
@@ -380,7 +380,7 @@ export class FilesApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetImageFills200Response>(url, options, ApiTypes.DEFAULT, FilesApi.apiName, undefined, 'getImageFills');
     return ret;
@@ -444,7 +444,7 @@ export class FilesApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetImages200Response>(url, options, ApiTypes.DEFAULT, FilesApi.apiName, undefined, 'getImages');
     return ret;

--- a/packages/@ama-styling/figma-sdk/src/api/library-analytics/library-analytics-api.ts
+++ b/packages/@ama-styling/figma-sdk/src/api/library-analytics/library-analytics-api.ts
@@ -164,7 +164,7 @@ export class LibraryAnalyticsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetLibraryAnalyticsComponentActions200Response>(url, options, ApiTypes.DEFAULT, LibraryAnalyticsApi.apiName, undefined, 'getLibraryAnalyticsComponentActions');
     return ret;
@@ -221,7 +221,7 @@ export class LibraryAnalyticsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetLibraryAnalyticsComponentUsages200Response>(url, options, ApiTypes.DEFAULT, LibraryAnalyticsApi.apiName, undefined, 'getLibraryAnalyticsComponentUsages');
     return ret;
@@ -278,7 +278,7 @@ export class LibraryAnalyticsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetLibraryAnalyticsStyleActions200Response>(url, options, ApiTypes.DEFAULT, LibraryAnalyticsApi.apiName, undefined, 'getLibraryAnalyticsStyleActions');
     return ret;
@@ -335,7 +335,7 @@ export class LibraryAnalyticsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetLibraryAnalyticsStyleUsages200Response>(url, options, ApiTypes.DEFAULT, LibraryAnalyticsApi.apiName, undefined, 'getLibraryAnalyticsStyleUsages');
     return ret;
@@ -392,7 +392,7 @@ export class LibraryAnalyticsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetLibraryAnalyticsVariableActions200Response>(url, options, ApiTypes.DEFAULT, LibraryAnalyticsApi.apiName, undefined, 'getLibraryAnalyticsVariableActions');
     return ret;
@@ -449,7 +449,7 @@ export class LibraryAnalyticsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetLibraryAnalyticsVariableUsages200Response>(url, options, ApiTypes.DEFAULT, LibraryAnalyticsApi.apiName, undefined, 'getLibraryAnalyticsVariableUsages');
     return ret;

--- a/packages/@ama-styling/figma-sdk/src/api/payments/payments-api.ts
+++ b/packages/@ama-styling/figma-sdk/src/api/payments/payments-api.ts
@@ -81,7 +81,7 @@ export class PaymentsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetPayments200Response>(url, options, ApiTypes.DEFAULT, PaymentsApi.apiName, undefined, 'getPayments');
     return ret;

--- a/packages/@ama-styling/figma-sdk/src/api/projects/projects-api.ts
+++ b/packages/@ama-styling/figma-sdk/src/api/projects/projects-api.ts
@@ -89,7 +89,7 @@ export class ProjectsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetProjectFiles200Response>(url, options, ApiTypes.DEFAULT, ProjectsApi.apiName, undefined, 'getProjectFiles');
     return ret;
@@ -141,7 +141,7 @@ export class ProjectsApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetTeamProjects200Response>(url, options, ApiTypes.DEFAULT, ProjectsApi.apiName, undefined, 'getTeamProjects');
     return ret;

--- a/packages/@ama-styling/figma-sdk/src/api/styles/styles-api.ts
+++ b/packages/@ama-styling/figma-sdk/src/api/styles/styles-api.ts
@@ -93,7 +93,7 @@ export class StylesApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetFileStyles200Response>(url, options, ApiTypes.DEFAULT, StylesApi.apiName, undefined, 'getFileStyles');
     return ret;
@@ -145,7 +145,7 @@ export class StylesApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetStyle200Response>(url, options, ApiTypes.DEFAULT, StylesApi.apiName, undefined, 'getStyle');
     return ret;
@@ -203,7 +203,7 @@ export class StylesApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetTeamStyles200Response>(url, options, ApiTypes.DEFAULT, StylesApi.apiName, undefined, 'getTeamStyles');
     return ret;

--- a/packages/@ama-styling/figma-sdk/src/api/users/users-api.ts
+++ b/packages/@ama-styling/figma-sdk/src/api/users/users-api.ts
@@ -63,7 +63,7 @@ export class UsersApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetMe200Response>(url, options, ApiTypes.DEFAULT, UsersApi.apiName, undefined, 'getMe');
     return ret;

--- a/packages/@ama-styling/figma-sdk/src/api/variables/variables-api.ts
+++ b/packages/@ama-styling/figma-sdk/src/api/variables/variables-api.ts
@@ -90,7 +90,7 @@ export class VariablesApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetLocalVariables200Response>(url, options, ApiTypes.DEFAULT, VariablesApi.apiName, undefined, 'getLocalVariables');
     return ret;
@@ -142,7 +142,7 @@ export class VariablesApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetPublishedVariables200Response>(url, options, ApiTypes.DEFAULT, VariablesApi.apiName, undefined, 'getPublishedVariables');
     return ret;
@@ -199,7 +199,7 @@ export class VariablesApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<PostVariables200Response>(url, options, ApiTypes.DEFAULT, VariablesApi.apiName, undefined, 'postVariables');
     return ret;

--- a/packages/@ama-styling/figma-sdk/src/api/webhooks/webhooks-api.ts
+++ b/packages/@ama-styling/figma-sdk/src/api/webhooks/webhooks-api.ts
@@ -106,7 +106,7 @@ export class WebhooksApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<WebhookV2>(url, options, ApiTypes.DEFAULT, WebhooksApi.apiName, undefined, 'deleteWebhook');
     return ret;
@@ -158,7 +158,7 @@ export class WebhooksApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetTeamWebhooks200Response>(url, options, ApiTypes.DEFAULT, WebhooksApi.apiName, undefined, 'getTeamWebhooks');
     return ret;
@@ -210,7 +210,7 @@ export class WebhooksApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<WebhookV2>(url, options, ApiTypes.DEFAULT, WebhooksApi.apiName, undefined, 'getWebhook');
     return ret;
@@ -262,7 +262,7 @@ export class WebhooksApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<GetWebhookRequests200Response>(url, options, ApiTypes.DEFAULT, WebhooksApi.apiName, undefined, 'getWebhookRequests');
     return ret;
@@ -309,7 +309,7 @@ export class WebhooksApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<WebhookV2>(url, options, ApiTypes.DEFAULT, WebhooksApi.apiName, undefined, 'postWebhook');
     return ret;
@@ -366,7 +366,7 @@ export class WebhooksApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+        const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<WebhookV2>(url, options, ApiTypes.DEFAULT, WebhooksApi.apiName, undefined, 'putWebhook');
     return ret;

--- a/packages/@o3r-training/showcase-sdk/src/api/pet/pet-api.ts
+++ b/packages/@o3r-training/showcase-sdk/src/api/pet/pet-api.ts
@@ -158,7 +158,7 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<Pet>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'addPet');
     return ret;
@@ -216,7 +216,7 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<string>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'deletePet');
     return ret;
@@ -272,7 +272,7 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<Pet[]>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'findPetsByStatus');
     return ret;
@@ -327,7 +327,7 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<Pet[]>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'findPetsByTags');
     return ret;
@@ -384,7 +384,7 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<Pet>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'getPetById');
     return ret;
@@ -437,7 +437,7 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<Pet>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'updatePet');
     return ret;
@@ -499,7 +499,7 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'updatePetWithForm');
     return ret;
@@ -567,7 +567,7 @@ export class PetApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<ApiResponse>(url, options, ApiTypes.DEFAULT, PetApi.apiName, undefined, 'uploadFile');
     return ret;

--- a/packages/@o3r-training/showcase-sdk/src/api/store/store-api.ts
+++ b/packages/@o3r-training/showcase-sdk/src/api/store/store-api.ts
@@ -99,7 +99,7 @@ export class StoreApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, StoreApi.apiName, undefined, 'deleteOrder');
     return ret;
@@ -146,7 +146,7 @@ export class StoreApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<Record<string, number>>(url, options, ApiTypes.DEFAULT, StoreApi.apiName, undefined, 'getInventory');
     return ret;
@@ -203,7 +203,7 @@ export class StoreApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<Order>(url, options, ApiTypes.DEFAULT, StoreApi.apiName, undefined, 'getOrderById');
     return ret;
@@ -256,7 +256,7 @@ export class StoreApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<Order>(url, options, ApiTypes.DEFAULT, StoreApi.apiName, undefined, 'placeOrder');
     return ret;

--- a/packages/@o3r-training/showcase-sdk/src/api/user/user-api.ts
+++ b/packages/@o3r-training/showcase-sdk/src/api/user/user-api.ts
@@ -124,7 +124,7 @@ export class UserApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'createUser');
     return ret;
@@ -177,7 +177,7 @@ export class UserApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<User>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'createUsersWithListInput');
     return ret;
@@ -234,7 +234,7 @@ export class UserApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'deleteUser');
     return ret;
@@ -291,7 +291,7 @@ export class UserApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<User>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'getUserByName');
     return ret;
@@ -346,7 +346,7 @@ export class UserApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<string>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'loginUser');
     return ret;
@@ -393,7 +393,7 @@ export class UserApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'logoutUser');
     return ret;
@@ -456,7 +456,7 @@ export class UserApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<never>(url, options, ApiTypes.DEFAULT, UserApi.apiName, undefined, 'updateUser');
     return ret;

--- a/packages/@o3r-training/training-sdk/src/api/dummy/dummy-api.ts
+++ b/packages/@o3r-training/training-sdk/src/api/dummy/dummy-api.ts
@@ -69,7 +69,7 @@ export class DummyApi implements Api {
     };
 
     const options = await this.client.getRequestOptions(requestOptions);
-    const url = this.client.options.enableParameterSerialization ? this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams) : this.client.prepareUrl(options.basePath, options.queryParams);
+    const url = this.client.prepareUrlWithQueryParams(options.basePath, options.queryParams, this.client.options.enableParameterSerialization);
 
     const ret = this.client.processCall<Flight>(url, options, ApiTypes.DEFAULT, DummyApi.apiName, { 200: reviveFlight } , 'dummyGet');
     return ret;


### PR DESCRIPTION
## Proposed change

Cleanup of `prepareUrl` which is deprecated and planned to be removed in v15

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
