### PR TITLE
refactor(showcase): migrate forms to Angular Signal Forms API

### DIFF
--- a/apps/showcase/src/components/showcase/basic/basic-pres.html
+++ b/apps/showcase/src/components/showcase/basic/basic-pres.html
@@ -14,11 +14,11 @@
           </h2>
         </div>
         <h3 class="row card-text mt-auto ms-1 h5">Where do you want to go?</h3>
-        <form class="row g-2" [formGroup]="form">
+        <form class="row g-2">
           <div class="col-12 col-xl-6">
             <div class="input-group">
               <label class="input-group-text w-50" for="destination">Destination</label>
-              <select class="form-select" id="destination" formControlName="destination">
+              <select class="form-select" id="destination" [formField]="formTree.destination">
                 <option disabled selected value> -- select a destination --</option>
                 <option value="London">London</option>
                 <option value="Paris">Paris</option>
@@ -28,7 +28,7 @@
           </div>
           <div class="col-12 col-xl-6">
             <o3r-date-picker-input-pres [label]="'Departure'" [id]="'date-outbound'" class="w-50"
-                                        formControlName="outboundDate" />
+                                        [formField]="formTree.outboundDate" />
           </div>
         </form>
       </div>

--- a/apps/showcase/src/components/showcase/basic/basic-pres.ts
+++ b/apps/showcase/src/components/showcase/basic/basic-pres.ts
@@ -4,15 +4,13 @@ import {
 import {
   ChangeDetectionStrategy,
   Component,
-  inject,
+  signal,
   ViewEncapsulation,
 } from '@angular/core';
 import {
-  FormBuilder,
-  FormControl,
-  FormGroup,
-  ReactiveFormsModule,
-} from '@angular/forms';
+  form,
+  FormField,
+} from '@angular/forms/signals';
 import {
   O3rComponent,
 } from '@o3r/core';
