### PR TITLE
feat(showcase): integrate WebMCP tools for AI agent testing

### DIFF
--- a/apps/showcase/package.json
+++ b/apps/showcase/package.json
@@ -118,6 +118,7 @@
     "@angular/cli": "~22.0.4",
     "@angular/compiler-cli": "~22.0.4",
     "@eslint-community/eslint-plugin-eslint-comments": "^4.4.0",
+    "@mcp-b/webmcp-types": "~4.0.0",
     "@nx/eslint-plugin": "~23.1.0",
     "@o3r-training/training-sdk": "workspace:~",
     "@o3r/build-helpers": "workspace:~",

--- a/apps/showcase/src/app/app.config.ts
+++ b/apps/showcase/src/app/app.config.ts
@@ -22,6 +22,7 @@ import {
 } from '@angular/platform-browser/animations';
 import {
   provideRouter,
+  withExperimentalAutoCleanupInjectors,
   withHashLocation,
   withInMemoryScrolling,
 } from '@angular/router';
@@ -53,6 +54,9 @@ import {
   OTTER_CONFIGURATION_DEVTOOLS_OPTIONS,
   provideConfigurationDevtools,
 } from '@o3r/configuration';
+import {
+  provideExperimentalWebMcpBridge,
+} from '@o3r/core';
 import {
   provideDynamicContent,
 } from '@o3r/dynamic-content';
