### PR TITLE
feat: add WebMCP infrastructure for local AI agent testing

### DIFF
--- a/apps/webmcp-bridge/README.md
+++ b/apps/webmcp-bridge/README.md
@@ -1,0 +1,122 @@
+# @o3r/webmcp-bridge
+
+> **Local development tool** — This package is private and not published to npm.
+
+WebSocket relay server that enables **local AI coding agents** (Claude, Kiro, Copilot, etc.) to interact with an Angular application's [WebMCP](https://webmachinelearning.github.io/webmcp/) tools at development time.
+
+## Why is this needed?
+
+The [WebMCP specification](https://webmachinelearning.github.io/webmcp/) defines how web applications expose tools via `document.modelContext`. In production, an AI agent will be embedded directly in the UI and will interact with these tools through the browser's native WebMCP API — no relay needed.
+
+However, **during local development**, you may want to test your WebMCP tools with external AI coding agents (Claude, Kiro, Copilot, etc.) that communicate over [MCP](https://modelcontextprotocol.io/) using stdio. These agents cannot connect directly to a browser tab.
+
+This relay server bridges that gap by acting as a **mock for the future in-app AI agent**, routing messages between:
+
+- **Browser clients** — the Angular app running in a browser tab
+- **MCP clients** — the `@ama-mcp/webmcp` MCP server that speaks stdio to AI agents
+
+This allows you to develop and test your WebMCP tools today with real AI agents, before the in-app AI integration is available.
+
+## Architecture
+
+```
+┌─────────────────┐     WebSocket      ┌──────────────────┐     WebSocket      ┌─────────────────┐     stdio      ┌──────────┐
+│  Angular App    │◄──────────────────►│  webmcp-bridge   │◄──────────────────►│  @ama-mcp/webmcp│◄─────────────►│ AI Agent │
+│  (browser tab)  │  ?role=browser      │  (this server)   │  ?role=mcp          │  (MCP server)   │               │          │
+└─────────────────┘                     └──────────────────┘                     └─────────────────┘               └──────────┘
+  provideExperimentalWebMcpBridge()       ws://localhost:3200                      ama-mcp-webmcp
+  from @o3r/core
+```
+
+The three pieces that work together:
+
+| Package | Role | Published |
+|---------|------|-----------|
+| `provideExperimentalWebMcpBridge()` from `@o3r/core` | Angular provider — connects the browser to the relay | ✅ (part of `@o3r/core`) |
+| `@o3r/webmcp-bridge` (this package) | WebSocket relay — routes messages between browser and MCP | ❌ (private, local only) |
+| `@ama-mcp/webmcp` | MCP server (stdio) — exposes browser tools to AI agents | ❌ (private, local only) |
+
+## Prerequisites
+
+The WebMCP API (`document.modelContext`) is not yet enabled by default in Chrome. You must activate it before using this tool:
+
+1. Open Chrome and navigate to `chrome://flags/#enable-webmcp-testing`
+2. Set the flag to **Enabled**
+3. Relaunch Chrome
+
+> Alternatively, you can enroll in the [WebMCP Origin Trial](https://developer.chrome.com/docs/ai/webmcp) starting from Chrome 149.
+
+## Usage
+
+### 1. Start the relay server
+
+```bash
+yarn nx start webmcp-bridge
+```
+
+This starts a WebSocket server on `ws://localhost:3200` by default.
+
+### 2. Add the provider to your Angular app
+
+```typescript
+import { provideExperimentalWebMcpBridge } from '@o3r/core';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideExperimentalWebMcpBridge(),
+    // ...
+  ]
+};
+```
+
+### 3. Configure your AI agent to use the MCP server
+
+Add `@ama-mcp/webmcp` as an MCP server in your agent's configuration (e.g. `.kiro/settings/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "webmcp": {
+      "command": "node",
+      "args": ["mcps/@ama-mcp/webmcp/dist/main.js"]
+    }
+  }
+}
+```
+
+> **Note:** Build `@ama-mcp/webmcp` first with `yarn nx build ama-mcp-webmcp` so that `dist/main.js` exists.
+
+### 4. Open your app in the browser
+
+Once the app loads, the bridge provider connects to the relay and registers all `document.modelContext` tools. The AI agent can then discover and call those tools through the MCP protocol.
+
+## Known limitations
+
+- **One active browser tab at a time.** The relay routes `tools/call` messages to the most recently connected browser tab (the one that last sent `tools/register`). If multiple tabs are open with the app, only the most recently active tab receives tool calls. Close extra tabs to avoid confusion.
+
+## Configuration
+
+| Environment variable | Default | Description |
+|---------------------|---------|-------------|
+| `PORT` | `3200` | WebSocket server port |
+
+## WebSocket protocol
+
+Clients connect with a `?role=` query parameter:
+
+- `?role=browser` — browser clients that register tools and handle tool calls
+- `?role=mcp` — MCP clients that request tool lists and initiate tool calls
+
+### Messages from browser → relay
+
+| Type | Description |
+|------|-------------|
+| `tools/register` | Registers the current tool list (`{ type, tools[] }`) |
+| `tools/call/response` | Returns a tool execution result (`{ type, id, result }`) |
+
+### Messages from MCP client → relay
+
+| Type | Description |
+|------|-------------|
+| `tools/list` | Requests the current tool list |
+| `tools/call` | Initiates a tool call (`{ type, id, name, arguments }`) |

--- a/apps/webmcp-bridge/eslint.config.mjs
+++ b/apps/webmcp-bridge/eslint.config.mjs
@@ -1,0 +1,7 @@
+import shared from '../../eslint.shared.config.mjs';
+import local from './eslint.local.config.mjs';
+
+export default [
+  ...shared,
+  ...local
+];

--- a/apps/webmcp-bridge/eslint.local.config.mjs
+++ b/apps/webmcp-bridge/eslint.local.config.mjs
@@ -1,0 +1,43 @@
+import {
+  dirname,
+} from 'node:path';
+import {
+  fileURLToPath,
+} from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+// __dirname is not defined in ES module scope
+const __dirname = dirname(__filename);
+
+export default [
+  {
+    name: '@o3r/webmcp-bridge/projects',
+    languageOptions: {
+      sourceType: 'module',
+      parserOptions: {
+        tsconfigRootDir: __dirname,
+        projectService: true
+      }
+    }
+  },
+  {
+    name: '@o3r/webmcp-bridge/node-globals',
+    files: ['**/*.ts'],
+    languageOptions: {
+      globals: {
+        Buffer: 'readonly',
+        console: 'readonly',
+        process: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
+        setInterval: 'readonly',
+        clearInterval: 'readonly',
+        URL: 'readonly',
+        URLSearchParams: 'readonly'
+      }
+    },
+    rules: {
+      'no-console': 'off'
+    }
+  }
+];

--- a/apps/webmcp-bridge/package.json
+++ b/apps/webmcp-bridge/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@o3r/webmcp-bridge",
+  "version": "0.0.0-placeholder",
+  "private": true,
+  "description": "WebSocket relay server bridging Angular WebMCP tools to MCP clients",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "ws": "~8.18.0"
+  },
+  "devDependencies": {
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.4.0",
+    "@nx/eslint": "~23.1.0",
+    "@nx/eslint-plugin": "~23.1.0",
+    "@o3r/eslint-config": "workspace:^",
+    "@o3r/eslint-plugin": "workspace:^",
+    "@stylistic/eslint-plugin": "~5.10.0",
+    "@types/node": "~24.13.0",
+    "@types/ws": "~8.18.0",
+    "@typescript-eslint/parser": "~8.67.0",
+    "eslint": "~9.39.0",
+    "eslint-import-resolver-node": "~0.4.0",
+    "eslint-import-resolver-typescript": "~4.4.0",
+    "eslint-plugin-import": "~2.32.0",
+    "eslint-plugin-import-newlines": "~1.4.0",
+    "eslint-plugin-jsdoc": "~61.7.0",
+    "eslint-plugin-prefer-arrow": "~1.2.3",
+    "eslint-plugin-unicorn": "~62.0.0",
+    "eslint-plugin-unused-imports": "~4.4.0",
+    "globals": "^16.0.0",
+    "jsonc-eslint-parser": "~2.4.0",
+    "tsx": "~4.19.0",
+    "typescript": "~6.0.3",
+    "typescript-eslint": "~8.67.0"
+  },
+  "engines": {
+    "node": "^22.22.3 || ^24.15.0 || ^26.0.0"
+  }
+}

--- a/apps/webmcp-bridge/project.json
+++ b/apps/webmcp-bridge/project.json
@@ -1,0 +1,16 @@
+{
+  "name": "webmcp-bridge",
+  "$schema": "https://raw.githubusercontent.com/nrwl/nx/master/packages/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "apps/webmcp-bridge/src",
+  "targets": {
+    "start": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "start"
+      }
+    },
+    "lint": {}
+  },
+  "tags": []
+}

--- a/apps/webmcp-bridge/src/index.ts
+++ b/apps/webmcp-bridge/src/index.ts
@@ -1,0 +1,145 @@
+import type {
+  IncomingMessage,
+} from 'node:http';
+import {
+  WebSocket,
+  WebSocketServer,
+} from 'ws';
+
+const PORT = Number.parseInt(process.env.PORT || '3200', 10);
+
+interface Tool {
+  name: string;
+  description?: string;
+  inputSchema?: object;
+}
+
+// In-memory state
+let currentTools: Tool[] = [];
+// The most recently registered browser tab is the one that handles tool calls.
+// Only one tab should be active at a time — see the "Known limitations" section of the README.
+let activeBrowserClient: WebSocket | null = null;
+const browserClients = new Set<WebSocket>();
+const mcpClients = new Set<WebSocket>();
+
+const wss = new WebSocketServer({ port: PORT });
+
+function log(msg: string): void {
+  console.error(`[webmcp-bridge] ${msg}`);
+}
+
+function send(ws: WebSocket, data: unknown): void {
+  if (ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify(data));
+  }
+}
+
+function broadcast(clients: Set<WebSocket>, data: unknown): void {
+  for (const client of clients) {
+    send(client, data);
+  }
+}
+
+wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
+  const url = new URL(req.url || '/', `http://localhost:${PORT}`);
+  const role = url.searchParams.get('role'); // 'browser' or 'mcp'
+
+  if (role === 'browser') {
+    browserClients.add(ws);
+    log(`Browser client connected (total: ${browserClients.size})`);
+    if (browserClients.size > 1) {
+      log('Warning: multiple browser tabs connected. Only the tab that last sent tools/register will receive tool calls.');
+    }
+
+    ws.on('close', () => {
+      browserClients.delete(ws);
+      if (activeBrowserClient === ws) {
+        activeBrowserClient = null;
+      }
+      log(`Browser client disconnected (total: ${browserClients.size})`);
+    });
+
+    ws.on('message', (raw: Buffer) => {
+      let msg: { type: string; tools?: Tool[]; id?: string; result?: unknown };
+      try {
+        msg = JSON.parse(raw.toString());
+      } catch {
+        return;
+      }
+
+      switch (msg.type) {
+        case 'tools/register': {
+          currentTools = msg.tools ?? [];
+          activeBrowserClient = ws;
+          log(`Tools registered: ${currentTools.map((t: Tool) => t.name).join(', ')}`);
+          // Notify all MCP clients of the update
+          broadcast(mcpClients, { type: 'tools/updated', tools: currentTools });
+          break;
+        }
+        case 'tools/call/response': {
+          // Forward tool call result to all MCP clients
+          broadcast(mcpClients, {
+            type: 'tools/call/response',
+            id: msg.id,
+            result: msg.result
+          });
+          break;
+        }
+      }
+    });
+  } else if (role === 'mcp') {
+    mcpClients.add(ws);
+    log(`MCP client connected (total: ${mcpClients.size})`);
+
+    ws.on('close', () => {
+      mcpClients.delete(ws);
+      log(`MCP client disconnected (total: ${mcpClients.size})`);
+    });
+
+    ws.on('message', (raw: Buffer) => {
+      let msg: { type: string; id?: string; name?: string; arguments?: unknown };
+      try {
+        msg = JSON.parse(raw.toString());
+      } catch {
+        return;
+      }
+
+      switch (msg.type) {
+        case 'tools/list': {
+          send(ws, { type: 'tools/list/response', tools: currentTools });
+          break;
+        }
+        case 'tools/call': {
+          if (!activeBrowserClient || activeBrowserClient.readyState !== WebSocket.OPEN) {
+            send(ws, {
+              type: 'tools/call/response',
+              id: msg.id,
+              result: { content: [{ type: 'text', text: 'Error: no browser tab is connected' }], isError: true }
+            });
+            break;
+          }
+          // Forward tool call to the active browser tab only
+          send(activeBrowserClient, {
+            type: 'tools/call',
+            id: msg.id,
+            name: msg.name,
+            arguments: msg.arguments
+          });
+          break;
+        }
+      }
+    });
+  } else {
+    log(`Client connected without valid role param (got: ${role}), closing.`);
+    ws.close(4000, 'Missing or invalid ?role= query parameter. Use ?role=browser or ?role=mcp');
+    return;
+  }
+
+  ws.on('error', (err: Error) => {
+    log(`WebSocket error: ${err.message}`);
+  });
+});
+
+log(`WebSocket relay server listening on ws://localhost:${PORT}`);
+log(`  Browser clients: ws://localhost:${PORT}?role=browser`);
+log(`  MCP clients:     ws://localhost:${PORT}?role=mcp`);

