### PR TITLE
fix: no-op command in renovate presets

### DIFF
--- a/tools/renovate/tasks/base-with-auth.json5
+++ b/tools/renovate/tasks/base-with-auth.json5
@@ -12,9 +12,9 @@
       ],
       "postUpgradeTasks": {
         "commands": [
-          "{{#unless (equals '{{arg0}}' '')}}npm config set --location=user registry https:{{arg0}}{{/unless}}",
-          "{{#unless (equals '{{arg0}}' '')}}npm config set --location=user ignore-scripts true{{/unless}}",
-          "{{#unless (equals '{{arg0}}' '')}}npm config set --location=user {{arg0}}:_auth \"${{arg1}}\"{{/unless}}",
+          "{{#unless (equals '{{arg0}}' '')}}npm config set --location=user registry https:{{arg0}}{{else}}:{{/unless}}",
+          "{{#unless (equals '{{arg0}}' '')}}npm config set --location=user ignore-scripts true{{else}}:{{/unless}}",
+          "{{#unless (equals '{{arg0}}' '')}}npm config set --location=user {{arg0}}:_auth \"${{arg1}}\"{{else}}:{{/unless}}",
           "{{{depName}}} install"
         ],
         "executionMode": "branch",

--- a/tools/renovate/tasks/otter-ng-update-with-auth.json5
+++ b/tools/renovate/tasks/otter-ng-update-with-auth.json5
@@ -8,9 +8,9 @@
       ],
       "postUpgradeTasks": {
         "commands": [
-          "{{#unless (equals '{{arg1}}' '')}}npm config set --location=user registry https:{{arg1}}{{/unless}}",
-          "{{#unless (equals '{{arg1}}' '')}}npm config set --location=user ignore-scripts true{{/unless}}",
-          "{{#unless (equals '{{arg1}}' '')}}npm config set --location=user {{arg1}}:_auth \"${{arg2}}\"{{/unless}}",
+          "{{#unless (equals '{{arg1}}' '')}}npm config set --location=user registry https:{{arg1}}{{else}}:{{/unless}}",
+          "{{#unless (equals '{{arg1}}' '')}}npm config set --location=user ignore-scripts true{{else}}:{{/unless}}",
+          "{{#unless (equals '{{arg1}}' '')}}npm config set --location=user {{arg1}}:_auth \"${{arg2}}\"{{else}}:{{/unless}}",
           "{{arg0}} install",
           "{{arg0}} run ng update {{{depName}}} {{#if (equals '{{arg0}}' 'npm')}}-- {{/if}}--from={{{currentVersion}}} --to={{{newVersion}}} --migrate-only --allow-dirty --force"
         ],

--- a/tools/renovate/tasks/sdk-regenerate-with-auth.json5
+++ b/tools/renovate/tasks/sdk-regenerate-with-auth.json5
@@ -8,9 +8,9 @@
       ],
       "postUpgradeTasks": {
         "commands": [
-          "{{#unless (equals '{{arg1}}' '')}}npm config set --location=user registry https:{{arg1}}{{/unless}}",
-          "{{#unless (equals '{{arg1}}' '')}}npm config set --location=user ignore-scripts true{{/unless}}",
-          "{{#unless (equals '{{arg1}}' '')}}npm config set --location=user {{arg1}}:_auth \"${{arg2}}\"{{/unless}}",
+          "{{#unless (equals '{{arg1}}' '')}}npm config set --location=user registry https:{{arg1}}{{else}}:{{/unless}}",
+          "{{#unless (equals '{{arg1}}' '')}}npm config set --location=user ignore-scripts true{{else}}:{{/unless}}",
+          "{{#unless (equals '{{arg1}}' '')}}npm config set --location=user {{arg1}}:_auth \"${{arg2}}\"{{else}}:{{/unless}}",
           "{{arg0}} install",
           "{{arg0}} exec schematics @ama-sdk/schematics:migrate {{#if (equals '{{arg0}}' 'npm')}}-- {{/if}}--from={{{currentVersion}}} --to={{{newVersion}}}",
           "{{arg0}} run spec:upgrade"

--- a/tools/renovate/tasks/sdk-spec-regenerate-with-auth.json5
+++ b/tools/renovate/tasks/sdk-spec-regenerate-with-auth.json5
@@ -8,9 +8,9 @@
       ],
       "postUpgradeTasks": {
         "commands": [
-          "{{#unless (equals '{{arg2}}' '')}}npm config set --location=user registry https:{{arg2}}{{/unless}}",
-          "{{#unless (equals '{{arg2}}' '')}}npm config set --location=user ignore-scripts true{{/unless}}",
-          "{{#unless (equals '{{arg2}}' '')}}npm config set --location=user {{arg2}}:_auth \"${{arg3}}\"{{/unless}}",
+          "{{#unless (equals '{{arg2}}' '')}}npm config set --location=user registry https:{{arg2}}{{else}}:{{/unless}}",
+          "{{#unless (equals '{{arg2}}' '')}}npm config set --location=user ignore-scripts true{{else}}:{{/unless}}",
+          "{{#unless (equals '{{arg2}}' '')}}npm config set --location=user {{arg2}}:_auth \"${{arg3}}\"{{else}}:{{/unless}}",
           "{{arg0}} install",
           "{{arg0}} run spec:upgrade"
         ],


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
-->

with the '' empty no operation in the renovate presets we have an error on the renovate run for the post upgrade task 
- so added the real no operation command in the presets 

here is the error:
⚠️ Artifact update problem
Renovate failed to update artifacts related to this branch. You probably do not want to merge this PR as-is.

♻ Renovate will retry this branch, including artifacts, only when one of the following happens:

any of the package files in this branch needs updating, or
the branch becomes conflicted, or
you click the rebase/retry checkbox if found above, or
you rename this PR's title to start with "rebase!" to trigger it manually
The artifact failure details are included below:

File name: undefined

The argument 'file' cannot be empty. Received ''

## Related issues

<!--
Please make sure to follow the [contribution guidelines](https://github.com/amadeus-digital/Otter/blob/main/CONTRIBUTING.md)
-->

*- No issue associated -*

<!-- * :bug: Fix #issue -->
<!-- * :bug: Fix resolves #issue -->
<!-- * :rocket: Feature #issue -->
<!-- * :rocket: Feature resolves #issue -->
<!-- * :octocat: Pull Request #issue -->
