### PR TITLE
chore: add enableInlineBuilds debug hint in yarnrc

### DIFF
--- a/.agents/build.md
+++ b/.agents/build.md
@@ -57,6 +57,16 @@ yarn create:scope <scope-name>
 yarn ng g library @<scope-name>/<library-name>
 ```
 
+## Debugging Postinstall Scripts
+
+If a postinstall (build) script fails silently or you need to see its output, enable inline builds in `.yarnrc.yml`:
+
+```yaml
+enableInlineBuilds: true
+```
+
+This makes Yarn display postinstall script output directly in the console instead of hiding it behind a log file path. Useful when diagnosing build script failures during `yarn install`.
+
 ## Schematics and Builders
 
 Many packages include Angular schematics and builders:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,6 +7,10 @@ enableGlobalCache: false
 
 enableScripts: false
 
+# Enable the following line will display postinstall script output in the console, which can be useful for debugging.
+# Documentation: https://yarnpkg.com/configuration/yarnrc#enableInlineBuilds
+enableInlineBuilds: false
+
 nodeLinker: pnp
 
 npmMinimalAgeGate: 4320


### PR DESCRIPTION
## Proposed change

Add a commented-out `enableInlineBuilds: true` option in `.yarnrc.yml` with an explanatory comment. This provides developers with a quick reference on how to enable inline build output for debugging postinstall scripts.

## Related issues

*- No issue associated -*