--- a/apps/webmcp-bridge/tsconfig.json
+++ b/apps/webmcp-bridge/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/mcps/@ama-mcp/webmcp/README.md
+++ b/mcps/@ama-mcp/webmcp/README.md
@@ -1,0 +1,116 @@
+# @ama-mcp/webmcp
+
+> **Local development tool** — This package is private and not published to npm.
+
+MCP server that exposes an Angular application's [WebMCP](https://webmachinelearning.github.io/webmcp/) tools to AI coding agents (Claude, Kiro, Copilot, etc.) via the standard [Model Context Protocol](https://modelcontextprotocol.io/).
+
+## What it does
+
+Angular applications can register tools on `document.modelContext` using the WebMCP browser API. In production, an AI agent embedded in the UI will call these tools directly through the browser's native WebMCP API.
+
+**During local development**, this package acts as the bridge that lets external AI coding agents interact with those same tools. It connects to a WebSocket relay server, discovers the tools registered by the Angular app, and re-exposes them as standard MCP tools over stdio.
+
+## Architecture
+
+This package is the **MCP server** piece of a three-part local development setup:
+
+```
+┌─────────────────┐     WebSocket      ┌──────────────────┐     WebSocket      ┌─────────────────┐     stdio      ┌──────────┐
+│  Angular App    │◄──────────────────►│  webmcp-bridge   │◄──────────────────►│  @ama-mcp/webmcp│◄─────────────►│ AI Agent │
+│  (browser tab)  │  ?role=browser      │  (relay server)  │  ?role=mcp          │  (this package) │               │          │
+└─────────────────┘                     └──────────────────┘                     └─────────────────┘               └──────────┘
+  provideExperimentalWebMcpBridge()       @o3r/webmcp-bridge                      ama-mcp-webmcp
+  from @o3r/core                          (apps/webmcp-bridge)
+```
+
+| Package | Role |
+|---------|------|
+| `provideExperimentalWebMcpBridge()` from `@o3r/core` | Angular provider — connects the browser to the relay |
+| `@o3r/webmcp-bridge` (`apps/webmcp-bridge`) | WebSocket relay — routes messages between browser and MCP |
+| **`@ama-mcp/webmcp`** (this package) | MCP server (stdio) — exposes browser tools to AI agents |
+
+## Quick start
+
+### Prerequisites
+
+1. **Enable WebMCP in Chrome** — the WebMCP API (`document.modelContext`) is not yet enabled by default:
+   1. Open Chrome and navigate to `chrome://flags/#enable-webmcp-testing`
+   2. Set the flag to **Enabled**
+   3. Relaunch Chrome
+
+   > Alternatively, you can enroll in the [WebMCP Origin Trial](https://developer.chrome.com/docs/ai/webmcp) starting from Chrome 149.
+
+2. The Angular app must include `provideExperimentalWebMcpBridge()` in its providers
+3. The relay server (`@o3r/webmcp-bridge`) must be running on `localhost:3200`
+4. This package must be built: `yarn nx build ama-mcp-webmcp`
+
+### Configure your AI agent
+
+Add this package as an MCP server in your agent's configuration.
+
+For **Kiro** (`.kiro/settings/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "webmcp": {
+      "command": "node",
+      "args": ["mcps/@ama-mcp/webmcp/dist/main.js"]
+    }
+  }
+}
+```
+
+For **Claude Code** (`.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "webmcp": {
+      "command": "node",
+      "args": ["mcps/@ama-mcp/webmcp/dist/main.js"]
+    }
+  }
+}
+```
+
+### Run the full stack
+
+```bash
+# 1. Build the MCP server
+yarn nx build ama-mcp-webmcp
+
+# 2. Start the relay server
+yarn nx start webmcp-bridge
+
+# 3. Start the Angular app
+yarn nx serve showcase
+
+# 4. Open the app in your browser, then use your AI agent
+#    The agent will automatically discover tools registered by the app
+```
+
+## Configuration
+
+| Environment variable | Default | Description |
+|---------------------|---------|-------------|
+| `WEBMCP_BRIDGE_URL` | `ws://localhost:3200?role=mcp` | WebSocket URL of the relay server |
+
+## How it works
+
+1. On startup, this server connects to the relay as an MCP client (`?role=mcp`)
+2. It requests the current tool list from the relay
+3. When the browser registers or unregisters tools, the relay pushes updates
+4. The server emits `notifications/tools/list_changed` so the AI agent refreshes its tool list
+5. When the AI agent calls a tool, this server forwards the request through the relay to the browser
+6. The browser executes the tool in the Angular injection context and returns the result
+7. Tool calls time out after 120 seconds
+
+## Development
+
+```bash
+# Build
+yarn nx build ama-mcp-webmcp
+
+# The built binary is at dist/main.js
+```

--- a/mcps/@ama-mcp/webmcp/eslint.config.mjs
+++ b/mcps/@ama-mcp/webmcp/eslint.config.mjs
@@ -1,0 +1,7 @@
+import shared from '../../../eslint.shared.config.mjs';
+import local from './eslint.local.config.mjs';
+
+export default [
+  ...shared,
+  ...local
+];

--- a/mcps/@ama-mcp/webmcp/eslint.local.config.mjs
+++ b/mcps/@ama-mcp/webmcp/eslint.local.config.mjs
@@ -1,0 +1,41 @@
+import {
+  dirname,
+} from 'node:path';
+import {
+  fileURLToPath,
+} from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+// __dirname is not defined in ES module scope
+const __dirname = dirname(__filename);
+
+export default [
+  {
+    name: '@ama-mcp/webmcp/projects',
+    languageOptions: {
+      sourceType: 'module',
+      parserOptions: {
+        tsconfigRootDir: __dirname,
+        projectService: true
+      }
+    }
+  },
+  {
+    name: '@ama-mcp/webmcp/node-globals',
+    files: ['**/*.ts'],
+    languageOptions: {
+      globals: {
+        Buffer: 'readonly',
+        console: 'readonly',
+        process: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
+        setInterval: 'readonly',
+        clearInterval: 'readonly'
+      }
+    },
+    rules: {
+      'unicorn/no-process-exit': 'off'
+    }
+  }
+];

--- a/mcps/@ama-mcp/webmcp/package.json
+++ b/mcps/@ama-mcp/webmcp/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@ama-mcp/webmcp",
+  "version": "0.0.0-placeholder",
+  "private": true,
+  "description": "Local development MCP server that bridges Angular WebMCP tools (document.modelContext) to AI coding agents via a WebSocket relay",
+  "keywords": [
+    "mcp",
+    "webmcp",
+    "angular",
+    "otter-module"
+  ],
+  "sideEffects": false,
+  "bin": {
+    "ama-mcp-webmcp": "./dist/main.js"
+  },
+  "exports": {
+    "./package.json": {
+      "default": "./package.json"
+    }
+  },
+  "scripts": {
+    "nx": "nx",
+    "ng": "yarn nx",
+    "build": "yarn nx build ama-mcp-webmcp",
+    "compile": "esbuild src/index.ts --bundle --platform=node --target=node22 --outfile=dist/main.js --banner:js=\"#!/usr/bin/env node\" --format=cjs",
+    "postbuild": "yarn cpy package.json dist && patch-package-json-main"
+  },
+  "dependencies": {
+    "@ama-mcp/core": "workspace:~",
+    "@modelcontextprotocol/server": "~2.0.0",
+    "ws": "~8.18.0"
+  },
+  "devDependencies": {
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.4.0",
+    "@nx/eslint": "~23.1.0",
+    "@nx/eslint-plugin": "~23.1.0",
+    "@o3r/build-helpers": "workspace:^",
+    "@o3r/eslint-config": "workspace:^",
+    "@o3r/eslint-plugin": "workspace:^",
+    "@stylistic/eslint-plugin": "~5.10.0",
+    "@types/node": "~24.13.0",
+    "@types/ws": "~8.18.0",
+    "@typescript-eslint/parser": "~8.67.0",
+    "cpy-cli": "^6.0.0",
+    "esbuild": "~0.28.0",
+    "eslint": "~9.39.0",
+    "eslint-import-resolver-node": "~0.4.0",
+    "eslint-import-resolver-typescript": "~4.4.0",
+    "eslint-plugin-import": "~2.32.0",
+    "eslint-plugin-import-newlines": "~1.4.0",
+    "eslint-plugin-jsdoc": "~61.7.0",
+    "eslint-plugin-prefer-arrow": "~1.2.3",
+    "eslint-plugin-unicorn": "~62.0.0",
+    "eslint-plugin-unused-imports": "~4.4.0",
+    "globals": "^16.0.0",
+    "jsonc-eslint-parser": "~2.4.0",
+    "typescript": "~6.0.3",
+    "typescript-eslint": "~8.67.0"
+  },
+  "engines": {
+    "node": "^22.22.3 || ^24.15.0 || ^26.0.0"
+  }
+}

--- a/mcps/@ama-mcp/webmcp/project.json
+++ b/mcps/@ama-mcp/webmcp/project.json
@@ -1,0 +1,29 @@
+{
+  "name": "ama-mcp-webmcp",
+  "$schema": "https://raw.githubusercontent.com/nrwl/nx/master/packages/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "mcps/@ama-mcp/webmcp/src",
+  "prefix": "o3r",
+  "targets": {
+    "build": {
+      "executor": "nx:run-script",
+      "outputs": [
+        "{projectRoot}/dist/package.json"
+      ],
+      "options": {
+        "script": "postbuild"
+      },
+      "dependsOn": [
+        "compile"
+      ]
+    },
+    "compile": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "compile"
+      }
+    },
+    "lint": {}
+  },
+  "tags": []
+}