@@ -98,6 +102,9 @@ import {
 import {
   appRoutes,
 } from './app.routes';
+import {
+  provideAppWebMcpTools,
+} from './app.webmcp';
 
 const runtimeChecks = {
   strictActionImmutability: false,
@@ -147,7 +154,8 @@ export const appConfig: ApplicationConfig = {
     provideRouter(
       appRoutes,
       withHashLocation(),
-      withInMemoryScrolling({ scrollPositionRestoration: 'enabled' })
+      withInMemoryScrolling({ scrollPositionRestoration: 'enabled' }),
+      withExperimentalAutoCleanupInjectors()
     ),
     provideStore({}, { runtimeChecks }),
     provideEffects(),
@@ -189,6 +197,8 @@ export const appConfig: ApplicationConfig = {
     { provide: NGX_MONACO_EDITOR_CONFIG, useValue: { baseUrl: `${location.origin}${location.pathname}assets/monaco/min/vs` } },
     provideLocalization(localizationConfigurationFactory),
     provideLocalizationDevtools(),
-    provideTranslocoMessageformat()
+    provideTranslocoMessageformat(),
+    provideExperimentalWebMcpBridge(),
+    provideAppWebMcpTools()
   ]
 };

--- a/apps/showcase/src/app/app.routes.ts
+++ b/apps/showcase/src/app/app.routes.ts
@@ -20,6 +20,12 @@ import {
 import {
   provideAssetRulesEngineAction,
 } from '@o3r/dynamic-content/rules-engine';
+import {
+  provideFormsWebMcpTools,
+} from './forms/forms.webmcp';
+import {
+  provideSdkWebMcpTools,
+} from './sdk/sdk.webmcp';
 
 export const appRoutes = [
   { path: '', redirectTo: '/home', pathMatch: 'full' },
@@ -29,16 +35,38 @@ export const appRoutes = [
     providers: [
       provideConfigurationStore()
     ],
-    title: 'Otter Showcase - Configuration'
+    title: 'Otter Showcase - Configuration',
+    data: { aiDescription: 'Demonstrates dynamic component configuration via CMS. Shows how Otter components can be configured at runtime without redeployment.' }
   },
-  { path: 'component-replacement', loadComponent: () => import('./component-replacement/index').then((m) => m.ComponentReplacement), title: 'Otter Showcase - Component replacement' },
-  { path: 'design-token', loadComponent: () => import('./design-token/index').then((m) => m.DesignToken), title: 'Otter Showcase - Design Token' },
-  { path: 'localization', loadComponent: () => import('./localization/index').then((m) => m.Localization), title: 'Otter Showcase - Localization' },
-  { path: 'dynamic-content', loadComponent: () => import('./dynamic-content/index').then((m) => m.DynamicContent), title: 'Otter Showcase - Dynamic Content' },
+  {
+    path: 'component-replacement',
+    loadComponent: () => import('./component-replacement/index').then((m) => m.ComponentReplacement),
+    title: 'Otter Showcase - Component replacement',
+    data: { aiDescription: 'Shows how components can be dynamically replaced at runtime, enabling A/B testing and progressive rollouts.' }
+  },
+  {
+    path: 'design-token',
+    loadComponent: () => import('./design-token/index').then((m) => m.DesignToken),
+    title: 'Otter Showcase - Design Token',
+    data: { aiDescription: 'Design token theming demonstration. Shows how to use design tokens for consistent styling across components.' }
+  },
+  {
+    path: 'localization',
+    loadComponent: () => import('./localization/index').then((m) => m.Localization),
+    title: 'Otter Showcase - Localization',
+    data: { aiDescription: 'Localization and internationalization features. Demonstrates translation management, locale switching, and ICU message format support.' }
+  },
+  {
+    path: 'dynamic-content',
+    loadComponent: () => import('./dynamic-content/index').then((m) => m.DynamicContent),
+    title: 'Otter Showcase - Dynamic Content',
+    data: { aiDescription: 'Dynamic content loading and management. Shows how assets and content can be overridden at runtime via a CMS.' }
+  },
   {
     path: 'rules-engine',
     loadComponent: () => import('./rules-engine/index').then((m) => m.RulesEngine),
     title: 'Otter Showcase - Rules Engine',
+    data: { aiDescription: 'Rules engine for dynamic UI behavior. Demonstrates how business rules can drive configuration, localization, and placeholder changes based on runtime facts.' },
     providers: [
       provideConfigurationRulesEngineAction(),
       provideAssetRulesEngineAction(),
@@ -48,20 +76,57 @@ export const appRoutes = [
       providePlaceholderRulesEngineAction()
     ]
   },
-  { path: 'home', loadComponent: () => import('./home/index').then((m) => m.Home), title: 'Otter Showcase - Home' },
-  { path: 'run-app-locally', loadComponent: () => import('./run-app-locally/index').then((m) => m.RunAppLocally), title: 'Otter Showcase - Run App Locally' },
-  { path: 'sdk', loadComponent: () => import('./sdk/index').then((m) => m.Sdk), title: 'Otter Showcase - SDK' },
-  { path: 'sdk-intro', loadComponent: () => import('./sdk-intro/index').then((m) => m.SdkIntro), title: 'Otter Showcase - SDK Introduction' },
+  {
+    path: 'home',
+    loadComponent: () => import('./home/index').then((m) => m.Home),
+    title: 'Otter Showcase - Home',
+    data: { aiDescription: 'Home page with an overview of the Otter framework and links to all feature demonstrations.' }
+  },
+  {
+    path: 'run-app-locally',
+    loadComponent: () => import('./run-app-locally/index').then((m) => m.RunAppLocally),
+    title: 'Otter Showcase - Run App Locally',
+    data: { aiDescription: 'Instructions and guide to run the Otter showcase application locally for development.' }
+  },
+  {
+    path: 'sdk',
+    loadComponent: () => import('./sdk/index').then((m) => m.Sdk),
+    title: 'Otter Showcase - SDK',
+    data: { aiDescription: 'Pet Store SDK demonstration. Shows how to use an Otter-generated TypeScript SDK to interact with a REST API (list, search, and view pets).' },
+    providers: [
+      provideSdkWebMcpTools()
+    ]
+  },
+  {
+    path: 'sdk-intro',
+    loadComponent: () => import('./sdk-intro/index').then((m) => m.SdkIntro),
+    title: 'Otter Showcase - SDK Introduction',
+    data: { aiDescription: 'Introduction to the Otter SDK generator. Explains how to generate type-safe TypeScript SDKs from OpenAPI specifications.' }
+  },
   {
     path: 'placeholder',
     loadComponent: () => import('./placeholder/index').then((m) => m.Placeholder),
     title: 'Otter Showcase - Placeholder',
+    data: { aiDescription: 'Placeholder mechanism for dynamic component loading. Demonstrates how placeholders can be filled with components driven by the rules engine.' },
     providers: [
       providePlaceholderRulesEngineAction(),
       providePlaceholder()
     ]
   },
-  { path: 'sdk-training', loadComponent: () => import('./sdk-training/index').then((m) => m.SdkTraining), title: 'Otter Showcase - SDK Training' },
-  { path: 'forms', loadComponent: () => import('./forms/index').then((m) => m.Forms), title: 'Otter Showcase - Forms' },
+  {
+    path: 'sdk-training',
+    loadComponent: () => import('./sdk-training/index').then((m) => m.SdkTraining),
+    title: 'Otter Showcase - SDK Training',
+    data: { aiDescription: 'Interactive SDK training exercises. Step-by-step tutorials to learn how to use the Otter SDK in a real application.' }
+  },
+  {
+    path: 'forms',
+    loadComponent: () => import('./forms/index').then((m) => m.Forms),
+    title: 'Otter Showcase - Forms',
+    data: { aiDescription: 'Form handling with validation and error management. Demonstrates personal info and emergency contact forms with cross-field validation.' },
+    providers: [
+      provideFormsWebMcpTools()
+    ]
+  },
   { path: '**', redirectTo: '/home', pathMatch: 'full' }
 ] as const satisfies Routes;

--- a/apps/showcase/src/app/app.webmcp.ts
+++ b/apps/showcase/src/app/app.webmcp.ts
@@ -1,0 +1,106 @@
+import {
+  inject,
+  provideExperimentalWebMcpTools,
+} from '@angular/core';
+import {
+  Router,
+} from '@angular/router';
+import {
+  LocalizationService,
+} from '@o3r/transloco';
+import {
+  appRoutes,
+} from './app.routes';
+
+/**
+ * Provides application-level WebMCP tools for navigation and localization.
+ * These tools are available globally across all routes.
+ */
+export function provideAppWebMcpTools() {
+  return provideExperimentalWebMcpTools([
+    {
+      name: 'navigateTo',
+      description: 'Navigate to a specific page in the Otter showcase application.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          route: {
+            type: 'string',
+            description: 'The route path to navigate to. Use listAvailablePages to see all available routes.'
+          }
+        },
+        required: ['route'],
+        additionalProperties: false
+      },
+      execute: async ({ route }) => {
+        const router = inject(Router);
+        const validRoutes = appRoutes.map((r) => r.path).filter((p) => !!p && !p.includes('*'));
+        if (typeof route !== 'string' || !validRoutes.includes(route as typeof validRoutes[number])) {
+          return { content: [{ type: 'text', text: `Invalid route "${String(route)}". Valid routes are: ${validRoutes.join(', ')}` }] };
+        }
+        const success = await router.navigate([`/${route}`]);
+        if (success) {
+          return { content: [{ type: 'text', text: `Successfully navigated to /${route}` }] };
+        }
+        return { content: [{ type: 'text', text: `Navigation to /${route} was rejected by a route guard` }] };
+      }
+    },
+    {
+      name: 'listAvailablePages',
+      description: 'List all available pages in the Otter showcase application with their descriptions.',
+      inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+      execute: () => {
+        const pages = appRoutes
+          .filter((r): r is typeof appRoutes[number] & { title: string; data: { aiDescription: string } } => !!r.path && !r.path.includes('*') && 'data' in r && !!(r as any).data?.aiDescription)
+          .map((r) => ({ route: r.path, title: r.title, description: r.data.aiDescription }));
+        return { content: [{ type: 'text', text: JSON.stringify(pages, null, 2) }] };
+      }
+    },
+    {
+      name: 'switchLanguage',
+      description: 'Switch the application language. Supported languages are en-GB (English) and fr-FR (French).',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          language: {
+            type: 'string',
+            description: 'The language code to switch to. Supported values: "en-GB", "fr-FR".'
+          }
+        },
+        required: ['language'],
+        additionalProperties: false
+      },
+      execute: ({ language }) => {
+        const localizationService = inject(LocalizationService);
+        const supportedLanguages = localizationService.getLanguages();
+        if (typeof language !== 'string' || !supportedLanguages.includes(language)) {
+          return { content: [{ type: 'text', text: `Invalid language "${String(language)}". Supported languages: ${supportedLanguages.join(', ')}` }] };
+        }
+        localizationService.useLanguage(language);
+        return { content: [{ type: 'text', text: `Language switched to ${language}` }] };
+      }
+    },
+    {
+      name: 'getCurrentLanguage',
+      description: 'Get the current active language of the application.',
+      inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+      execute: () => {
+        const localizationService = inject(LocalizationService);
+        const currentLang = localizationService.getCurrentLanguage();
+        const availableLangs = localizationService.getLanguages();
+        return { content: [{ type: 'text', text: JSON.stringify({ currentLanguage: currentLang, availableLanguages: availableLangs }) }] };
+      }
+    },
+    {
+      name: 'getCurrentRoute',
+      description: 'Get the current active route of the application.',
+      inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+      execute: () => {
+        const router = inject(Router);
+        const url = router.url.replace(/^\//, '');
+        const route = appRoutes.find((r) => r.path === url);
+        return { content: [{ type: 'text', text: JSON.stringify({ route: url, title: route && 'title' in route ? route.title : null }) }] };
+      }
+    }
+  ]);
+}

