### PR TITLE
fix(deps): resolve critical audit vulnerabilities in vm2

### DIFF
--- a/packages/@o3r/extractors/package.json
+++ b/packages/@o3r/extractors/package.json
@@ -147,7 +147,7 @@
     "type-fest": "^5.3.1",
     "typescript": "~6.0.3",
     "typescript-eslint": "~8.65.0",
-    "typescript-json-schema": "^0.67.0"
+    "typescript-json-schema": "^0.68.0"
   },
   "engines": {
     "node": "^22.22.3 || ^24.15.0 || ^26.0.0"

--- a/packages/@o3r/rules-engine/package.json
+++ b/packages/@o3r/rules-engine/package.json
@@ -63,7 +63,7 @@
     "rxjs": "^7.8.1",
     "type-fest": "^5.3.1",
     "typescript": "^6.0.0",
-    "typescript-json-schema": "^0.67.0"
+    "typescript-json-schema": "^0.68.0"
   },
   "peerDependenciesMeta": {
     "@angular-devkit/core": {
@@ -184,7 +184,7 @@
     "type-fest": "^5.3.1",
     "typescript": "~6.0.3",
     "typescript-eslint": "~8.65.0",
-    "typescript-json-schema": "^0.67.0",
+    "typescript-json-schema": "^0.68.0",
     "unionfs": "~4.6.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10128,7 +10128,7 @@ __metadata:
     typedoc: "npm:~0.28.0"
     typescript: "npm:~6.0.3"
     typescript-eslint: "npm:~8.65.0"
-    typescript-json-schema: "npm:^0.67.0"
+    typescript-json-schema: "npm:^0.68.0"
   peerDependencies:
     "@angular-devkit/architect": ">=0.2200.0 <0.2300.0-0"
     "@angular-devkit/core": ^22.0.0
@@ -11292,7 +11292,7 @@ __metadata:
     type-fest: "npm:^5.3.1"
     typescript: "npm:~6.0.3"
     typescript-eslint: "npm:~8.65.0"
-    typescript-json-schema: "npm:^0.67.0"
+    typescript-json-schema: "npm:^0.68.0"
     unionfs: "npm:~4.6.0"
   peerDependencies:
     "@angular-devkit/architect": ">=0.2200.0 <0.2300.0-0"
@@ -11319,7 +11319,7 @@ __metadata:
     rxjs: ^7.8.1
     type-fest: ^5.3.1
     typescript: ^6.0.0
-    typescript-json-schema: ^0.67.0
+    typescript-json-schema: ^0.68.0
   peerDependenciesMeta:
     "@angular-devkit/core":
       optional: true
@@ -18267,7 +18267,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-walk@npm:^8.1.1, acorn-walk@npm:^8.2.0, acorn-walk@npm:^8.3.4":
+"acorn-walk@npm:^8.1.1, acorn-walk@npm:^8.2.0":
   version: 8.3.5
   resolution: "acorn-walk@npm:8.3.5"
   dependencies:
@@ -37713,9 +37713,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-json-schema@npm:^0.67.0":
-  version: 0.67.4
-  resolution: "typescript-json-schema@npm:0.67.4"
+"typescript-json-schema@npm:^0.68.0":
+  version: 0.68.0
+  resolution: "typescript-json-schema@npm:0.68.0"
   dependencies:
     "@types/json-schema": "npm:^7.0.15"
     "@types/node": "npm:^24.10.2"
@@ -37724,11 +37724,10 @@ __metadata:
     safe-stable-stringify: "npm:^2.5.0"
     ts-node: "npm:^10.9.2"
     typescript: "npm:~5.9.3"
-    vm2: "npm:^3.11.3"
     yargs: "npm:^18.0.0"
   bin:
     typescript-json-schema: bin/typescript-json-schema
-  checksum: 10/221b8e5efc589cf5784d64e5bf6eaf00f3fe19ef40008e7aaa24dd4c7c5a70c780980cb4824590a969e791606af55875e737d16b899aa296391d2eedbb54811f
+  checksum: 10/ebd68ee732cc278f59d204db7047f48c477a77218fe1281ddf0cc7bec799140b403fcd1d8164746f73ed8d9b08b76b95bfe03893bc270d6eae68a0f0f3365012
   languageName: node
   linkType: hard
 
@@ -38579,18 +38578,6 @@ __metadata:
   bin:
     vitest: ./vitest.mjs
   checksum: 10/64f9d1a0aae92c493c39822ecae8ec5b5a336fc27166f776d08c01ae79ef1ec5485a1826ef1451bb05df2edaae109894125c2ecceadaa56c17be2690f66f9758
-  languageName: node
-  linkType: hard
-
-"vm2@npm:~3.11.4":
-  version: 3.11.5
-  resolution: "vm2@npm:3.11.5"
-  dependencies:
-    acorn: "npm:^8.15.0"
-    acorn-walk: "npm:^8.3.4"
-  bin:
-    vm2: bin/vm2
-  checksum: 10/aaaea54b3c51e61bcefb38a1c67c2779efb73a83c1dd73e371652f704097ce71822df510e694a523aa8a3fc47b9ef394c1917b7457f30ef6c6fe62f757442dd4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed change

Upgrade `typescript-json-schema` from `^0.67.0` to `^0.68.0` in `@o3r/extractors` and `@o3r/rules-engine`.

Version 0.68.0 of `typescript-json-schema` removes the `vm2` dependency entirely. This eliminates three critical-severity CVEs that were causing the NPM Audit CI job to fail:

- [GHSA-m5w8-4gq2-6f8x](https://github.com/advisories/GHSA-m5w8-4gq2-6f8x) — vm2: NodeVM `builtin: ['*']` exposes `os` and `dns`, allowing host hijacking
- [GHSA-cfcw-xp6x-25gj](https://github.com/advisories/GHSA-cfcw-xp6x-25gj) — vm2: Sandbox Breakout Using Dangerous Host Proto Mutators
- [GHSA-m283-3h24-438v](https://github.com/advisories/GHSA-m283-3h24-438v) — VM2: Missing Error.cause Sanitization enabling Sandbox Escape to RCE

## Related issues

* :octocat: Pull Request https://github.com/AmadeusITGroup/otter/actions/runs/32134194917/job/95701672410