--- a/mcps/@ama-mcp/webmcp/src/index.ts
+++ b/mcps/@ama-mcp/webmcp/src/index.ts
@@ -1,0 +1,233 @@
+import {
+  AmaMcpServer,
+  type LogLevel,
+  MCPLogger,
+} from '@ama-mcp/core';
+import type {
+  RegisteredTool,
+} from '@modelcontextprotocol/server';
+import {
+  StdioServerTransport,
+} from '@modelcontextprotocol/server/stdio';
+import WebSocket from 'ws';
+
+const BRIDGE_URL = process.env.WEBMCP_BRIDGE_URL || 'ws://localhost:3200?role=mcp';
+const RECONNECT_INTERVAL = 3000;
+const TOOL_CALL_TIMEOUT = 120_000;
+
+interface RelayTool {
+  name: string;
+  description: string;
+  inputSchema: object;
+}
+
+interface RelayMessage {
+  type: string;
+  tools?: RelayTool[];
+  id?: string;
+  name?: string;
+  arguments?: Record<string, unknown>;
+  result?: object;
+}
+
+const logger = new MCPLogger('@ama-mcp/webmcp', (process.env.WEBMCP_LOG_LEVEL as LogLevel) || 'info');
+
+const server = new AmaMcpServer(
+  logger,
+  { name: '@ama-mcp/webmcp', version: '0.0.0' }
+);
+
+let ws: WebSocket | null = null;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+const pendingCalls = new Map<string, { resolve: (value: object) => void; reject: (reason: Error) => void }>();
+const registeredTools = new Map<string, RegisteredTool>();
+
+/**
+ * Sends a JSON message to the relay server.
+ * @param message - The message payload to send
+ */
+function sendToRelay(message: RelayMessage): void {
+  if (ws?.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify(message));
+  }
+}
+
+/**
+ * Calls a tool on the browser via the relay and returns the result.
+ * @param name - Tool name to invoke
+ * @param args - Tool arguments
+ */
+async function callBrowserTool(name: string, args: Record<string, unknown>): Promise<{ content: { type: 'text'; text: string }[]; isError?: boolean }> {
+  if (!ws || ws.readyState !== WebSocket.OPEN) {
+    return {
+      content: [{ type: 'text', text: 'Error: WebSocket not connected to relay server' }],
+      isError: true
+    };
+  }
+
+  const id = crypto.randomUUID();
+
+  const resultPromise = new Promise<object>((resolve, reject) => {
+    pendingCalls.set(id, { resolve, reject });
+    setTimeout(() => {
+      if (pendingCalls.has(id)) {
+        pendingCalls.delete(id);
+        reject(new Error('Tool call timed out'));
+      }
+    }, TOOL_CALL_TIMEOUT);
+  });
+
+  sendToRelay({ type: 'tools/call', id, name, arguments: args });
+
+  try {
+    const result = await resultPromise;
+    return result as { content: { type: 'text'; text: string }[]; isError?: boolean };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return {
+      content: [{ type: 'text', text: `Error: ${errorMessage}` }],
+      isError: true
+    };
+  }
+}
+
+/**
+ * Synchronizes the MCP server's registered tools with the tools reported by the browser.
+ * Removes tools that are no longer present and registers new ones.
+ * @param tools - The current list of tools from the browser
+ */
+function syncTools(tools: RelayTool[]): void {
+  const incomingNames = new Set(tools.map((t) => t.name));
+
+  // Remove tools that are no longer present
+  for (const [name, registered] of registeredTools) {
+    if (!incomingNames.has(name)) {
+      registered.remove();
+      registeredTools.delete(name);
+      logger.debug(`Tool removed: ${name}`);
+    }
+  }
+
+  // Register new tools and update existing ones
+  for (const tool of tools) {
+    if (registeredTools.has(tool.name)) {
+      continue;
+    }
+
+    const registered = server.registerTool(
+      tool.name,
+      {
+        description: tool.description,
+        inputSchema: tool.inputSchema as Record<string, unknown>
+      },
+      async ({ args }) => {
+        return callBrowserTool(tool.name, (args ?? {}) as Record<string, unknown>);
+      }
+    );
+    registeredTools.set(tool.name, registered);
+    logger.debug(`Tool registered: ${tool.name}`);
+  }
+
+  logger.info(`Tools synced: ${tools.map((t) => t.name).join(', ') || '(none)'}`);
+}
+
+/**
+ * Handles incoming messages from the relay server.
+ * @param data - Raw message data from WebSocket
+ */
+function handleRelayMessage(data: WebSocket.Data): void {
+  let message: RelayMessage;
+  let raw: string;
+  if (typeof data === 'string') {
+    raw = data;
+  } else if (Buffer.isBuffer(data)) {
+    raw = data.toString('utf8');
+  } else if (data instanceof ArrayBuffer) {
+    raw = Buffer.from(data).toString('utf8');
+  } else {
+    raw = Buffer.concat(data).toString('utf8');
+  }
+  try {
+    message = JSON.parse(raw);
+  } catch {
+    logger.error('Failed to parse relay message');
+    return;
+  }
+
+  switch (message.type) {
+    case 'tools/list/response':
+    case 'tools/updated': {
+      syncTools(message.tools || []);
+      break;
+    }
+
+    case 'tools/call/response': {
+      if (message.id && pendingCalls.has(message.id)) {
+        const pending = pendingCalls.get(message.id)!;
+        pendingCalls.delete(message.id);
+        pending.resolve(message.result || { content: [{ type: 'text', text: 'No result returned' }] });
+      }
+      break;
+    }
+
+    default: {
+      logger.warn(`Unknown relay message type: ${message.type}`);
+    }
+  }
+}
+
+/**
+ * Establishes a WebSocket connection to the relay server with auto-reconnect.
+ */
+function connectWebSocket(): void {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+
+  ws = new WebSocket(BRIDGE_URL);
+
+  ws.on('open', () => {
+    logger.info(`Connected to relay at ${BRIDGE_URL}`);
+    sendToRelay({ type: 'tools/list' });
+  });
+
+  ws.on('message', handleRelayMessage);
+
+  ws.on('close', () => {
+    logger.info(`Disconnected from relay. Reconnecting in ${String(RECONNECT_INTERVAL / 1000)}s...`);
+    ws = null;
+    scheduleReconnect();
+  });
+
+  ws.on('error', (error) => {
+    logger.error(`WebSocket error: ${error.message}`);
+  });
+}
+
+/**
+ * Schedules a reconnection attempt after the configured interval.
+ */
+function scheduleReconnect(): void {
+  if (reconnectTimer) {
+    return;
+  }
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    connectWebSocket();
+  }, RECONNECT_INTERVAL);
+}
+
+async function main(): Promise<void> {
+  connectWebSocket();
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  logger.info('MCP server started on stdio');
+}
+
+main().catch((error) => {
+  logger.error(`Fatal error: ${String(error)}`);
+  process.exit(1);
+});