--- a/apps/showcase/src/app/forms/forms.webmcp.ts
+++ b/apps/showcase/src/app/forms/forms.webmcp.ts
@@ -1,0 +1,123 @@
+import {
+  provideExperimentalWebMcpTools,
+} from '@angular/core';
+
+/**
+ * Provides WebMCP tools for the Forms page.
+ * These tools allow AI agents to fill and submit the personal info and emergency contact forms.
+ */
+export function provideFormsWebMcpTools() {
+  return provideExperimentalWebMcpTools([
+    {
+      name: 'fillPersonalInfo',
+      description: 'Fill the personal information form with the provided data. The form requires a name and a date of birth.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description: 'The full name of the person.'
+          },
+          dateOfBirth: {
+            type: 'string',
+            description: 'Date of birth in YYYY-MM-DD format.'
+          }
+        },
+        required: ['name', 'dateOfBirth'],
+        additionalProperties: false
+      },
+      execute: ({ name, dateOfBirth }) => {
+        if (typeof name !== 'string' || !name.trim()) {
+          return { content: [{ type: 'text', text: 'Error: name is required and must be a non-empty string.' }] };
+        }
+        if (typeof dateOfBirth !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(dateOfBirth)) {
+          return { content: [{ type: 'text', text: 'Error: dateOfBirth must be in YYYY-MM-DD format.' }] };
+        }
+        const formElement = document.querySelector<HTMLInputElement>('o3r-forms-personal-info-pres input[id*="name"]');
+        const dateElement = document.querySelector<HTMLInputElement>('o3r-forms-personal-info-pres input[type="date"], o3r-forms-personal-info-pres o3r-date-picker-input-pres input');
+        if (formElement) {
+          formElement.value = name;
+          formElement.dispatchEvent(new Event('input', { bubbles: true }));
+          formElement.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+        if (dateElement) {
+          dateElement.value = dateOfBirth;
+          dateElement.dispatchEvent(new Event('input', { bubbles: true }));
+          dateElement.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+        return { content: [{ type: 'text', text: JSON.stringify({ filled: true, personalInfo: { name, dateOfBirth } }) }] };
+      }
+    },
+    {
+      name: 'fillEmergencyContact',
+      description: 'Fill the emergency contact form with the provided data.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description: 'The name of the emergency contact.'
+          },
+          phone: {
+            type: 'string',
+            description: 'The phone number of the emergency contact.'
+          },
+          email: {
+            type: 'string',
+            description: 'The email address of the emergency contact.'
+          }
+        },
+        required: ['name', 'phone', 'email'],
+        additionalProperties: false
+      },
+      execute: ({ name, phone, email }) => {
+        if (typeof name !== 'string' || !name.trim()) {
+          return { content: [{ type: 'text', text: 'Error: name is required.' }] };
+        }
+        if (typeof phone !== 'string' || !phone.trim()) {
+          return { content: [{ type: 'text', text: 'Error: phone is required.' }] };
+        }
+        if (typeof email !== 'string' || !email.trim()) {
+          return { content: [{ type: 'text', text: 'Error: email is required.' }] };
+        }
+        const nameEl = document.querySelector<HTMLInputElement>('o3r-forms-emergency-contact-pres input[id*="name"]');
+        const phoneEl = document.querySelector<HTMLInputElement>('o3r-forms-emergency-contact-pres input[id*="phone"]');
+        const emailEl = document.querySelector<HTMLInputElement>('o3r-forms-emergency-contact-pres input[id*="email"]');
+        if (nameEl) {
+          nameEl.value = name;
+          nameEl.dispatchEvent(new Event('input', { bubbles: true }));
+          nameEl.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+        if (phoneEl) {
+          phoneEl.value = phone;
+          phoneEl.dispatchEvent(new Event('input', { bubbles: true }));
+          phoneEl.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+        if (emailEl) {
+          emailEl.value = email;
+          emailEl.dispatchEvent(new Event('input', { bubbles: true }));
+          emailEl.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+        return { content: [{ type: 'text', text: JSON.stringify({ filled: true, emergencyContact: { name, phone, email } }) }] };
+      }
+    },
+    {
+      name: 'submitForms',
+      description: 'Submit the forms on the page and return the result.',
+      inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+      execute: () => {
+        const submitButton = document.querySelector<HTMLButtonElement>('o3r-forms-parent button[type="submit"]');
+        if (!submitButton) {
+          return { content: [{ type: 'text', text: 'Error: Submit button not found. Make sure you are on the forms page.' }] };
+        }
+        submitButton.click();
+        const errorElements = document.querySelectorAll('o3r-forms-parent .invalid-feedback, o3r-forms-parent .text-danger');
+        const errors = Array.from(errorElements).map((el) => el.textContent?.trim()).filter(Boolean);
+        if (errors.length > 0) {
+          return { content: [{ type: 'text', text: JSON.stringify({ submitted: true, valid: false, errors }) }] };
+        }
+        return { content: [{ type: 'text', text: JSON.stringify({ submitted: true, valid: true }) }] };
+      }
+    }
+  ]);
+}