@@ -25,7 +23,7 @@ const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
 @O3rComponent({ componentType: 'Component' })
 @Component({
   selector: 'o3r-basic-pres',
-  imports: [ReactiveFormsModule, DatePickerInputPres],
+  imports: [FormField, DatePickerInputPres],
   templateUrl: './basic-pres.html',
   styleUrls: ['./basic-pres.scss'],
   encapsulation: ViewEncapsulation.None,
@@ -33,12 +31,17 @@ const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
 })
 export class BasicPres {
   /**
-   * Form group
+   * Form model
    */
-  public form: FormGroup<{ destination: FormControl<string | null>; outboundDate: FormControl<string | null> }> = inject(FormBuilder).group({
-    destination: new FormControl<string | null>(null),
-    outboundDate: new FormControl<string | null>(this.formatDate(Date.now() + 7 * ONE_DAY_IN_MS))
+  public model = signal({
+    destination: '',
+    outboundDate: this.formatDate(Date.now() + 7 * ONE_DAY_IN_MS)
   });
+
+  /**
+   * Form tree
+   */
+  public formTree = form(this.model);
 
   private formatDate(dateTime: number) {
     return formatDate(dateTime, 'yyyy-MM-dd', 'en-GB');

--- a/apps/showcase/src/components/showcase/configuration/configuration-pres.html
+++ b/apps/showcase/src/components/showcase/configuration/configuration-pres.html
@@ -14,11 +14,11 @@
           </h2>
         </div>
         <h3 class="row card-text mt-auto ms-1 h5">Where do you want to go?</h3>
-        <form class="row g-2" [formGroup]="form">
+        <form class="row g-2">
           <div class="col-12 col-xl-6" [class.col-xl-12]="shouldProposeRoundTrip()">
             <div class="input-group">
               <label class="input-group-text w-50" for="destination">Destination</label>
-              <select class="form-select" id="destination" formControlName="destination">
+              <select class="form-select" id="destination" [formField]="formTree.destination">
                 <option disabled selected value> -- select a destination --</option>
                 @for (destination of destinations(); track destination.cityCode) {
                   <option [disabled]="!destination.available"
@@ -30,12 +30,12 @@
           </div>
           <div class="col-12 col-xl-6">
             <o3r-date-picker-input-pres [id]="'date-outbound'" [label]="'Departure'"
-                                        formControlName="outboundDate" />
+                                        [formField]="formTree.outboundDate" />
           </div>
           @if (shouldProposeRoundTrip()) {
             <div class="col-12 col-xl-6">
               <o3r-date-picker-input-pres [id]="'date-inbound'" [label]="'Return'"
-                                          formControlName="inboundDate" />
+                                          [formField]="formTree.inboundDate" />
             </div>
           }
         </form>

--- a/apps/showcase/src/components/showcase/configuration/configuration-pres.ts
+++ b/apps/showcase/src/components/showcase/configuration/configuration-pres.ts
@@ -5,16 +5,14 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
-  effect,
-  inject,
   input,
+  linkedSignal,
   ViewEncapsulation,
 } from '@angular/core';
 import {
-  FormBuilder,
-  FormControl,
-  ReactiveFormsModule,
-} from '@angular/forms';
+  form,
+  FormField,
+} from '@angular/forms/signals';
 import {
   configSignal,
   DynamicConfigurableWithSignal,
@@ -37,15 +35,13 @@ const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
 @O3rComponent({ componentType: 'ExposedComponent' })
 @Component({
   selector: 'o3r-configuration-pres',
-  imports: [ReactiveFormsModule, DatePickerInputPres],
+  imports: [FormField, DatePickerInputPres],
   templateUrl: './configuration-pres.html',
   styleUrls: ['./configuration-pres.scss'],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ConfigurationPres implements DynamicConfigurableWithSignal<ConfigurationPresConfig> {
-  private readonly fb = inject(FormBuilder);
-
   /** Input configuration to override the default configuration of the component */
   public readonly config = input<Partial<ConfigurationPresConfig>>();
   /** Configuration signal based on the input and the stored configuration */
@@ -60,39 +56,51 @@ export class ConfigurationPres implements DynamicConfigurableWithSignal<Configur
   public shouldProposeRoundTrip = computed(() => this.configSignal().shouldProposeRoundTrip);
 
   /**
-   * Form group
+   * Form model – reactively resets when config changes (inXDays, destinations),
+   * while remaining writable from the form.
    */
-  public form = this.fb.group({
-    destination: new FormControl<string | null>(null),
-    outboundDate: new FormControl<string | null>(this.formatDate(Date.now() + 7 * ONE_DAY_IN_MS)),
-    inboundDate: new FormControl<string | null>(this.formatDate(Date.now() + 14 * ONE_DAY_IN_MS))
+  public model = linkedSignal<{ inXDays: number; destinations: ConfigurationPresConfig['destinations'] }, { destination: string; outboundDate: string; inboundDate: string }>({
+    source: () => ({
+      inXDays: this.configSignal().inXDays,
+      destinations: this.configSignal().destinations
+    }),
+    computation: ({ inXDays, destinations }, previous) => {
+      if (!previous) {
+        return {
+          destination: '',
+          outboundDate: this.formatDate(Date.now() + inXDays * ONE_DAY_IN_MS),
+          inboundDate: this.formatDate(Date.now() + (inXDays + 7) * ONE_DAY_IN_MS)
+        };
+      }
+
+      const prev = previous.value;
+      let outboundDate = prev.outboundDate;
+      let inboundDate = prev.inboundDate;
+      let destination = prev.destination;
+
+      // React to inXDays changes
+      const newOutboundDate = this.formatDate(Date.now() + inXDays * ONE_DAY_IN_MS);
+      if (outboundDate !== newOutboundDate) {
+        outboundDate = newOutboundDate;
+        if (inboundDate && inboundDate <= outboundDate) {
+          inboundDate = this.formatDate(new Date(outboundDate).getTime() + 7 * ONE_DAY_IN_MS);
+        }
+      }
+
+      // React to destinations changes – reset unavailable destination
+      const selected = destinations.find((d) => d.cityName === destination);
+      if (selected && !selected.available) {
+        destination = '';
+      }
+
+      return { destination, outboundDate, inboundDate };
+    }
   });
 
-  constructor() {
-    const inXDays = computed(() => this.configSignal().inXDays);
-    effect(
-      () => {
-        this.form.controls.outboundDate.setValue(this.formatDate(Date.now() + inXDays() * ONE_DAY_IN_MS));
-        if (this.form.value.inboundDate && this.form.value.outboundDate && this.form.value.inboundDate <= this.form.value.outboundDate) {
-          this.form.controls.inboundDate.setValue(
-            this.formatDate((this.form.value.outboundDate ? (new Date(this.form.value.outboundDate)).getTime() : Date.now()) + 7 * ONE_DAY_IN_MS)
-          );
-        }
-      },
-      // Needed because inboundDate input is handled by signal
-      { allowSignalWrites: true }
-    );
-    effect(
-      () => {
-        const selectedDestination = this.destinations().find((d) => d.cityName === this.form.value.destination);
-        if (selectedDestination && !selectedDestination.available) {
-          this.form.controls.destination.reset();
-        }
-      },
-      // Needed because destination input is handled by signal
-      { allowSignalWrites: true }
-    );
-  }
+  /**
+   * Form tree
+   */
+  public formTree = form(this.model);
 
   private formatDate(dateTime: number) {
     return formatDate(dateTime, 'yyyy-MM-dd', 'en-GB');

--- a/apps/showcase/src/components/showcase/design-token/design-token-pres.html
+++ b/apps/showcase/src/components/showcase/design-token/design-token-pres.html
@@ -3,11 +3,11 @@
     <div class="col-8 container p-3">
       <div class="card-body d-flex flex-column h-100">
         <h3 class="row card-text mt-auto ms-1 h5">Select a theme</h3>
-        <form class="row g-2" [formGroup]="form">
+        <form class="row g-2">
           <div class="col-12 col-xl-6">
             <div class="input-group">
               <label class="input-group-text w-50" for="theme">Theme</label>
-              <select class="form-select" id="theme" formControlName="theme">
+              <select class="form-select" id="theme" [formField]="formTree.theme">
                 <option selected value> Default </option>
                 <option value="dark"> Dark </option>
                 <option value="horizon"> Horizon </option>

--- a/apps/showcase/src/components/showcase/design-token/design-token-pres.ts
+++ b/apps/showcase/src/components/showcase/design-token/design-token-pres.ts
@@ -2,19 +2,16 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
+  effect,
   inject,
+  signal,
+  untracked,
   ViewEncapsulation,
 } from '@angular/core';
 import {
-  takeUntilDestroyed,
-} from '@angular/core/rxjs-interop';
-import {
-  FormBuilder,
-  FormControl,
-  FormGroup,
-  FormsModule,
-  ReactiveFormsModule,
-} from '@angular/forms';
+  form,
+  FormField,
+} from '@angular/forms/signals';
 import {
   O3rComponent,
 } from '@o3r/core';
@@ -26,8 +23,7 @@ import {
 @Component({
   selector: 'o3r-design-token-pres',
   imports: [
-    FormsModule,
-    ReactiveFormsModule
+    FormField
   ],
   templateUrl: './design-token-pres.html',
   styleUrl: './design-token-pres.scss',
@@ -38,11 +34,16 @@ export class DesignTokenPres {
   private readonly styleLoader = inject(StyleLazyLoader);
 
   /**
-   * Form group
+   * Form model
    */
-  public form: FormGroup<{ theme: FormControl<string | null> }> = inject(FormBuilder).group({
-    theme: new FormControl<string | null>('')
+  public model = signal({
+    theme: ''
   });
+
+  /**
+   * Form tree
+   */
+  public formTree = form(this.model);
 
   constructor() {
     let style: HTMLElement | null = null;
@@ -52,13 +53,16 @@ export class DesignTokenPres {
         style = null;
       }
     };
-    this.form.valueChanges.pipe(takeUntilDestroyed()).subscribe((value) => {
-      cleanUpStyle();
-      if (value.theme === 'dark') {
-        style = this.styleLoader.loadStyleFromURL({ href: 'dark-theme.css' });
-      } else if (value.theme === 'horizon') {
-        style = this.styleLoader.loadStyleFromURL({ href: 'horizon-theme.css' });
-      }
+    effect(() => {
+      const theme = this.model().theme;
+      untracked(() => {
+        cleanUpStyle();
+        if (theme === 'dark') {
+          style = this.styleLoader.loadStyleFromURL({ href: 'dark-theme.css' });
+        } else if (theme === 'horizon') {
+          style = this.styleLoader.loadStyleFromURL({ href: 'horizon-theme.css' });
+        }
+      });
     });
     inject(DestroyRef).onDestroy(cleanUpStyle);
   }

--- a/apps/showcase/src/components/showcase/dynamic-content/dynamic-content-pres.html
+++ b/apps/showcase/src/components/showcase/dynamic-content/dynamic-content-pres.html
@@ -15,11 +15,11 @@
           </h2>
         </div>
         <h3 class="row card-text mt-auto ms-1 h5">Where do you want to go?</h3>
-        <form class="row g-2" [formGroup]="form">
+        <form class="row g-2">
           <div class="col-12 col-xl-6">
             <div class="input-group">
               <label class="input-group-text w-50" for="destination">Destination</label>
-              <select class="form-select" id="destination" formControlName="destination">
+              <select class="form-select" id="destination" [formField]="formTree.destination">
                 <option disabled selected value> -- select a destination --</option>
                 <option value="London">London</option>
                 <option value="Paris">Paris</option>
@@ -29,7 +29,7 @@
           </div>
           <div class="col-12 col-xl-6">
             <o3r-date-picker-input-pres [id]="'date-outbound'" [label]="'Departure'"
-                                        formControlName="outboundDate" />
+                                        [formField]="formTree.outboundDate" />
           </div>
         </form>
       </div>

--- a/apps/showcase/src/components/showcase/dynamic-content/dynamic-content-pres.ts
+++ b/apps/showcase/src/components/showcase/dynamic-content/dynamic-content-pres.ts
@@ -4,15 +4,13 @@ import {
 import {
   ChangeDetectionStrategy,
   Component,
-  inject,
+  signal,
   ViewEncapsulation,
 } from '@angular/core';
 import {
-  FormBuilder,
-  FormControl,
-  FormGroup,
-  ReactiveFormsModule,
-} from '@angular/forms';
+  form,
+  FormField,
+} from '@angular/forms/signals';
 import {
   O3rComponent,
 } from '@o3r/core';
@@ -28,7 +26,7 @@ const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
 @O3rComponent({ componentType: 'Component' })
 @Component({
   selector: 'o3r-dynamic-content-pres',
-  imports: [ReactiveFormsModule, O3rDynamicContentPipe, DatePickerInputPres],
+  imports: [FormField, O3rDynamicContentPipe, DatePickerInputPres],
   templateUrl: './dynamic-content-pres.html',
   styleUrls: ['./dynamic-content-pres.scss'],
   encapsulation: ViewEncapsulation.None,
@@ -36,12 +34,17 @@ const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
 })
 export class DynamicContentPres {
   /**
-   * Form group
+   * Form model
    */
-  public form: FormGroup<{ destination: FormControl<string | null>; outboundDate: FormControl<string | null> }> = inject(FormBuilder).group({
-    destination: new FormControl<string | null>(null),
-    outboundDate: new FormControl<string | null>(this.formatDate(Date.now() + 7 * ONE_DAY_IN_MS))
+  public model = signal({
+    destination: '',
+    outboundDate: this.formatDate(Date.now() + 7 * ONE_DAY_IN_MS)
   });
+
+  /**
+   * Form tree
+   */
+  public formTree = form(this.model);
 
   private formatDate(dateTime: number) {
     return formatDate(dateTime, 'yyyy-MM-dd', 'en-GB');

--- a/apps/showcase/src/components/showcase/forms-parent/forms-parent.html
+++ b/apps/showcase/src/components/showcase/forms-parent/forms-parent.html
@@ -5,17 +5,15 @@
         [id]="'personal-info'"
         [config]="{nameMaxLength: 5}"
         [customValidators]="personalInfoValidators"
-        (registerInteraction)="registerPersonalInfoInteraction($event)"
         (submitPersonalInfoForm)="submitPersonalInfoForm()"
-        [formControl]="personalInfoFormControl" />
+        [formField]="parentForm.personalInfo" />
     </div>
     <div class="col-6 align-items-center justify-center">
       <o3r-forms-emergency-contact-pres
         [id]="'emergency-contact'"
         [customValidators]="emergencyContactValidators"
-        (registerInteraction)="registerEmergencyContactInteraction($event)"
         (submitEmergencyContactForm)="submitEmergencyContactForm()"
-        [formControl]="emergencyContactFormControl" />
+        [formField]="parentForm.emergencyContact" />
     </div>
   </div>
   <div class="row m-auto pb-3">

--- a/apps/showcase/src/components/showcase/forms-parent/forms-parent.spec.ts
+++ b/apps/showcase/src/components/showcase/forms-parent/forms-parent.spec.ts
@@ -3,9 +3,6 @@ import {
   TestBed,
 } from '@angular/core/testing';
 import {
-  ReactiveFormsModule,
-} from '@angular/forms';
-import {
   provideLocalizationMock,
 } from '@o3r/testing/transloco';
 import {
@@ -21,7 +18,7 @@ describe('FormsParent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FormsParent, ReactiveFormsModule],
+      imports: [FormsParent],
       providers: [provideMarkdown(), provideLocalizationMock()]
     }).compileComponents();
 

--- a/apps/showcase/src/components/showcase/forms-parent/forms-parent.ts
+++ b/apps/showcase/src/components/showcase/forms-parent/forms-parent.ts
@@ -5,12 +5,16 @@ import {
   ChangeDetectionStrategy,
   Component,
   Input,
+  signal,
   ViewEncapsulation,
 } from '@angular/core';
 import {
-  ReactiveFormsModule,
-  UntypedFormControl,
-} from '@angular/forms';
+  apply,
+  form,
+  FormField,
+  maxLength,
+  validate,
+} from '@angular/forms/signals';
 import {
   O3rComponent,
 } from '@o3r/core';
@@ -28,6 +32,12 @@ import {
   FormsEmergencyContactPres,
   FormsPersonalInfoPres,
 } from '../../utilities';
+import {
+  emergencyContactSchema,
+} from '../../utilities/forms-emergency-contact/forms-emergency-contact-pres';
+import {
+  personalInfoSchema,
+} from '../../utilities/forms-personal-info/forms-personal-info-pres';
 import {
   EmergencyContact,
   PersonalInfo,
@@ -47,7 +57,7 @@ import {
   imports: [
     FormsEmergencyContactPres,
     FormsPersonalInfoPres,
-    ReactiveFormsModule,
+    FormField,
     LanguagePipe,
     MarkdownComponent
   ],
@@ -62,15 +72,49 @@ export class FormsParent {
   @Localization('./forms-parent-localization.json')
   public translations: FormsParentTranslation = translations;
 
-  /** The personal info form object model */
-  public personalInfo: PersonalInfo = { name: '', dateOfBirth: this.formatDate(Date.now()) };
-  /** The emergency contact form object model */
-  public emergencyContact: EmergencyContact = { name: '', phone: '', email: '' };
+  /** The combined model for both sub-forms */
+  public parentModel = signal({
+    personalInfo: { name: '', dateOfBirth: formatDate(Date.now(), 'yyyy-MM-dd', 'en-GB') },
+    emergencyContact: { name: '', phone: '', email: '' }
+  });
 
-  /** The form control object bind to the personal info component */
-  public personalInfoFormControl: UntypedFormControl = new UntypedFormControl(this.personalInfo);
-  /** The form control object bind to the emergency contact component */
-  public emergencyContactFormControl: UntypedFormControl = new UntypedFormControl(this.emergencyContact);
+  /** The signal form tree binding to the model, with child schemas applied for parent-level validation */
+  public parentForm = form(this.parentModel, (p) => {
+    // Apply the reusable schemas from the child components so that
+    // the parent's field tree reflects the children's validation state.
+    apply(p.personalInfo, personalInfoSchema);
+    apply(p.emergencyContact, emergencyContactSchema);
+
+    // Additional parent-level validation for personalInfo
+    maxLength(p.personalInfo.name, 5);
+
+    // Custom validator: forbidden name on personal info (global)
+    validate(p.personalInfo, ({ value }) => {
+      const v = value();
+      if (v.name === this.forbiddenName) {
+        return { kind: 'forbiddenName', message: translations.globalForbiddenName };
+      }
+      return undefined;
+    });
+
+    // Custom validator: date must not be in the future
+    validate(p.personalInfo.dateOfBirth, ({ value }) => {
+      const dateStr = formatDate(value(), 'yyyy-MM-dd', 'en-GB');
+      if (dateStr && dateStr > formatDate(Date.now(), 'yyyy-MM-dd', 'en-GB')) {
+        return { kind: 'dateInFuture', message: translations.dateInThePast };
+      }
+      return undefined;
+    });
+
+    // Custom validator: forbidden name on emergency contact (global)
+    validate(p.emergencyContact, ({ value }) => {
+      const v = value();
+      if (v.name === this.forbiddenName) {
+        return { kind: 'forbiddenName', message: translations.globalForbiddenName };
+      }
+      return undefined;
+    });
+  });
 
   public submittedFormValue = '';
 
@@ -80,7 +124,7 @@ export class FormsParent {
 
   private readonly forbiddenName = 'Test';
 
-  /** Form validators for personal info */
+  /** Form validators for personal info (passed to child for internal display) */
   public personalInfoValidators: CustomFormValidation<PersonalInfo> = {
     global: formsParentValidatorGlobal(this.forbiddenName, translations.globalForbiddenName, translations.globalForbiddenNameLong, { name: this.forbiddenName }),
     fields: {
@@ -88,71 +132,50 @@ export class FormsParent {
     }
   };
 
-  /** Form validators for emergency contact */
+  /** Form validators for emergency contact (passed to child for internal display) */
   public emergencyContactValidators: CustomFormValidation<EmergencyContact> = {
     global: formsParentValidatorGlobal(this.forbiddenName, translations.globalForbiddenName, translations.globalForbiddenNameLong, { name: this.forbiddenName })
   };
 
-  private formatDate(dateTime: number) {
-    return formatDate(dateTime, 'yyyy-MM-dd', 'en-GB');
-  }
-
-  /** This will store the function to make the personal info form as dirty and touched */
-  public _markPersonalInfoInteraction: () => void = () => {};
-  /** This will store the function to make the emergency contact form as dirty and touched */
-  public _markEmergencyContactInteraction: () => void = () => {};
-
-  /**
-   * Register the function to be called to mark the personal info form as touched and dirty
-   * @param fn
-   */
-  public registerPersonalInfoInteraction(fn: () => void) {
-    this._markPersonalInfoInteraction = fn;
-  }
-
-  /**
-   * Register the function to be called to mark the personal emergency contact form as touched and dirty
-   * @param fn
-   */
-  public registerEmergencyContactInteraction(fn: () => void) {
-    this._markEmergencyContactInteraction = fn;
-  }
-
   /** submit function */
   public submitAction() {
     if (this.firstSubmit) {
-      this._markPersonalInfoInteraction();
-      this._markEmergencyContactInteraction();
+      this.parentForm.personalInfo().markAsTouched();
+      this.parentForm.personalInfo().markAsDirty();
+      this.parentForm.emergencyContact().markAsTouched();
+      this.parentForm.emergencyContact().markAsDirty();
       this.firstSubmit = false;
       this.firstPersonalInfoFormSubmit = false;
       this.firstEmergencyContactFormSubmit = false;
     }
     this.submitPersonalInfoForm();
     this.submitEmergencyContactForm();
-    this.submittedFormValue = JSON.stringify(this.personalInfoFormControl.value) + '\n' + JSON.stringify(this.emergencyContactFormControl.value);
+    this.submittedFormValue = JSON.stringify(this.parentModel().personalInfo) + '\n' + JSON.stringify(this.parentModel().emergencyContact);
   }
 
-  /** Submit emergency contact form */
+  /** Submit personal info form */
   public submitPersonalInfoForm() {
     if (this.firstPersonalInfoFormSubmit) {
-      this._markPersonalInfoInteraction();
+      this.parentForm.personalInfo().markAsTouched();
+      this.parentForm.personalInfo().markAsDirty();
       this.firstPersonalInfoFormSubmit = false;
     }
-    const isValid = !this.personalInfoFormControl.errors;
+    const isValid = !this.parentForm.personalInfo().invalid();
     if (isValid) {
-      this.submittedFormValue = JSON.stringify(this.personalInfoFormControl.value);
+      this.submittedFormValue = JSON.stringify(this.parentModel().personalInfo);
     }
   }
 
   /** Submit emergency contact form */
   public submitEmergencyContactForm() {
     if (this.firstEmergencyContactFormSubmit) {
-      this._markEmergencyContactInteraction();
+      this.parentForm.emergencyContact().markAsTouched();
+      this.parentForm.emergencyContact().markAsDirty();
       this.firstEmergencyContactFormSubmit = false;
     }
-    const isValid = !this.emergencyContactFormControl.errors;
+    const isValid = !this.parentForm.emergencyContact().invalid();
     if (isValid) {
-      this.submittedFormValue = JSON.stringify(this.emergencyContactFormControl.value);
+      this.submittedFormValue = JSON.stringify(this.parentModel().emergencyContact);
     }
   }
 }

--- a/apps/showcase/src/components/showcase/localization/localization-pres.html
+++ b/apps/showcase/src/components/showcase/localization/localization-pres.html
@@ -8,8 +8,8 @@
         <div class="row card-title flex-fill d-flex align-items-center m-auto">
           <h2
             class="bg-body-tertiary text-secondary border border-light-subtle border-3 bubble py-3 px-5 position-relative">
-            @if (form.value.destination) {
-              {{ translations.welcomeWithCityName | o3rTranslate: {cityName: (translations.cityName + '.' + form.value.destination) | o3rTranslate} }}
+            @if (model().destination) {
+              {{ translations.welcomeWithCityName | o3rTranslate: {cityName: (translations.cityName + '.' + model().destination) | o3rTranslate} }}
             } @else {
               {{ translations.welcome | o3rTranslate }}
             }
@@ -18,12 +18,12 @@
           </h2>
         </div>
         <h3 class="row card-text mt-auto ms-1 h5">{{ translations.question | o3rTranslate }}</h3>
-        <form class="row g-2" [formGroup]="form">
+        <form class="row g-2">
           <div class="col-12 col-xl-6">
             <div class="input-group">
               <label class="input-group-text w-50"
                      for="destination">{{ translations.destinationLabel | o3rTranslate }}</label>
-              <select class="form-select" id="destination" formControlName="destination">
+              <select class="form-select" id="destination" [formField]="formTree.destination">
                 <option disabled selected value>{{ translations.destinationPlaceholder | o3rTranslate }}</option>
                 <option value="LON">{{ (translations.cityName + '.LON') | o3rTranslate }}</option>
                 <option value="PAR">{{ (translations.cityName + '.PAR') | o3rTranslate }}</option>
@@ -33,7 +33,7 @@
           </div>
           <div class="col-12 col-xl-6">
             <o3r-date-picker-input-pres [id]="'date-outbound'" [label]="translations.departureLabel | o3rTranslate"
-                                        formControlName="outboundDate" />
+                                        [formField]="formTree.outboundDate" />
           </div>
         </form>
       </div>

--- a/apps/showcase/src/components/showcase/localization/localization-pres.ts
+++ b/apps/showcase/src/components/showcase/localization/localization-pres.ts
@@ -4,19 +4,17 @@ import {
 import {
   ChangeDetectionStrategy,
   Component,
+  effect,
   inject,
   Input,
+  signal,
+  untracked,
   ViewEncapsulation,
 } from '@angular/core';
 import {
-  takeUntilDestroyed,
-} from '@angular/core/rxjs-interop';
-import {
-  FormBuilder,
-  FormControl,
-  FormGroup,
-  ReactiveFormsModule,
-} from '@angular/forms';
+  form,
+  FormField,
+} from '@angular/forms/signals';
 import {
   O3rComponent,
 } from '@o3r/core';
@@ -43,18 +41,23 @@ const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
   styleUrls: ['./localization-pres.scss'],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ReactiveFormsModule, DatePickerInputPres, O3rLocalizationTranslatePipe]
+  imports: [FormField, DatePickerInputPres, O3rLocalizationTranslatePipe]
 })
 export class LocalizationPres implements Translatable<LocalizationPresTranslation> {
   private readonly localizationService = inject(LocalizationService);
 
   /**
-   * Form group
+   * Form model
    */
-  public form: FormGroup<{ destination: FormControl<string | null>; outboundDate: FormControl<string | null> }> = inject(FormBuilder).group({
-    destination: new FormControl<string | null>(null),
-    outboundDate: new FormControl<string | null>(this.formatDate(Date.now() + 7 * ONE_DAY_IN_MS))
+  public model = signal({
+    destination: '',
+    outboundDate: this.formatDate(Date.now() + 7 * ONE_DAY_IN_MS)
   });
+
+  /**
+   * Form tree
+   */
+  public formTree = form(this.model);
 
   /** Localization of the component*/
   @Input()
@@ -62,19 +65,22 @@ export class LocalizationPres implements Translatable<LocalizationPresTranslatio
   public translations: LocalizationPresTranslation = translations;
 
   constructor() {
-    this.form.controls.destination.valueChanges.pipe(takeUntilDestroyed()).subscribe((value) => {
-      let language = 'en-GB';
-      switch (value) {
-        case 'PAR': {
-          language = 'fr-FR';
-          break;
+    effect(() => {
+      const destination = this.model().destination;
+      untracked(() => {
+        let language = 'en-GB';
+        switch (destination) {
+          case 'PAR': {
+            language = 'fr-FR';
+            break;
+          }
+          case 'NYC': {
+            language = 'en-US';
+            break;
+          }
         }
-        case 'NYC': {
-          language = 'en-US';
-          break;
-        }
-      }
-      this.localizationService.useLanguage(language);
+        this.localizationService.useLanguage(language);
+      });
     });
   }
 

--- a/apps/showcase/src/components/showcase/placeholder/placeholder-pres.html
+++ b/apps/showcase/src/components/showcase/placeholder/placeholder-pres.html
@@ -15,11 +15,11 @@
           </o3r-placeholder>
         </div>
         <h3 class="row card-text mt-auto ms-1 h5">Where do you want to go?</h3>
-        <form class="row g-2" [formGroup]="form">
+        <form class="row g-2">
           <div class="col-12 col-xl-6">
             <div class="input-group">
               <label class="input-group-text w-50" for="destination">Destination</label>
-              <select class="form-select" id="destination" formControlName="destination">
+              <select class="form-select" id="destination" [formField]="formTree.destination">
                 <option disabled selected value> -- select a destination -- </option>
                 <option value="London">London</option>
                 <option value="Paris">Paris</option>
@@ -28,7 +28,7 @@
             </div>
           </div>
           <div class="col-12 col-xl-6">
-              <o3r-date-picker-input-pres [id]="'date-outbound'" [label]="'Departure'" formControlName="outboundDate" />
+              <o3r-date-picker-input-pres [id]="'date-outbound'" [label]="'Departure'" [formField]="formTree.outboundDate" />
           </div>
         </form>
       </div>

--- a/apps/showcase/src/components/showcase/placeholder/placeholder-pres.ts
+++ b/apps/showcase/src/components/showcase/placeholder/placeholder-pres.ts
@@ -4,18 +4,16 @@ import {
 import {
   ChangeDetectionStrategy,
   Component,
+  effect,
   inject,
+  signal,
+  untracked,
   ViewEncapsulation,
 } from '@angular/core';
 import {
-  takeUntilDestroyed,
-} from '@angular/core/rxjs-interop';
-import {
-  FormBuilder,
-  FormControl,
-  FormGroup,
-  ReactiveFormsModule,
-} from '@angular/forms';
+  form,
+  FormField,
+} from '@angular/forms/signals';
 import {
   PlaceholderComponent,
 } from '@o3r/components';
@@ -39,7 +37,7 @@ const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    ReactiveFormsModule,
+    FormField,
     DatePickerInputPres,
     PlaceholderComponent
   ]
@@ -48,20 +46,33 @@ export class PlaceholderPres {
   private readonly tripService = inject(TripFactsService);
 
   /**
-   * Form group
+   * Form model
    */
-  public form: FormGroup<{ destination: FormControl<string | null>; outboundDate: FormControl<string | null> }> = inject(FormBuilder).group({
-    destination: new FormControl<string | null>(null),
-    outboundDate: new FormControl<string | null>(this.formatDate(Date.now() + 7 * ONE_DAY_IN_MS))
+  public model = signal({
+    destination: '',
+    outboundDate: this.formatDate(Date.now() + 7 * ONE_DAY_IN_MS)
   });
 
-  constructor() {
-    this.tripService.updateDestination(this.form.controls.destination.value);
-    this.tripService.updateOutboundDate(this.form.controls.outboundDate.value);
+  /**
+   * Form tree
+   */
+  public formTree = form(this.model);
 
-    this.form.controls.destination.valueChanges.pipe(takeUntilDestroyed()).subscribe((destination) => this.tripService.updateDestination(destination));
-    this.form.controls.outboundDate.valueChanges.pipe(takeUntilDestroyed()).subscribe((outboundDate) => {
-      this.tripService.updateOutboundDate(outboundDate);
+  constructor() {
+    // Initial service calls with default values
+    this.tripService.updateDestination(this.model().destination);
+    this.tripService.updateOutboundDate(this.model().outboundDate);
+
+    // Track destination changes
+    effect(() => {
+      const destination = this.model().destination;
+      untracked(() => this.tripService.updateDestination(destination));
+    });
+
+    // Track outbound date changes
+    effect(() => {
+      const outboundDate = this.model().outboundDate;
+      untracked(() => this.tripService.updateOutboundDate(outboundDate));
     });
   }
 

--- a/apps/showcase/src/components/showcase/rules-engine/rules-engine-pres.html
+++ b/apps/showcase/src/components/showcase/rules-engine/rules-engine-pres.html
@@ -9,8 +9,8 @@
         <div class="row card-title flex-fill d-flex align-items-center m-auto">
           <h2
             class="bg-body-tertiary text-secondary border border-light-subtle border-3 bubble py-3 px-5 position-relative w-auto m-auto">
-            @if (form.value.destination) {
-              {{ translations.welcomeWithCityName | o3rTranslate: {cityName: (translations.cityName + '.' + form.value.destination) | o3rTranslate} }}
+            @if (model().destination) {
+              {{ translations.welcomeWithCityName | o3rTranslate: {cityName: (translations.cityName + '.' + model().destination) | o3rTranslate} }}
             } @else {
               {{ translations.welcome | o3rTranslate }}
             }
@@ -19,12 +19,12 @@
           </h2>
         </div>
         <h3 class="row card-text mt-auto ms-1 h5">{{ translations.question | o3rTranslate }}</h3>
-        <form class="row g-2" [formGroup]="form">
+        <form class="row g-2">
           <div class="col-12 col-xl-6" [class.col-xl-12]="configSignal().shouldProposeRoundTrip">
             <div class="input-group">
               <label class="input-group-text w-50"
                      for="destination">{{ translations.destinationLabel | o3rTranslate }}</label>
-              <select class="form-select" id="destination" formControlName="destination">
+              <select class="form-select" id="destination" [formField]="formTree.destination">
                 <option disabled selected value>{{ translations.destinationPlaceholder | o3rTranslate }}</option>
                 @for (destination of configSignal().destinations; track destination.cityCode) {
                   <option [disabled]="!destination.available" [value]="destination.cityCode">
@@ -37,12 +37,12 @@
           <div class="col-12 col-xl-6">
             <o3r-date-picker-input-pres [id]="'date-outbound'"
                                         [label]="translations.departureLabel | o3rTranslate"
-                                        formControlName="outboundDate" />
+                                        [formField]="formTree.outboundDate" />
           </div>
           @if (configSignal().shouldProposeRoundTrip) {
             <div class="col-12 col-xl-6">
               <o3r-date-picker-input-pres [id]="'date-inbound'" [label]="translations.returnLabel | o3rTranslate"
-                                          formControlName="inboundDate" />
+                                          [formField]="formTree.inboundDate" />
             </div>
           }
         </form>

--- a/apps/showcase/src/components/showcase/rules-engine/rules-engine-pres.ts
+++ b/apps/showcase/src/components/showcase/rules-engine/rules-engine-pres.ts
@@ -4,24 +4,20 @@ import {
 import {
   ChangeDetectionStrategy,
   Component,
-  computed,
+  effect,
   inject,
   Input,
   input,
+  linkedSignal,
   type OnDestroy,
   OnInit,
+  untracked,
   ViewEncapsulation,
 } from '@angular/core';
 import {
-  takeUntilDestroyed,
-  toObservable,
-} from '@angular/core/rxjs-interop';
-import {
-  FormBuilder,
-  FormControl,
-  FormGroup,
-  ReactiveFormsModule,
-} from '@angular/forms';
+  form,
+  FormField,
+} from '@angular/forms/signals';
 import {
   configSignal,
   DynamicConfigurableWithSignal,
@@ -70,7 +66,7 @@ const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
   imports: [
     O3rDynamicContentPipe,
     O3rLocalizationTranslatePipe,
-    ReactiveFormsModule,
+    FormField,
     DatePickerInputPres
   ]
 })
@@ -84,17 +80,51 @@ export class RulesEnginePres implements OnDestroy, DynamicConfigurableWithSignal
   public translations: RulesEnginePresTranslation = translations;
 
   /**
-   * Form group
+   * Form model – reactively resets when config changes (inXDays, destinations),
+   * while remaining writable from the form.
    */
-  public form: FormGroup<{
-    destination: FormControl<string | null>;
-    outboundDate: FormControl<string | null>;
-    inboundDate: FormControl<string | null>;
-  }> = inject(FormBuilder).group({
-    destination: new FormControl<string | null>(null),
-    outboundDate: new FormControl<string | null>(this.formatDate(Date.now() + 7 * ONE_DAY_IN_MS)),
-    inboundDate: new FormControl<string | null>(this.formatDate(Date.now() + 14 * ONE_DAY_IN_MS))
+  public model = linkedSignal<{ inXDays: number; destinations: RulesEnginePresConfig['destinations'] }, { destination: string; outboundDate: string; inboundDate: string }>({
+    source: () => ({
+      inXDays: this.configSignal().inXDays,
+      destinations: this.configSignal().destinations
+    }),
+    computation: ({ inXDays, destinations }, previous) => {
+      if (!previous) {
+        return {
+          destination: '',
+          outboundDate: this.formatDate(Date.now() + inXDays * ONE_DAY_IN_MS),
+          inboundDate: this.formatDate(Date.now() + (inXDays + 7) * ONE_DAY_IN_MS)
+        };
+      }
+
+      const prev = previous.value;
+      let outboundDate = prev.outboundDate;
+      let inboundDate = prev.inboundDate;
+      let destination = prev.destination;
+
+      // React to inXDays changes
+      const newOutboundDate = this.formatDate(Date.now() + inXDays * ONE_DAY_IN_MS);
+      if (outboundDate !== newOutboundDate) {
+        outboundDate = newOutboundDate;
+        if (inboundDate && inboundDate <= outboundDate) {
+          inboundDate = this.formatDate(new Date(outboundDate).getTime() + 7 * ONE_DAY_IN_MS);
+        }
+      }
+
+      // React to destinations changes – reset unavailable destination
+      const selected = destinations.find((d) => d.cityName === destination);
+      if (selected && !selected.available) {
+        destination = '';
+      }
+
+      return { destination, outboundDate, inboundDate };
+    }
   });
+
+  /**
+   * Form tree
+   */
+  public formTree = form(this.model);
 
   /** Input configuration to override the default configuration of the component */
   public readonly config = input<Partial<RulesEnginePresConfig>>();
@@ -107,35 +137,30 @@ export class RulesEnginePres implements OnDestroy, DynamicConfigurableWithSignal
   );
 
   constructor() {
-    this.form.controls.destination.valueChanges.pipe(takeUntilDestroyed()).subscribe((destination) => this.tripService.updateDestination(destination));
-    this.form.controls.outboundDate.valueChanges.pipe(takeUntilDestroyed()).subscribe((outboundDate) => this.tripService.updateOutboundDate(outboundDate));
-    const inXDays$ = toObservable(computed(() => this.configSignal().inXDays));
-    inXDays$.pipe(takeUntilDestroyed()).subscribe((inXDays) => {
-      this.form.controls.outboundDate.setValue(this.formatDate(Date.now() + inXDays * ONE_DAY_IN_MS));
-      if (this.form.value.inboundDate && this.form.value.outboundDate && this.form.value.inboundDate <= this.form.value.outboundDate) {
-        this.form.controls.inboundDate.setValue(this.formatDate((this.form.value.outboundDate ? (new Date(this.form.value.outboundDate)).getTime() : Date.now()) + 7 * ONE_DAY_IN_MS));
-      }
-    });
-    const destinations$ = toObservable(computed(() => this.configSignal().destinations));
-    destinations$.pipe(takeUntilDestroyed()).subscribe((destinations) => {
-      const selectedDestination = destinations.find((d) => d.cityName === this.form.value.destination);
-      if (selectedDestination && !selectedDestination.available) {
-        this.form.controls.destination.reset();
-      }
-    });
-    this.form.controls.destination.valueChanges.pipe(takeUntilDestroyed()).subscribe((value) => {
-      let language = 'en-GB';
-      switch (value) {
-        case 'PAR': {
-          language = 'fr-FR';
-          break;
+    // Track destination changes and update trip service + language
+    effect(() => {
+      const destination = this.model().destination;
+      untracked(() => {
+        this.tripService.updateDestination(destination);
+        let language = 'en-GB';
+        switch (destination) {
+          case 'PAR': {
+            language = 'fr-FR';
+            break;
+          }
+          case 'NYC': {
+            language = 'en-US';
+            break;
+          }
         }
-        case 'NYC': {
-          language = 'en-US';
-          break;
-        }
-      }
-      this.localizationService.useLanguage(language);
+        this.localizationService.useLanguage(language);
+      });
+    });
+
+    // Track outbound date changes and update trip service
+    effect(() => {
+      const outboundDate = this.model().outboundDate;
+      untracked(() => this.tripService.updateOutboundDate(outboundDate));
     });
   }
 

--- a/apps/showcase/src/components/training/code-editor-view/code-editor-view.html
+++ b/apps/showcase/src/components/training/code-editor-view/code-editor-view.html
@@ -1,10 +1,10 @@
 <as-split direction="vertical">
   <as-split-area [size]="editorMode() === 'interactive' ? 50 : 100">
-    <form [formGroup]="form" class="editor h-100 overflow-hidden position-relative">
+    <form class="editor h-100 overflow-hidden position-relative">
       <as-split direction="horizontal">
         <as-split-area [size]="25">
           <monaco-tree [tree]="(cwdTree$ | async) || []"
-                       [currentFile]="form.controls.file.value"
+                       [currentFile]="model().file"
                        (currentFileChange)="onClickFile($event)"
                        [width]="'auto'"
                        [height]="'auto'"
@@ -14,10 +14,10 @@
           @if (editorOptions()) {
             <ngx-monaco-editor class="h-100 position-relative"
                                [options]="editorOptions()"
-                               [model]="(model$ | async)!"
+                               [model]="(editorModel$ | async)!"
                                (keydown)="onEditorKeyDown($event)"
                                (onInit)="newMonacoEditorCreated.next()"
-                               formControlName="code" />
+                               [formField]="formTree.code" />
           }
         </as-split-area>
       </as-split>

--- a/apps/showcase/src/components/training/code-editor-view/code-editor-view.ts
+++ b/apps/showcase/src/components/training/code-editor-view/code-editor-view.ts
@@ -8,21 +8,20 @@ import {
   effect,
   inject,
   input,
+  linkedSignal,
   OnDestroy,
   untracked,
   ViewEncapsulation,
 } from '@angular/core';
 import {
   takeUntilDestroyed,
+  toObservable,
   toSignal,
 } from '@angular/core/rxjs-interop';
 import {
-  FormBuilder,
-  FormControl,
-  FormGroup,
-  FormsModule,
-  ReactiveFormsModule,
-} from '@angular/forms';
+  form,
+  FormField,
+} from '@angular/forms/signals';
 import {
   NgbModal,
 } from '@ng-bootstrap/ng-bootstrap';
@@ -120,10 +119,9 @@ export class MonacoFailedToLoadError extends Error {
   imports: [
     AsyncPipe,
     CodeEditorControl,
-    FormsModule,
+    FormField,
     MonacoEditorModule,
     NgxMonacoTreeComponent,
-    ReactiveFormsModule,
     AngularSplitModule
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -132,11 +130,6 @@ export class MonacoFailedToLoadError extends Error {
   styleUrl: './code-editor-view.scss'
 })
 export class CodeEditorView implements OnDestroy {
-  /**
-   * @see {FormBuilder}
-   */
-  private readonly formBuilder = inject(FormBuilder);
-
   /**
    * Stream of the working directory for this component to use it to compute the monaco tree from the
    * {@link WebContainerService} tree
@@ -190,15 +183,31 @@ export class CodeEditorView implements OnDestroy {
   public cwdTreeSignal = toSignal(this.cwdTree$, { initialValue: [] });
 
   /**
-   * Form with the selected file and its content which can be edited in the Monaco Editor
+   * Signal model for the form data (selected file and its code content).
+   * Resets `file` to the project's starting file when the project input changes.
    */
-  public form: FormGroup<{
-    code: FormControl<string | null>;
-    file: FormControl<string | null>;
-  }> = this.formBuilder.group({
-    code: '',
-    file: ''
+  public model = linkedSignal<TrainingProject, { code: string; file: string }>({
+    source: this.project,
+    computation: (project, previous) => ({
+      code: previous?.value.code ?? '',
+      file: project.startingFile
+    })
   });
+
+  /**
+   * Signal form field tree for binding to UI controls
+   */
+  public formTree = form(this.model);
+
+  /**
+   * Observable that emits file path changes (from signal)
+   */
+  private readonly file$ = toObservable(computed(() => this.model().file));
+
+  /**
+   * Observable that emits code changes (from signal)
+   */
+  private readonly code$ = toObservable(computed(() => this.model().code));
 
   /**
    * Subject used to notify when a new monaco editor has been created
@@ -231,7 +240,7 @@ export class CodeEditorView implements OnDestroy {
   private readonly forceSave = new Subject<void>();
 
   private readonly fileContentLoaded$ = combineLatest([
-    this.form.controls.file.valueChanges,
+    this.file$,
     this.forceReload.pipe(startWith(undefined))
   ]).pipe(
     takeUntilDestroyed(),
@@ -253,8 +262,8 @@ export class CodeEditorView implements OnDestroy {
    * Model used for monaco editor for the currently selected file.
    * We need that to associate the opened file to a URI which is necessary to resolve relative paths on imports.
    */
-  public model$ = combineLatest([
-    this.form.controls.file.valueChanges,
+  public editorModel$ = combineLatest([
+    this.file$,
     this.fileContentLoaded$
   ]).pipe(
     map(([filename, value]) => {
@@ -274,7 +283,7 @@ export class CodeEditorView implements OnDestroy {
       await untracked(async () => {
         if (project.files) {
           await this.webContainerService.loadProject(project.files, project.commands, project.cwd);
-          this.loadNewProject();
+          this.forceReload.next();
           this.cwd$.next(project?.cwd || '');
         }
       });
@@ -292,8 +301,8 @@ export class CodeEditorView implements OnDestroy {
       }
     });
     merge(
-      this.forceSave.pipe(map(() => this.form.value.code)),
-      this.form.controls.code.valueChanges.pipe(
+      this.forceSave.pipe(map(() => this.model().code)),
+      this.code$.pipe(
         distinctUntilChanged(),
         skip(1),
         debounceTime(1000)
@@ -311,15 +320,15 @@ export class CodeEditorView implements OnDestroy {
       if (text !== this.fileContent() || localStorage.getItem(cwd)) {
         localStorage.setItem(cwd, JSON.stringify({
           ...JSON.parse(localStorage.getItem(cwd) || '{}'),
-          [this.form.controls.file.value!]: text
+          [this.model().file]: text
         }));
       }
-      const path = `${this.project().cwd}/${this.form.controls.file.value}`;
+      const path = `${this.project().cwd}/${this.model().file}`;
       this.loggerService.log('Writing file', path);
       void this.webContainerService.writeFile(path, text);
     });
     this.fileContentLoaded$.subscribe(
-      (content) => this.form.controls.code.setValue(content)
+      (content) => this.model.update((m) => ({ ...m, code: content }))
     );
 
     // Reload definition types when finishing install
@@ -354,7 +363,7 @@ export class CodeEditorView implements OnDestroy {
           const monacoTree = this.cwdTreeSignal();
           const pathElements = resource.path.split('/').filter((pathElement) => !!pathElement);
           if (checkIfPathInMonacoTree(monacoTree, pathElements)) {
-            this.form.controls.file.setValue(filePath);
+            this.model.update((m) => ({ ...m, file: filePath }));
             if (selectionOrPosition) {
               revealCodeInEditorRequest.next(selectionOrPosition);
             }
@@ -447,14 +456,6 @@ export class CodeEditorView implements OnDestroy {
   }
 
   /**
-   * Load a new project in global monaco editor and update local form accordingly
-   */
-  private loadNewProject() {
-    this.form.controls.file.setValue(this.project().startingFile);
-    this.forceReload.next();
-  }
-
-  /**
    * Reload declaration types from web-container
    */
   public async reloadDeclarationTypes() {
@@ -487,7 +488,7 @@ export class CodeEditorView implements OnDestroy {
   public async onClickFile(filePath: string | null) {
     const path = `${this.project().cwd}/${filePath}`;
     if (await this.webContainerService.isFile(path)) {
-      this.form.controls.file.setValue(filePath);
+      this.model.update((m) => ({ ...m, file: filePath || '' }));
     }
   }
 

--- a/apps/showcase/src/components/utilities/forms-emergency-contact/forms-emergency-contact-pres.html
+++ b/apps/showcase/src/components/utilities/forms-emergency-contact/forms-emergency-contact-pres.html
@@ -1,15 +1,15 @@
 <div class="p-3">
   <h3 class="row card-text mt-auto ms-1 h5">Emergency Contact Information</h3>
-  <form [formGroup]="form">
+  <form>
     <div class="row mb-3">
       <div class="input-group">
         <label class="input-group-text w-50" for="name">Name</label>
-        <input class="form-control" formControlName="name" [id]="'name'">
+        <input class="form-control" [formField]="formTree.name" [id]="'name'">
       </div>
-      @if (form.controls.name.touched && form.controls.name.dirty) {
+      @if (formTree.name().touched() && formTree.name().dirty()) {
         <ng-container>
           <div class="row mb-3">
-            @if (form.controls.name.errors?.required) {
+            @if (formTree.name().getError('required')) {
               <div class="text-danger">{{translations.nameRequired | o3rTranslate}}</div>
             }
           </div>
@@ -19,15 +19,15 @@
     <div class="row mb-3">
       <div class="input-group">
         <label class="input-group-text w-50" for="phone">Phone Number</label>
-        <input class="form-control" formControlName="phone" [id]="'phone'">
+        <input class="form-control" [formField]="formTree.phone" [id]="'phone'">
       </div>
-      @if (form.controls.phone.touched && form.controls.phone.dirty) {
+      @if (formTree.phone().touched() && formTree.phone().dirty()) {
         <ng-container>
           <div class="row mb-3">
-            @if (form.controls.phone.errors?.required) {
+            @if (formTree.phone().getError('required')) {
               <div class="text-danger">{{translations.phoneRequired | o3rTranslate}}</div>
             }
-            @if (form.controls.phone.errors?.pattern) {
+            @if (formTree.phone().getError('pattern')) {
               <div class="text-danger">{{translations.phonePattern | o3rTranslate}}</div>
             }
           </div>
@@ -37,13 +37,13 @@
     <div class="row mb-3">
       <div class="input-group">
         <label class="input-group-text w-50" for="email">Email address</label>
-        <input class="form-control" formControlName="email" [id]="'email'">
+        <input class="form-control" [formField]="formTree.email" [id]="'email'">
       </div>
     </div>
-    @if (form.controls.email.touched && form.controls.email.dirty) {
+    @if (formTree.email().touched() && formTree.email().dirty()) {
       <ng-container>
         <div class="row mb-3">
-          @if (form.controls.email.errors?.email) {
+          @if (formTree.email().getError('email')) {
             <div class="text-danger">{{translations.emailPatternLong | o3rTranslate}}</div>
           }
         </div>
@@ -51,8 +51,8 @@
     }
   </form>
   <div class="row mb-3">
-    @if (form.errors) {
-      <div class="text-danger">Global validator: {{form.errors | json}}</div>
+    @if (formTree().errors().length > 0) {
+      <div class="text-danger">Global validator: {{formTree().errors() | json}}</div>
     }
   </div>
   <div class="m-auto pb-3">

--- a/apps/showcase/src/components/utilities/forms-emergency-contact/forms-emergency-contact-pres.spec.ts
+++ b/apps/showcase/src/components/utilities/forms-emergency-contact/forms-emergency-contact-pres.spec.ts
@@ -3,9 +3,6 @@ import {
   TestBed,
 } from '@angular/core/testing';
 import {
-  ReactiveFormsModule,
-} from '@angular/forms';
-import {
   provideLocalizationMock,
 } from '@o3r/testing/transloco';
 import {
@@ -18,7 +15,7 @@ describe('FormsEmergencyContactPres', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FormsEmergencyContactPres, ReactiveFormsModule],
+      imports: [FormsEmergencyContactPres],
       providers: [provideLocalizationMock()]
     }).compileComponents();
 

--- a/apps/showcase/src/components/utilities/forms-emergency-contact/forms-emergency-contact-pres.ts
+++ b/apps/showcase/src/components/utilities/forms-emergency-contact/forms-emergency-contact-pres.ts
@@ -3,48 +3,39 @@ import {
 } from '@angular/common';
 import {
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
-  forwardRef,
-  inject,
   Input,
   input,
-  type OnDestroy,
-  type OnInit,
+  model,
   output,
   ViewEncapsulation,
 } from '@angular/core';
 import {
   AbstractControl,
-  ControlValueAccessor,
-  FormBuilder,
-  FormControl,
-  FormGroup,
-  FormsModule,
-  NG_VALIDATORS,
-  NG_VALUE_ACCESSOR,
-  ReactiveFormsModule,
-  ValidationErrors,
-  Validator,
-  Validators,
 } from '@angular/forms';
+import {
+  email as emailValidator,
+  type FieldTree,
+  form,
+  FormField,
+  type FormValueControl,
+  pattern,
+  required,
+  schema,
+  type Schema,
+  validate,
+} from '@angular/forms/signals';
 import {
   O3rComponent,
 } from '@o3r/core';
 import {
-  ControlFlatErrors,
   CustomFormValidation,
-  getFlatControlErrors,
-  markAllControlsDirtyAndTouched,
 } from '@o3r/forms';
 import {
   Localization,
   O3rLocalizationTranslatePipe,
   Translatable,
 } from '@o3r/transloco';
-import {
-  Subscription,
-} from 'rxjs';
 import {
   EmergencyContact,
 } from '../../showcase/forms-parent/contracts';
@@ -53,35 +44,31 @@ import {
   translations,
 } from './forms-emergency-contact-pres-translation';
 
+/**
+ * Reusable schema for EmergencyContact validation.
+ * Can be applied in parent forms via `apply(p.emergencyContact, emergencyContactSchema)`.
+ */
+export const emergencyContactSchema: Schema<EmergencyContact> = schema<EmergencyContact>((p) => {
+  required(p.name);
+  required(p.phone);
+  pattern(p.phone, /^[0-9]{10}$/);
+  emailValidator(p.email);
+});
+
 @O3rComponent({ componentType: 'Component' })
 @Component({
   selector: 'o3r-forms-emergency-contact-pres',
   imports: [
-    FormsModule,
+    FormField,
     JsonPipe,
-    O3rLocalizationTranslatePipe,
-    ReactiveFormsModule
+    O3rLocalizationTranslatePipe
   ],
   templateUrl: './forms-emergency-contact-pres.html',
   styleUrl: './forms-emergency-contact-pres.scss',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [
-    {
-      provide: NG_VALUE_ACCESSOR,
-      useExisting: forwardRef(() => FormsEmergencyContactPres),
-      multi: true
-    },
-    {
-      provide: NG_VALIDATORS,
-      useExisting: forwardRef(() => FormsEmergencyContactPres),
-      multi: true
-    }
-  ]
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class FormsEmergencyContactPres implements OnInit, OnDestroy, ControlValueAccessor, Validator, Translatable<FormsEmergencyContactPresTranslation> {
-  private readonly subscription = new Subscription();
-
+export class FormsEmergencyContactPres implements FormValueControl<EmergencyContact>, Translatable<FormsEmergencyContactPresTranslation> {
   /** Localization of the component */
   @Input()
   @Localization('./forms-emergency-contact-pres-localization.json')
@@ -93,129 +80,81 @@ export class FormsEmergencyContactPres implements OnInit, OnDestroy, ControlValu
   /** Custom validators applied on the form */
   public readonly customValidators = input<CustomFormValidation<EmergencyContact>>();
 
-  /** Register a function to be called when the submit is done outside of the presenter (from page) */
-  public readonly registerInteraction = output<() => void>();
-
   /** Emit when the submit has been fired on the form */
   public readonly submitEmergencyContactForm = output<void>();
 
-  protected changeDetector = inject(ChangeDetectorRef);
+  /** FormValueControl: the value model signal, kept in sync by [formField] */
+  public readonly value = model<EmergencyContact>({ name: '', phone: '', email: '' });
 
-  /** Form group */
-  public form: FormGroup<{
-    name: FormControl<string | null>;
-    phone: FormControl<string | null>;
-    email: FormControl<string | null>;
-  }> = inject(FormBuilder).group({
-    name: new FormControl<string>(''),
-    phone: new FormControl<string>(''),
-    email: new FormControl<string>('')
+  /** FormValueControl: output emitted to mark the field as touched */
+  public readonly touch = output<void>();
+
+  /** FormValueControl: input to receive the disabled status from the parent field */
+  public readonly disabled = input<boolean>(false);
+
+  /** Signal form tree with built-in validators, driven by the value model */
+  public formTree: FieldTree<EmergencyContact> = form(this.value, (p) => {
+    required(p.name);
+    required(p.phone);
+    pattern(p.phone, /^[0-9]{10}$/);
+    emailValidator(p.email);
+
+    // Custom validators from parent - global
+    validate(p, ({ value }) => {
+      const cv = this.customValidators();
+      if (cv?.global) {
+        const result = cv.global({ value: value() } as unknown as AbstractControl);
+        if (result?.customErrors) {
+          return result.customErrors.map((e: { translationKey: string }) => ({ kind: 'custom', message: e.translationKey }));
+        }
+      }
+      return undefined;
+    });
+
+    // Custom validators from parent - field-level name
+    validate(p.name, ({ value }) => {
+      const cv = this.customValidators();
+      if (cv?.fields?.name) {
+        const result = cv.fields.name({ value: value() } as unknown as AbstractControl);
+        if (result?.customErrors) {
+          return result.customErrors.map((e: { translationKey: string }) => ({ kind: 'custom', message: e.translationKey }));
+        }
+      }
+      return undefined;
+    });
+
+    // Custom validators from parent - field-level phone
+    validate(p.phone, ({ value }) => {
+      const cv = this.customValidators();
+      if (cv?.fields?.phone) {
+        const result = cv.fields.phone({ value: value() } as unknown as AbstractControl);
+        if (result?.customErrors) {
+          return result.customErrors.map((e: { translationKey: string }) => ({ kind: 'custom', message: e.translationKey }));
+        }
+      }
+      return undefined;
+    });
+
+    // Custom validators from parent - field-level email
+    validate(p.email, ({ value }) => {
+      const cv = this.customValidators();
+      if (cv?.fields?.email) {
+        const result = cv.fields.email({ value: value() } as unknown as AbstractControl);
+        if (result?.customErrors) {
+          return result.customErrors.map((e: { translationKey: string }) => ({ kind: 'custom', message: e.translationKey }));
+        }
+      }
+      return undefined;
+    });
   });
 
   public componentSelector = 'o3r-forms-emergency-contact-pres';
 
-  public ngOnInit() {
-    this.applyValidation();
-    this.subscription.add(this.form.valueChanges.subscribe((value) => this.propagateChange(value)));
-    this.registerInteraction.emit(() => {
-      markAllControlsDirtyAndTouched(this.form);
-      this.changeDetector.markForCheck();
-    });
-  }
-
-  public ngOnDestroy() {
-    this.subscription.unsubscribe();
-  }
-
-  /** @inheritDoc */
-  public writeValue(value?: any) {
-    if (value) {
-      this.form.setValue(value);
-    }
-  }
-
-  /** Function registered to propagate a change to the parent */
-  public propagateChange: any = () => {};
-  /** Function registered to propagate touched to the parent */
-  public propagateTouched: any = () => {};
-
-  /** @inheritDoc */
-  public registerOnChange(fn: any) {
-    this.propagateChange = fn;
-  }
-
-  /** @inheritDoc */
-  public registerOnTouched(fn: any) {
-    this.propagateTouched = fn;
-  }
-
-  /**
-   * Get custom validators and primitive validators and apply them on the form
-   */
-  public applyValidation() {
-    const customValidators = this.customValidators();
-    const globalValidators = [];
-    if (customValidators && customValidators.global) {
-      globalValidators.push(customValidators.global);
-    }
-    this.form.setValidators(globalValidators);
-
-    /* eslint-disable @typescript-eslint/unbound-method -- Validators are bound methods */
-    const nameValidators = [Validators.required];
-    const phoneValidators = [Validators.required, Validators.pattern('^[0-9]{10}$')];
-    const emailValidators = [Validators.email];
-    /* eslint-enable @typescript-eslint/unbound-method */
-    if (customValidators && customValidators.fields) {
-      if (customValidators.fields.name) {
-        nameValidators.push(customValidators.fields.name);
-      }
-      if (customValidators.fields.phone) {
-        phoneValidators.push(customValidators.fields.phone);
-      }
-      if (customValidators.fields.email) {
-        emailValidators.push(customValidators.fields.email);
-      }
-    }
-    this.form.controls.name.setValidators(nameValidators);
-    this.form.controls.phone.setValidators(phoneValidators);
-    this.form.controls.email.setValidators(emailValidators);
-    this.form.updateValueAndValidity();
-  }
-
-  /**
-   * @inheritDoc
-   */
-  public validate(_control: AbstractControl): ValidationErrors | null {
-    if (this.form.status === 'VALID') {
-      return null;
-    }
-
-    const formErrors = getFlatControlErrors(this.form);
-
-    return formErrors.reduce((errorsMap: ValidationErrors, controlFlatErrors: ControlFlatErrors) => {
-      return {
-        ...errorsMap,
-        [controlFlatErrors.controlName || 'global']: {
-          htmlElementId: `${this.id()}${controlFlatErrors.controlName || ''}`,
-          errorMessages: (controlFlatErrors.customErrors || []).concat(
-            controlFlatErrors.errors.map((error) => {
-              const translationKey = `${this.componentSelector}.${controlFlatErrors.controlName || ''}.${error.errorKey}`;
-              return {
-                translationKey,
-                longTranslationKey: this.translations[`${error.errorKey}Long`] || undefined,
-                validationError: error.validationError
-              };
-            })
-          )
-        }
-      };
-    }, {});
-  }
-
   /** Submit emergency contact form */
   public submitForm() {
-    markAllControlsDirtyAndTouched(this.form);
-    this.form.updateValueAndValidity();
+    this.formTree().markAsTouched();
+    this.formTree().markAsDirty();
+    this.touch.emit();
     this.submitEmergencyContactForm.emit();
   }
 }

--- a/apps/showcase/src/components/utilities/forms-personal-info/forms-personal-info-pres.html
+++ b/apps/showcase/src/components/utilities/forms-personal-info/forms-personal-info-pres.html
@@ -1,42 +1,42 @@
 <div class="p-3">
   <h3 class="row card-text mt-auto ms-1 h5">Personal Information</h3>
-  <form [formGroup]="form">
+  <form>
     <div class="row mb-3">
       <div class="input-group">
         <label class="input-group-text w-50" for="name">Name</label>
-        <input class="form-control" formControlName="name" [id]="'name'">
+        <input class="form-control" [formField]="formTree.name" [id]="'name'">
       </div>
-      @if (form.controls.name.touched && form.controls.name.dirty) {
+      @if (formTree.name().touched() && formTree.name().dirty()) {
         <ng-container>
           <div class="row mb-3">
-            @if (form.controls.name.errors?.required) {
+            @if (formTree.name().getError('required')) {
               <div class="text-danger">{{translations.required | o3rTranslate}}</div>
             }
-            @if (form.controls.name.errors?.maxlength) {
-              <div class="text-danger">{{translations.maxLength | o3rTranslate: {maxLength: form.controls.name.errors?.maxlength.requiredLength} }}</div>
+            @if (formTree.name().getError('maxLength'); as maxLengthError) {
+              <div class="text-danger">{{translations.maxLength | o3rTranslate: {maxLength: maxLengthError['maxLength']} }}</div>
             }
           </div>
         </ng-container>
       }
     </div>
     <div class="row mb-3">
-      <o3r-date-picker-input-pres [label]="'Date of birth'" [id]="'dateOfBirth'" formControlName="dateOfBirth" />
+      <o3r-date-picker-input-pres [label]="'Date of birth'" [id]="'dateOfBirth'" [formField]="formTree.dateOfBirth" />
     </div>
     <div class="row mb-3">
-      @if (form.controls.dateOfBirth.errors?.date) {
+      @if (formTree.dateOfBirth().getError('date')) {
         <div class="text-danger">{{translations.date | o3rTranslate}}</div>
       }
-      @if (form.controls.dateOfBirth.errors?.max) {
-        <div class="text-danger">{{translations.max | o3rTranslate: {max: form.controls.dateOfBirth.errors?.max.max} }}</div>
+      @if (formTree.dateOfBirth().getError('max'); as maxError) {
+        <div class="text-danger">{{translations.max | o3rTranslate: {max: maxError['max']} }}</div>
       }
-      @for (customError of form.controls.dateOfBirth.errors?.customErrors; track customError.translationKey) {
-        <div class="text-danger">{{customError.translationKey | o3rTranslate: customError.translationParams}}</div>
+      @for (error of getCustomErrors(formTree.dateOfBirth); track $index) {
+        <div class="text-danger">{{error.translationKey | o3rTranslate: error.translationParams}}</div>
       }
     </div>
   </form>
   <div class="row mb-3">
-    @if(form.errors) {
-      <div class="text-danger">Global validator: {{form.errors | json}}</div>
+    @if (formTree().errors().length > 0) {
+      <div class="text-danger">Global validator: {{formTree().errors() | json}}</div>
     }
   </div>
   <div class="m-auto pb-3">

--- a/apps/showcase/src/components/utilities/forms-personal-info/forms-personal-info-pres.spec.ts
+++ b/apps/showcase/src/components/utilities/forms-personal-info/forms-personal-info-pres.spec.ts
@@ -3,9 +3,6 @@ import {
   TestBed,
 } from '@angular/core/testing';
 import {
-  ReactiveFormsModule,
-} from '@angular/forms';
-import {
   provideLocalizationMock,
 } from '@o3r/testing/transloco';
 import {
@@ -18,7 +15,7 @@ describe('FormsPersonalInfoPres', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FormsPersonalInfoPres, ReactiveFormsModule],
+      imports: [FormsPersonalInfoPres],
       providers: [provideLocalizationMock()]
     }).compileComponents();
 

--- a/apps/showcase/src/components/utilities/forms-personal-info/forms-personal-info-pres.ts
+++ b/apps/showcase/src/components/utilities/forms-personal-info/forms-personal-info-pres.ts
@@ -4,49 +4,39 @@ import {
 } from '@angular/common';
 import {
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
-  forwardRef,
-  inject,
   Input,
   input,
-  type OnDestroy,
-  type OnInit,
+  model,
   output,
   ViewEncapsulation,
 } from '@angular/core';
 import {
   AbstractControl,
-  ControlValueAccessor,
-  FormBuilder,
-  FormControl,
-  FormGroup,
-  FormsModule,
-  NG_VALIDATORS,
-  NG_VALUE_ACCESSOR,
-  ReactiveFormsModule,
-  ValidationErrors,
-  Validator,
-  Validators,
 } from '@angular/forms';
+import {
+  type FieldTree,
+  form,
+  FormField,
+  type FormValueControl,
+  maxLength,
+  required,
+  schema,
+  type Schema,
+  validate,
+  type ValidationError,
+} from '@angular/forms/signals';
 import {
   O3rComponent,
 } from '@o3r/core';
 import {
-  ControlFlatErrors,
   CustomFormValidation,
-  FlatError,
-  getFlatControlErrors,
-  markAllControlsDirtyAndTouched,
 } from '@o3r/forms';
 import {
   Localization,
   O3rLocalizationTranslatePipe,
   Translatable,
 } from '@o3r/transloco';
-import {
-  Subscription,
-} from 'rxjs';
 import {
   PersonalInfo,
 } from '../../showcase/forms-parent/contracts';
@@ -61,36 +51,32 @@ import {
   translations,
 } from './forms-personal-info-pres-translation';
 
+/**
+ * Reusable schema for PersonalInfo validation.
+ * Can be applied in parent forms via `apply(p.personalInfo, personalInfoSchema)`.
+ *
+ * Note: maxLength is not included here as it depends on a config input.
+ * The parent should add maxLength separately or the child handles it internally.
+ */
+export const personalInfoSchema: Schema<PersonalInfo> = schema<PersonalInfo>((p) => {
+  required(p.name);
+});
+
 @O3rComponent({ componentType: 'Component' })
 @Component({
   selector: 'o3r-forms-personal-info-pres',
   imports: [
     DatePickerInputPres,
-    FormsModule,
+    FormField,
     JsonPipe,
-    O3rLocalizationTranslatePipe,
-    ReactiveFormsModule
+    O3rLocalizationTranslatePipe
   ],
   templateUrl: './forms-personal-info-pres.html',
   styleUrl: './forms-personal-info-pres.scss',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [
-    {
-      provide: NG_VALUE_ACCESSOR,
-      useExisting: forwardRef(() => FormsPersonalInfoPres),
-      multi: true
-    },
-    {
-      provide: NG_VALIDATORS,
-      useExisting: forwardRef(() => FormsPersonalInfoPres),
-      multi: true
-    }
-  ]
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class FormsPersonalInfoPres implements OnInit, OnDestroy, ControlValueAccessor, Validator, Translatable<FormsPersonalInfoPresTranslation> {
-  private readonly subscription = new Subscription();
-
+export class FormsPersonalInfoPres implements FormValueControl<PersonalInfo>, Translatable<FormsPersonalInfoPresTranslation> {
   /** Localization of the component */
   @Input()
   @Localization('./forms-personal-info-pres-localization.json')
@@ -105,21 +91,64 @@ export class FormsPersonalInfoPres implements OnInit, OnDestroy, ControlValueAcc
   /** Custom validators applied on the form */
   public readonly customValidators = input<CustomFormValidation<PersonalInfo>>();
 
-  /** Register a function to be called when the submit is done outside of the presenter (from page) */
-  public readonly registerInteraction = output<() => void>();
-
   /** Emit when the submit has been fired on the form */
   public readonly submitPersonalInfoForm = output<void>();
 
-  protected changeDetector = inject(ChangeDetectorRef);
+  /** FormValueControl: the value model signal, kept in sync by [formField] */
+  public readonly value = model<PersonalInfo>({ name: '', dateOfBirth: this.formatDate(Date.now()) });
 
-  /** Form group */
-  public form: FormGroup<{
-    name: FormControl<string | null>;
-    dateOfBirth: FormControl<string | null>;
-  }> = inject(FormBuilder).group({
-    name: new FormControl<string>(''),
-    dateOfBirth: new FormControl<string>(this.formatDate(Date.now()))
+  /** FormValueControl: output emitted to mark the field as touched */
+  public readonly touch = output<void>();
+
+  /** FormValueControl: input to receive the disabled status from the parent field */
+  public readonly disabled = input<boolean>(false);
+
+  /** Signal form tree with built-in validators, driven by the value model */
+  public formTree: FieldTree<PersonalInfo> = form(this.value, (p) => {
+    required(p.name);
+
+    // Reactive maxLength based on config input
+    maxLength(p.name, () => this.config()?.nameMaxLength ?? Infinity);
+
+    // Custom validators from parent - global
+    validate(p, ({ value }) => {
+      const cv = this.customValidators();
+      if (cv?.global) {
+        const result = cv.global({ value: value() } as unknown as AbstractControl);
+        if (result?.customErrors) {
+          return result.customErrors.map((e: { translationKey: string }) => ({ kind: 'custom', message: e.translationKey }));
+        }
+      }
+      return undefined;
+    });
+
+    // Custom validators from parent - field-level name
+    validate(p.name, ({ value }) => {
+      const cv = this.customValidators();
+      if (cv?.fields?.name) {
+        const result = cv.fields.name({ value: value() } as unknown as AbstractControl);
+        if (result?.customErrors) {
+          return result.customErrors.map((e: { translationKey: string }) => ({ kind: 'custom', message: e.translationKey }));
+        }
+      }
+      return undefined;
+    });
+
+    // Custom validators from parent - field-level dateOfBirth
+    validate(p.dateOfBirth, ({ value }) => {
+      const cv = this.customValidators();
+      if (cv?.fields?.dateOfBirth) {
+        const result = cv.fields.dateOfBirth({ value: value() } as unknown as AbstractControl);
+        if (result?.customErrors) {
+          return result.customErrors.map((e: { translationKey: string; translationParams?: Record<string, unknown> }) => ({
+            kind: 'custom',
+            message: e.translationKey,
+            translationParams: e.translationParams
+          }));
+        }
+      }
+      return undefined;
+    });
   });
 
   public componentSelector = 'o3r-forms-personal-info-pres';
@@ -128,114 +157,17 @@ export class FormsPersonalInfoPres implements OnInit, OnDestroy, ControlValueAcc
     return formatDate(dateTime, 'yyyy-MM-dd', 'en-GB');
   }
 
-  public ngOnInit() {
-    this.applyValidation();
-    this.subscription.add(this.form.valueChanges.subscribe((value) => this.propagateChange(value)));
-    this.registerInteraction.emit(() => {
-      markAllControlsDirtyAndTouched(this.form);
-      this.changeDetector.markForCheck();
-    });
-  }
-
-  public ngOnDestroy() {
-    this.subscription.unsubscribe();
-  }
-
-  /** @inheritDoc */
-  public writeValue(value?: any) {
-    if (value) {
-      this.form.setValue(value);
-    }
-  }
-
-  /** Function registered to propagate a change to the parent */
-  public propagateChange: any = () => {};
-  /** Function registered to propagate touched to the parent */
-  public propagateTouched: any = () => {};
-
-  /** @inheritDoc */
-  public registerOnChange(fn: any) {
-    this.propagateChange = fn;
-  }
-
-  /** @inheritDoc */
-  public registerOnTouched(fn: any) {
-    this.propagateTouched = fn;
-  }
-
-  /**
-   * Get custom validators and primitive validators and apply them on the form
-   */
-  public applyValidation() {
-    const customValidators = this.customValidators();
-    const config = this.config();
-    const globalValidators = [];
-    if (customValidators && customValidators.global) {
-      globalValidators.push(customValidators.global);
-    }
-    this.form.setValidators(globalValidators);
-
-    // eslint-disable-next-line @typescript-eslint/unbound-method -- Validators are bound methods
-    const nameValidators = [Validators.required];
-    const dateOfBirthValidators = [];
-    if (config?.nameMaxLength) {
-      nameValidators.push(Validators.maxLength(config.nameMaxLength));
-    }
-    if (customValidators && customValidators.fields) {
-      if (customValidators.fields.name) {
-        nameValidators.push(customValidators.fields.name);
-      }
-      if (customValidators.fields.dateOfBirth) {
-        dateOfBirthValidators.push(customValidators.fields.dateOfBirth);
-      }
-    }
-    this.form.controls.name.setValidators(nameValidators);
-    this.form.controls.dateOfBirth.setValidators(dateOfBirthValidators);
-    this.form.updateValueAndValidity();
-  }
-
-  /**
-   * @inheritDoc
-   */
-  public validate(_control: AbstractControl): ValidationErrors | null {
-    if (this.form.status === 'VALID') {
-      return null;
-    }
-
-    const formErrors = getFlatControlErrors(this.form);
-
-    return formErrors.reduce((errorsMap: ValidationErrors, controlFlatErrors: ControlFlatErrors) => {
-      return {
-        ...errorsMap,
-        [controlFlatErrors.controlName || 'global']: {
-          htmlElementId: `${this.id()}${controlFlatErrors.controlName || ''}`,
-          errorMessages: (controlFlatErrors.customErrors || []).concat(
-            controlFlatErrors.errors.map((error) => {
-              const translationKey = `${this.componentSelector}.${controlFlatErrors.controlName || ''}.${error.errorKey}`;
-              return {
-                translationKey,
-                longTranslationKey: this.translations[`${error.errorKey}Long`] || undefined,
-                validationError: error.validationError,
-                translationParams: this.getTranslationParamsFromFlatErrors(controlFlatErrors.controlName || '', error)
-              };
-            })
-          )
-        }
-      };
-    }, {});
-  }
-
   /**
    * Create the translation parameters for each form control error
    * @param controlName
    * @param error
    */
-  public getTranslationParamsFromFlatErrors(controlName: string, error: FlatError) {
+  public getTranslationParamsFromError(controlName: string, error: ValidationError.WithFieldTree) {
     switch (controlName) {
       case 'dateOfBirth': {
-        switch (error.errorKey) {
+        switch (error.kind) {
           case 'max': {
-            return { max: error.errorValue.max };
+            return { max: (error as unknown as { max?: unknown }).max };
           }
           default: {
             return {};
@@ -243,9 +175,9 @@ export class FormsPersonalInfoPres implements OnInit, OnDestroy, ControlValueAcc
         }
       }
       case 'name': {
-        switch (error.errorKey) {
-          case 'maxlength': {
-            return { requiredLength: error.errorValue.requiredLength };
+        switch (error.kind) {
+          case 'maxLength': {
+            return { requiredLength: (error as unknown as { maxLength?: unknown }).maxLength };
           }
           default: {
             return {};
@@ -258,10 +190,25 @@ export class FormsPersonalInfoPres implements OnInit, OnDestroy, ControlValueAcc
     }
   }
 
-  /** Submit emergency contact form */
+  /** Submit personal info form */
   public submitForm() {
-    markAllControlsDirtyAndTouched(this.form);
-    this.form.updateValueAndValidity();
+    this.formTree().markAsTouched();
+    this.formTree().markAsDirty();
+    this.touch.emit();
     this.submitPersonalInfoForm.emit();
+  }
+
+  /**
+   * Extract custom errors from a field tree node for template display.
+   * Custom errors have kind 'custom' and carry translationKey in the message field.
+   * @param fieldTree
+   */
+  public getCustomErrors(fieldTree: FieldTree<string>): { translationKey: string; translationParams: Record<string, unknown> }[] {
+    return fieldTree().errors()
+      .filter((e) => e.kind === 'custom')
+      .map((e) => ({
+        translationKey: e.message ?? '',
+        translationParams: (e as unknown as { translationParams?: Record<string, unknown> }).translationParams ?? {}
+      }));
   }
 }

--- a/apps/showcase/src/components/utilities/otter-picker/otter-picker-pres.html
+++ b/apps/showcase/src/components/utilities/otter-picker/otter-picker-pres.html
@@ -1,7 +1,7 @@
 <div ngbDropdown class="d-inline-block w-100">
-  <button type="button" class="btn btn-outline-primary otter-dropdown w-100" [class.selected]="!!selectedOtter()" [id]="id()" ngbDropdownToggle>
-    @if (selectedOtter()) {
-      <div class="w-100"><img alt="Otter image" [src]="baseUrl+selectedOtter()" width="34" height="34" /></div>
+  <button type="button" class="btn btn-outline-primary otter-dropdown w-100" [class.selected]="!!value()" [id]="id()" ngbDropdownToggle>
+    @if (value()) {
+      <div class="w-100"><img alt="Otter image" [src]="baseUrl+value()" width="34" height="34" /></div>
     } @else {
       <span>Pick an icon</span>
     }

--- a/apps/showcase/src/components/utilities/otter-picker/otter-picker-pres.ts
+++ b/apps/showcase/src/components/utilities/otter-picker/otter-picker-pres.ts
@@ -1,15 +1,14 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  forwardRef,
   input,
-  signal,
+  model,
+  output,
   ViewEncapsulation,
 } from '@angular/core';
-import {
-  ControlValueAccessor,
-  NG_VALUE_ACCESSOR,
-} from '@angular/forms';
+import type {
+  FormValueControl,
+} from '@angular/forms/signals';
 import {
   NgbDropdownModule,
 } from '@ng-bootstrap/ng-bootstrap';
@@ -26,22 +25,21 @@ import {
   imports: [NgbDropdownModule],
   templateUrl: './otter-picker-pres.html',
   styleUrls: ['./otter-picker-pres.scss'],
-  providers: [
-    {
-      provide: NG_VALUE_ACCESSOR,
-      useExisting: forwardRef(() => OtterPickerPres),
-      multi: true
-    }
-  ],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class OtterPickerPres implements ControlValueAccessor {
+export class OtterPickerPres implements FormValueControl<string> {
   /** ID of the html element used for selection */
   public readonly id = input.required<string>();
 
-  /** Currently selected otter */
-  public selectedOtter = signal('');
+  /** The currently selected otter value */
+  public value = model<string>('');
+
+  /** Emits when the control is touched */
+  public touch = output<void>();
+
+  /** Disabled state of the picker */
+  public disabled = input<boolean>(false);
 
   /** List of available otters */
   public otters = OTTER_ICONS;
@@ -49,49 +47,12 @@ export class OtterPickerPres implements ControlValueAccessor {
   /** Base URL where the images can be fetched */
   public baseUrl = location.href.split('/#', 1)[0];
 
-  private onChanges!: (val: string) => void;
-  private onTouched!: () => void;
-  private readonly isDisabled = signal(false);
-
   /**
    * Select an otter and notify the parent
-   * @param otter
+   * @param otter selected otter icon path
    */
   public selectOtter(otter: string) {
-    this.selectedOtter.set(otter);
-    this.onChanges(otter);
-    this.onTouched();
-  }
-
-  /**
-   * Implements ControlValueAccessor
-   * @param fn
-   */
-  public registerOnChange(fn: any): void {
-    this.onChanges = fn;
-  }
-
-  /**
-   * Implements ControlValueAccessor
-   * @param fn
-   */
-  public registerOnTouched(fn: any): void {
-    this.onTouched = fn;
-  }
-
-  /**
-   * Implements ControlValueAccessor
-   * @param isDisabled
-   */
-  public setDisabledState(isDisabled: boolean): void {
-    this.isDisabled.set(isDisabled);
-  }
-
-  /**
-   * Implements ControlValueAccessor
-   * @param obj
-   */
-  public writeValue(obj: any): void {
-    this.selectedOtter.set(obj);
+    this.value.set(otter);
+    this.touch.emit();
   }
 }


### PR DESCRIPTION
## Proposed change

Migrate showcase app components from the legacy Reactive Forms API (`FormControl`, `FormGroup`, `FormBuilder`, `ControlValueAccessor`, `NG_VALUE_ACCESSOR`) to the new **Angular Signal Forms API** (`@angular/forms/signals`).

This replaces imperative form patterns with the signal-based `form()`, `FormField`, `schema()`, `validate()`, `required()`, `maxLength()`, and `model()` APIs, aligning the showcase with the Angular roadmap for signal-based reactivity.

### Components migrated

- **Forms components:** `forms-parent`, `forms-personal-info-pres`, `forms-emergency-contact-pres`
- **Showcase presenters:** `basic-pres`, `configuration-pres`, `design-token-pres`, `dynamic-content-pres`, `localization-pres`, `placeholder-pres`, `rules-engine-pres`
- **Training/Utilities:** `code-editor-view`, `otter-picker-pres`

### What is NOT included (intentionally)

The **component-replacement (c11n)** and **date-picker-input** components are **intentionally excluded** from this migration. They rely on `ControlValueAccessor` and have not yet been migrated to signal inputs. Since c11n must remain backward-compatible with what is already available, migrating it should be done in a **dedicated follow-up PR** after the input signal migration is in place.

## Related issues

*- No issue associated -*