--- a/mcps/@ama-mcp/webmcp/tsconfig.build.json
+++ b/mcps/@ama-mcp/webmcp/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.build",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "lib": ["ES2024"],
+    "tsBuildInfoFile": "build/.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["**/*.spec.ts"]
+}

--- a/mcps/@ama-mcp/webmcp/tsconfig.json
+++ b/mcps/@ama-mcp/webmcp/tsconfig.json
@@ -1,0 +1,11 @@
+/* For IDE and EsLint usage */
+{
+  "extends": "../../../tsconfig.base",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "lib": ["ES2024"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@o3r/core/package.json
+++ b/packages/@o3r/core/package.json
@@ -101,6 +101,7 @@
     "@babel/preset-typescript": "~7.29.0",
     "@compodoc/compodoc": "^1.1.32",
     "@eslint-community/eslint-plugin-eslint-comments": "^4.4.0",
+    "@mcp-b/webmcp-types": "~4.0.0",
     "@ngrx/entity": "22.0.0-rc.0",
     "@ngrx/store": "22.0.0-rc.0",
     "@nx/eslint": "~23.1.0",

--- a/packages/@o3r/core/src/core/index.ts
+++ b/packages/@o3r/core/src/core/index.ts
@@ -4,3 +4,4 @@ export * from './devkit/index';
 export * from './interfaces/index';
 export * from './metadata/index';
 export * from './rules-engine/index';
+export * from './webmcp/index';

--- a/packages/@o3r/core/src/core/webmcp/index.ts
+++ b/packages/@o3r/core/src/core/webmcp/index.ts
@@ -1,0 +1,1 @@
+export * from './webmcp-bridge.provider';

--- a/packages/@o3r/core/src/core/webmcp/webmcp-bridge.provider.ts
+++ b/packages/@o3r/core/src/core/webmcp/webmcp-bridge.provider.ts
@@ -24,21 +24,8 @@ export interface WebMcpBridgeOptions {
   reconnectInterval?: number;
 }
 
-/** Minimal local typing for the WebMCP browser API surface used by this provider. */
-interface ModelContextTool {
-  name: string;
-  description: string;
-  inputSchema: string | Record<string, unknown>;
-}
-
-interface ModelContext extends EventTarget {
-  getTools(): Promise<ModelContextTool[]>;
-  executeTool(tool: ModelContextTool, args: string): Promise<string>;
-}
-
-interface DocumentWithModelContext extends Document {
-  modelContext: ModelContext;
-}
+/** Tool info type returned by `document.modelContext.getTools()`, declared by `@mcp-b/webmcp-types`. */
+type ModelContextToolInfo = Awaited<ReturnType<Document['modelContext']['getTools']>>[number];
 
 /**
  * Provides the WebMCP bridge for **local development and testing with AI coding agents**.
@@ -87,11 +74,14 @@ export function provideExperimentalWebMcpBridge(options?: WebMcpBridgeOptions): 
       return;
     }
 
-    const modelContext = (document as DocumentWithModelContext).modelContext;
+    const modelContext = document.modelContext;
 
     let ws: WebSocket | null = null;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     let destroyed = false;
+    // Cached tool references from the last getTools() call, kept in sync via toolchange events.
+    // Used to look up the tool object for executeTool() without an extra async getTools() round-trip on each call.
+    let cachedTools: ModelContextToolInfo[] = [];
 
     destroyRef.onDestroy(() => {
       destroyed = true;
@@ -103,19 +93,16 @@ export function provideExperimentalWebMcpBridge(options?: WebMcpBridgeOptions): 
       }
     });
 
-    const getTools = async () => {
+    const refreshAndRegisterTools = async (socket: WebSocket) => {
       const tools = await modelContext.getTools();
-      return tools.map((tool) => ({
+      cachedTools = tools;
+      const serializedTools = tools.map((tool) => ({
         name: tool.name,
         description: tool.description,
         inputSchema: typeof tool.inputSchema === 'string' ? JSON.parse(tool.inputSchema) as Record<string, unknown> : tool.inputSchema
       }));
-    };
-
-    const registerTools = async (socket: WebSocket) => {
-      const tools = await getTools();
-      console.log(`[WebMCP Bridge] Sending ${String(tools.length)} tools to relay:`, tools.map((t) => t.name));
-      socket.send(JSON.stringify({ type: 'tools/register', tools }));
+      console.log(`[WebMCP Bridge] Sending ${String(serializedTools.length)} tools to relay:`, serializedTools.map((t) => t.name));
+      socket.send(JSON.stringify({ type: 'tools/register', tools: serializedTools }));
     };
 
     const connect = () => {
@@ -127,7 +114,7 @@ export function provideExperimentalWebMcpBridge(options?: WebMcpBridgeOptions): 
 
       ws.addEventListener('open', () => {
         console.log('[WebMCP Bridge] Connected to relay');
-        void registerTools(ws!);
+        void refreshAndRegisterTools(ws!);
       });
 
       ws.addEventListener('message', (event: MessageEvent) => {
@@ -139,26 +126,22 @@ export function provideExperimentalWebMcpBridge(options?: WebMcpBridgeOptions): 
         }
 
         if (message.type === 'tools/call') {
-          void modelContext.getTools().then((tools) => {
-            const tool = tools.find((t) => t.name === message.name);
-            if (!tool) {
+          const tool = cachedTools.find((t) => t.name === message.name);
+          if (!tool) {
+            ws?.send(JSON.stringify({
+              type: 'tools/call/response',
+              id: message.id,
+              result: { content: [{ type: 'text', text: `Tool "${message.name}" not found` }], isError: true }
+            }));
+            return;
+          }
+          void modelContext.executeTool(tool, JSON.stringify(message.arguments ?? {})).then(
+            (result) => {
               ws?.send(JSON.stringify({
                 type: 'tools/call/response',
                 id: message.id,
-                result: { content: [{ type: 'text', text: `Tool "${message.name}" not found` }], isError: true }
+                result: { content: [{ type: 'text', text: result ?? 'null' }] }
               }));
-              return;
-            }
-            return modelContext.executeTool(tool, JSON.stringify(message.arguments ?? {}));
-          }).then(
-            (result) => {
-              if (result !== undefined) {
-                ws?.send(JSON.stringify({
-                  type: 'tools/call/response',
-                  id: message.id,
-                  result: { content: [{ type: 'text', text: result ?? 'null' }] }
-                }));
-              }
             },
             (error: unknown) => {
               ws?.send(JSON.stringify({
@@ -186,7 +169,7 @@ export function provideExperimentalWebMcpBridge(options?: WebMcpBridgeOptions): 
       // Listen to toolchange events and re-register tools with the relay
       const onToolChange = () => {
         if (ws?.readyState === WebSocket.OPEN) {
-          void registerTools(ws);
+          void refreshAndRegisterTools(ws);
         }
       };
 

--- a/packages/@o3r/core/src/core/webmcp/webmcp-bridge.provider.ts
+++ b/packages/@o3r/core/src/core/webmcp/webmcp-bridge.provider.ts
@@ -1,0 +1,201 @@
+/* eslint-disable no-console -- this is an experimental dev-only bridge; console output is intentional for visibility in the browser DevTools */
+import {
+  DestroyRef,
+  EnvironmentProviders,
+  inject,
+  NgZone,
+  provideEnvironmentInitializer,
+} from '@angular/core';
+
+/**
+ * Options for {@link provideExperimentalWebMcpBridge}.
+ */
+export interface WebMcpBridgeOptions {
+  /**
+   * WebSocket URL of the relay server.
+   * @default 'ws://localhost:3200?role=browser'
+   */
+  url?: string;
+  /**
+   * Interval in milliseconds between reconnection attempts when the WebSocket
+   * connection is lost.
+   * @default 3000
+   */
+  reconnectInterval?: number;
+}
+
+/** Minimal local typing for the WebMCP browser API surface used by this provider. */
+interface ModelContextTool {
+  name: string;
+  description: string;
+  inputSchema: string | Record<string, unknown>;
+}
+
+interface ModelContext extends EventTarget {
+  getTools(): Promise<ModelContextTool[]>;
+  executeTool(tool: ModelContextTool, args: string): Promise<string>;
+}
+
+interface DocumentWithModelContext extends Document {
+  modelContext: ModelContext;
+}
+
+/**
+ * Provides the WebMCP bridge for **local development and testing with AI coding agents**.
+ *
+ * This provider connects the Angular application's {@link https://webmachinelearning.github.io/webmcp/ | WebMCP} tools
+ * (registered via `document.modelContext`) to a WebSocket relay server. It is designed to work together with:
+ *
+ * - **`@o3r/webmcp-bridge`** — a local WebSocket relay server (`apps/webmcp-bridge`) that routes
+ *   messages between the browser and MCP clients. Start it with `yarn nx start webmcp-bridge`.
+ * - **`@ama-mcp/webmcp`** — an MCP server (stdio transport) that connects to the relay and exposes
+ *   the browser tools to AI agents (Claude, Kiro, Copilot, etc.) via the standard MCP protocol.
+ *
+ * The full data flow is:
+ * ```
+ * Angular App (browser) ↔ WebSocket Relay ↔ MCP Server (stdio) ↔ AI Agent
+ * ```
+ *
+ * The relay server is needed because browsers cannot speak stdio MCP directly. In production,
+ * the AI agent will be integrated directly into the UI via the WebMCP browser API, making the
+ * relay unnecessary. This provider is only needed during development to test with external
+ * AI agents (Claude, Kiro, etc.) that communicate over MCP stdio.
+ * @note
+ * The WebMCP API (`document.modelContext`) must be enabled in Chrome before using this provider.
+ * Navigate to `chrome://flags/#enable-webmcp-testing`, set the flag to **Enabled**, and relaunch Chrome.
+ * Alternatively, enroll in the {@link https://developer.chrome.com/docs/ai/webmcp | WebMCP Origin Trial} starting from Chrome 149.
+ * @note
+ * This provider should only be included in development builds. It has no effect if the relay
+ * server is not running — the connection will silently retry at the configured interval.
+ * @note
+ * **Only one browser tab should have the app open at a time.** The relay routes `tools/call`
+ * requests to the most recently registered browser tab only. If multiple tabs are open, only the
+ * last tab to call `tools/register` will receive tool calls.
+ * @experimental
+ * @param options - Optional configuration for the bridge
+ */
+export function provideExperimentalWebMcpBridge(options?: WebMcpBridgeOptions): EnvironmentProviders {
+  const wsUrl = options?.url ?? 'ws://localhost:3200?role=browser';
+  const reconnectMs = options?.reconnectInterval ?? 3000;
+
+  return provideEnvironmentInitializer(() => {
+    const ngZone = inject(NgZone);
+    const destroyRef = inject(DestroyRef);
+
+    if (!('modelContext' in document)) {
+      console.warn('[WebMCP Bridge] document.modelContext is not available. Enable the WebMCP API in Chrome (chrome://flags/#enable-webmcp-testing) or enroll in the Origin Trial.');
+      return;
+    }
+
+    const modelContext = (document as DocumentWithModelContext).modelContext;
+
+    let ws: WebSocket | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let destroyed = false;
+
+    destroyRef.onDestroy(() => {
+      destroyed = true;
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+      }
+      if (ws) {
+        ws.close();
+      }
+    });
+
+    const getTools = async () => {
+      const tools = await modelContext.getTools();
+      return tools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        inputSchema: typeof tool.inputSchema === 'string' ? JSON.parse(tool.inputSchema) as Record<string, unknown> : tool.inputSchema
+      }));
+    };
+
+    const registerTools = async (socket: WebSocket) => {
+      const tools = await getTools();
+      console.log(`[WebMCP Bridge] Sending ${String(tools.length)} tools to relay:`, tools.map((t) => t.name));
+      socket.send(JSON.stringify({ type: 'tools/register', tools }));
+    };
+
+    const connect = () => {
+      if (destroyed) {
+        return;
+      }
+
+      ws = new WebSocket(wsUrl);
+
+      ws.addEventListener('open', () => {
+        console.log('[WebMCP Bridge] Connected to relay');
+        void registerTools(ws!);
+      });
+
+      ws.addEventListener('message', (event: MessageEvent) => {
+        let message: { type: string; id: string; name: string; arguments: Record<string, unknown> };
+        try {
+          message = JSON.parse(event.data as string) as typeof message;
+        } catch {
+          return;
+        }
+
+        if (message.type === 'tools/call') {
+          void modelContext.getTools().then((tools) => {
+            const tool = tools.find((t) => t.name === message.name);
+            if (!tool) {
+              ws?.send(JSON.stringify({
+                type: 'tools/call/response',
+                id: message.id,
+                result: { content: [{ type: 'text', text: `Tool "${message.name}" not found` }], isError: true }
+              }));
+              return;
+            }
+            return modelContext.executeTool(tool, JSON.stringify(message.arguments ?? {}));
+          }).then(
+            (result) => {
+              if (result !== undefined) {
+                ws?.send(JSON.stringify({
+                  type: 'tools/call/response',
+                  id: message.id,
+                  result: { content: [{ type: 'text', text: result ?? 'null' }] }
+                }));
+              }
+            },
+            (error: unknown) => {
+              ws?.send(JSON.stringify({
+                type: 'tools/call/response',
+                id: message.id,
+                result: { content: [{ type: 'text', text: error instanceof Error ? error.message : String(error) }], isError: true }
+              }));
+            }
+          );
+        }
+      });
+
+      ws.addEventListener('close', () => {
+        if (!destroyed) {
+          reconnectTimer = setTimeout(() => connect(), reconnectMs);
+        }
+      });
+
+      ws.addEventListener('error', () => {
+        ws?.close();
+      });
+    };
+
+    ngZone.runOutsideAngular(() => {
+      // Listen to toolchange events and re-register tools with the relay
+      const onToolChange = () => {
+        if (ws?.readyState === WebSocket.OPEN) {
+          void registerTools(ws);
+        }
+      };
+
+      modelContext.addEventListener('toolchange', onToolChange);
+      destroyRef.onDestroy(() => {
+        modelContext.removeEventListener('toolchange', onToolChange);
+      });
+
+      connect();
+    });
+  });
+}