--- a/apps/showcase/src/app/sdk/sdk.webmcp.ts
+++ b/apps/showcase/src/app/sdk/sdk.webmcp.ts
@@ -1,0 +1,107 @@
+import {
+  inject,
+  provideExperimentalWebMcpTools,
+} from '@angular/core';
+import {
+  PetApi,
+} from '@o3r-training/showcase-sdk';
+
+/**
+ * Provides WebMCP tools for the SDK page.
+ * These tools expose read-only access to the Pet Store API for AI agents.
+ */
+export function provideSdkWebMcpTools() {
+  return provideExperimentalWebMcpTools([
+    {
+      name: 'listPets',
+      description: 'List available pets from the Pet Store API filtered by status.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          status: {
+            type: 'string',
+            description: 'Filter pets by status. Possible values: "available", "pending", "sold". Defaults to "available".'
+          }
+        },
+        additionalProperties: false
+      },
+      execute: async ({ status }) => {
+        const petApi = inject(PetApi);
+        const petStatus = (status === 'pending' || status === 'sold') ? status : 'available';
+        try {
+          const pets = await petApi.findPetsByStatus({ status: petStatus });
+          const otterPets = pets.filter((p) => p.category?.name === 'otter');
+          const summary = otterPets.map((p) => ({ id: p.id, name: p.name, status: p.status, tags: p.tags?.map((t) => t.name) }));
+          return { content: [{ type: 'text', text: JSON.stringify({ total: summary.length, pets: summary }, null, 2) }] };
+        } catch {
+          return { content: [{ type: 'text', text: 'Error: Failed to fetch pets from the Pet Store API.' }] };
+        }
+      }
+    },
+    {
+      name: 'searchPets',
+      description: 'Search for pets by name, tag, or category keyword in the Pet Store.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description: 'Search keyword to filter pets by name, tag, or category.'
+          }
+        },
+        required: ['query'],
+        additionalProperties: false
+      },
+      execute: async ({ query }) => {
+        const petApi = inject(PetApi);
+        if (typeof query !== 'string' || !query.trim()) {
+          return { content: [{ type: 'text', text: 'Error: A non-empty search query is required.' }] };
+        }
+        try {
+          const pets = await petApi.findPetsByStatus({ status: 'available' });
+          const matchString = new RegExp(query.replace(/[\s#$()*+,.?[\\\]^{|}-]/g, '\\$&'), 'i');
+          const filtered = pets.filter((pet) =>
+            matchString.test(pet.name)
+            || (pet.category?.name && matchString.test(pet.category.name))
+            || (pet.tags?.some((tag) => tag.name && matchString.test(tag.name)))
+          );
+          const summary = filtered.map((p) => ({ id: p.id, name: p.name, status: p.status, category: p.category?.name, tags: p.tags?.map((t) => t.name) }));
+          return { content: [{ type: 'text', text: JSON.stringify({ query, total: summary.length, pets: summary }, null, 2) }] };
+        } catch {
+          return { content: [{ type: 'text', text: 'Error: Failed to search pets from the Pet Store API.' }] };
+        }
+      }
+    },
+    {
+      name: 'getPetById',
+      description: 'Get details of a specific pet by its ID.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          petId: {
+            type: 'number',
+            description: 'The unique identifier of the pet.'
+          }
+        },
+        required: ['petId'],
+        additionalProperties: false
+      },
+      execute: async ({ petId }) => {
+        const petApi = inject(PetApi);
+        if (typeof petId !== 'number') {
+          return { content: [{ type: 'text', text: 'Error: petId must be a number.' }] };
+        }
+        try {
+          const pet = await petApi.getPetById({ petId });
+          const result = {
+            id: pet.id, name: pet.name, status: pet.status,
+            category: pet.category?.name, tags: pet.tags?.map((t) => t.name), photoUrls: pet.photoUrls
+          };
+          return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+        } catch {
+          return { content: [{ type: 'text', text: `Error: Could not find pet with ID ${String(petId)}.` }] };
+        }
+      }
+    }
+  ]);
+}

