### PR TITLE
fix: update MCP plugin versions and add renovate auto-update

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -121,6 +121,17 @@
       "matchStrings": [
         "\"openApiSupportedVersion\": \"~(?<currentValue>[^\"]+)\""
       ]
+    },
+    {
+      "customType": "regex",
+      "datasourceTemplate": "npm",
+      "fileMatch": [
+        "tools/llm/plugins/otter/\\.mcp\\.json$",
+        "collections/otter\\.collection\\.yml$"
+      ],
+      "matchStrings": [
+        "(?<depName>@[\\w-]+/[\\w-]+)@(?<currentValue>[~^]?[\\d.]+[\\w.-]*)"
+      ]
     }
   ],
   "github-actions": {

--- a/collections/otter.collection.yml
+++ b/collections/otter.collection.yml
@@ -73,18 +73,18 @@ mcp:
       args:
         - -y
         - -p
-        - '@o3r/mcp@^14.0.0'
+        - '@o3r/mcp@^15.0.0'
         - o3r-mcp-start
 
     angular:
       command: npx
       args:
         - -y
-        - '@angular/cli@^21.0.0'
+        - '@angular/cli@^22.0.0'
         - mcp
 
     playwright:
       command: npx
       args:
         - -y
-        - '@playwright/mcp@~0.0.70'
+        - '@playwright/mcp@~0.0.79'

--- a/tools/llm/plugins/otter/.mcp.json
+++ b/tools/llm/plugins/otter/.mcp.json
@@ -5,7 +5,7 @@
       "args": [
         "-y",
         "-p",
-        "@o3r/mcp@^14.0.0",
+        "@o3r/mcp@^15.0.0",
         "o3r-mcp-start"
       ]
     },
@@ -13,7 +13,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@angular/cli@^21.0.0",
+        "@angular/cli@^22.0.0",
         "mcp"
       ]
     },
@@ -21,7 +21,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@playwright/mcp@~0.0.70"
+        "@playwright/mcp@~0.0.79"
       ]
     }
   }


### PR DESCRIPTION
## Proposed change

Update MCP plugin versions in `.mcp.json` and `otter.collection.yml`:
- `@o3r/mcp`: `^14.0.0` → `^15.0.0`
- `@angular/cli`: `^21.0.0` → `^22.0.0`
- `@playwright/mcp`: `~0.0.70` → `~0.0.79`

Add a Renovate custom regex manager so these versions are automatically kept up-to-date via Renovate PRs in the future.

## Related issues

*- No issue associated -*