--- a/packages/@o3r/core/tsconfig.build.json
+++ b/packages/@o3r/core/tsconfig.build.json
@@ -2,7 +2,10 @@
   "extends": "../../../tsconfig.build",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": [
+      "@mcp-b/webmcp-types"
+    ]
   },
   "include": [
     "src/**/*.ts"

--- a/packages/@o3r/core/tsconfig.spec.json
+++ b/packages/@o3r/core/tsconfig.spec.json
@@ -2,7 +2,10 @@
   "extends": "../../../tsconfig.jest",
   "compilerOptions": {
     "outDir": "test",
-    "rootDir": "."
+    "rootDir": ".",
+    "types": [
+      "@mcp-b/webmcp-types"
+    ]
   },
   "include": [
     "./builders/**/*.spec.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -677,6 +677,43 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@ama-mcp/webmcp@workspace:mcps/@ama-mcp/webmcp":
+  version: 0.0.0-use.local
+  resolution: "@ama-mcp/webmcp@workspace:mcps/@ama-mcp/webmcp"
+  dependencies:
+    "@ama-mcp/core": "workspace:~"
+    "@eslint-community/eslint-plugin-eslint-comments": "npm:^4.4.0"
+    "@modelcontextprotocol/server": "npm:~2.0.0"
+    "@nx/eslint": "npm:~23.1.0"
+    "@nx/eslint-plugin": "npm:~23.1.0"
+    "@o3r/build-helpers": "workspace:^"
+    "@o3r/eslint-config": "workspace:^"
+    "@o3r/eslint-plugin": "workspace:^"
+    "@stylistic/eslint-plugin": "npm:~5.10.0"
+    "@types/node": "npm:~24.13.0"
+    "@types/ws": "npm:~8.18.0"
+    "@typescript-eslint/parser": "npm:~8.67.0"
+    cpy-cli: "npm:^6.0.0"
+    esbuild: "npm:~0.28.0"
+    eslint: "npm:~9.39.0"
+    eslint-import-resolver-node: "npm:~0.4.0"
+    eslint-import-resolver-typescript: "npm:~4.4.0"
+    eslint-plugin-import: "npm:~2.32.0"
+    eslint-plugin-import-newlines: "npm:~1.4.0"
+    eslint-plugin-jsdoc: "npm:~61.7.0"
+    eslint-plugin-prefer-arrow: "npm:~1.2.3"
+    eslint-plugin-unicorn: "npm:~62.0.0"
+    eslint-plugin-unused-imports: "npm:~4.4.0"
+    globals: "npm:^16.0.0"
+    jsonc-eslint-parser: "npm:~2.4.0"
+    typescript: "npm:~6.0.3"
+    typescript-eslint: "npm:~8.67.0"
+    ws: "npm:~8.18.0"
+  bin:
+    ama-mcp-webmcp: ./dist/main.js
+  languageName: unknown
+  linkType: soft
+
 "@ama-mfe/messages@workspace:packages/@ama-mfe/messages, @ama-mfe/messages@workspace:~":
   version: 0.0.0-use.local
   resolution: "@ama-mfe/messages@workspace:packages/@ama-mfe/messages"
@@ -5311,10 +5348,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/aix-ppc64@npm:0.25.12"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/aix-ppc64@npm:0.28.1":
   version: 0.28.1
   resolution: "@esbuild/aix-ppc64@npm:0.28.1"
   conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/android-arm64@npm:0.25.12"
+  conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -5325,10 +5376,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/android-arm@npm:0.25.12"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm@npm:0.28.1":
   version: 0.28.1
   resolution: "@esbuild/android-arm@npm:0.28.1"
   conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/android-x64@npm:0.25.12"
+  conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
 
@@ -5339,10 +5404,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/darwin-arm64@npm:0.25.12"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-arm64@npm:0.28.1":
   version: 0.28.1
   resolution: "@esbuild/darwin-arm64@npm:0.28.1"
   conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/darwin-x64@npm:0.25.12"
+  conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
@@ -5353,10 +5432,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/freebsd-arm64@npm:0.25.12"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-arm64@npm:0.28.1":
   version: 0.28.1
   resolution: "@esbuild/freebsd-arm64@npm:0.28.1"
   conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/freebsd-x64@npm:0.25.12"
+  conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
@@ -5367,10 +5460,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-arm64@npm:0.25.12"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm64@npm:0.28.1":
   version: 0.28.1
   resolution: "@esbuild/linux-arm64@npm:0.28.1"
   conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-arm@npm:0.25.12"
+  conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
@@ -5381,10 +5488,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ia32@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-ia32@npm:0.25.12"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ia32@npm:0.28.1":
   version: 0.28.1
   resolution: "@esbuild/linux-ia32@npm:0.28.1"
   conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-loong64@npm:0.25.12"
+  conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
@@ -5395,10 +5516,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-mips64el@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-mips64el@npm:0.25.12"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-mips64el@npm:0.28.1":
   version: 0.28.1
   resolution: "@esbuild/linux-mips64el@npm:0.28.1"
   conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-ppc64@npm:0.25.12"
+  conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
@@ -5409,10 +5544,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-riscv64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-riscv64@npm:0.25.12"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-riscv64@npm:0.28.1":
   version: 0.28.1
   resolution: "@esbuild/linux-riscv64@npm:0.28.1"
   conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-s390x@npm:0.25.12"
+  conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
 
@@ -5423,10 +5572,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-x64@npm:0.25.12"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-x64@npm:0.28.1":
   version: 0.28.1
   resolution: "@esbuild/linux-x64@npm:0.28.1"
   conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/netbsd-arm64@npm:0.25.12"
+  conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -5437,10 +5600,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/netbsd-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/netbsd-x64@npm:0.25.12"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/netbsd-x64@npm:0.28.1":
   version: 0.28.1
   resolution: "@esbuild/netbsd-x64@npm:0.28.1"
   conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/openbsd-arm64@npm:0.25.12"
+  conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -5451,10 +5628,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/openbsd-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/openbsd-x64@npm:0.25.12"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openbsd-x64@npm:0.28.1":
   version: 0.28.1
   resolution: "@esbuild/openbsd-x64@npm:0.28.1"
   conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/openharmony-arm64@npm:0.25.12"
+  conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -5465,10 +5656,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/sunos-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/sunos-x64@npm:0.25.12"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/sunos-x64@npm:0.28.1":
   version: 0.28.1
   resolution: "@esbuild/sunos-x64@npm:0.28.1"
   conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/win32-arm64@npm:0.25.12"
+  conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -5479,10 +5684,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/win32-ia32@npm:0.25.12"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-ia32@npm:0.28.1":
   version: 0.28.1
   resolution: "@esbuild/win32-ia32@npm:0.28.1"
   conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/win32-x64@npm:0.25.12"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -7238,6 +7457,13 @@ __metadata:
     "@material/theme": "npm:^14.0.0"
     tslib: "npm:^2.1.0"
   checksum: 10/37071c19d3021764b6a8805dbd24aa59fd25eab21555cf7d3f603b5306a798149069df229622d727400caebec08edf4853b33c6c479b1b426745732af88ee8ca
+  languageName: node
+  linkType: hard
+
+"@mcp-b/webmcp-types@npm:~4.0.0":
+  version: 4.0.0
+  resolution: "@mcp-b/webmcp-types@npm:4.0.0"
+  checksum: 10/651f71477731061d6610353ecbc5aa7587a5ee994c39809643b274e0b7917df6cbe7cb627ee3eb9bbb6c0e12671a677bc56ba6ffe7de25a0d5545a713f29d8f9
   languageName: node
   linkType: hard
 
@@ -9644,6 +9870,7 @@ __metadata:
     "@babel/preset-typescript": "npm:~7.29.0"
     "@compodoc/compodoc": "npm:^1.1.32"
     "@eslint-community/eslint-plugin-eslint-comments": "npm:^4.4.0"
+    "@mcp-b/webmcp-types": "npm:~4.0.0"
     "@ngrx/entity": "npm:22.0.0-rc.0"
     "@ngrx/store": "npm:22.0.0-rc.0"
     "@nx/eslint": "npm:~23.1.0"
@@ -12209,6 +12436,37 @@ __metadata:
       optional: true
     typescript:
       optional: true
+  languageName: unknown
+  linkType: soft
+
+"@o3r/webmcp-bridge@workspace:apps/webmcp-bridge":
+  version: 0.0.0-use.local
+  resolution: "@o3r/webmcp-bridge@workspace:apps/webmcp-bridge"
+  dependencies:
+    "@eslint-community/eslint-plugin-eslint-comments": "npm:^4.4.0"
+    "@nx/eslint": "npm:~23.1.0"
+    "@nx/eslint-plugin": "npm:~23.1.0"
+    "@o3r/eslint-config": "workspace:^"
+    "@o3r/eslint-plugin": "workspace:^"
+    "@stylistic/eslint-plugin": "npm:~5.10.0"
+    "@types/node": "npm:~24.13.0"
+    "@types/ws": "npm:~8.18.0"
+    "@typescript-eslint/parser": "npm:~8.67.0"
+    eslint: "npm:~9.39.0"
+    eslint-import-resolver-node: "npm:~0.4.0"
+    eslint-import-resolver-typescript: "npm:~4.4.0"
+    eslint-plugin-import: "npm:~2.32.0"
+    eslint-plugin-import-newlines: "npm:~1.4.0"
+    eslint-plugin-jsdoc: "npm:~61.7.0"
+    eslint-plugin-prefer-arrow: "npm:~1.2.3"
+    eslint-plugin-unicorn: "npm:~62.0.0"
+    eslint-plugin-unused-imports: "npm:~4.4.0"
+    globals: "npm:^16.0.0"
+    jsonc-eslint-parser: "npm:~2.4.0"
+    tsx: "npm:~4.19.0"
+    typescript: "npm:~6.0.3"
+    typescript-eslint: "npm:~8.67.0"
+    ws: "npm:~8.18.0"
   languageName: unknown
   linkType: soft
 
@@ -16184,7 +16442,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ws@npm:^8.5.10":
+"@types/ws@npm:^8.5.10, @types/ws@npm:~8.18.0":
   version: 8.18.1
   resolution: "@types/ws@npm:8.18.1"
   dependencies:
@@ -22939,6 +23197,95 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild@npm:~0.25.0":
+  version: 0.25.12
+  resolution: "esbuild@npm:0.25.12"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.25.12"
+    "@esbuild/android-arm": "npm:0.25.12"
+    "@esbuild/android-arm64": "npm:0.25.12"
+    "@esbuild/android-x64": "npm:0.25.12"
+    "@esbuild/darwin-arm64": "npm:0.25.12"
+    "@esbuild/darwin-x64": "npm:0.25.12"
+    "@esbuild/freebsd-arm64": "npm:0.25.12"
+    "@esbuild/freebsd-x64": "npm:0.25.12"
+    "@esbuild/linux-arm": "npm:0.25.12"
+    "@esbuild/linux-arm64": "npm:0.25.12"
+    "@esbuild/linux-ia32": "npm:0.25.12"
+    "@esbuild/linux-loong64": "npm:0.25.12"
+    "@esbuild/linux-mips64el": "npm:0.25.12"
+    "@esbuild/linux-ppc64": "npm:0.25.12"
+    "@esbuild/linux-riscv64": "npm:0.25.12"
+    "@esbuild/linux-s390x": "npm:0.25.12"
+    "@esbuild/linux-x64": "npm:0.25.12"
+    "@esbuild/netbsd-arm64": "npm:0.25.12"
+    "@esbuild/netbsd-x64": "npm:0.25.12"
+    "@esbuild/openbsd-arm64": "npm:0.25.12"
+    "@esbuild/openbsd-x64": "npm:0.25.12"
+    "@esbuild/openharmony-arm64": "npm:0.25.12"
+    "@esbuild/sunos-x64": "npm:0.25.12"
+    "@esbuild/win32-arm64": "npm:0.25.12"
+    "@esbuild/win32-ia32": "npm:0.25.12"
+    "@esbuild/win32-x64": "npm:0.25.12"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10/bc9c03d64e96a0632a926662c9d29decafb13a40e5c91790f632f02939bc568edc9abe0ee5d8055085a2819a00139eb12e223cfb8126dbf89bbc569f125d91fd
+  languageName: node
+  linkType: hard
+
 "escalade@npm:3.2.0, escalade@npm:^3.1.1, escalade@npm:^3.2.0":
   version: 3.2.0
   resolution: "escalade@npm:3.2.0"
@@ -24775,6 +25122,15 @@ __metadata:
   dependencies:
     resolve-pkg-maps: "npm:^1.0.0"
   checksum: 10/f5626971905ca386c9ddeb302504e8a2301b9c05641803267223ebd50b7c81aaf9324d29cf9f4e4ff3f245632c3392aa83719dc6cb3e98b4e4a1702a27c5cc5d
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:^4.7.5":
+  version: 4.14.3
+  resolution: "get-tsconfig@npm:4.14.3"
+  dependencies:
+    resolve-pkg-maps: "npm:^1.0.0"
+  checksum: 10/ac18243ffd5c2e7c0cbecc11d053599c73a4c534a626988fe545b686695bf2fa789ba47bc2af87e30d85c657dbcadc26b4e3e328096894fde6a9229615c67253
   languageName: node
   linkType: hard
 
@@ -37202,6 +37558,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tsx@npm:~4.19.0":
+  version: 4.19.4
+  resolution: "tsx@npm:4.19.4"
+  dependencies:
+    esbuild: "npm:~0.25.0"
+    fsevents: "npm:~2.3.3"
+    get-tsconfig: "npm:^4.7.5"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.mjs
+  checksum: 10/4dde315aeda70b9cadfecbc8d05b1625f5831018b9cb2db25cbbd03c5f5ee9c59cdc6652a0fd8492176b50944a5af1d5af352b944d024f4a719f58d6f2ac3a7f
+  languageName: node
+  linkType: hard
+
 "tsyringe@npm:^4.10.0":
   version: 4.10.0
   resolution: "tsyringe@npm:4.10.0"
@@ -39154,6 +39526,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10/088411956432c8f876158409d5a285cb9ad1382f593391f51d3a599bd0a5b277f876609ebd00fc3596321c4a4c9064d6fffe1ebad960e8ea7fd9ae25324f35c2
+  languageName: node
+  linkType: hard
+
+"ws@npm:~8.18.0":
+  version: 8.18.3
+  resolution: "ws@npm:8.18.3"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10/725964438d752f0ab0de582cd48d6eeada58d1511c3f613485b5598a83680bedac6187c765b0fe082e2d8cc4341fc57707c813ae780feee82d0c5efe6a4c61b6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed change

Add the foundational WebMCP infrastructure that enables local AI agents (Claude, Kiro, etc.) to interact with an Angular application through the standard MCP protocol.

This PR introduces three new packages that work together:

- **`@o3r/core` — `provideExperimentalWebMcpBridge()`**: An Angular provider that connects the browser's [WebMCP API](https://developer.chrome.com/docs/ai/webmcp) (`document.modelContext`) to an external WebSocket relay server. It discovers tools registered by the app, forwards JSON-RPC calls from the relay to the browser, and sends responses back.

- **`@o3r/webmcp-bridge`** (new app): A lightweight WebSocket relay server (Node.js + `ws`) that sits between the browser and an MCP server. It accepts a WebSocket connection from the Angular app and communicates with an MCP server via stdio, routing JSON-RPC messages in both directions.

- **`@ama-mcp/webmcp`** (new MCP server): An MCP server that exposes browser-registered WebMCP tools to AI agents. It connects to the relay, discovers available tools, and serves them through the standard MCP `tools/list` and `tools/call` protocol.

### Architecture

```
AI Agent (Claude/Kiro) ←stdio→ @ama-mcp/webmcp ←WebSocket→ @o3r/webmcp-bridge ←WebSocket→ Browser (Angular app)
```

> **Note:** All three packages are private/local-only and marked `@experimental`. The WebMCP Chrome API requires enabling `chrome://flags/#enable-webmcp-testing`.

## Related issues

*- No issue associated -*