--- a/apps/showcase/src/components/utilities/forms-personal-info/forms-personal-info-pres.html
+++ b/apps/showcase/src/components/utilities/forms-personal-info/forms-personal-info-pres.html
@@ -13,7 +13,7 @@
               <div class="text-danger">{{translations.required | o3rTranslate}}</div>
             }
             @if (form.controls.name.errors?.maxlength) {
-              <div class="text-danger">{{translations.maxLength | o3rTranslate: {maxLength: form.controls.name.errors?.maxlength.requiredLength} }}</div>
+              <div class="text-danger">{{translations.maxLength | o3rTranslate: {maxLength: form.controls.name.errors.maxlength.requiredLength} }}</div>
             }
           </div>
         </ng-container>
@@ -27,7 +27,7 @@
         <div class="text-danger">{{translations.date | o3rTranslate}}</div>
       }
       @if (form.controls.dateOfBirth.errors?.max) {
-        <div class="text-danger">{{translations.max | o3rTranslate: {max: form.controls.dateOfBirth.errors?.max.max} }}</div>
+        <div class="text-danger">{{translations.max | o3rTranslate: {max: form.controls.dateOfBirth.errors.max.max} }}</div>
       }
       @for (customError of form.controls.dateOfBirth.errors?.customErrors; track customError.translationKey) {
         <div class="text-danger">{{customError.translationKey | o3rTranslate: customError.translationParams}}</div>

--- a/apps/showcase/tsconfig.app.json
+++ b/apps/showcase/tsconfig.app.json
@@ -40,6 +40,9 @@
       "dom",
       "dom.iterable"
     ],
+    "types": [
+      "@mcp-b/webmcp-types"
+    ],
     "skipLibCheck": true /* because of @webcontainer/api 1.4.0 */
   },
   "angularCompilerOptions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11738,6 +11738,7 @@ __metadata:
     "@jsverse/transloco": "npm:~8.3.0"
     "@jsverse/transloco-messageformat": "npm:~8.3.0"
     "@jsverse/utils": "npm:1.0.0-beta.6"
+    "@mcp-b/webmcp-types": "npm:~4.0.0"
     "@ng-bootstrap/ng-bootstrap": "npm:~21.0.0"
     "@ng-select/ng-select": "npm:~23.11.0"
     "@ngrx/effects": "npm:22.0.0-rc.0"


### PR DESCRIPTION
## Proposed change

Integrate the WebMCP bridge (from PR #4458) into the showcase application, exposing Angular component capabilities as tools that AI agents can discover and invoke during local development.

### What's added

- **`provideExperimentalWebMcpBridge()`** wired into the app configuration, connecting the showcase to the relay server on `localhost:3200`
- **`app.webmcp.ts`** — registers top-level tools: page navigation (`navigate_to_page`) and route listing (`list_pages`)
- **`forms.webmcp.ts`** — registers form-related tools: `fill_personal_info_form`, `get_form_state`, `submit_form`, targeting the personal info form by field name attributes
- **`sdk.webmcp.ts`** — registers SDK-related tools: `fetch_pets`, `get_sdk_state`, for interacting with the pet store demo API
- **Route metadata** extended with WebMCP tool declarations so tools are registered/unregistered as the user navigates between pages
- **`name` attributes** added to form fields in `forms-personal-info-pres.html` to enable tool-based field targeting

### How to test

1. Enable WebMCP in Chrome (`chrome://flags/#enable-webmcp-testing`)
2. Start the relay: `yarn nx start webmcp-bridge`
3. Start the showcase: `yarn nx serve showcase`
4. Configure your AI agent to use `@ama-mcp/webmcp` as an MCP server
5. Ask the agent to interact with the showcase (e.g. "fill the personal info form")

> Depends on PR #4458 (WebMCP infrastructure)

## Related issues

*- No issue associated -*
